### PR TITLE
Add mail inbox filters to view any agent's mail

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "factoryfactory",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.71.2",
         "@prisma/adapter-pg": "^7.3.0",

--- a/src/backend/resource_accessors/mail.accessor.ts
+++ b/src/backend/resource_accessors/mail.accessor.ts
@@ -68,6 +68,7 @@ export class MailAccessor {
       orderBy: { createdAt: 'desc' },
       include: {
         fromAgent: true,
+        toAgent: true,
       },
     });
   }
@@ -86,6 +87,24 @@ export class MailAccessor {
       orderBy: { createdAt: 'desc' },
       include: {
         fromAgent: true,
+        toAgent: true,
+      },
+    });
+  }
+
+  async listAll(includeRead = true): Promise<Mail[]> {
+    const where: Prisma.MailWhereInput = {};
+
+    if (!includeRead) {
+      where.isRead = false;
+    }
+
+    return prisma.mail.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+      include: {
+        fromAgent: true,
+        toAgent: true,
       },
     });
   }


### PR DESCRIPTION
## Summary
Users can now filter mail by agent, view all system mail, or stay with their inbox. The filter bar includes "My Inbox" and "All Mail" buttons plus a dropdown to select specific agents by type.

## Changes
- Backend: Added `listAll()` and `listAgentInbox()` queries to fetch all system mail or specific agent inboxes
- Backend: Modified `getById` to only auto-mark-as-read for human-directed mail (preserves agent-to-agent read state)
- Frontend: Added filter state management with three modes (all, human, agent)
- Frontend: Added filter UI with buttons and agent dropdown
- Frontend: Updated mail list to show sender → recipient when viewing all mail

## Testing
- Test "My Inbox" filter to view only human-directed mail
- Test "All Mail" filter to view all system mail including agent-to-agent
- Test agent dropdown to view specific agent inboxes
- Verify agent-to-agent mail doesn't auto-mark as read when viewed

🤖 Generated with Claude Code