### PR TITLE
Add .editorconfig for consistent editor formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{json,yaml,yml}]
+indent_size = 2


### PR DESCRIPTION
## Summary
- Adds `.editorconfig` to ensure consistent formatting across all editors and IDEs

## Changes
- 2-space indentation (aligns with `biome.json`)
- LF line endings
- UTF-8 charset
- Trailing whitespace trimmed (except in markdown files)
- Final newline inserted
- JSON/YAML files explicitly set to 2-space indent

## Benefits
- Works in any editor (VS Code, Vim, JetBrains, etc.) without Biome
- Reduces formatting noise in diffs
- Helps agents produce correctly formatted code on first attempt

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)