### PR TITLE
Add tRPC middleware for project-scoped requests

### DIFF
--- a/src/app/projects/[slug]/epics/new/page.tsx
+++ b/src/app/projects/[slug]/epics/new/page.tsx
@@ -40,7 +40,7 @@ export default function NewEpicPage() {
       return;
     }
 
-    createEpic.mutate({ projectId: project.id, title, description, design });
+    createEpic.mutate({ title, description, design });
   };
 
   if (!project) {

--- a/src/app/projects/[slug]/epics/page.tsx
+++ b/src/app/projects/[slug]/epics/page.tsx
@@ -23,7 +23,6 @@ export default function ProjectEpicsPage() {
 
   const { data: epics, isLoading } = trpc.epic.list.useQuery(
     {
-      projectId: project?.id,
       state: stateFilter ? (stateFilter as EpicState) : undefined,
     },
     { enabled: !!project?.id, refetchInterval: 5000 }

--- a/src/app/projects/[slug]/layout.tsx
+++ b/src/app/projects/[slug]/layout.tsx
@@ -2,7 +2,7 @@
 
 import { useParams, useRouter } from 'next/navigation';
 import { useEffect } from 'react';
-import { trpc } from '../../../frontend/lib/trpc';
+import { setProjectContext, trpc } from '../../../frontend/lib/trpc';
 
 export default function ProjectLayout({ children }: { children: React.ReactNode }) {
   const params = useParams();
@@ -14,6 +14,17 @@ export default function ProjectLayout({ children }: { children: React.ReactNode 
     isLoading,
     error,
   } = trpc.project.getBySlug.useQuery({ slug }, { enabled: !!slug });
+
+  // Set project context for tRPC requests when project is loaded
+  useEffect(() => {
+    if (project?.id) {
+      setProjectContext(project.id);
+    }
+    return () => {
+      // Clear project context when leaving project pages
+      setProjectContext(undefined);
+    };
+  }, [project?.id]);
 
   useEffect(() => {
     if (!(isLoading || project || error)) {

--- a/src/app/projects/[slug]/logs/page.tsx
+++ b/src/app/projects/[slug]/logs/page.tsx
@@ -15,17 +15,16 @@ export default function ProjectLogsPage() {
 
   // Get project for filtering
   const { data: project } = trpc.project.getBySlug.useQuery({ slug });
-  const projectId = project?.id;
 
   const { data: logsData, isLoading } = trpc.decisionLog.listRecent.useQuery(
-    { limit: 100, projectId },
-    { enabled: !!projectId, refetchInterval: 5000 }
+    { limit: 100 },
+    { enabled: !!project?.id, refetchInterval: 5000 }
   );
 
   // Cast to include relations
   const logs = logsData as DecisionLogWithRelations[] | undefined;
 
-  const { data: agents } = trpc.agent.list.useQuery({ projectId }, { enabled: !!projectId });
+  const { data: agents } = trpc.agent.list.useQuery({}, { enabled: !!project?.id });
 
   const filteredLogs = logs?.filter((log) => {
     if (!agentFilter) {

--- a/src/app/projects/[slug]/tasks/page.tsx
+++ b/src/app/projects/[slug]/tasks/page.tsx
@@ -25,7 +25,6 @@ export default function ProjectTasksPage() {
 
   const { data: tasks, isLoading } = trpc.task.list.useQuery(
     {
-      projectId: project?.id,
       state: stateFilter ? (stateFilter as TaskState) : undefined,
     },
     { enabled: !!project?.id, refetchInterval: 5000 }

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -55,7 +55,7 @@ app.use((req, res, next): void => {
   res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
   res.header(
     'Access-Control-Allow-Headers',
-    'Origin, X-Requested-With, Content-Type, Accept, Authorization'
+    'Origin, X-Requested-With, Content-Type, Accept, Authorization, X-Project-Id, X-Epic-Id'
   );
   res.header('Access-Control-Allow-Credentials', 'true');
 

--- a/src/backend/trpc/decision-log.trpc.ts
+++ b/src/backend/trpc/decision-log.trpc.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { decisionLogAccessor } from '../resource_accessors/decision-log.accessor';
+import { projectScopedProcedure } from './procedures/project-scoped.js';
 import { publicProcedure, router } from './trpc';
 
 export const decisionLogRouter = router({
@@ -15,18 +16,17 @@ export const decisionLogRouter = router({
       return decisionLogAccessor.findByAgentId(input.agentId, input.limit ?? 50);
     }),
 
-  // List recent decision logs across all agents
-  listRecent: publicProcedure
+  // List recent decision logs across all agents (scoped to project from context)
+  listRecent: projectScopedProcedure
     .input(
       z
         .object({
           limit: z.number().min(1).max(100).optional(),
-          projectId: z.string().optional(),
         })
         .optional()
     )
-    .query(async ({ input }) => {
-      return decisionLogAccessor.findRecent(input?.limit ?? 100, input?.projectId);
+    .query(async ({ ctx, input }) => {
+      return decisionLogAccessor.findRecent(input?.limit ?? 100, ctx.projectId);
     }),
 
   // Get decision log by ID

--- a/src/backend/trpc/index.ts
+++ b/src/backend/trpc/index.ts
@@ -20,5 +20,6 @@ export const appRouter = router({
 // Export type for use in frontend
 export type AppRouter = typeof appRouter;
 
+export { epicScopedProcedure, projectScopedProcedure } from './procedures/index.js';
 // Re-export context and procedure helpers
-export { createContext } from './trpc';
+export { createContext, publicProcedure } from './trpc';

--- a/src/backend/trpc/procedures/epic-scoped.ts
+++ b/src/backend/trpc/procedures/epic-scoped.ts
@@ -1,0 +1,37 @@
+import { TRPCError } from '@trpc/server';
+import { middleware, publicProcedure } from '../trpc.js';
+
+/**
+ * Middleware that validates epic context is present.
+ * Requires X-Epic-Id header to be set on the request.
+ * Also validates that project context is present (epics belong to projects).
+ */
+const requiresEpic = middleware(({ ctx, next }) => {
+  if (!ctx.projectId) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'Project scope required. Set X-Project-Id header.',
+    });
+  }
+
+  if (!ctx.epicId) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'Epic scope required. Set X-Epic-Id header.',
+    });
+  }
+
+  return next({
+    ctx: {
+      ...ctx,
+      projectId: ctx.projectId,
+      epicId: ctx.epicId,
+    },
+  });
+});
+
+/**
+ * Procedure that requires epic context.
+ * Use for endpoints that should be scoped to a specific epic.
+ */
+export const epicScopedProcedure = publicProcedure.use(requiresEpic);

--- a/src/backend/trpc/procedures/index.ts
+++ b/src/backend/trpc/procedures/index.ts
@@ -1,0 +1,2 @@
+export { epicScopedProcedure } from './epic-scoped.js';
+export { projectScopedProcedure } from './project-scoped.js';

--- a/src/backend/trpc/procedures/project-scoped.ts
+++ b/src/backend/trpc/procedures/project-scoped.ts
@@ -1,0 +1,28 @@
+import { TRPCError } from '@trpc/server';
+import { middleware, publicProcedure } from '../trpc.js';
+
+/**
+ * Middleware that validates project context is present.
+ * Requires X-Project-Id header to be set on the request.
+ */
+const requiresProject = middleware(({ ctx, next }) => {
+  if (!ctx.projectId) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'Project scope required. Set X-Project-Id header.',
+    });
+  }
+
+  return next({
+    ctx: {
+      ...ctx,
+      projectId: ctx.projectId,
+    },
+  });
+});
+
+/**
+ * Procedure that requires project context.
+ * Use for endpoints that should be scoped to a specific project.
+ */
+export const projectScopedProcedure = publicProcedure.use(requiresProject);

--- a/src/backend/trpc/trpc.ts
+++ b/src/backend/trpc/trpc.ts
@@ -1,12 +1,30 @@
 import { initTRPC } from '@trpc/server';
+import type { Request } from 'express';
 import superjson from 'superjson';
 
-// Context for tRPC procedures
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export type Context = {};
+/**
+ * Context for tRPC procedures.
+ * Contains optional project/epic scoping from request headers.
+ */
+export type Context = {
+  /** Project ID from X-Project-Id header */
+  projectId?: string;
+  /** Epic ID from X-Epic-Id header */
+  epicId?: string;
+};
 
-export const createContext = (): Context => {
-  return {};
+/**
+ * Creates tRPC context from Express request.
+ * Extracts project and epic scope from headers.
+ */
+export const createContext = ({ req }: { req: Request }): Context => {
+  const projectId = req.headers['x-project-id'];
+  const epicId = req.headers['x-epic-id'];
+
+  return {
+    projectId: typeof projectId === 'string' ? projectId : undefined,
+    epicId: typeof epicId === 'string' ? epicId : undefined,
+  };
 };
 
 const t = initTRPC.context<Context>().create({

--- a/src/frontend/components/navigation.tsx
+++ b/src/frontend/components/navigation.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
-import { trpc } from '../lib/trpc';
+import { setProjectContext, trpc } from '../lib/trpc';
 
 // Key for storing selected project in localStorage
 const SELECTED_PROJECT_KEY = 'factoryfactory_selected_project_slug';
@@ -106,13 +106,17 @@ export function Navigation() {
   // Get the selected project's ID for scoped queries
   const selectedProjectId = projects?.find((p) => p.slug === selectedProjectSlug)?.id;
 
-  const { data: unreadCount } = trpc.mail.getUnreadCount.useQuery(
-    { projectId: selectedProjectId },
-    {
-      refetchInterval: 5000,
-      enabled: !!selectedProjectId,
+  // Set project context for tRPC headers when selectedProjectId changes
+  useEffect(() => {
+    if (selectedProjectId) {
+      setProjectContext(selectedProjectId);
     }
-  );
+  }, [selectedProjectId]);
+
+  const { data: unreadCount } = trpc.mail.getUnreadCount.useQuery(undefined, {
+    refetchInterval: 5000,
+    enabled: !!selectedProjectId,
+  });
 
   // Get project slug from URL or localStorage
   useEffect(() => {

--- a/src/frontend/lib/trpc.ts
+++ b/src/frontend/lib/trpc.ts
@@ -16,11 +16,37 @@ const getBaseUrl = () => {
   return `http://localhost:${process.env.BACKEND_PORT || 3001}`;
 };
 
+/**
+ * Global store for project context.
+ * Set via setProjectContext() and automatically included in tRPC request headers.
+ */
+let currentProjectId: string | undefined;
+let currentEpicId: string | undefined;
+
+export function setProjectContext(projectId?: string, epicId?: string) {
+  currentProjectId = projectId;
+  currentEpicId = epicId;
+}
+
+export function getProjectContext() {
+  return { projectId: currentProjectId, epicId: currentEpicId };
+}
+
 export const trpcClient = trpc.createClient({
   links: [
     httpBatchLink({
       url: `${getBaseUrl()}/api/trpc`,
       transformer: superjson,
+      headers() {
+        const headers: Record<string, string> = {};
+        if (currentProjectId) {
+          headers['X-Project-Id'] = currentProjectId;
+        }
+        if (currentEpicId) {
+          headers['X-Epic-Id'] = currentEpicId;
+        }
+        return headers;
+      },
     }),
   ],
 });


### PR DESCRIPTION
## Summary

- Implement tRPC middleware to ensure requests are properly scoped to a project/epic
- Add `projectScopedProcedure` and `epicScopedProcedure` that validate context from headers
- Update routers (epic, task, agent, mail, decisionLog) to use scoped procedures where appropriate
- Update frontend tRPC client to send X-Project-Id headers automatically based on current project context

## Test plan

- [ ] Verify project layout sets context when navigating to project pages
- [ ] Verify list endpoints return only data for the current project
- [ ] Verify create endpoints use project from context (not input)
- [ ] Verify unread mail count in navigation updates per project
- [ ] Verify scoped procedures return BAD_REQUEST when headers missing

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)