### PR TITLE
Add lint rule to block async imports

### DIFF
--- a/biome-rules/no-await-import.grit
+++ b/biome-rules/no-await-import.grit
@@ -1,0 +1,3 @@
+`await import($_)` as $import where {
+  register_diagnostic(span=$import, message="Do not use 'await import()'. Use static imports instead. If you have circular dependencies, extract shared code to a separate module.")
+}

--- a/biome.json
+++ b/biome.json
@@ -99,6 +99,7 @@
       }
     }
   },
+  "plugins": ["biome-rules/no-await-import.grit"],
   "overrides": [
     {
       "includes": ["src/backend/**/*.ts", "scripts/**/*.ts", "test-*.ts"],

--- a/src/backend/routers/mcp/task.mcp.ts
+++ b/src/backend/routers/mcp/task.mcp.ts
@@ -1,6 +1,6 @@
 import { AgentType, TaskState } from '@prisma-gen/client';
 import { z } from 'zod';
-import { startWorker } from '../../agents/worker/lifecycle.js';
+import { killWorkerAndCleanup, startWorker } from '../../agents/worker/lifecycle.js';
 import { type GitClient, GitClientFactory } from '../../clients/git.client.js';
 import type { PRInfo, PRStatus } from '../../clients/github.client.js';
 import { githubClient } from '../../clients/index.js';
@@ -129,7 +129,6 @@ async function cleanupWorker(agentId: string | null): Promise<boolean> {
   }
 
   try {
-    const { killWorkerAndCleanup } = await import('../../agents/worker/lifecycle.js');
     await killWorkerAndCleanup(agentId);
     console.log(`Cleaned up worker ${agentId} after task approval`);
     return true;
@@ -350,7 +349,6 @@ ${failedSection}
  * Cleanup workers for all tasks
  */
 async function cleanupAllWorkers(tasks: { assignedAgentId: string | null }[]): Promise<number> {
-  const { killWorkerAndCleanup } = await import('../../agents/worker/lifecycle.js');
   let count = 0;
 
   for (const task of tasks) {


### PR DESCRIPTION
## Summary
- Add GritQL rule (`biome-rules/no-await-import.grit`) that flags `await import()` usage
- Configure biome.json to use the new plugin
- Fix existing violations in `task.mcp.ts` by converting dynamic imports to static imports

Closes #83

## Test plan
- [x] Verified rule catches `await import()` patterns
- [x] Verified static imports don't trigger the rule
- [x] Verified no existing violations remain in src/
- [x] TypeScript checks pass
- [x] Biome check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)