### PR TITLE
Fix supervisor agent not displaying in epic view (Vibe Kanban)

### DIFF
--- a/src/backend/resource_accessors/agent.accessor.ts
+++ b/src/backend/resource_accessors/agent.accessor.ts
@@ -246,6 +246,36 @@ export class AgentAccessor {
       },
     });
   }
+
+  /**
+   * Find all agents for a specific epic (workers and supervisors)
+   */
+  async findAgentsByEpicId(epicId: string): Promise<Agent[]> {
+    return prisma.agent.findMany({
+      where: {
+        OR: [
+          // Workers assigned to tasks in this epic
+          {
+            type: AgentType.WORKER,
+            assignedTasks: {
+              some: {
+                epicId,
+              },
+            },
+          },
+          // Supervisor orchestrating this epic
+          {
+            type: AgentType.SUPERVISOR,
+            currentEpicId: epicId,
+          },
+        ],
+      },
+      include: {
+        currentEpic: true,
+        assignedTasks: true,
+      },
+    });
+  }
 }
 
 export const agentAccessor = new AgentAccessor();

--- a/src/backend/trpc/agent.trpc.ts
+++ b/src/backend/trpc/agent.trpc.ts
@@ -126,11 +126,11 @@ export const agentRouter = router({
     };
   }),
 
-  // Get workers for a specific epic
+  // Get agents for a specific epic (workers and supervisors)
   listByEpic: publicProcedure
     .input(z.object({ epicId: z.string() }))
     .query(async ({ input }) => {
-      const agents = await agentAccessor.findWorkersByEpicId(input.epicId);
+      const agents = await agentAccessor.findAgentsByEpicId(input.epicId);
       const now = Date.now();
 
       return agents.map((agent) => {


### PR DESCRIPTION
## Summary

Fixes a bug where the "Supervisor Agent" section in the epic view page always showed "No supervisor assigned yet", even when a supervisor was actively orchestrating the epic.

## Changes

- **Added `findAgentsByEpicId()` method** in `agent.accessor.ts` - A new query method that retrieves both worker agents (via assigned tasks) and supervisor agents (via `currentEpicId`) for a given epic
- **Updated `listByEpic` TRPC endpoint** in `agent.trpc.ts` - Changed to use the new `findAgentsByEpicId()` method instead of `findWorkersByEpicId()`

## Root Cause

The `listByEpic` endpoint was calling `findWorkersByEpicId()`, which explicitly filtered for `type: AgentType.WORKER` only. Supervisor agents are linked to epics differently - they use the `currentEpicId` field rather than having assigned tasks. This meant supervisors were never included in the query results, causing the UI to always show the fallback "No supervisor assigned yet" message.

## Implementation Details

The new `findAgentsByEpicId()` method uses a Prisma `OR` query to fetch:
1. Workers with `assignedTasks` containing the epic ID
2. Supervisors with `currentEpicId` matching the epic ID

This preserves the existing worker-fetching behavior while adding supervisor support.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)