### PR TITLE
Add Claude session ID tracking for context preservation

### DIFF
--- a/src/backend/agents/orchestrator/orchestrator.agent.ts
+++ b/src/backend/agents/orchestrator/orchestrator.agent.ts
@@ -151,10 +151,14 @@ export async function createOrchestrator(): Promise<string> {
 async function createOrchestratorSession(
   agentId: string,
   systemPrompt: string,
-  workingDir: string
+  workingDir: string,
+  options?: { resumeSessionId?: string }
 ): Promise<{ sessionId: string; tmuxSessionName: string }> {
   // Use the worker session creator but with orchestrator naming
-  const context = await createWorkerSession(agentId, systemPrompt, workingDir);
+  const context = await createWorkerSession(agentId, systemPrompt, workingDir, {
+    agentType: 'orchestrator',
+    resumeSessionId: options?.resumeSessionId,
+  });
 
   // Rename tmux session to orchestrator naming
   const orchestratorTmuxName = getOrchestratorTmuxSessionName(agentId);

--- a/src/backend/agents/supervisor/lifecycle.ts
+++ b/src/backend/agents/supervisor/lifecycle.ts
@@ -1,6 +1,7 @@
 import { AgentType } from '@prisma-gen/client';
 import { agentAccessor } from '../../resource_accessors/index.js';
 import {
+  type CreateSupervisorOptions,
   createSupervisor,
   isSupervisorRunning,
   killSupervisor,
@@ -11,13 +12,21 @@ import {
 // Re-export runSupervisor so it can be used to start an existing supervisor
 export { runSupervisor };
 
+export interface StartSupervisorOptions extends CreateSupervisorOptions {}
+
 /**
  * Start a supervisor for a top-level task
  * Creates the supervisor agent, sets up environment, and starts execution
+ *
+ * @param taskId - The top-level task to start a supervisor for
+ * @param options - Optional settings including resumeSessionId for crash recovery
  */
-export async function startSupervisorForTask(taskId: string): Promise<string> {
-  // Create supervisor
-  const agentId = await createSupervisor(taskId);
+export async function startSupervisorForTask(
+  taskId: string,
+  options?: StartSupervisorOptions
+): Promise<string> {
+  // Create supervisor (with optional resume session ID for crash recovery)
+  const agentId = await createSupervisor(taskId, options);
 
   console.log(`Starting supervisor ${agentId} for task ${taskId}...`);
 

--- a/src/backend/agents/worker/lifecycle.ts
+++ b/src/backend/agents/worker/lifecycle.ts
@@ -1,5 +1,6 @@
 import { agentAccessor, taskAccessor } from '../../resource_accessors/index.js';
 import {
+  type CreateWorkerOptions,
   createWorker,
   isWorkerRunning,
   killWorker,
@@ -7,12 +8,17 @@ import {
   stopWorker,
 } from './worker.agent.js';
 
+export interface StartWorkerOptions extends CreateWorkerOptions {}
+
 /**
  * Start a worker for a task
  * Creates the worker agent, sets up environment, and starts execution
  * This function is idempotent - if a worker already exists for the task, it returns the existing ID
+ *
+ * @param taskId - The task to start a worker for
+ * @param options - Optional settings including resumeSessionId for crash recovery
  */
-export async function startWorker(taskId: string): Promise<string> {
+export async function startWorker(taskId: string, options?: StartWorkerOptions): Promise<string> {
   // Check if a worker already exists for this task
   const task = await taskAccessor.findById(taskId);
   if (!task) {
@@ -35,8 +41,8 @@ export async function startWorker(taskId: string): Promise<string> {
     }
   }
 
-  // Create new worker
-  const agentId = await createWorker(taskId);
+  // Create new worker (with optional resume session ID for crash recovery)
+  const agentId = await createWorker(taskId, options);
 
   console.log(`Starting worker ${agentId} for task ${taskId}...`);
 

--- a/src/backend/clients/claude-code.client.test.ts
+++ b/src/backend/clients/claude-code.client.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { generateSessionId } from './claude-code.client.js';
+
+describe('claude-code.client', () => {
+  describe('generateSessionId', () => {
+    beforeEach(() => {
+      // Mock Date.now to return a consistent timestamp
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2024-01-25T12:00:00Z'));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should generate session ID in correct format for worker', () => {
+      const sessionId = generateSessionId('worker', 'abc12345-6789-0123-4567-890abcdef012');
+      expect(sessionId).toBe('worker-abc12345-1706184000');
+    });
+
+    it('should generate session ID in correct format for supervisor', () => {
+      const sessionId = generateSessionId('supervisor', 'def67890-1234-5678-9012-345678901234');
+      expect(sessionId).toBe('supervisor-def67890-1706184000');
+    });
+
+    it('should generate session ID in correct format for orchestrator', () => {
+      const sessionId = generateSessionId('orchestrator', 'ghi12345-abcd-efgh-ijkl-mnopqrstuvwx');
+      expect(sessionId).toBe('orchestrator-ghi12345-1706184000');
+    });
+
+    it('should handle short agent IDs gracefully', () => {
+      const sessionId = generateSessionId('worker', 'short');
+      expect(sessionId).toBe('worker-short-1706184000');
+    });
+
+    it('should handle exactly 8 character agent IDs', () => {
+      const sessionId = generateSessionId('worker', 'exactly8');
+      expect(sessionId).toBe('worker-exactly8-1706184000');
+    });
+
+    it('should truncate long agent IDs to 8 characters', () => {
+      const sessionId = generateSessionId('worker', 'verylongagentid12345');
+      expect(sessionId).toBe('worker-verylong-1706184000');
+    });
+
+    it('should include unix timestamp in seconds', () => {
+      const sessionId = generateSessionId('worker', 'testid12');
+      // 2024-01-25T12:00:00Z = 1706184000 seconds since epoch
+      expect(sessionId).toMatch(/worker-testid12-\d+/);
+      expect(sessionId.split('-')[2]).toBe('1706184000');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Update `generateSessionId()` to use descriptive format: `{agentType}-{agentId}-{timestamp}` (e.g., `worker-abc123-1706123456`)
- Add resume support to crash recovery for workers and supervisors
- When agents crash, new instances resume Claude conversations using `--resume` flag
- Preserves conversation history and context instead of starting fresh

## Implementation Details

### Session ID Format
Changed from UUID to descriptive format that includes:
- Agent type (worker/supervisor/orchestrator)
- Truncated agent ID (first 8 chars)
- Unix timestamp

### Crash Recovery Flow
1. When a worker/supervisor crashes, recovery logic captures the old `sessionId`
2. New agent instance is created with the `resumeSessionId` option
3. Claude is started with `--resume <old-session-id>` instead of `--session-id <new-id>`
4. Preserves full conversation history and in-progress reasoning

### Files Changed
- `claude-code.client.ts` - Updated session ID generation and added resume support
- `worker.agent.ts` / `supervisor.agent.ts` - Added resume options to create functions
- `worker/lifecycle.ts` / `supervisor/lifecycle.ts` - Added resume options to start functions  
- `supervisor/health.ts` - Worker recovery now passes old session ID
- `orchestrator/health.ts` - Supervisor recovery now passes old session ID

## Test Plan
- [x] TypeScript type checking passes
- [x] Biome linting passes
- [x] All 148 unit tests pass
- [ ] Manual testing: Crash a worker and verify it resumes with context

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)