### PR TITLE
Design overhaul: Dense Linear/GitHub-style UI with FACTORY FACTORY branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# FactoryFactory
+# FACTORY FACTORY
+
+<p align="center">
+  <img src="public/logo.svg" alt="Factory Factory Logo" width="80" height="80">
+</p>
 
 Autonomous software development orchestration system that uses AI agents to execute tasks from Linear issues.
 

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "dotenv": "^17.2.3",
     "embla-carousel-react": "^8.6.0",
     "express": "^5.2.1",
+    "geist": "^1.5.1",
     "inngest": "^3.49.3",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.563.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       express:
         specifier: ^5.2.1
         version: 5.2.1
+      geist:
+        specifier: ^1.5.1
+        version: 1.5.1(next@16.1.4(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       inngest:
         specifier: ^3.49.3
         version: 3.49.3(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(express@5.2.1)(hono@4.11.4)(next@16.1.4(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(zod@4.3.6)
@@ -2711,6 +2714,11 @@ packages:
   gcp-metadata@6.1.1:
     resolution: {integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==}
     engines: {node: '>=14'}
+
+  geist@1.5.1:
+    resolution: {integrity: sha512-mAHZxIsL2o3ZITFaBVFBnwyDOw+zNLYum6A6nIjpzCGIO8QtC3V76XF2RnZTyLx1wlDTmMDy8jg3Ib52MIjGvQ==}
+    peerDependencies:
+      next: '>=13.2.0'
 
   generate-function@2.3.1:
     resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
@@ -6397,6 +6405,10 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  geist@1.5.1(next@16.1.4(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
+    dependencies:
+      next: 16.1.4(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
   generate-function@2.3.1:
     dependencies:

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,26 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- White background -->
+  <rect width="32" height="32" rx="6" fill="white"/>
+  <!-- Outer square: scaled to fit -->
+  <rect
+    x="4"
+    y="4"
+    width="24"
+    height="24"
+    stroke="#1a1a1a"
+    stroke-width="2.5"
+    fill="none"
+    rx="1"
+  />
+  <!-- Inner square: concentric -->
+  <rect
+    x="8"
+    y="8"
+    width="16"
+    height="16"
+    stroke="#1a1a1a"
+    stroke-width="2.5"
+    fill="none"
+    rx="1"
+  />
+</svg>

--- a/public/logo-full.svg
+++ b/public/logo-full.svg
@@ -1,0 +1,11 @@
+<svg width="300" height="200" viewBox="0 0 300 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Outer square -->
+  <rect x="110" y="20" width="90" height="90" stroke="currentColor" stroke-width="6" fill="none" rx="2"/>
+  <!-- Inner square -->
+  <rect x="90" y="40" width="70" height="70" stroke="currentColor" stroke-width="6" fill="none" rx="2"/>
+  <!-- Text: FACTORY (light) FACTORY (bold) -->
+  <text x="150" y="150" text-anchor="middle" font-family="var(--font-geist-sans), system-ui, sans-serif" fill="currentColor">
+    <tspan font-size="20" font-weight="300" letter-spacing="0.1em">FACTORY</tspan>
+    <tspan font-size="20" font-weight="700" letter-spacing="0.1em" dx="8">FACTORY</tspan>
+  </text>
+</svg>

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,24 @@
+<svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Outer square: 80x80 at (0, 0) -->
+  <rect
+    x="0"
+    y="0"
+    width="80"
+    height="80"
+    stroke="currentColor"
+    stroke-width="6"
+    fill="none"
+    rx="2"
+  />
+  <!-- Inner square: 60x60 at (10, 10) - concentric -->
+  <rect
+    x="10"
+    y="10"
+    width="60"
+    height="60"
+    stroke="currentColor"
+    stroke-width="6"
+    fill="none"
+    rx="2"
+  />
+</svg>

--- a/src/app/admin/system/page.tsx
+++ b/src/app/admin/system/page.tsx
@@ -41,12 +41,12 @@ export default function AdminSystemPage() {
       </div>
 
       {/* Agent Profiles */}
-      <div className="bg-white rounded-lg shadow-sm p-6">
+      <div className="bg-white rounded-lg shadow-sm p-4">
         <h2 className="text-lg font-semibold mb-4">Agent Profiles</h2>
         <p className="text-sm text-gray-600 mb-4">
           Agent models and permissions can be configured via environment variables.
         </p>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           {profiles?.profiles &&
             Object.entries(profiles.profiles).map(([type, profile]) => (
               <div key={type} className="border border-gray-200 rounded-lg p-4">
@@ -107,9 +107,9 @@ export default function AdminSystemPage() {
       </div>
 
       {/* Rate Limits */}
-      <div className="bg-white rounded-lg shadow-sm p-6">
+      <div className="bg-white rounded-lg shadow-sm p-4">
         <h2 className="text-lg font-semibold mb-4">Rate Limits</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">
               Claude Requests/min
@@ -206,7 +206,7 @@ export default function AdminSystemPage() {
       </div>
 
       {/* API Usage by Agent */}
-      <div className="bg-white rounded-lg shadow-sm p-6">
+      <div className="bg-white rounded-lg shadow-sm p-4">
         <h2 className="text-lg font-semibold mb-4">API Usage by Agent</h2>
         {apiUsage?.byAgent && Object.keys(apiUsage.byAgent).length > 0 ? (
           <div className="overflow-x-auto">
@@ -240,7 +240,7 @@ export default function AdminSystemPage() {
       </div>
 
       {/* API Usage by Top-Level Task */}
-      <div className="bg-white rounded-lg shadow-sm p-6">
+      <div className="bg-white rounded-lg shadow-sm p-4">
         <h2 className="text-lg font-semibold mb-4">API Usage by Top-Level Task</h2>
         {apiUsage?.byTopLevelTask && Object.keys(apiUsage.byTopLevelTask).length > 0 ? (
           <div className="overflow-x-auto">
@@ -280,7 +280,7 @@ export default function AdminSystemPage() {
       </div>
 
       {/* Feature Flags */}
-      <div className="bg-white rounded-lg shadow-sm p-6">
+      <div className="bg-white rounded-lg shadow-sm p-4">
         <h2 className="text-lg font-semibold mb-4">Feature Flags</h2>
         <div className="space-y-3">
           <div className="flex items-center justify-between py-2 border-b border-gray-100">
@@ -336,7 +336,7 @@ export default function AdminSystemPage() {
       </div>
 
       {/* Available Models */}
-      <div className="bg-white rounded-lg shadow-sm p-6">
+      <div className="bg-white rounded-lg shadow-sm p-4">
         <h2 className="text-lg font-semibold mb-4">Available Models</h2>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           {profiles?.availableModels?.map((m) => (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,6 +7,8 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
+  --font-sans: var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;
+  --font-mono: var(--font-geist-mono), ui-monospace, monospace;
   --foreground-rgb: 0, 0, 0;
   --background-start-rgb: 214, 219, 220;
   --background-end-rgb: 255, 255, 255;

--- a/src/app/icon.svg
+++ b/src/app/icon.svg
@@ -1,0 +1,26 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- White background -->
+  <rect width="32" height="32" rx="6" fill="white"/>
+  <!-- Outer square: scaled to fit -->
+  <rect
+    x="4"
+    y="4"
+    width="24"
+    height="24"
+    stroke="#1a1a1a"
+    stroke-width="2.5"
+    fill="none"
+    rx="1"
+  />
+  <!-- Inner square: concentric -->
+  <rect
+    x="8"
+    y="8"
+    width="16"
+    height="16"
+    stroke="#1a1a1a"
+    stroke-width="2.5"
+    fill="none"
+    rx="1"
+  />
+</svg>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,5 @@
+import { GeistMono } from 'geist/font/mono';
+import { GeistSans } from 'geist/font/sans';
 import type { Metadata } from 'next';
 import './globals.css';
 import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
@@ -5,18 +7,18 @@ import { AppSidebar } from '../frontend/components/app-sidebar';
 import { TRPCProvider } from '../frontend/lib/providers';
 
 export const metadata: Metadata = {
-  title: 'FactoryFactory',
+  title: 'FACTORY FACTORY',
   description: 'Autonomous software development orchestration system',
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
-      <body className="min-h-screen bg-background">
+    <html lang="en" className={`${GeistSans.variable} ${GeistMono.variable}`}>
+      <body className="min-h-screen bg-background font-sans antialiased">
         <TRPCProvider>
           <SidebarProvider>
             <AppSidebar />
-            <SidebarInset className="p-6">{children}</SidebarInset>
+            <SidebarInset className="p-4">{children}</SidebarInset>
           </SidebarProvider>
         </TRPCProvider>
       </body>

--- a/src/app/projects/[slug]/epics/[id]/page.tsx
+++ b/src/app/projects/[slug]/epics/[id]/page.tsx
@@ -67,7 +67,7 @@ export default function EpicDetailPage() {
   const workers = agents?.filter((a) => a.type === 'WORKER') ?? [];
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       <div className="flex items-start justify-between">
         <div className="flex items-center gap-4">
           <Button variant="ghost" size="icon" asChild>

--- a/src/app/projects/[slug]/epics/new/page.tsx
+++ b/src/app/projects/[slug]/epics/new/page.tsx
@@ -57,7 +57,7 @@ export default function NewEpicPage() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       <div className="flex items-center gap-4">
         <Button variant="ghost" size="icon" asChild>
           <Link href={`/projects/${slug}/epics`}>
@@ -72,7 +72,7 @@ export default function NewEpicPage() {
 
       <Card>
         <CardContent className="pt-6">
-          <form onSubmit={handleSubmit} className="space-y-6">
+          <form onSubmit={handleSubmit} className="space-y-4">
             {error && (
               <Alert variant="destructive">
                 <AlertDescription>{error}</AlertDescription>

--- a/src/app/projects/[slug]/epics/page.tsx
+++ b/src/app/projects/[slug]/epics/page.tsx
@@ -62,7 +62,7 @@ export default function ProjectEpicsPage() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       <PageHeader title="Epics" description={project.name}>
         <Button asChild>
           <Link href={`/projects/${slug}/epics/new`}>

--- a/src/app/projects/[slug]/logs/page.tsx
+++ b/src/app/projects/[slug]/logs/page.tsx
@@ -51,7 +51,7 @@ export default function ProjectLogsPage() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       <PageHeader title="Decision Logs" description="Audit trail of all agent decisions" />
 
       <Card>

--- a/src/app/projects/[slug]/mail/[id]/page.tsx
+++ b/src/app/projects/[slug]/mail/[id]/page.tsx
@@ -68,7 +68,7 @@ export default function ProjectMailDetailPage() {
   };
 
   return (
-    <div className="max-w-3xl mx-auto space-y-6">
+    <div className="max-w-3xl mx-auto space-y-4">
       <div className="flex items-center gap-4">
         <Button variant="ghost" size="icon" asChild>
           <Link href={`/projects/${slug}/mail`}>

--- a/src/app/projects/[slug]/mail/page.tsx
+++ b/src/app/projects/[slug]/mail/page.tsx
@@ -122,7 +122,7 @@ export default function ProjectMailPage() {
     filter.type === 'agent' ? agents?.find((a) => a.id === filter.agentId) : null;
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       <PageHeader
         title={getFilterTitle(filter)}
         description={`${getFilterDescription(filter, selectedAgent?.type)}${unreadCount > 0 ? ` (${unreadCount} unread)` : ''}`}
@@ -204,7 +204,7 @@ export default function ProjectMailPage() {
               <Link
                 key={item.id}
                 href={`/projects/${slug}/mail/${item.id}`}
-                className={`block p-4 hover:bg-muted/50 transition-colors ${!item.isRead ? 'bg-primary/5' : ''}`}
+                className={`block p-3 hover:bg-muted/50 transition-colors ${!item.isRead ? 'bg-primary/5' : ''}`}
               >
                 <div className="flex items-start justify-between">
                   <div className="flex-1 min-w-0">

--- a/src/app/projects/[slug]/tasks/page.tsx
+++ b/src/app/projects/[slug]/tasks/page.tsx
@@ -56,7 +56,7 @@ export default function ProjectTasksPage() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       <PageHeader title="Tasks" description={project.name} />
 
       <Card>

--- a/src/app/projects/new/page.tsx
+++ b/src/app/projects/new/page.tsx
@@ -10,6 +10,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Spinner } from '@/components/ui/spinner';
+import { Logo } from '../../../frontend/components/logo';
 import { trpc } from '../../../frontend/lib/trpc';
 
 export default function NewProjectPage() {
@@ -46,9 +47,9 @@ export default function NewProjectPage() {
     return (
       <div className="flex min-h-[80vh] items-center justify-center">
         <div className="w-full max-w-lg space-y-8">
-          <div className="text-center space-y-2">
-            <h1 className="text-4xl font-bold tracking-tight">FactoryFactory</h1>
-            <p className="text-lg text-muted-foreground">
+          <div className="flex flex-col items-center space-y-4">
+            <Logo iconClassName="size-16" textClassName="text-2xl" className="flex-col gap-3" />
+            <p className="text-muted-foreground">
               Autonomous software development orchestration system
             </p>
           </div>
@@ -61,7 +62,7 @@ export default function NewProjectPage() {
               </CardDescription>
             </CardHeader>
             <CardContent>
-              <form onSubmit={handleSubmit} className="space-y-6">
+              <form onSubmit={handleSubmit} className="space-y-4">
                 {error && (
                   <Alert variant="destructive">
                     <AlertDescription>{error}</AlertDescription>
@@ -98,7 +99,7 @@ export default function NewProjectPage() {
 
   // Normal view when projects already exist
   return (
-    <div className="max-w-2xl mx-auto space-y-6">
+    <div className="max-w-2xl mx-auto space-y-4">
       <div className="flex items-center gap-4">
         <Button variant="ghost" size="icon" asChild>
           <Link href="/projects">
@@ -121,7 +122,7 @@ export default function NewProjectPage() {
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <form onSubmit={handleSubmit} className="space-y-6">
+          <form onSubmit={handleSubmit} className="space-y-4">
             {error && (
               <Alert variant="destructive">
                 <AlertDescription>{error}</AlertDescription>

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -38,7 +38,7 @@ export default function ProjectsPage() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       <div className="flex justify-between items-center">
         <div>
           <h1 className="text-2xl font-bold text-foreground">Projects</h1>

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -15,7 +15,7 @@ Card.displayName = 'Card';
 
 const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />
+    <div ref={ref} className={cn('flex flex-col space-y-1.5 p-4', className)} {...props} />
   )
 );
 CardHeader.displayName = 'CardHeader';
@@ -40,14 +40,14 @@ CardDescription.displayName = 'CardDescription';
 
 const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+    <div ref={ref} className={cn('p-4 pt-0', className)} {...props} />
   )
 );
 CardContent.displayName = 'CardContent';
 
 const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('flex items-center p-6 pt-0', className)} {...props} />
+    <div ref={ref} className={cn('flex items-center p-4 pt-0', className)} {...props} />
   )
 );
 CardFooter.displayName = 'CardFooter';

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -38,7 +38,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-3 border bg-background p-4 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
         className
       )}
       {...props}
@@ -54,7 +54,7 @@ const DialogContent = React.forwardRef<
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />
+  <div className={cn('flex flex-col space-y-1 text-center sm:text-left', className)} {...props} />
 );
 DialogHeader.displayName = 'DialogHeader';
 

--- a/src/components/ui/empty.tsx
+++ b/src/components/ui/empty.tsx
@@ -7,7 +7,7 @@ function Empty({ className, ...props }: React.ComponentProps<'div'>) {
     <div
       data-slot="empty"
       className={cn(
-        'flex min-w-0 flex-1 flex-col items-center justify-center gap-6 text-balance rounded-lg border-dashed p-6 text-center md:p-12',
+        'flex min-w-0 flex-1 flex-col items-center justify-center gap-4 text-balance rounded-lg border-dashed p-4 text-center md:p-8',
         className
       )}
       {...props}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -31,7 +31,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
 const sheetVariants = cva(
-  'fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out',
+  'fixed z-50 gap-3 bg-background p-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out',
   {
     variants: {
       side: {

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -60,7 +60,7 @@ const TableHead = React.forwardRef<
   <th
     ref={ref}
     className={cn(
-      'h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+      'h-9 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
       className
     )}
     {...props}

--- a/src/frontend/components/app-sidebar.tsx
+++ b/src/frontend/components/app-sidebar.tsx
@@ -28,6 +28,7 @@ import {
 } from '@/components/ui/sidebar';
 import { Skeleton } from '@/components/ui/skeleton';
 import { setProjectContext, trpc } from '../lib/trpc';
+import { Logo } from './logo';
 
 const SELECTED_PROJECT_KEY = 'factoryfactory_selected_project_slug';
 
@@ -127,7 +128,7 @@ export function AppSidebar() {
     return (
       <Sidebar collapsible="none">
         <SidebarHeader className="border-b border-sidebar-border p-4">
-          <h1 className="text-xl font-bold">FactoryFactory</h1>
+          <Logo iconClassName="size-6" textClassName="text-sm" />
           <p className="text-xs text-muted-foreground mt-1">Loading...</p>
         </SidebarHeader>
         <SidebarContent>
@@ -153,8 +154,7 @@ export function AppSidebar() {
   return (
     <Sidebar collapsible="none">
       <SidebarHeader className="border-b border-sidebar-border p-4">
-        <h1 className="text-xl font-bold">FactoryFactory</h1>
-        <p className="text-xs text-muted-foreground mt-1">Autonomous Dev System</p>
+        <Logo iconClassName="size-6" textClassName="text-sm" />
 
         {projects && projects.length > 0 && (
           <div className="mt-3">

--- a/src/frontend/components/logo.tsx
+++ b/src/frontend/components/logo.tsx
@@ -1,0 +1,68 @@
+import { cn } from '@/lib/utils';
+
+interface LogoIconProps {
+  className?: string;
+}
+
+export function LogoIcon({ className }: LogoIconProps) {
+  return (
+    <svg
+      viewBox="0 0 80 80"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={cn('size-8', className)}
+    >
+      {/* Outer square: 80x80 at (0, 0) */}
+      <rect
+        x="0"
+        y="0"
+        width="80"
+        height="80"
+        stroke="currentColor"
+        strokeWidth="6"
+        fill="none"
+        rx="2"
+      />
+      {/* Inner square: 60x60 at (10, 10) - concentric */}
+      <rect
+        x="10"
+        y="10"
+        width="60"
+        height="60"
+        stroke="currentColor"
+        strokeWidth="6"
+        fill="none"
+        rx="2"
+      />
+    </svg>
+  );
+}
+
+interface LogoTextProps {
+  className?: string;
+}
+
+export function LogoText({ className }: LogoTextProps) {
+  return (
+    <span className={cn('tracking-tight uppercase', className)}>
+      <span className="font-light">Factory</span>
+      <span className="font-bold ml-1">Factory</span>
+    </span>
+  );
+}
+
+interface LogoProps {
+  showText?: boolean;
+  iconClassName?: string;
+  textClassName?: string;
+  className?: string;
+}
+
+export function Logo({ showText = true, iconClassName, textClassName, className }: LogoProps) {
+  return (
+    <div className={cn('flex items-center gap-2', className)}>
+      <LogoIcon className={iconClassName} />
+      {showText && <LogoText className={textClassName} />}
+    </div>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,7 +7,12 @@ const config: Config = {
     './src/frontend/lib/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ['var(--font-geist-sans)', 'system-ui', 'sans-serif'],
+        mono: ['var(--font-geist-mono)', 'monospace'],
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- Add Geist Sans and Geist Mono fonts for modern, clean typography
- Reduce spacing ~33% across all components for information-dense UI (Linear/GitHub style)
- Create FACTORY FACTORY logo with concentric squares design
- Add favicon with white background for visibility in browser tabs
- Update README with new branding and logo

## Changes

### Typography
- Install `geist` package for Geist Sans and Geist Mono fonts
- Configure font families in Tailwind and CSS variables

### Density
- Update shadcn/ui components: card, table, dialog, sheet, empty
- Update all page files with tighter spacing (space-y-6 → space-y-4, p-6 → p-4)

### Branding
- Create Logo component with icon and text variants
- Concentric squares logo design (80×80 outer, 60×60 inner)
- Favicon with white rounded background
- Page title: "FACTORY FACTORY"

## Test plan
- [ ] Verify Geist fonts render correctly throughout the app
- [ ] Check spacing is tighter but not cramped on all pages
- [ ] Verify logo displays correctly in sidebar
- [ ] Check favicon appears in browser tab
- [ ] Test on `/projects`, `/projects/[slug]/tasks`, `/projects/[slug]/mail`

🤖 Generated with [Claude Code](https://claude.ai/code)