### PR TITLE
Fix tmux message escaping and centralize tmux operations

### DIFF
--- a/src/backend/agents/orchestrator/orchestrator.agent.ts
+++ b/src/backend/agents/orchestrator/orchestrator.agent.ts
@@ -8,8 +8,12 @@
  * There should only be ONE orchestrator instance running at a time.
  */
 
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { AgentState, AgentType } from '@prisma-gen/client';
 import { createWorkerSession } from '../../clients/claude-code.client.js';
+import { tmuxClient } from '../../clients/tmux.client.js';
 import { agentAccessor, decisionLogAccessor } from '../../resource_accessors/index.js';
 import { executeMcpTool } from '../../routers/mcp/server.js';
 import { startSupervisorForEpic } from '../supervisor/lifecycle.js';
@@ -157,10 +161,7 @@ async function createOrchestratorSession(
   // Rename tmux session to orchestrator naming
   const orchestratorTmuxName = getOrchestratorTmuxSessionName(agentId);
   try {
-    const { exec } = await import('node:child_process');
-    const { promisify } = await import('node:util');
-    const execAsync = promisify(exec);
-    await execAsync(`tmux rename-session -t ${context.tmuxSessionName} ${orchestratorTmuxName}`);
+    await tmuxClient.renameSession(context.tmuxSessionName, orchestratorTmuxName);
   } catch (error) {
     console.warn(`Could not rename tmux session: ${error}`);
   }
@@ -246,21 +247,7 @@ export async function runOrchestrator(agentId: string): Promise<void> {
  */
 async function sendOrchestratorMessage(agentId: string, message: string): Promise<void> {
   const tmuxSessionName = getOrchestratorTmuxSessionName(agentId);
-
-  const { exec } = await import('node:child_process');
-  const { promisify } = await import('node:util');
-  const execAsync = promisify(exec);
-
-  // Check session exists
-  try {
-    await execAsync(`tmux has-session -t ${tmuxSessionName} 2>/dev/null`);
-  } catch {
-    throw new Error(`Tmux session ${tmuxSessionName} does not exist`);
-  }
-
-  // Atomic message sending - pass message via env var to avoid escaping issues
-  const cmdStr = `tmux set-buffer -- "$TMUX_MESSAGE" && tmux paste-buffer -t ${tmuxSessionName} && tmux send-keys -t ${tmuxSessionName} Enter`;
-  await execAsync(`sh -c '${cmdStr}'`, { env: { ...process.env, TMUX_MESSAGE: message } });
+  await tmuxClient.sendMessage(tmuxSessionName, message);
 }
 
 /**
@@ -268,22 +255,7 @@ async function sendOrchestratorMessage(agentId: string, message: string): Promis
  */
 async function captureOrchestratorOutput(agentId: string, lines: number = 100): Promise<string> {
   const tmuxSessionName = getOrchestratorTmuxSessionName(agentId);
-
-  const { exec } = await import('node:child_process');
-  const { promisify } = await import('node:util');
-  const execAsync = promisify(exec);
-
-  // Check session exists
-  try {
-    await execAsync(`tmux has-session -t ${tmuxSessionName} 2>/dev/null`);
-  } catch {
-    throw new Error(`Tmux session ${tmuxSessionName} does not exist`);
-  }
-
-  // Capture pane content
-  const { stdout } = await execAsync(`tmux capture-pane -t ${tmuxSessionName} -p -S -${lines}`);
-
-  return stdout;
+  return tmuxClient.capturePane(tmuxSessionName, lines);
 }
 
 /**
@@ -479,12 +451,8 @@ export async function stopOrchestrator(agentId: string): Promise<void> {
 
   // Send Ctrl+C to stop Claude
   const tmuxSessionName = getOrchestratorTmuxSessionName(agentId);
-  const { exec } = await import('node:child_process');
-  const { promisify } = await import('node:util');
-  const execAsync = promisify(exec);
-
   try {
-    await execAsync(`tmux send-keys -t ${tmuxSessionName} C-c`);
+    await tmuxClient.sendInterrupt(tmuxSessionName);
     await new Promise((resolve) => setTimeout(resolve, 1000));
   } catch {
     // Session may not exist
@@ -519,23 +487,16 @@ export async function killOrchestrator(agentId: string): Promise<void> {
 
   // Kill tmux session
   const tmuxSessionName = getOrchestratorTmuxSessionName(agentId);
-  const { exec } = await import('node:child_process');
-  const { promisify } = await import('node:util');
-  const execAsync = promisify(exec);
-
   try {
-    await execAsync(`tmux kill-session -t ${tmuxSessionName}`);
+    await tmuxClient.killSession(tmuxSessionName);
   } catch {
     // Session may not exist
   }
 
   // Clean up system prompt file
-  const { promises: fs } = await import('node:fs');
-  const path = await import('node:path');
-  const os = await import('node:os');
   const systemPromptPath = path.join(os.tmpdir(), `factoryfactory-prompt-${agentId}.txt`);
   try {
-    await fs.unlink(systemPromptPath);
+    fs.unlinkSync(systemPromptPath);
   } catch {
     // File may not exist
   }

--- a/src/backend/agents/orchestrator/orchestrator.agent.ts
+++ b/src/backend/agents/orchestrator/orchestrator.agent.ts
@@ -258,9 +258,9 @@ async function sendOrchestratorMessage(agentId: string, message: string): Promis
     throw new Error(`Tmux session ${tmuxSessionName} does not exist`);
   }
 
-  // Atomic message sending
-  const cmdStr = `tmux set-buffer -- "$1" && tmux paste-buffer -t ${tmuxSessionName} && tmux send-keys -t ${tmuxSessionName} Enter`;
-  await execAsync(`sh -c '${cmdStr}' sh "${message.replace(/"/g, '\\"').replace(/'/g, "'\\''")}"`);
+  // Atomic message sending - pass message via env var to avoid escaping issues
+  const cmdStr = `tmux set-buffer -- "$TMUX_MESSAGE" && tmux paste-buffer -t ${tmuxSessionName} && tmux send-keys -t ${tmuxSessionName} Enter`;
+  await execAsync(`sh -c '${cmdStr}'`, { env: { ...process.env, TMUX_MESSAGE: message } });
 }
 
 /**

--- a/src/backend/agents/supervisor/supervisor.agent.ts
+++ b/src/backend/agents/supervisor/supervisor.agent.ts
@@ -1,6 +1,10 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { AgentState, AgentType, EpicState } from '@prisma-gen/client';
 import { createWorkerSession } from '../../clients/claude-code.client.js';
 import { gitClient } from '../../clients/git.client.js';
+import { tmuxClient } from '../../clients/tmux.client.js';
 import {
   agentAccessor,
   epicAccessor,
@@ -158,10 +162,7 @@ async function createSupervisorSession(
   // Rename tmux session to supervisor naming
   const supervisorTmuxName = getSupervisorTmuxSessionName(agentId);
   try {
-    const { exec } = await import('node:child_process');
-    const { promisify } = await import('node:util');
-    const execAsync = promisify(exec);
-    await execAsync(`tmux rename-session -t ${context.tmuxSessionName} ${supervisorTmuxName}`);
+    await tmuxClient.renameSession(context.tmuxSessionName, supervisorTmuxName);
   } catch (error) {
     console.warn(`Could not rename tmux session: ${error}`);
   }
@@ -264,22 +265,7 @@ export async function runSupervisor(agentId: string): Promise<void> {
  */
 async function sendSupervisorMessage(agentId: string, message: string): Promise<void> {
   const tmuxSessionName = getSupervisorTmuxSessionName(agentId);
-
-  // Use the same atomic pattern as worker
-  const { exec } = await import('node:child_process');
-  const { promisify } = await import('node:util');
-  const execAsync = promisify(exec);
-
-  // Check session exists
-  try {
-    await execAsync(`tmux has-session -t ${tmuxSessionName} 2>/dev/null`);
-  } catch {
-    throw new Error(`Tmux session ${tmuxSessionName} does not exist`);
-  }
-
-  // Atomic message sending - pass message via env var to avoid escaping issues
-  const cmdStr = `tmux set-buffer -- "$TMUX_MESSAGE" && tmux paste-buffer -t ${tmuxSessionName} && tmux send-keys -t ${tmuxSessionName} Enter`;
-  await execAsync(`sh -c '${cmdStr}'`, { env: { ...process.env, TMUX_MESSAGE: message } });
+  await tmuxClient.sendMessage(tmuxSessionName, message);
 }
 
 /**
@@ -287,22 +273,7 @@ async function sendSupervisorMessage(agentId: string, message: string): Promise<
  */
 async function captureSupervisorOutput(agentId: string, lines: number = 100): Promise<string> {
   const tmuxSessionName = getSupervisorTmuxSessionName(agentId);
-
-  const { exec } = await import('node:child_process');
-  const { promisify } = await import('node:util');
-  const execAsync = promisify(exec);
-
-  // Check session exists
-  try {
-    await execAsync(`tmux has-session -t ${tmuxSessionName} 2>/dev/null`);
-  } catch {
-    throw new Error(`Tmux session ${tmuxSessionName} does not exist`);
-  }
-
-  // Capture pane content
-  const { stdout } = await execAsync(`tmux capture-pane -t ${tmuxSessionName} -p -S -${lines}`);
-
-  return stdout;
+  return tmuxClient.capturePane(tmuxSessionName, lines);
 }
 
 /**
@@ -559,12 +530,8 @@ export async function stopSupervisor(agentId: string): Promise<void> {
 
   // Stop Claude session
   const tmuxSessionName = getSupervisorTmuxSessionName(agentId);
-  const { exec } = await import('node:child_process');
-  const { promisify } = await import('node:util');
-  const execAsync = promisify(exec);
-
   try {
-    await execAsync(`tmux send-keys -t ${tmuxSessionName} C-c`);
+    await tmuxClient.sendInterrupt(tmuxSessionName);
     await new Promise((resolve) => setTimeout(resolve, 1000));
   } catch {
     // Session may not exist
@@ -599,12 +566,8 @@ export async function killSupervisor(agentId: string): Promise<void> {
 
   // Kill tmux session
   const tmuxSessionName = getSupervisorTmuxSessionName(agentId);
-  const { exec } = await import('node:child_process');
-  const { promisify } = await import('node:util');
-  const execAsync = promisify(exec);
-
   try {
-    await execAsync(`tmux kill-session -t ${tmuxSessionName}`);
+    await tmuxClient.killSession(tmuxSessionName);
   } catch {
     // Session may not exist
   }
@@ -620,12 +583,9 @@ export async function killSupervisor(agentId: string): Promise<void> {
   }
 
   // Clean up system prompt file
-  const { promises: fs } = await import('node:fs');
-  const path = await import('node:path');
-  const os = await import('node:os');
   const systemPromptPath = path.join(os.tmpdir(), `factoryfactory-prompt-${agentId}.txt`);
   try {
-    await fs.unlink(systemPromptPath);
+    fs.unlinkSync(systemPromptPath);
   } catch {
     // File may not exist
   }

--- a/src/backend/agents/supervisor/supervisor.agent.ts
+++ b/src/backend/agents/supervisor/supervisor.agent.ts
@@ -277,9 +277,9 @@ async function sendSupervisorMessage(agentId: string, message: string): Promise<
     throw new Error(`Tmux session ${tmuxSessionName} does not exist`);
   }
 
-  // Atomic message sending
-  const cmdStr = `tmux set-buffer -- "$1" && tmux paste-buffer -t ${tmuxSessionName} && tmux send-keys -t ${tmuxSessionName} Enter`;
-  await execAsync(`sh -c '${cmdStr}' sh "${message.replace(/"/g, '\\"').replace(/'/g, "'\\''")}"`);
+  // Atomic message sending - pass message via env var to avoid escaping issues
+  const cmdStr = `tmux set-buffer -- "$TMUX_MESSAGE" && tmux paste-buffer -t ${tmuxSessionName} && tmux send-keys -t ${tmuxSessionName} Enter`;
+  await execAsync(`sh -c '${cmdStr}'`, { env: { ...process.env, TMUX_MESSAGE: message } });
 }
 
 /**

--- a/src/backend/clients/claude-code.client.ts
+++ b/src/backend/clients/claude-code.client.ts
@@ -1,32 +1,9 @@
-import { exec } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { promisify } from 'node:util';
 import { v4 as uuidv4 } from 'uuid';
 import { requireClaudeSetup } from './claude-auth.js';
-
-const execAsync = promisify(exec);
-
-/**
- * Escape a string for safe use in shell commands
- * Uses single quotes and escapes any embedded single quotes
- */
-function shellEscape(str: string): string {
-  // Replace single quotes with '\'' (end quote, escaped quote, start quote)
-  return `'${str.replace(/'/g, "'\\''")}'`;
-}
-
-/**
- * Validate tmux session name to prevent injection
- * Session names should only contain alphanumeric chars, underscores, and dashes
- */
-function validateSessionName(name: string): string {
-  if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
-    throw new Error(`Invalid tmux session name: ${name}`);
-  }
-  return name;
-}
+import { tmuxClient } from './tmux.client.js';
 
 export interface AgentExecutionProfile {
   model?: string;
@@ -69,20 +46,6 @@ function getTmuxSessionName(agentId: string): string {
 }
 
 /**
- * Check if tmux session exists
- */
-async function tmuxSessionExists(sessionName: string): Promise<boolean> {
-  try {
-    // Session name should already be validated, but check again for safety
-    const validatedName = validateSessionName(sessionName);
-    await execAsync(`tmux has-session -t ${validatedName} 2>/dev/null`);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/**
  * Create new worker session with Claude Code CLI
  */
 export async function createWorkerSession(
@@ -95,7 +58,7 @@ export async function createWorkerSession(
 
   // Generate session ID
   const sessionId = generateSessionId();
-  const tmuxSessionName = validateSessionName(getTmuxSessionName(agentId));
+  const tmuxSessionName = getTmuxSessionName(agentId);
 
   // Write system prompt to temporary file
   const systemPromptPath = path.join(os.tmpdir(), `factoryfactory-prompt-${agentId}.txt`);
@@ -107,26 +70,20 @@ export async function createWorkerSession(
   // Build Claude CLI command
   const claudeCommand = buildClaudeCommand(sessionId, systemPromptPath, workingDir, profile);
 
-  // Create tmux session
-  const exists = await tmuxSessionExists(tmuxSessionName);
+  // Create tmux session (kill existing if needed)
+  const exists = await tmuxClient.sessionExists(tmuxSessionName);
   if (exists) {
-    // Kill existing session
-    await execAsync(`tmux kill-session -t ${tmuxSessionName}`);
+    await tmuxClient.killSession(tmuxSessionName);
   }
 
-  // Create new tmux session running Claude
-  // Use -d flag to create detached session
-  // Use shell escaping for workingDir to prevent command injection
-  await execAsync(`tmux new-session -d -s ${tmuxSessionName} -c ${shellEscape(workingDir)}`);
+  // Create new tmux session
+  await tmuxClient.createSession(tmuxSessionName, workingDir);
 
   // Remove ANTHROPIC_API_KEY from environment (force OAuth)
-  await execAsync(`tmux set-environment -t ${tmuxSessionName} -r ANTHROPIC_API_KEY`);
+  await tmuxClient.setEnvironment(tmuxSessionName, 'ANTHROPIC_API_KEY');
 
-  // Send Claude command to tmux session using atomic pattern for cross-platform reliability
-  // Uses set-buffer + paste-buffer + send-keys Enter to handle special characters and different tmux versions
-  // Pass the command via environment variable to avoid shell escaping issues
-  const cmdStr = `tmux set-buffer -- "$TMUX_MESSAGE" && tmux paste-buffer -t ${tmuxSessionName} && tmux send-keys -t ${tmuxSessionName} Enter`;
-  await execAsync(`sh -c '${cmdStr}'`, { env: { ...process.env, TMUX_MESSAGE: claudeCommand } });
+  // Send Claude command to tmux session
+  await tmuxClient.sendMessage(tmuxSessionName, claudeCommand);
 
   // Wait a moment for Claude to initialize
   await new Promise((resolve) => setTimeout(resolve, 2000));
@@ -180,11 +137,11 @@ export async function resumeSession(
 ): Promise<WorkerSessionContext> {
   await requireClaudeSetup();
 
-  const tmuxSessionName = validateSessionName(getTmuxSessionName(agentId));
+  const tmuxSessionName = getTmuxSessionName(agentId);
   const profile = AGENT_PROFILES.WORKER;
 
   // Check if tmux session exists
-  const exists = await tmuxSessionExists(tmuxSessionName);
+  const exists = await tmuxClient.sessionExists(tmuxSessionName);
   if (!exists) {
     throw new Error(`Tmux session ${tmuxSessionName} does not exist. Cannot resume.`);
   }
@@ -192,10 +149,8 @@ export async function resumeSession(
   // Build resume command
   const resumeCommand = buildResumeCommand(sessionId, profile);
 
-  // Send resume command to tmux using atomic pattern for cross-platform reliability
-  // Pass the command via environment variable to avoid shell escaping issues
-  const cmdStr = `tmux set-buffer -- "$TMUX_MESSAGE" && tmux paste-buffer -t ${tmuxSessionName} && tmux send-keys -t ${tmuxSessionName} Enter`;
-  await execAsync(`sh -c '${cmdStr}'`, { env: { ...process.env, TMUX_MESSAGE: resumeCommand } });
+  // Send resume command to tmux
+  await tmuxClient.sendMessage(tmuxSessionName, resumeCommand);
 
   return {
     agentId,
@@ -230,24 +185,10 @@ function buildResumeCommand(sessionId: string, profile: AgentExecutionProfile): 
 
 /**
  * Send message to Claude via tmux
- * Uses atomic set-buffer + paste-buffer + send-keys Enter pattern
- * This prevents race conditions and handles all text correctly
  */
 export async function sendMessage(agentId: string, message: string): Promise<void> {
-  const tmuxSessionName = validateSessionName(getTmuxSessionName(agentId));
-
-  // Check session exists
-  const exists = await tmuxSessionExists(tmuxSessionName);
-  if (!exists) {
-    throw new Error(`Tmux session ${tmuxSessionName} does not exist`);
-  }
-
-  // Use atomic command chaining pattern from multiclaude:
-  // set-buffer (load text) -> paste-buffer (insert to pane) -> send-keys Enter (submit)
-  // Pass the message via environment variable to avoid shell escaping issues
-  const cmdStr = `tmux set-buffer -- "$TMUX_MESSAGE" && tmux paste-buffer -t ${tmuxSessionName} && tmux send-keys -t ${tmuxSessionName} Enter`;
-
-  await execAsync(`sh -c '${cmdStr}'`, { env: { ...process.env, TMUX_MESSAGE: message } });
+  const tmuxSessionName = getTmuxSessionName(agentId);
+  await tmuxClient.sendMessage(tmuxSessionName, message);
 }
 
 /**
@@ -255,17 +196,8 @@ export async function sendMessage(agentId: string, message: string): Promise<voi
  * Returns last N lines of visible content
  */
 export async function captureOutput(agentId: string, lines: number = 100): Promise<string> {
-  const tmuxSessionName = validateSessionName(getTmuxSessionName(agentId));
-
-  const exists = await tmuxSessionExists(tmuxSessionName);
-  if (!exists) {
-    throw new Error(`Tmux session ${tmuxSessionName} does not exist`);
-  }
-
-  // Capture pane content
-  const { stdout } = await execAsync(`tmux capture-pane -t ${tmuxSessionName} -p -S -${lines}`);
-
-  return stdout;
+  const tmuxSessionName = getTmuxSessionName(agentId);
+  return tmuxClient.capturePane(tmuxSessionName, lines);
 }
 
 /**
@@ -275,23 +207,17 @@ export async function getSessionStatus(agentId: string): Promise<{
   exists: boolean;
   running: boolean;
 }> {
-  const tmuxSessionName = validateSessionName(getTmuxSessionName(agentId));
+  const tmuxSessionName = getTmuxSessionName(agentId);
 
-  const exists = await tmuxSessionExists(tmuxSessionName);
+  const exists = await tmuxClient.sessionExists(tmuxSessionName);
   if (!exists) {
     return { exists: false, running: false };
   }
 
   // Check if any process is running (not just shell prompt)
-  // This is a heuristic - we check if there's activity
   try {
-    const { stdout } = await execAsync(
-      `tmux list-panes -t ${tmuxSessionName} -F "#{pane_current_command}"`
-    );
-
-    const command = stdout.trim();
+    const command = await tmuxClient.getPaneCommand(tmuxSessionName);
     const running = command !== 'bash' && command !== 'zsh' && command !== 'sh';
-
     return { exists: true, running };
   } catch {
     return { exists: false, running: false };
@@ -303,15 +229,15 @@ export async function getSessionStatus(agentId: string): Promise<{
  * Sends Ctrl+C to the tmux session
  */
 export async function stopSession(agentId: string): Promise<void> {
-  const tmuxSessionName = validateSessionName(getTmuxSessionName(agentId));
+  const tmuxSessionName = getTmuxSessionName(agentId);
 
-  const exists = await tmuxSessionExists(tmuxSessionName);
+  const exists = await tmuxClient.sessionExists(tmuxSessionName);
   if (!exists) {
     return; // Already stopped
   }
 
   // Send Ctrl+C to interrupt Claude
-  await execAsync(`tmux send-keys -t ${tmuxSessionName} C-c`);
+  await tmuxClient.sendInterrupt(tmuxSessionName);
 
   // Wait a moment
   await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -322,15 +248,15 @@ export async function stopSession(agentId: string): Promise<void> {
  * Use this for force cleanup
  */
 export async function killSession(agentId: string): Promise<void> {
-  const tmuxSessionName = validateSessionName(getTmuxSessionName(agentId));
+  const tmuxSessionName = getTmuxSessionName(agentId);
 
-  const exists = await tmuxSessionExists(tmuxSessionName);
+  const exists = await tmuxClient.sessionExists(tmuxSessionName);
   if (!exists) {
     return;
   }
 
   // Kill tmux session
-  await execAsync(`tmux kill-session -t ${tmuxSessionName}`);
+  await tmuxClient.killSession(tmuxSessionName);
 
   // Cleanup system prompt file if it exists
   const systemPromptPath = path.join(os.tmpdir(), `factoryfactory-prompt-${agentId}.txt`);
@@ -343,11 +269,5 @@ export async function killSession(agentId: string): Promise<void> {
  * List all worker tmux sessions
  */
 export async function listWorkerSessions(): Promise<string[]> {
-  try {
-    const { stdout } = await execAsync('tmux list-sessions -F "#{session_name}"');
-    const sessions = stdout.trim().split('\n');
-    return sessions.filter((name) => name.startsWith('worker-'));
-  } catch {
-    return []; // No sessions
-  }
+  return tmuxClient.listSessionsByPrefix('worker-');
 }

--- a/src/backend/clients/tmux.client.ts
+++ b/src/backend/clients/tmux.client.ts
@@ -10,6 +10,29 @@ export interface TmuxSession {
   attached: boolean;
 }
 
+/**
+ * Validate tmux session name to prevent injection
+ * Session names should only contain alphanumeric chars, underscores, and dashes
+ */
+function validateSessionName(name: string): string {
+  if (!/^[\w-]+$/.test(name)) {
+    throw new Error(`Invalid tmux session name: ${name}`);
+  }
+  return name;
+}
+
+/**
+ * Escape a string for safe use in shell commands
+ * Uses single quotes and escapes any embedded single quotes
+ */
+function shellEscape(str: string): string {
+  return `'${str.replace(/'/g, "'\\''")}'`;
+}
+
+/**
+ * Centralized tmux client for all tmux operations.
+ * All tmux commands should go through this client to ensure consistency.
+ */
 export class TmuxClient {
   private socketPath?: string;
 
@@ -21,13 +44,32 @@ export class TmuxClient {
     return this.socketPath ? `-S "${this.socketPath}"` : '';
   }
 
-  async createSession(sessionName: string): Promise<string> {
+  /**
+   * Check if a tmux session exists
+   */
+  async sessionExists(sessionName: string): Promise<boolean> {
+    const validatedName = validateSessionName(sessionName);
     const socketArg = this.getSocketArg();
-    const command = `tmux ${socketArg} new-session -d -s "${sessionName}"`;
 
     try {
-      await execAsync(command);
-      return sessionName;
+      await execAsync(`tmux ${socketArg} has-session -t ${validatedName} 2>/dev/null`);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Create a new detached tmux session
+   */
+  async createSession(sessionName: string, workingDir?: string): Promise<string> {
+    const validatedName = validateSessionName(sessionName);
+    const socketArg = this.getSocketArg();
+    const dirArg = workingDir ? `-c ${shellEscape(workingDir)}` : '';
+
+    try {
+      await execAsync(`tmux ${socketArg} new-session -d -s ${validatedName} ${dirArg}`);
+      return validatedName;
     } catch (error) {
       throw new Error(
         `Failed to create tmux session: ${error instanceof Error ? error.message : String(error)}`
@@ -35,12 +77,15 @@ export class TmuxClient {
     }
   }
 
+  /**
+   * Kill a tmux session
+   */
   async killSession(sessionName: string): Promise<void> {
+    const validatedName = validateSessionName(sessionName);
     const socketArg = this.getSocketArg();
-    const command = `tmux ${socketArg} kill-session -t "${sessionName}"`;
 
     try {
-      await execAsync(command);
+      await execAsync(`tmux ${socketArg} kill-session -t ${validatedName}`);
     } catch (error) {
       throw new Error(
         `Failed to kill tmux session: ${error instanceof Error ? error.message : String(error)}`
@@ -48,18 +93,26 @@ export class TmuxClient {
     }
   }
 
-  async sessionExists(sessionName: string): Promise<boolean> {
+  /**
+   * Rename a tmux session
+   */
+  async renameSession(oldName: string, newName: string): Promise<void> {
+    const validatedOld = validateSessionName(oldName);
+    const validatedNew = validateSessionName(newName);
     const socketArg = this.getSocketArg();
-    const command = `tmux ${socketArg} has-session -t "${sessionName}"`;
 
     try {
-      await execAsync(command);
-      return true;
-    } catch {
-      return false;
+      await execAsync(`tmux ${socketArg} rename-session -t ${validatedOld} ${validatedNew}`);
+    } catch (error) {
+      throw new Error(
+        `Failed to rename tmux session: ${error instanceof Error ? error.message : String(error)}`
+      );
     }
   }
 
+  /**
+   * List all tmux sessions
+   */
   async listSessions(): Promise<TmuxSession[]> {
     const socketArg = this.getSocketArg();
     const command = `tmux ${socketArg} list-sessions -F "#{session_name}:#{session_windows}:#{session_created}:#{session_attached}"`;
@@ -96,29 +149,85 @@ export class TmuxClient {
     }
   }
 
-  async sendKeys(sessionName: string, keys: string, enter = true): Promise<void> {
+  /**
+   * List sessions matching a prefix
+   */
+  async listSessionsByPrefix(prefix: string): Promise<string[]> {
+    const sessions = await this.listSessions();
+    return sessions.filter((s) => s.name.startsWith(prefix)).map((s) => s.name);
+  }
+
+  /**
+   * Send a message to a tmux session using atomic buffer pattern.
+   * This is the correct way to send text that may contain special characters.
+   * Uses set-buffer + paste-buffer + send-keys Enter for reliability.
+   */
+  async sendMessage(sessionName: string, message: string): Promise<void> {
+    const validatedName = validateSessionName(sessionName);
     const socketArg = this.getSocketArg();
-    const keysToSend = enter ? `${keys}` : keys;
-    const enterArg = enter ? 'Enter' : '';
-    const command = `tmux ${socketArg} send-keys -t "${sessionName}" "${keysToSend}" ${enterArg}`;
+
+    // Check session exists
+    const exists = await this.sessionExists(validatedName);
+    if (!exists) {
+      throw new Error(`Tmux session ${validatedName} does not exist`);
+    }
+
+    // Use atomic command chaining pattern:
+    // set-buffer (load text) -> paste-buffer (insert to pane) -> send-keys Enter (submit)
+    // Pass the message via environment variable to avoid shell escaping issues
+    const cmdStr = `tmux ${socketArg} set-buffer -- "$TMUX_MESSAGE" && tmux ${socketArg} paste-buffer -t ${validatedName} && tmux ${socketArg} send-keys -t ${validatedName} Enter`;
 
     try {
-      await execAsync(command);
+      await execAsync(`sh -c '${cmdStr}'`, { env: { ...process.env, TMUX_MESSAGE: message } });
     } catch (error) {
       throw new Error(
-        `Failed to send keys to tmux session: ${
-          error instanceof Error ? error.message : String(error)
-        }`
+        `Failed to send message to tmux session: ${error instanceof Error ? error.message : String(error)}`
       );
     }
   }
 
-  async capturePane(sessionName: string, lines = 100): Promise<string> {
+  /**
+   * Send raw keys to a tmux session.
+   * Use this for control sequences like C-c, Enter, etc.
+   * For sending text messages, use sendMessage() instead.
+   */
+  async sendKeys(sessionName: string, keys: string): Promise<void> {
+    const validatedName = validateSessionName(sessionName);
     const socketArg = this.getSocketArg();
-    const command = `tmux ${socketArg} capture-pane -t "${sessionName}" -p -S -${lines}`;
 
     try {
-      const { stdout } = await execAsync(command);
+      await execAsync(`tmux ${socketArg} send-keys -t ${validatedName} ${keys}`);
+    } catch (error) {
+      throw new Error(
+        `Failed to send keys to tmux session: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  /**
+   * Send interrupt (Ctrl+C) to a tmux session
+   */
+  async sendInterrupt(sessionName: string): Promise<void> {
+    await this.sendKeys(sessionName, 'C-c');
+  }
+
+  /**
+   * Capture pane content from a tmux session
+   */
+  async capturePane(sessionName: string, lines = 100): Promise<string> {
+    const validatedName = validateSessionName(sessionName);
+    const socketArg = this.getSocketArg();
+
+    // Check session exists
+    const exists = await this.sessionExists(validatedName);
+    if (!exists) {
+      throw new Error(`Tmux session ${validatedName} does not exist`);
+    }
+
+    try {
+      const { stdout } = await execAsync(
+        `tmux ${socketArg} capture-pane -t ${validatedName} -p -S -${lines}`
+      );
       return stdout;
     } catch (error) {
       throw new Error(
@@ -126,6 +235,49 @@ export class TmuxClient {
       );
     }
   }
+
+  /**
+   * Set or unset an environment variable in a tmux session
+   */
+  async setEnvironment(sessionName: string, varName: string, value?: string): Promise<void> {
+    const validatedName = validateSessionName(sessionName);
+    const socketArg = this.getSocketArg();
+
+    try {
+      if (value === undefined) {
+        // Unset the variable with -r flag
+        await execAsync(`tmux ${socketArg} set-environment -t ${validatedName} -r ${varName}`);
+      } else {
+        await execAsync(
+          `tmux ${socketArg} set-environment -t ${validatedName} ${varName} ${shellEscape(value)}`
+        );
+      }
+    } catch (error) {
+      throw new Error(
+        `Failed to set environment in tmux session: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  /**
+   * Get the current command running in a tmux session's pane
+   */
+  async getPaneCommand(sessionName: string): Promise<string> {
+    const validatedName = validateSessionName(sessionName);
+    const socketArg = this.getSocketArg();
+
+    try {
+      const { stdout } = await execAsync(
+        `tmux ${socketArg} list-panes -t ${validatedName} -F "#{pane_current_command}"`
+      );
+      return stdout.trim();
+    } catch (error) {
+      throw new Error(
+        `Failed to get pane command: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
 }
 
+// Singleton instance for convenience
 export const tmuxClient = new TmuxClient();


### PR DESCRIPTION
## Summary

- Fixed a bug where messages sent to Claude tmux sessions weren't being submitted because the Enter key wasn't working correctly
- The root cause was incorrect shell escaping that caused literal backslashes to appear in pasted text
- Refactored all tmux operations into a centralized `TmuxClient` class to prevent this type of bug from recurring

## Changes

**Bug Fix:**
- Changed message passing to use environment variables (`$TMUX_MESSAGE`) instead of shell argument escaping
- This ensures special characters (quotes, dollars, backticks) are handled correctly

**Refactoring:**
- Enhanced `TmuxClient` with all common tmux operations
- Updated `claude-code.client.ts`, `supervisor.agent.ts`, and `orchestrator.agent.ts` to use the centralized client
- Removed duplicate tmux code across the codebase

## Test plan

- [x] Verified messages are correctly sent to Claude tmux sessions
- [x] Verified Enter key properly submits messages
- [x] TypeScript compiles without errors
- [x] Biome lint/format passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)