### PR TITLE
Include branch name in epic completion mail notifications (Vibe Kanban)

### DIFF
--- a/src/backend/routers/mcp/epic.mcp.ts
+++ b/src/backend/routers/mcp/epic.mcp.ts
@@ -878,8 +878,8 @@ ${failedTasks.length > 0 ? `## Failed Tasks (${failedTasks.length})\n${failedTas
       isForHuman: true,
       subject: `Epic Complete: ${epic.title}`,
       body: prCreated
-        ? `The epic "${epic.title}" has been completed and is ready for review.\n\nPR URL: ${prInfo!.url}\n\nCompleted tasks: ${completedTasks.length}\nFailed tasks: ${failedTasks.length}`
-        : `The epic "${epic.title}" has been completed locally.\n\nNote: PR could not be created (no remote configured).\n\nCompleted tasks: ${completedTasks.length}\nFailed tasks: ${failedTasks.length}`,
+        ? `The epic "${epic.title}" has been completed and is ready for review.\n\nPR URL: ${prInfo!.url}\nBranch: ${epicBranchName}\n\nCompleted tasks: ${completedTasks.length}\nFailed tasks: ${failedTasks.length}`
+        : `The epic "${epic.title}" has been completed locally.\n\nNote: PR could not be created (no remote configured).\nBranch: ${epicBranchName}\n\nCompleted tasks: ${completedTasks.length}\nFailed tasks: ${failedTasks.length}`,
     });
 
     // Log decision


### PR DESCRIPTION
## Summary

This PR adds the branch name to the email notification sent to humans when an epic is completed.

## Changes Made

Modified the epic completion mail in `src/backend/routers/mcp/epic.mcp.ts` to include the `epicBranchName` (format: `factoryfactory/epic-{epicId}`) in the notification body.

The branch name is now included in both scenarios:
- **When PR is successfully created**: The mail includes both the PR URL and the branch name
- **When PR creation fails** (e.g., no remote configured): The mail includes the branch name so the human can still locate the code

## Why This Change

Previously, if a PR could not be created (due to no remote being configured or other issues), the human receiving the notification had no easy way to find where the completed work was located. By including the branch name in all cases, users can always locate the code by checking out the branch directly, regardless of whether the PR was successfully created.

## Implementation Details

- Uses the existing `epicBranchName` variable which is already defined earlier in the `createEpicPR` function
- No new dependencies or configuration required
- Backwards compatible - only adds information to the notification, doesn't change existing behavior

---

This PR was written using [Vibe Kanban](https://vibekanban.com)