### PR TITLE
Enable stricter Biome lint rules and fix violations

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -14,6 +14,13 @@
     "indentWidth": 2,
     "lineWidth": 100
   },
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  },
   "javascript": {
     "formatter": {
       "quoteStyle": "single",
@@ -61,13 +68,14 @@
         "noConfusingVoidType": "error",
         "noEmptyBlockStatements": "error",
         "noMisleadingCharacterClass": "error",
-        "useAwait": "off",
+        "useAwait": "error",
         "useIterableCallbackReturn": "off",
-        "noArrayIndexKey": "off"
+        "noArrayIndexKey": "error",
+        "noUnsafeDeclarationMerging": "error"
       },
       "complexity": {
-        "noBannedTypes": "off",
-        "noExcessiveCognitiveComplexity": "warn",
+        "noBannedTypes": "error",
+        "noExcessiveCognitiveComplexity": "error",
         "noStaticOnlyClass": "off",
         "noUselessThisAlias": "error",
         "noUselessTypeConstraint": "error",
@@ -86,7 +94,7 @@
       },
       "performance": {
         "noAccumulatingSpread": "error",
-        "noDelete": "warn"
+        "noDelete": "error"
       }
     }
   },

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -49,8 +49,8 @@ function IssuesList({ issues }: { issues: string[] }) {
 
   return (
     <ul className="space-y-2">
-      {issues.map((issue, i) => (
-        <li key={i} className="flex items-center gap-2 text-red-600">
+      {issues.map((issue) => (
+        <li key={issue} className="flex items-center gap-2 text-red-600">
           <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
             <path
               fillRule="evenodd"

--- a/src/backend/agents/orchestrator/orchestrator.agent.ts
+++ b/src/backend/agents/orchestrator/orchestrator.agent.ts
@@ -251,7 +251,7 @@ async function sendOrchestratorMessage(agentId: string, message: string): Promis
 /**
  * Capture output from orchestrator tmux session
  */
-async function captureOrchestratorOutput(agentId: string, lines: number = 100): Promise<string> {
+function captureOrchestratorOutput(agentId: string, lines: number = 100): Promise<string> {
   const tmuxSessionName = getOrchestratorTmuxSessionName(agentId);
   return tmuxClient.capturePane(tmuxSessionName, lines);
 }

--- a/src/backend/agents/supervisor/supervisor.agent.ts
+++ b/src/backend/agents/supervisor/supervisor.agent.ts
@@ -281,7 +281,7 @@ async function sendSupervisorMessage(agentId: string, message: string): Promise<
 /**
  * Capture output from supervisor tmux session
  */
-async function captureSupervisorOutput(agentId: string, lines: number = 100): Promise<string> {
+function captureSupervisorOutput(agentId: string, lines: number = 100): Promise<string> {
   const tmuxSessionName = getSupervisorTmuxSessionName(agentId);
   return tmuxClient.capturePane(tmuxSessionName, lines);
 }

--- a/src/backend/clients/claude-code.client.ts
+++ b/src/backend/clients/claude-code.client.ts
@@ -192,7 +192,7 @@ export async function sendMessage(agentId: string, message: string): Promise<voi
  * Capture output from tmux session
  * Returns last N lines of visible content
  */
-export async function captureOutput(agentId: string, lines: number = 100): Promise<string> {
+export function captureOutput(agentId: string, lines: number = 100): Promise<string> {
   const tmuxSessionName = getTmuxSessionName(agentId);
   return tmuxClient.capturePane(tmuxSessionName, lines);
 }
@@ -262,6 +262,6 @@ export async function killSession(agentId: string): Promise<void> {
 /**
  * List all worker tmux sessions
  */
-export async function listWorkerSessions(): Promise<string[]> {
+export function listWorkerSessions(): Promise<string[]> {
   return tmuxClient.listSessionsByPrefix('worker-');
 }

--- a/src/backend/clients/terminal.client.ts
+++ b/src/backend/clients/terminal.client.ts
@@ -9,7 +9,7 @@ import { spawn } from 'node:child_process';
 /**
  * Check if a tmux session exists
  */
-export async function tmuxSessionExists(sessionName: string): Promise<boolean> {
+export function tmuxSessionExists(sessionName: string): Promise<boolean> {
   return new Promise((resolve) => {
     const proc = spawn('tmux', ['has-session', '-t', sessionName]);
 
@@ -46,7 +46,7 @@ export async function attachToTmuxSession(sessionName: string): Promise<{
 /**
  * Read session output from tmux session buffer
  */
-export async function readSessionOutput(sessionName: string, lines = 100): Promise<string> {
+export function readSessionOutput(sessionName: string, lines = 100): Promise<string> {
   return new Promise((resolve, reject) => {
     // Verify session exists
     const hasSession = spawn('tmux', ['has-session', '-t', sessionName]);
@@ -94,7 +94,7 @@ export async function readSessionOutput(sessionName: string, lines = 100): Promi
 /**
  * List all tmux sessions
  */
-export async function listTmuxSessions(): Promise<
+export function listTmuxSessions(): Promise<
   Array<{ name: string; created: string; attached: boolean }>
 > {
   return new Promise((resolve, reject) => {
@@ -139,7 +139,7 @@ export async function listTmuxSessions(): Promise<
 /**
  * Send keys to a tmux session
  */
-export async function sendKeysToSession(sessionName: string, keys: string): Promise<void> {
+export function sendKeysToSession(sessionName: string, keys: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const proc = spawn('tmux', ['send-keys', '-t', sessionName, keys]);
 

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -131,7 +131,7 @@ app.get('/health/database', async (_req, res) => {
 /**
  * Inngest health check
  */
-app.get('/health/inngest', async (_req, res) => {
+app.get('/health/inngest', (_req, res) => {
   // Check if Inngest client is configured
   const hasEventKey = !!process.env.INNGEST_EVENT_KEY || configService.isDevelopment();
   const hasSigningKey = !!process.env.INNGEST_SIGNING_KEY || configService.isDevelopment();

--- a/src/backend/inngest/functions/agent-completed.ts
+++ b/src/backend/inngest/functions/agent-completed.ts
@@ -57,6 +57,7 @@ export const agentCompletedHandler = inngest.createFunction(
     }
 
     // Step 2: Handle completion based on agent type
+    // biome-ignore lint/suspicious/useAwait: Inngest step.run requires async for proper type inference
     const completionResult = await step.run('handle-completion', async () => {
       switch (agentInfo.type) {
         case AgentType.WORKER:

--- a/src/backend/inngest/functions/supervisor-check.ts
+++ b/src/backend/inngest/functions/supervisor-check.ts
@@ -176,6 +176,7 @@ export const supervisorCheckHandler = inngest.createFunction(
     }
 
     // Step 2: Check worker health for each supervisor
+    // biome-ignore lint/suspicious/useAwait: Inngest step.run requires async for proper type inference
     const results = await step.run('check-all-supervisors', async () => {
       return Promise.all(activeSupervisors.map((supervisor) => checkSupervisorWorkers(supervisor)));
     });

--- a/src/backend/lib/shell.ts
+++ b/src/backend/lib/shell.ts
@@ -155,7 +155,7 @@ export function validatePath(path: string): string {
  * await execCommand('git', ['commit', '-m', userMessage], { cwd: '/repo' });
  * await execCommand('mkdir', ['-p', '/path/with spaces/ok']);
  */
-export async function execCommand(
+export function execCommand(
   command: string,
   args: string[],
   options?: SpawnOptions
@@ -221,7 +221,7 @@ export async function execShell(
  * await gitCommand(['commit', '-m', userMessage], '/repo/path');
  * await gitCommand(['worktree', 'add', '-b', branch, path, base], repoPath);
  */
-export async function gitCommand(args: string[], cwd: string): Promise<ExecResult> {
+export function gitCommand(args: string[], cwd: string): Promise<ExecResult> {
   return execCommand('git', args, { cwd });
 }
 
@@ -232,7 +232,7 @@ export async function gitCommand(args: string[], cwd: string): Promise<ExecResul
  * await gitCommandC(repoPath, ['status']);
  * await gitCommandC(repoPath, ['diff', '--stat', 'main...HEAD']);
  */
-export async function gitCommandC(repoPath: string, args: string[]): Promise<ExecResult> {
+export function gitCommandC(repoPath: string, args: string[]): Promise<ExecResult> {
   return execCommand('git', ['-C', repoPath, ...args]);
 }
 
@@ -247,7 +247,7 @@ export async function gitCommandC(repoPath: string, args: string[]): Promise<Exe
  * await tmuxCommand(['has-session', '-t', sessionName]);
  * await tmuxCommand(['capture-pane', '-t', session, '-p']);
  */
-export async function tmuxCommand(args: string[], socketPath?: string): Promise<ExecResult> {
+export function tmuxCommand(args: string[], socketPath?: string): Promise<ExecResult> {
   const fullArgs = socketPath ? ['-S', socketPath, ...args] : args;
   return execCommand('tmux', fullArgs);
 }

--- a/src/backend/resource_accessors/agent.accessor.ts
+++ b/src/backend/resource_accessors/agent.accessor.ts
@@ -28,7 +28,7 @@ export interface ListAgentsFilters {
 }
 
 export class AgentAccessor {
-  async create(data: CreateAgentInput): Promise<Agent> {
+  create(data: CreateAgentInput): Promise<Agent> {
     return prisma.agent.create({
       data: {
         type: data.type,
@@ -40,7 +40,7 @@ export class AgentAccessor {
     });
   }
 
-  async findById(id: string): Promise<Agent | null> {
+  findById(id: string): Promise<Agent | null> {
     return prisma.agent.findUnique({
       where: { id },
       include: {
@@ -54,14 +54,14 @@ export class AgentAccessor {
     });
   }
 
-  async update(id: string, data: UpdateAgentInput): Promise<Agent> {
+  update(id: string, data: UpdateAgentInput): Promise<Agent> {
     return prisma.agent.update({
       where: { id },
       data,
     });
   }
 
-  async list(filters?: ListAgentsFilters): Promise<Agent[]> {
+  list(filters?: ListAgentsFilters): Promise<Agent[]> {
     const where: Prisma.AgentWhereInput = {};
 
     if (filters?.type) {
@@ -89,7 +89,7 @@ export class AgentAccessor {
     });
   }
 
-  async findByType(type: AgentType): Promise<Agent[]> {
+  findByType(type: AgentType): Promise<Agent[]> {
     return prisma.agent.findMany({
       where: { type },
       include: {
@@ -99,7 +99,7 @@ export class AgentAccessor {
     });
   }
 
-  async findByEpicId(epicId: string): Promise<Agent | null> {
+  findByEpicId(epicId: string): Promise<Agent | null> {
     return prisma.agent.findFirst({
       where: { currentEpicId: epicId },
       include: {
@@ -109,7 +109,7 @@ export class AgentAccessor {
     });
   }
 
-  async delete(id: string): Promise<Agent> {
+  delete(id: string): Promise<Agent> {
     return prisma.agent.delete({
       where: { id },
     });
@@ -118,7 +118,7 @@ export class AgentAccessor {
   /**
    * Update an agent's heartbeat (lastActiveAt) to now
    */
-  async updateHeartbeat(id: string): Promise<Agent> {
+  updateHeartbeat(id: string): Promise<Agent> {
     return prisma.agent.update({
       where: { id },
       data: { lastActiveAt: new Date() },
@@ -128,7 +128,7 @@ export class AgentAccessor {
   /**
    * Get agents whose last heartbeat is older than the specified number of minutes
    */
-  async getAgentsSinceHeartbeat(minutes: number): Promise<Agent[]> {
+  getAgentsSinceHeartbeat(minutes: number): Promise<Agent[]> {
     const threshold = new Date(Date.now() - minutes * 60 * 1000);
     return prisma.agent.findMany({
       where: {
@@ -146,7 +146,7 @@ export class AgentAccessor {
   /**
    * Get healthy agents of a specific type (heartbeat within threshold)
    */
-  async getHealthyAgents(type: AgentType, minutes: number): Promise<Agent[]> {
+  getHealthyAgents(type: AgentType, minutes: number): Promise<Agent[]> {
     const threshold = new Date(Date.now() - minutes * 60 * 1000);
     return prisma.agent.findMany({
       where: {
@@ -168,7 +168,7 @@ export class AgentAccessor {
   /**
    * Get unhealthy agents of a specific type (heartbeat older than threshold)
    */
-  async getUnhealthyAgents(type: AgentType, minutes: number): Promise<Agent[]> {
+  getUnhealthyAgents(type: AgentType, minutes: number): Promise<Agent[]> {
     const threshold = new Date(Date.now() - minutes * 60 * 1000);
     return prisma.agent.findMany({
       where: {
@@ -222,7 +222,7 @@ export class AgentAccessor {
   /**
    * Find agent by task ID (for workers)
    */
-  async findByTaskId(taskId: string): Promise<Agent | null> {
+  findByTaskId(taskId: string): Promise<Agent | null> {
     return prisma.agent.findFirst({
       where: { currentTaskId: taskId },
       include: {
@@ -235,7 +235,7 @@ export class AgentAccessor {
   /**
    * Find all workers for a specific epic
    */
-  async findWorkersByEpicId(epicId: string): Promise<Agent[]> {
+  findWorkersByEpicId(epicId: string): Promise<Agent[]> {
     return prisma.agent.findMany({
       where: {
         type: AgentType.WORKER,
@@ -255,7 +255,7 @@ export class AgentAccessor {
   /**
    * Find all agents for a specific epic (workers and supervisors)
    */
-  async findAgentsByEpicId(epicId: string): Promise<Agent[]> {
+  findAgentsByEpicId(epicId: string): Promise<Agent[]> {
     return prisma.agent.findMany({
       where: {
         OR: [

--- a/src/backend/resource_accessors/decision-log.accessor.ts
+++ b/src/backend/resource_accessors/decision-log.accessor.ts
@@ -9,7 +9,7 @@ export interface CreateDecisionLogInput {
 }
 
 export class DecisionLogAccessor {
-  async create(data: CreateDecisionLogInput): Promise<DecisionLog> {
+  create(data: CreateDecisionLogInput): Promise<DecisionLog> {
     return prisma.decisionLog.create({
       data: {
         agentId: data.agentId,
@@ -20,7 +20,7 @@ export class DecisionLogAccessor {
     });
   }
 
-  async findById(id: string): Promise<DecisionLog | null> {
+  findById(id: string): Promise<DecisionLog | null> {
     return prisma.decisionLog.findUnique({
       where: { id },
       include: {
@@ -29,7 +29,7 @@ export class DecisionLogAccessor {
     });
   }
 
-  async findByAgentId(agentId: string, limit = 50): Promise<DecisionLog[]> {
+  findByAgentId(agentId: string, limit = 50): Promise<DecisionLog[]> {
     return prisma.decisionLog.findMany({
       where: { agentId },
       orderBy: { timestamp: 'desc' },
@@ -40,7 +40,7 @@ export class DecisionLogAccessor {
     });
   }
 
-  async findRecent(limit = 100, projectId?: string): Promise<DecisionLog[]> {
+  findRecent(limit = 100, projectId?: string): Promise<DecisionLog[]> {
     const where: { agent?: { currentEpic: { projectId: string } } } = {};
 
     // Filter by project via agent → currentEpic → projectId
@@ -62,7 +62,7 @@ export class DecisionLogAccessor {
     });
   }
 
-  async delete(id: string): Promise<DecisionLog> {
+  delete(id: string): Promise<DecisionLog> {
     return prisma.decisionLog.delete({
       where: { id },
     });
@@ -71,7 +71,7 @@ export class DecisionLogAccessor {
   /**
    * Create an automatic decision log entry for MCP tool calls
    */
-  async createAutomatic(
+  createAutomatic(
     agentId: string,
     toolName: string,
     type: 'invocation' | 'result' | 'error',
@@ -110,7 +110,7 @@ export class DecisionLogAccessor {
   /**
    * Create a manual decision log entry for business logic
    */
-  async createManual(
+  createManual(
     agentId: string,
     title: string,
     body: string,
@@ -127,25 +127,21 @@ export class DecisionLogAccessor {
   /**
    * Get recent logs for a specific agent
    */
-  async findByAgentIdRecent(agentId: string, limit = 50): Promise<DecisionLog[]> {
+  findByAgentIdRecent(agentId: string, limit = 50): Promise<DecisionLog[]> {
     return this.findByAgentId(agentId, limit);
   }
 
   /**
    * Get recent logs across all agents
    */
-  async findAllRecent(limit = 100): Promise<DecisionLog[]> {
+  findAllRecent(limit = 100): Promise<DecisionLog[]> {
     return this.findRecent(limit);
   }
 
   /**
    * List decision logs with optional filters
    */
-  async list(options: {
-    agentId?: string;
-    projectId?: string;
-    limit?: number;
-  }): Promise<DecisionLog[]> {
+  list(options: { agentId?: string; projectId?: string; limit?: number }): Promise<DecisionLog[]> {
     const { agentId, projectId, limit = 100 } = options;
 
     if (agentId) {

--- a/src/backend/resource_accessors/epic.accessor.ts
+++ b/src/backend/resource_accessors/epic.accessor.ts
@@ -31,7 +31,7 @@ export interface ListEpicsFilters {
 }
 
 export class EpicAccessor {
-  async create(data: CreateEpicInput): Promise<EpicWithRelations> {
+  create(data: CreateEpicInput): Promise<EpicWithRelations> {
     return prisma.epic.create({
       data: {
         projectId: data.projectId,
@@ -49,7 +49,7 @@ export class EpicAccessor {
     });
   }
 
-  async findById(id: string): Promise<EpicWithRelations | null> {
+  findById(id: string): Promise<EpicWithRelations | null> {
     return prisma.epic.findUnique({
       where: { id },
       include: {
@@ -60,7 +60,7 @@ export class EpicAccessor {
     });
   }
 
-  async findByLinearIssueId(linearIssueId: string): Promise<EpicWithRelations | null> {
+  findByLinearIssueId(linearIssueId: string): Promise<EpicWithRelations | null> {
     return prisma.epic.findUnique({
       where: { linearIssueId },
       include: {
@@ -71,14 +71,14 @@ export class EpicAccessor {
     });
   }
 
-  async update(id: string, data: UpdateEpicInput): Promise<Epic> {
+  update(id: string, data: UpdateEpicInput): Promise<Epic> {
     return prisma.epic.update({
       where: { id },
       data,
     });
   }
 
-  async list(filters?: ListEpicsFilters): Promise<EpicWithRelations[]> {
+  list(filters?: ListEpicsFilters): Promise<EpicWithRelations[]> {
     const where: Prisma.EpicWhereInput = {};
 
     if (filters?.projectId) {
@@ -102,7 +102,7 @@ export class EpicAccessor {
     });
   }
 
-  async delete(id: string): Promise<Epic> {
+  delete(id: string): Promise<Epic> {
     return prisma.epic.delete({
       where: { id },
     });

--- a/src/backend/resource_accessors/mail.accessor.ts
+++ b/src/backend/resource_accessors/mail.accessor.ts
@@ -15,7 +15,7 @@ export interface UpdateMailInput {
 }
 
 export class MailAccessor {
-  async create(data: CreateMailInput): Promise<Mail> {
+  create(data: CreateMailInput): Promise<Mail> {
     return prisma.mail.create({
       data: {
         fromAgentId: data.fromAgentId,
@@ -27,7 +27,7 @@ export class MailAccessor {
     });
   }
 
-  async findById(id: string): Promise<Mail | null> {
+  findById(id: string): Promise<Mail | null> {
     return prisma.mail.findUnique({
       where: { id },
       include: {
@@ -37,7 +37,7 @@ export class MailAccessor {
     });
   }
 
-  async update(id: string, data: UpdateMailInput): Promise<Mail> {
+  update(id: string, data: UpdateMailInput): Promise<Mail> {
     const updateData: Prisma.MailUpdateInput = {
       isRead: data.isRead,
     };
@@ -54,7 +54,7 @@ export class MailAccessor {
     });
   }
 
-  async listInbox(agentId: string, includeRead = false): Promise<Mail[]> {
+  listInbox(agentId: string, includeRead = false): Promise<Mail[]> {
     const where: Prisma.MailWhereInput = {
       toAgentId: agentId,
     };
@@ -73,7 +73,7 @@ export class MailAccessor {
     });
   }
 
-  async listHumanInbox(includeRead = false, projectId?: string): Promise<Mail[]> {
+  listHumanInbox(includeRead = false, projectId?: string): Promise<Mail[]> {
     const where: Prisma.MailWhereInput = {
       isForHuman: true,
     };
@@ -101,7 +101,7 @@ export class MailAccessor {
     });
   }
 
-  async listAll(includeRead = true, projectId?: string): Promise<Mail[]> {
+  listAll(includeRead = true, projectId?: string): Promise<Mail[]> {
     const where: Prisma.MailWhereInput = {};
 
     if (!includeRead) {
@@ -138,11 +138,11 @@ export class MailAccessor {
     });
   }
 
-  async markAsRead(id: string): Promise<Mail> {
+  markAsRead(id: string): Promise<Mail> {
     return this.update(id, { isRead: true });
   }
 
-  async delete(id: string): Promise<Mail> {
+  delete(id: string): Promise<Mail> {
     return prisma.mail.delete({
       where: { id },
     });

--- a/src/backend/resource_accessors/project.accessor.ts
+++ b/src/backend/resource_accessors/project.accessor.ts
@@ -149,7 +149,7 @@ export class ProjectAccessor {
     throw new Error(`Unable to create project: too many projects with similar names`);
   }
 
-  async findById(id: string): Promise<ProjectWithEpics | null> {
+  findById(id: string): Promise<ProjectWithEpics | null> {
     return prisma.project.findUnique({
       where: { id },
       include: {
@@ -161,7 +161,7 @@ export class ProjectAccessor {
     });
   }
 
-  async findBySlug(slug: string): Promise<ProjectWithEpics | null> {
+  findBySlug(slug: string): Promise<ProjectWithEpics | null> {
     return prisma.project.findUnique({
       where: { slug },
       include: {
@@ -173,14 +173,14 @@ export class ProjectAccessor {
     });
   }
 
-  async update(id: string, data: UpdateProjectInput): Promise<Project> {
+  update(id: string, data: UpdateProjectInput): Promise<Project> {
     return prisma.project.update({
       where: { id },
       data,
     });
   }
 
-  async list(filters?: ListProjectsFilters): Promise<Project[]> {
+  list(filters?: ListProjectsFilters): Promise<Project[]> {
     const where: Prisma.ProjectWhereInput = {};
 
     if (filters?.isArchived !== undefined) {
@@ -200,7 +200,7 @@ export class ProjectAccessor {
     });
   }
 
-  async archive(id: string): Promise<Project> {
+  archive(id: string): Promise<Project> {
     return prisma.project.update({
       where: { id },
       data: { isArchived: true },

--- a/src/backend/resource_accessors/task.accessor.ts
+++ b/src/backend/resource_accessors/task.accessor.ts
@@ -37,7 +37,7 @@ export interface ListTasksFilters {
 }
 
 export class TaskAccessor {
-  async create(data: CreateTaskInput): Promise<Task> {
+  create(data: CreateTaskInput): Promise<Task> {
     return prisma.task.create({
       data: {
         epicId: data.epicId,
@@ -48,7 +48,7 @@ export class TaskAccessor {
     });
   }
 
-  async findById(id: string): Promise<TaskWithRelations | null> {
+  findById(id: string): Promise<TaskWithRelations | null> {
     return prisma.task.findUnique({
       where: { id },
       include: {
@@ -62,14 +62,14 @@ export class TaskAccessor {
     });
   }
 
-  async update(id: string, data: UpdateTaskInput): Promise<Task> {
+  update(id: string, data: UpdateTaskInput): Promise<Task> {
     return prisma.task.update({
       where: { id },
       data,
     });
   }
 
-  async list(filters?: ListTasksFilters): Promise<Task[]> {
+  list(filters?: ListTasksFilters): Promise<Task[]> {
     const where: Prisma.TaskWhereInput = {};
 
     if (filters?.projectId) {
@@ -97,7 +97,7 @@ export class TaskAccessor {
     });
   }
 
-  async findByEpicId(epicId: string): Promise<Task[]> {
+  findByEpicId(epicId: string): Promise<Task[]> {
     return prisma.task.findMany({
       where: { epicId },
       orderBy: { createdAt: 'asc' },
@@ -107,7 +107,7 @@ export class TaskAccessor {
     });
   }
 
-  async delete(id: string): Promise<Task> {
+  delete(id: string): Promise<Task> {
     return prisma.task.delete({
       where: { id },
     });

--- a/src/backend/services/crash-recovery.service.ts
+++ b/src/backend/services/crash-recovery.service.ts
@@ -117,7 +117,7 @@ export class CrashRecoveryService {
   /**
    * Handle agent crash with recovery logic
    */
-  async handleAgentCrash(
+  handleAgentCrash(
     agentId: string,
     agentType: AgentType,
     epicId?: string,
@@ -151,11 +151,11 @@ export class CrashRecoveryService {
         return this.recoverOrchestrator(agentId);
 
       default:
-        return {
+        return Promise.resolve({
           success: false,
-          action: 'no_action',
+          action: 'no_action' as const,
           message: `Unknown agent type: ${agentType}`,
-        };
+        });
     }
   }
 

--- a/src/backend/services/rate-limiter.service.ts
+++ b/src/backend/services/rate-limiter.service.ts
@@ -155,7 +155,7 @@ export class RateLimiter {
    * Acquire a rate limit slot for an API request
    * Returns a promise that resolves when the request can proceed
    */
-  async acquireSlot(
+  acquireSlot(
     agentId: string,
     epicId: string | null,
     priority: RequestPriority = RequestPriority.WORKER
@@ -163,12 +163,12 @@ export class RateLimiter {
     // Check if we can proceed immediately
     if (!this.isRateLimited()) {
       this.recordRequest(agentId, epicId);
-      return;
+      return Promise.resolve();
     }
 
     // Queue the request
     if (this.requestQueue.length >= this.config.maxQueueSize) {
-      throw new Error('Rate limit queue is full');
+      return Promise.reject(new Error('Rate limit queue is full'));
     }
 
     return new Promise<void>((resolve, reject) => {

--- a/src/backend/trpc/admin.trpc.ts
+++ b/src/backend/trpc/admin.trpc.ts
@@ -338,7 +338,7 @@ export const adminRouter = router({
         maxConcurrentEpics: z.number().optional(),
       })
     )
-    .mutation(async ({ input }) => {
+    .mutation(({ input }) => {
       logger.info('Updating rate limits', input);
 
       rateLimiter.updateConfig(input);
@@ -358,7 +358,7 @@ export const adminRouter = router({
         agentId: z.string().optional(),
       })
     )
-    .mutation(async ({ input }) => {
+    .mutation(({ input }) => {
       if (input.agentId) {
         crashRecoveryService.clearCrashRecords(input.agentId);
         return { success: true, message: `Crash records cleared for ${input.agentId}` };

--- a/src/backend/trpc/decision-log.trpc.ts
+++ b/src/backend/trpc/decision-log.trpc.ts
@@ -12,7 +12,7 @@ export const decisionLogRouter = router({
         limit: z.number().min(1).max(100).optional(),
       })
     )
-    .query(async ({ input }) => {
+    .query(({ input }) => {
       return decisionLogAccessor.findByAgentId(input.agentId, input.limit ?? 50);
     }),
 
@@ -25,7 +25,7 @@ export const decisionLogRouter = router({
         })
         .optional()
     )
-    .query(async ({ ctx, input }) => {
+    .query(({ ctx, input }) => {
       return decisionLogAccessor.findRecent(input?.limit ?? 100, ctx.projectId);
     }),
 

--- a/src/backend/trpc/epic.trpc.ts
+++ b/src/backend/trpc/epic.trpc.ts
@@ -17,7 +17,7 @@ export const epicRouter = router({
         })
         .optional()
     )
-    .query(async ({ ctx, input }) => {
+    .query(({ ctx, input }) => {
       return epicAccessor.list({
         ...input,
         projectId: ctx.projectId,
@@ -107,7 +107,7 @@ export const epicRouter = router({
     }),
 
   // Delete an epic
-  delete: publicProcedure.input(z.object({ id: z.string() })).mutation(async ({ input }) => {
+  delete: publicProcedure.input(z.object({ id: z.string() })).mutation(({ input }) => {
     return epicAccessor.delete(input.id);
   }),
 

--- a/src/backend/trpc/mail.trpc.ts
+++ b/src/backend/trpc/mail.trpc.ts
@@ -14,7 +14,7 @@ export const mailRouter = router({
         })
         .optional()
     )
-    .query(async ({ ctx, input }) => {
+    .query(({ ctx, input }) => {
       return mailAccessor.listHumanInbox(input?.includeRead ?? true, ctx.projectId);
     }),
 
@@ -27,7 +27,7 @@ export const mailRouter = router({
         })
         .optional()
     )
-    .query(async ({ ctx, input }) => {
+    .query(({ ctx, input }) => {
       return mailAccessor.listAll(input?.includeRead ?? true, ctx.projectId);
     }),
 
@@ -39,7 +39,7 @@ export const mailRouter = router({
         includeRead: z.boolean().optional(),
       })
     )
-    .query(async ({ input }) => {
+    .query(({ input }) => {
       return mailAccessor.listInbox(input.agentId, input.includeRead ?? true);
     }),
 
@@ -133,7 +133,7 @@ export const mailRouter = router({
     }),
 
   // Mark mail as read
-  markAsRead: publicProcedure.input(z.object({ id: z.string() })).mutation(async ({ input }) => {
+  markAsRead: publicProcedure.input(z.object({ id: z.string() })).mutation(({ input }) => {
     return mailAccessor.markAsRead(input.id);
   }),
 

--- a/src/backend/trpc/project.trpc.ts
+++ b/src/backend/trpc/project.trpc.ts
@@ -14,7 +14,7 @@ export const projectRouter = router({
         })
         .optional()
     )
-    .query(async ({ input }) => {
+    .query(({ input }) => {
       return projectAccessor.list(input);
     }),
 
@@ -80,14 +80,12 @@ export const projectRouter = router({
     }),
 
   // Archive a project (soft delete)
-  archive: publicProcedure.input(z.object({ id: z.string() })).mutation(async ({ input }) => {
+  archive: publicProcedure.input(z.object({ id: z.string() })).mutation(({ input }) => {
     return projectAccessor.archive(input.id);
   }),
 
   // Validate repo path
-  validateRepoPath: publicProcedure
-    .input(z.object({ repoPath: z.string() }))
-    .query(async ({ input }) => {
-      return projectAccessor.validateRepoPath(input.repoPath);
-    }),
+  validateRepoPath: publicProcedure.input(z.object({ repoPath: z.string() })).query(({ input }) => {
+    return projectAccessor.validateRepoPath(input.repoPath);
+  }),
 });

--- a/src/backend/trpc/task.trpc.ts
+++ b/src/backend/trpc/task.trpc.ts
@@ -18,7 +18,7 @@ export const taskRouter = router({
         })
         .optional()
     )
-    .query(async ({ ctx, input }) => {
+    .query(({ ctx, input }) => {
       return taskAccessor.list({
         ...input,
         projectId: ctx.projectId,
@@ -35,7 +35,7 @@ export const taskRouter = router({
   }),
 
   // Get tasks by epic ID
-  listByEpic: publicProcedure.input(z.object({ epicId: z.string() })).query(async ({ input }) => {
+  listByEpic: publicProcedure.input(z.object({ epicId: z.string() })).query(({ input }) => {
     return taskAccessor.findByEpicId(input.epicId);
   }),
 
@@ -49,7 +49,7 @@ export const taskRouter = router({
         state: z.nativeEnum(TaskState).optional(),
       })
     )
-    .mutation(async ({ input }) => {
+    .mutation(({ input }) => {
       const { id, ...updates } = input;
 
       // If completing, set completedAt


### PR DESCRIPTION
## Summary
- Enable stricter Biome lint rules (`useAwait`, `noArrayIndexKey`, `noBannedTypes`, `noExcessiveCognitiveComplexity`, `noDelete`, `noUnsafeDeclarationMerging`) as errors
- Remove redundant `async` keywords from functions that directly return Promises without using `await`
- Extract helper functions to reduce cognitive complexity in `epic.mcp.ts`, `worker.agent.ts`, and `mail/page.tsx`
- Add `organizeImports` assist action to biome config

## Test plan
- [x] TypeScript type checking passes (`npm run typecheck`)
- [x] Biome lint and format passes (`npm run check:fix`)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)