### PR TITLE
Fix Biome cognitive complexity lints and add project documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm run dev:all       # Start frontend + backend + Inngest
+npm run db:migrate    # Run Prisma migrations
+npm run db:generate   # Regenerate Prisma client after schema changes
+npm run check:fix     # Lint + format with Biome
+npm run typecheck     # TypeScript checking
+npm run build:all     # Build for production
+```
+
+## Architecture
+
+Three-tier agent hierarchy that processes Linear issues:
+
+```
+Orchestrator (1 per system) → monitors health, manages supervisors
+    └── Supervisor (1 per Epic) → breaks down epic, reviews/merges PRs
+            └── Worker (1 per Task) → implements in isolated git worktree
+```
+
+Agents communicate via Mail system and are triggered by Inngest events (`epic.created` → supervisor, `task.created` → worker). PRs are merged sequentially to avoid complex conflicts.
+
+## Code Patterns
+
+- **Path aliases:** `@/*` → `src/`, `@prisma-gen/*` → `prisma/generated/`
+- **Backend imports:** Use `.js` extension for local imports (ESM requirement)
+- **Database access:** All queries go through `src/backend/resource_accessors/`
+- **Agent tools:** MCP tools in `src/backend/routers/mcp/`, permissions per agent type in `permissions.ts`

--- a/README.md
+++ b/README.md
@@ -1,347 +1,93 @@
 # FactoryFactory
 
-FactoryFactory is an autonomous software development orchestration system that uses AI agents to manage and execute software development tasks from Linear issues.
-
-## Overview
-
-FactoryFactory coordinates multiple AI agents to autonomously:
-- Break down Linear epics into implementable tasks
-- Create git worktrees and branches for isolated work
-- Execute tasks using tmux sessions
-- Create pull requests and manage code reviews
-- Orchestrate complex development workflows
+Autonomous software development orchestration system that uses AI agents to execute tasks from Linear issues.
 
 ## Prerequisites
 
-Before setting up FactoryFactory, ensure you have the following installed:
-
-- **Node.js 18+** - [Download](https://nodejs.org/)
-- **Docker and Docker Compose** - [Download](https://www.docker.com/products/docker-desktop)
-- **GitHub CLI (`gh`)** - [Installation guide](https://cli.github.com/)
-- **tmux** - Install via your package manager (e.g., `brew install tmux` on macOS)
-- **Anthropic API Key** - [Get your key](https://console.anthropic.com/)
+- **Node.js 18+**
+- **Docker** (for PostgreSQL)
+- **GitHub CLI (`gh`)** - authenticated
+- **tmux**
+- **Anthropic API Key**
 
 ## Quick Start
 
-### 1. Clone and Install
-
 ```bash
-git clone <repository-url>
-cd FactoryFactory
+# 1. Install
 npm install
-```
 
-### 2. Set Up Environment Variables
-
-```bash
+# 2. Configure
 cp .env.example .env
-```
+# Edit .env: set ANTHROPIC_API_KEY, GIT_BASE_REPO_PATH, GIT_WORKTREE_BASE
 
-Edit `.env` and fill in the required values:
-- `DATABASE_URL` - PostgreSQL connection string (default works with Docker setup)
-- `ANTHROPIC_API_KEY` - Your Claude API key
-- `GIT_BASE_REPO_PATH` - Path to your test repository (e.g., `~/Programming/monorepo`)
-- `GIT_WORKTREE_BASE` - Directory for git worktrees (e.g., `/tmp/factoryfactory-worktrees`)
-- `INNGEST_EVENT_KEY` and `INNGEST_SIGNING_KEY` - Generate these for local dev
-
-### 3. Start PostgreSQL
-
-```bash
+# 3. Start PostgreSQL
 docker-compose up -d
-```
 
-### 4. Run Database Migrations
-
-```bash
+# 4. Run migrations
 npm run db:migrate
-```
 
-### 5. Start Development Servers
-
-In separate terminal windows:
-
-```bash
-# Terminal 1: Backend server
-npm run backend:dev
-
-# Terminal 2: Frontend (Next.js)
-npm run dev
-
-# Terminal 3: Inngest dev server
-npm run inngest:dev
+# 5. Start all servers
+npm run dev:all
 ```
 
 ## Verify Installation
 
-- **Frontend**: http://localhost:3000
-- **Backend Health Check**: http://localhost:3001/health
-- **Inngest Dashboard**: http://localhost:8288
-- **Prisma Studio**: `npm run db:studio` (opens on http://localhost:5555)
-
-## Project Structure
-
-```
-FactoryFactory/
-├── prisma/
-│   └── schema.prisma          # Database schema
-├── src/
-│   ├── backend/
-│   │   ├── clients/           # Git, GitHub, Tmux, Terminal clients
-│   │   ├── inngest/           # Event-driven functions
-│   │   │   └── functions/     # Event handlers (mail.sent, etc.)
-│   │   ├── resource_accessors/# Database access layer
-│   │   ├── routers/
-│   │   │   └── mcp/          # MCP tool implementations
-│   │   ├── testing/           # Mock agent utilities
-│   │   ├── db.ts              # Prisma client
-│   │   └── index.ts           # Backend server
-│   └── frontend/
-│       ├── app/               # Next.js App Router
-│       └── components/        # React components (tmux-terminal, etc.)
-├── docs/
-│   ├── MCP_TOOLS.md          # MCP tools documentation
-│   ├── ARCHITECTURE.md       # System architecture details
-│   ├── DEPLOYMENT_GUIDE.md   # Production deployment guide
-│   └── USER_GUIDE.md         # End-user documentation
-├── docker-compose.yml         # Docker services (dev/production)
-├── Dockerfile                 # Production container image
-├── nginx.conf                 # Production reverse proxy config
-└── package.json
-```
-
-## Database Schema
-
-The system uses five main models:
-
-- **Epic** - Top-level features from Linear
-- **Task** - Individual work items within epics
-- **Agent** - AI agents (Supervisor, Orchestrator, Worker)
-- **Mail** - Inter-agent communication
-- **DecisionLog** - Audit trail of agent decisions
-
-## Development Workflow
-
-1. **Create an epic** in the database (via Prisma Studio or API)
-2. **Agents autonomously**:
-   - Break down the epic into tasks
-   - Assign tasks to worker agents
-   - Create git worktrees and branches
-   - Execute code changes
-   - Create pull requests
-   - Monitor and orchestrate completion
-
-## Available Scripts
-
-### Development
-- `npm run dev` - Start Next.js frontend
-- `npm run backend:dev` - Start backend server with hot reload
-- `npm run inngest:dev` - Start Inngest dev server
-- `npm run dev:all` - Start all development servers concurrently
-
-### Database
-- `npm run db:migrate` - Run Prisma migrations (dev)
-- `npm run db:migrate:deploy` - Run Prisma migrations (production)
-- `npm run db:generate` - Generate Prisma client
-- `npm run db:studio` - Open Prisma Studio GUI
-
-### Production
-- `npm run build` - Build Next.js frontend
-- `npm run build:backend` - Build backend TypeScript
-- `npm run build:all` - Build frontend and backend
-- `npm run start` - Start production frontend
-- `npm run start:backend` - Start production backend
-- `npm run start:all` - Start all production servers
-
-### Quality
-- `npm run lint` - Lint code
-- `npm run lint:fix` - Lint and auto-fix
-- `npm run format` - Format code with Prettier
-- `npm run format:check` - Check formatting
-- `npm run typecheck` - TypeScript type checking
-
-### Health
-- `npm run health` - Quick health check
-- `npm run health:all` - Comprehensive health check
-
-## Environment Variables
-
-See `.env.example` for a complete list of environment variables with descriptions.
-
-### Required Variables
-
-- `DATABASE_URL` - PostgreSQL connection string
-- `ANTHROPIC_API_KEY` - Claude API key
-- `GIT_BASE_REPO_PATH` - Path to your repository
-- `GIT_WORKTREE_BASE` - Base directory for worktrees
-
-### Optional Variables
-
-- `TMUX_SOCKET_PATH` - Custom tmux socket path
-- `BACKEND_PORT` - Backend server port (default: 3001)
-- `FRONTEND_PORT` - Frontend server port (default: 3000)
-- `CLAUDE_MODEL` - Override Claude model version
-- `REQUIRE_HUMAN_APPROVAL` - Require human approval for actions
-
-## Test Repository Setup
-
-FactoryFactory needs a Git repository to manage worktrees. By default, it expects a repository at `~/Programming/monorepo`.
-
-To use a different repository:
-
-1. Update `GIT_BASE_REPO_PATH` in `.env`
-2. Ensure the repository is a valid git repository
-3. Ensure you have write access to the repository
+- Frontend: http://localhost:3000
+- Backend: http://localhost:3001/health
+- Inngest: http://localhost:8288
+- Prisma Studio: `npm run db:studio`
 
 ## Architecture
 
-FactoryFactory uses a multi-agent architecture:
+Three-tier agent hierarchy:
 
-- **Supervisor Agent** - High-level orchestrator, monitors all epics
-- **Orchestrator Agents** - Manage individual epics, create and assign tasks
-- **Worker Agents** - Execute individual tasks in isolated environments
+```
+Orchestrator (1 per system) - system health, supervisor lifecycle
+    └── Supervisor (1 per Epic) - breaks down epic, reviews/merges PRs
+            └── Worker (1 per Task) - implements in isolated git worktree
+```
 
 Agents communicate via:
-- **Database** - Shared state (epics, tasks, agents)
-- **Mail System** - Asynchronous messages between agents
-- **Inngest Events** - Event-driven triggers and workflows
+- **Mail System** - async messages between agents
+- **Inngest Events** - triggers workflows (`epic.created` → supervisor, `task.created` → worker)
+- **Database** - shared state
 
-## Implementation Status
-
-### Phase 0: Foundation & Infrastructure ✅
-- ✅ PostgreSQL database with Prisma
-- ✅ Resource accessors for all models
-- ✅ Git, GitHub, and Tmux clients
-- ✅ Basic Inngest infrastructure
-- ✅ Next.js frontend shell
-- ✅ Backend server with health check
-
-### Phase 1: MCP Infrastructure & Mail System ✅
-- ✅ MCP server with tool registry
-- ✅ Tool permission system (by agent type)
-- ✅ Mail communication tools (`mcp__mail__*`)
-- ✅ Agent introspection tools (`mcp__agent__*`)
-- ✅ System tools (`mcp__system__*`)
-- ✅ Decision logging infrastructure
-- ✅ Terminal integration for tmux viewing
-- ✅ Mock agent testing utilities
-- ✅ Inngest event handlers for mail
-
-### Phase 2-6: Agent Implementation ✅
-- ✅ Real agent implementation with Claude SDK
-- ✅ Worker, Supervisor, and Orchestrator agents
-- ✅ Epic and task management workflows
-- ✅ Git worktree and PR management
-- ✅ Frontend UI for monitoring
-
-### Phase 7: Polish & Production Readiness ✅
-- ✅ Edge case handling (epic/task lifecycle, PR conflicts)
-- ✅ Agent crash recovery with loop detection
-- ✅ Claude API rate limiting and concurrency controls
-- ✅ Resource management (worktree cleanup)
-- ✅ Agent execution profiles (model/permission configuration)
-- ✅ Admin tools and debugging utilities
-- ✅ Security hardening (input validation, CORS, sanitization)
-- ✅ Production deployment (Docker, Nginx, docker-compose)
-- ✅ Monitoring and observability (structured logging, health checks)
-- ✅ Comprehensive documentation
-
-## MCP Tools
-
-Phase 1 introduces the MCP (Model Context Protocol) server for agent communication and tool execution.
-
-### Available Tools
-
-See [docs/MCP_TOOLS.md](docs/MCP_TOOLS.md) for complete documentation.
-
-**Mail Tools:**
-- `mcp__mail__list_inbox` - List inbox messages
-- `mcp__mail__read` - Read and mark mail as read
-- `mcp__mail__send` - Send mail to agents or humans
-- `mcp__mail__reply` - Reply to received mail
-
-**Agent Introspection Tools:**
-- `mcp__agent__get_status` - Get agent status and metadata
-- `mcp__agent__get_task` - Get current task (WORKER only)
-- `mcp__agent__get_epic` - Get current epic
-
-**System Tools:**
-- `mcp__system__log_decision` - Manually log decisions
-
-### Testing MCP Tools
-
-Run the test suite:
-
-```bash
-# Start the backend server
-npm run backend:dev
-
-# In another terminal, run tests
-tsx src/backend/testing/test-scenarios.ts
-```
-
-### Example: Send Mail via MCP
-
-```bash
-curl -X POST http://localhost:3001/mcp/execute \
-  -H "Content-Type: application/json" \
-  -d '{
-    "agentId": "agent-id-here",
-    "toolName": "mcp__mail__send",
-    "input": {
-      "toHuman": true,
-      "subject": "Test Mail",
-      "body": "This is a test message"
-    }
-  }'
-```
+PRs are merged sequentially to avoid complex conflicts. Workers rebase when requested.
 
 ## Troubleshooting
 
-### PostgreSQL connection issues
-- Ensure Docker is running: `docker ps`
-- Check PostgreSQL logs: `docker-compose logs postgres`
-- Verify connection string in `.env`
+**PostgreSQL connection:**
+```bash
+docker ps                        # Ensure Docker is running
+docker-compose logs postgres     # Check logs
+```
 
-### GitHub CLI authentication
+**GitHub CLI:**
 ```bash
 gh auth status
 gh auth login
 ```
 
-### Prisma issues
+**Prisma issues:**
 ```bash
-# Reset database (WARNING: destroys data)
-npx prisma migrate reset
-
-# Re-generate Prisma client
-npm run db:generate
+npx prisma migrate reset    # Reset database (destroys data)
+npm run db:generate         # Regenerate client
 ```
 
 ## Documentation
 
-- [User Guide](docs/USER_GUIDE.md) - Getting started and usage instructions
-- [Deployment Guide](docs/DEPLOYMENT_GUIDE.md) - Production deployment and configuration
-- [Architecture](docs/ARCHITECTURE.md) - System design and technical details
-- [MCP Tools](docs/MCP_TOOLS.md) - Agent tools and protocols
+- [User Guide](docs/USER_GUIDE.md)
+- [Deployment Guide](docs/DEPLOYMENT_GUIDE.md)
+- [Architecture](docs/ARCHITECTURE.md)
+- [MCP Tools](docs/MCP_TOOLS.md)
 
-## Production Deployment
-
-For production deployment:
+## Production
 
 ```bash
-# Build and start with Docker
 docker-compose --profile production up -d
-
-# Or manually
-npm run build:all
-npm run start:all
 ```
 
-See [Deployment Guide](docs/DEPLOYMENT_GUIDE.md) for complete instructions.
-
-## Contributing
-
-This is an experimental project. See the DESIGN.md and PHASE-*.md files for the complete architecture and roadmap.
+See [Deployment Guide](docs/DEPLOYMENT_GUIDE.md) for details.
 
 ## License
 

--- a/biome.json
+++ b/biome.json
@@ -67,7 +67,7 @@
       },
       "complexity": {
         "noBannedTypes": "off",
-        "noExcessiveCognitiveComplexity": "warn",
+        "noExcessiveCognitiveComplexity": "error",
         "noUselessThisAlias": "error",
         "noUselessTypeConstraint": "error",
         "useFlatMap": "error",


### PR DESCRIPTION
## Summary

- Fix 6 cognitive complexity violations (all functions now under max threshold of 15)
- Enable stricter Biome linting rules
- Add CLAUDE.md with project context for Claude Code
- Update README.md with simplified project documentation
- Apply Biome formatting fixes across frontend and backend files

### Cognitive Complexity Fixes

| File | Function | Before | After |
|------|----------|--------|-------|
| task.mcp.ts | createPR | 16 | ≤15 |
| worktree.service.ts | listWorktrees | 16 | ≤15 |
| worktree.service.ts | findOrphanedWorktrees | 27 | ≤15 |
| epic.mcp.ts | approveTask | 17 | ≤15 |
| orchestrator.mcp.ts | recoverSupervisor | 20 | ≤15 |
| server.ts | executeMcpTool | 23 | ≤15 |

Each fix extracts helper functions to reduce nesting and improve readability.

## Test plan

- [x] `npm run check:fix` passes with 0 errors
- [x] `npm run typecheck` - only pre-existing frontend type errors remain (unrelated to this PR)
- [ ] Manual smoke test of affected MCP tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)