### PR TITLE
Implement reconciliation-based task infrastructure

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,22 +11,16 @@ datasource db {
 }
 
 // Enums
+
+// Task state - about the WORK being done
 enum TaskState {
-  // Parent task states (for tasks with children)
-  PLANNING       // Task is being planned/broken down
-  PLANNED        // Subtasks created, ready for execution
-
-  // Leaf task states (for implementable tasks)
-  PENDING        // Task waiting to be picked up
-  ASSIGNED       // Task assigned to an agent
-  IN_PROGRESS    // Task being worked on
-  REVIEW         // Task waiting for review
-
-  // Terminal states (any task)
-  COMPLETED      // Task completed successfully
-  BLOCKED        // Task is blocked (dependencies or external)
-  FAILED         // Task failed
-  CANCELLED      // Task was cancelled
+  PENDING        // Not started (subtasks waiting to be picked up)
+  PLANNING       // Top-level only: supervisor breaking down work
+  IN_PROGRESS    // Being worked on (replaces ASSIGNED, PLANNED)
+  REVIEW         // Submitted for review
+  COMPLETED      // Work accepted and merged
+  FAILED         // Work abandoned
+  BLOCKED        // External blocker (dependencies, etc.)
 }
 
 enum AgentType {
@@ -35,11 +29,20 @@ enum AgentType {
   WORKER         // Task executor
 }
 
-enum AgentState {
-  IDLE           // Agent is idle
-  BUSY           // Agent is working
-  WAITING        // Agent is waiting for something
-  FAILED         // Agent encountered an error
+// Agent execution state - what the agent IS currently doing (actual state)
+enum ExecutionState {
+  IDLE           // Agent is idle, not running
+  ACTIVE         // Agent is actively running
+  PAUSED         // Agent is paused but can be resumed
+  CRASHED        // Agent process crashed unexpectedly
+}
+
+// Desired execution state - what we WANT the agent to be doing
+// (subset of ExecutionState - CRASHED is never desired)
+enum DesiredExecutionState {
+  IDLE           // We want the agent to be idle/stopped
+  ACTIVE         // We want the agent to be running
+  PAUSED         // We want the agent to be paused
 }
 
 // Models
@@ -75,9 +78,13 @@ model Task {
   assignedAgentId   String?
   worktreePath      String?
   branchName        String?
-  prUrl             String?
+  prUrl             String?     // Draft PR URL, created after first commit
   attempts          Int         @default(0)
   failureReason     String?     @db.Text
+
+  // Reconciliation tracking
+  lastReconcileAt   DateTime?   // Last time this task was reconciled
+  reconcileFailures Json?       // Array of {timestamp, error, action} for debugging
 
   // Timestamps
   createdAt         DateTime    @default(now())
@@ -99,6 +106,7 @@ model Task {
   @@index([parentId])
   @@index([state])
   @@index([assignedAgentId])
+  @@index([lastReconcileAt])
 }
 
 model TaskDependency {
@@ -117,26 +125,39 @@ model TaskDependency {
 }
 
 model Agent {
-  id                String      @id @default(cuid())
-  type              AgentType
-  state             AgentState  @default(IDLE)
-  currentTaskId     String?     @unique  // For both supervisors (top-level) and workers (leaf)
-  tmuxSessionName   String?
-  sessionId         String?     // Claude Code CLI session ID for resume
-  createdAt         DateTime    @default(now())
-  updatedAt         DateTime    @updatedAt
-  lastActiveAt      DateTime    @default(now())
+  id                      String              @id @default(cuid())
+  type                    AgentType
+  currentTaskId           String?             @unique  // For both supervisors (top-level) and workers (leaf)
+
+  // Execution state (reconciler-managed)
+  executionState          ExecutionState      @default(IDLE)    // ACTUAL: what agent IS doing
+  desiredExecutionState   DesiredExecutionState @default(IDLE)  // WANTED: what we want agent to do
+
+  // Session management
+  tmuxSessionName         String?
+  sessionId               String?             // Claude Code CLI session ID for resume
+
+  // Health tracking
+  lastHeartbeat           DateTime?           // Last agent heartbeat (set by agent itself)
+  lastReconcileAt         DateTime?           // Last time this agent was reconciled
+  reconcileFailures       Json?               // Array of {timestamp, error, action} for debugging
+
+  // Timestamps
+  createdAt               DateTime            @default(now())
+  updatedAt               DateTime            @updatedAt
 
   // Relations
-  currentTask       Task?       @relation("SupervisorTask", fields: [currentTaskId], references: [id])
-  assignedTasks     Task[]      @relation("AssignedTasks")
-  mailReceived      Mail[]      @relation("ReceiverAgent")
-  mailSent          Mail[]      @relation("SenderAgent")
-  decisionLogs      DecisionLog[]
+  currentTask             Task?               @relation("SupervisorTask", fields: [currentTaskId], references: [id])
+  assignedTasks           Task[]              @relation("AssignedTasks")
+  mailReceived            Mail[]              @relation("ReceiverAgent")
+  mailSent                Mail[]              @relation("SenderAgent")
+  decisionLogs            DecisionLog[]
 
   @@index([type])
-  @@index([state])
+  @@index([executionState])
+  @@index([desiredExecutionState])
   @@index([currentTaskId])
+  @@index([lastHeartbeat])
 }
 
 model Mail {

--- a/src/app/admin/agents/page.tsx
+++ b/src/app/admin/agents/page.tsx
@@ -7,9 +7,9 @@ import { trpc } from '../../../frontend/lib/trpc';
 function AgentStateIndicator({ state, isInCrashLoop }: { state: string; isInCrashLoop: boolean }) {
   const stateColors: Record<string, string> = {
     IDLE: 'bg-muted text-muted-foreground',
-    BUSY: 'bg-info/15 text-info',
-    WAITING: 'bg-warning/15 text-warning-foreground',
-    FAILED: 'bg-destructive/15 text-destructive',
+    ACTIVE: 'bg-info/15 text-info',
+    PAUSED: 'bg-warning/15 text-warning-foreground',
+    CRASHED: 'bg-destructive/15 text-destructive',
   };
 
   return (
@@ -127,10 +127,13 @@ export default function AdminAgentsPage() {
                 <tr key={agent.id} className="hover:bg-muted">
                   <td className="px-6 py-4 text-sm font-mono">{agent.id.slice(0, 8)}...</td>
                   <td className="px-6 py-4">
-                    <AgentStateIndicator state={agent.state} isInCrashLoop={agent.isInCrashLoop} />
+                    <AgentStateIndicator
+                      state={agent.executionState}
+                      isInCrashLoop={agent.isInCrashLoop}
+                    />
                   </td>
                   <td className="px-6 py-4 text-sm text-muted-foreground">
-                    {new Date(agent.lastActiveAt).toLocaleString()}
+                    {agent.lastHeartbeat ? new Date(agent.lastHeartbeat).toLocaleString() : 'Never'}
                   </td>
                   <td className="px-6 py-4">
                     <div className="flex gap-2">
@@ -195,7 +198,10 @@ export default function AdminAgentsPage() {
                     </Link>
                   </td>
                   <td className="px-6 py-4">
-                    <AgentStateIndicator state={agent.state} isInCrashLoop={agent.isInCrashLoop} />
+                    <AgentStateIndicator
+                      state={agent.executionState}
+                      isInCrashLoop={agent.isInCrashLoop}
+                    />
                   </td>
                   <td className="px-6 py-4 text-sm">
                     {agent.currentTaskId ? (
@@ -213,7 +219,7 @@ export default function AdminAgentsPage() {
                     {agent.tmuxSessionName || '-'}
                   </td>
                   <td className="px-6 py-4 text-sm text-muted-foreground">
-                    {new Date(agent.lastActiveAt).toLocaleString()}
+                    {agent.lastHeartbeat ? new Date(agent.lastHeartbeat).toLocaleString() : 'Never'}
                   </td>
                   <td className="px-6 py-4">
                     <div className="flex gap-2">
@@ -289,7 +295,10 @@ export default function AdminAgentsPage() {
                     </Link>
                   </td>
                   <td className="px-6 py-4">
-                    <AgentStateIndicator state={agent.state} isInCrashLoop={agent.isInCrashLoop} />
+                    <AgentStateIndicator
+                      state={agent.executionState}
+                      isInCrashLoop={agent.isInCrashLoop}
+                    />
                   </td>
                   <td className="px-6 py-4 text-sm">
                     {agent.currentTaskId ? (
@@ -307,7 +316,7 @@ export default function AdminAgentsPage() {
                     {agent.tmuxSessionName || '-'}
                   </td>
                   <td className="px-6 py-4 text-sm text-muted-foreground">
-                    {new Date(agent.lastActiveAt).toLocaleString()}
+                    {agent.lastHeartbeat ? new Date(agent.lastHeartbeat).toLocaleString() : 'Never'}
                   </td>
                   <td className="px-6 py-4">
                     <div className="flex gap-2">

--- a/src/app/projects/[slug]/epics/[id]/page.tsx
+++ b/src/app/projects/[slug]/epics/[id]/page.tsx
@@ -11,15 +11,16 @@ import { trpc } from '../../../../../frontend/lib/trpc';
 
 const stateVariants: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
   PLANNING: 'secondary',
+  PENDING: 'outline',
   IN_PROGRESS: 'default',
   BLOCKED: 'destructive',
   COMPLETED: 'secondary',
-  CANCELLED: 'outline',
+  FAILED: 'destructive',
 };
 
 const taskStateVariants: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
   PENDING: 'outline',
-  ASSIGNED: 'default',
+  PLANNING: 'secondary',
   IN_PROGRESS: 'default',
   REVIEW: 'default',
   BLOCKED: 'destructive',
@@ -111,7 +112,7 @@ export default function EpicDetailPage() {
                 <p>
                   Agent ID: <span className="font-mono">{supervisor.id}</span>
                 </p>
-                <p>State: {supervisor.state}</p>
+                <p>State: {supervisor.executionState}</p>
               </div>
               {supervisor.tmuxSessionName && (
                 <Button variant="outline" size="sm" asChild>
@@ -198,7 +199,7 @@ export default function EpicDetailPage() {
                       title={agent.isHealthy ? 'Healthy' : 'Unhealthy'}
                     />
                   </div>
-                  <p className="text-sm text-muted-foreground">State: {agent.state}</p>
+                  <p className="text-sm text-muted-foreground">State: {agent.executionState}</p>
                   <Button variant="link" size="sm" className="px-0 mt-2" asChild>
                     <Link href={`/projects/${slug}/agents/${agent.id}`}>View Details</Link>
                   </Button>

--- a/src/app/projects/[slug]/mail/page.tsx
+++ b/src/app/projects/[slug]/mail/page.tsx
@@ -354,7 +354,7 @@ function ComposeForm({ onSent }: { onSent: () => void }) {
           <SelectContent>
             {agents?.map((agent) => (
               <SelectItem key={agent.id} value={agent.id}>
-                {agent.type} - {agent.id.slice(0, 8)}... ({agent.state})
+                {agent.type} - {agent.id.slice(0, 8)}... ({agent.executionState})
               </SelectItem>
             ))}
           </SelectContent>

--- a/src/backend/agents/supervisor/lifecycle.ts
+++ b/src/backend/agents/supervisor/lifecycle.ts
@@ -91,7 +91,7 @@ export async function recreateSupervisor(taskId: string): Promise<string> {
 export async function getSupervisorStatus(agentId: string): Promise<{
   agentId: string;
   isRunning: boolean;
-  agentState: string;
+  executionState: string;
   taskId: string | null;
   tmuxSession: string | null;
 }> {
@@ -103,7 +103,7 @@ export async function getSupervisorStatus(agentId: string): Promise<{
   return {
     agentId: agent.id,
     isRunning: isSupervisorRunning(agentId),
-    agentState: agent.state,
+    executionState: agent.executionState,
     taskId: agent.currentTaskId,
     tmuxSession: agent.tmuxSessionName,
   };
@@ -124,7 +124,7 @@ export async function listAllSupervisors(): Promise<
   Array<{
     agentId: string;
     taskId: string | null;
-    state: string;
+    executionState: string;
     isRunning: boolean;
   }>
 > {
@@ -133,7 +133,7 @@ export async function listAllSupervisors(): Promise<
   return supervisors.map((s) => ({
     agentId: s.id,
     taskId: s.currentTaskId,
-    state: s.state,
+    executionState: s.executionState,
     isRunning: isSupervisorRunning(s.id),
   }));
 }

--- a/src/backend/agents/worker/lifecycle.ts
+++ b/src/backend/agents/worker/lifecycle.ts
@@ -105,7 +105,7 @@ export async function recreateWorker(taskId: string): Promise<string> {
 export async function getWorkerStatus(agentId: string): Promise<{
   agentId: string;
   isRunning: boolean;
-  agentState: string;
+  executionState: string;
   taskId: string | null;
   tmuxSession: string | null;
 }> {
@@ -117,7 +117,7 @@ export async function getWorkerStatus(agentId: string): Promise<{
   return {
     agentId: agent.id,
     isRunning: isWorkerRunning(agentId),
-    agentState: agent.state,
+    executionState: agent.executionState,
     taskId: agent.currentTaskId,
     tmuxSession: agent.tmuxSessionName,
   };

--- a/src/backend/agents/worker/worker.agent.ts
+++ b/src/backend/agents/worker/worker.agent.ts
@@ -1,4 +1,4 @@
-import { AgentState, AgentType, TaskState } from '@prisma-gen/client';
+import { AgentType, DesiredExecutionState, ExecutionState, TaskState } from '@prisma-gen/client';
 import {
   captureOutput,
   createWorkerSession,
@@ -116,7 +116,8 @@ export async function createWorker(taskId: string, options?: CreateWorkerOptions
   // Create agent record
   const agent = await agentAccessor.create({
     type: AgentType.WORKER,
-    state: AgentState.IDLE,
+    executionState: ExecutionState.IDLE,
+    desiredExecutionState: DesiredExecutionState.IDLE,
     currentTaskId: taskId,
   });
 
@@ -135,7 +136,7 @@ export async function createWorker(taskId: string, options?: CreateWorkerOptions
     assignedAgentId: agent.id,
     worktreePath: worktreeInfo.path,
     branchName: worktreeInfo.branchName,
-    state: TaskState.ASSIGNED,
+    state: TaskState.IN_PROGRESS,
   });
 
   // Backend URL for API calls
@@ -226,7 +227,7 @@ export async function runWorker(agentId: string): Promise<void> {
 
   // Update agent state
   await agentAccessor.update(agentId, {
-    state: AgentState.BUSY,
+    executionState: ExecutionState.ACTIVE,
   });
 
   console.log(`Starting worker ${agentId}`);
@@ -419,7 +420,7 @@ async function handleWorkerCompletion(agentId: string, reason: string): Promise<
 
   // Update agent state
   await agentAccessor.update(agentId, {
-    state: AgentState.IDLE,
+    executionState: ExecutionState.IDLE,
   });
 
   // Check task state to determine if successful
@@ -459,7 +460,7 @@ export async function stopWorker(agentId: string): Promise<void> {
 
   // Update agent state
   await agentAccessor.update(agentId, {
-    state: AgentState.IDLE,
+    executionState: ExecutionState.IDLE,
   });
 
   console.log(`Worker ${agentId} stopped`);

--- a/src/backend/inngest/events.ts
+++ b/src/backend/inngest/events.ts
@@ -81,4 +81,19 @@ export type Events = {
       timestamp: number;
     };
   };
+  /**
+   * Triggered to run a reconciliation cycle.
+   * Can be triggered immediately after state changes or periodically via cron.
+   */
+  'reconcile.requested': {
+    data: {
+      /** Optional: specific task ID to reconcile */
+      taskId?: string;
+      /** Optional: specific agent ID to reconcile */
+      agentId?: string;
+      /** Source of the reconciliation request */
+      source: 'cron' | 'event' | 'manual';
+      timestamp: number;
+    };
+  };
 };

--- a/src/backend/inngest/functions/agent-completed.ts
+++ b/src/backend/inngest/functions/agent-completed.ts
@@ -1,4 +1,4 @@
-import { AgentState, AgentType } from '@prisma-gen/client';
+import { AgentType, ExecutionState } from '@prisma-gen/client';
 import { killSupervisorAndCleanup } from '../../agents/supervisor/lifecycle.js';
 import { killWorkerAndCleanup } from '../../agents/worker/lifecycle.js';
 import {
@@ -40,7 +40,7 @@ export const agentCompletedHandler = inngest.createFunction(
       return {
         id: agent.id,
         type: agent.type,
-        state: agent.state,
+        executionState: agent.executionState,
         currentTaskId: agent.currentTaskId,
         tmuxSessionName: agent.tmuxSessionName,
       };
@@ -64,7 +64,7 @@ export const agentCompletedHandler = inngest.createFunction(
         case AgentType.SUPERVISOR:
           return handleSupervisorCompletion(
             agentId,
-            topLevelTaskId || agentInfo.currentTaskId || undefined
+            topLevelTaskId ?? agentInfo.currentTaskId ?? undefined
           );
 
         case AgentType.ORCHESTRATOR:
@@ -82,7 +82,7 @@ export const agentCompletedHandler = inngest.createFunction(
     await step.run('update-agent-state', async () => {
       try {
         await agentAccessor.update(agentId, {
-          state: AgentState.IDLE,
+          executionState: ExecutionState.IDLE,
         });
       } catch (error) {
         // Agent may have been deleted during cleanup

--- a/src/backend/inngest/functions/index.ts
+++ b/src/backend/inngest/functions/index.ts
@@ -1,6 +1,13 @@
 export { agentCompletedHandler } from './agent-completed.js';
 export { mailSentHandler } from './mail-sent.js';
 export { orchestratorCheckHandler } from './orchestrator-check.js';
+export {
+  reconciliationCronHandler,
+  reconciliationEventHandler,
+  triggerAgentReconciliation,
+  triggerFullReconciliation,
+  triggerTaskReconciliation,
+} from './reconciliation.js';
 export { supervisorCheckHandler } from './supervisor-check.js';
 export { taskCreatedHandler } from './task-created.js';
 export { topLevelTaskCreatedHandler } from './top-level-task-created.js';

--- a/src/backend/inngest/functions/reconciliation.ts
+++ b/src/backend/inngest/functions/reconciliation.ts
@@ -16,7 +16,8 @@ import { inngest } from '../client.js';
  * This is the "backup" reconciliation that catches any drift
  * that wasn't handled by event-triggered reconciliation.
  *
- * Schedule: Every 30 seconds
+ * Schedule: Every 30 seconds (using Inngest's 6-field cron syntax with seconds)
+ * Format: second minute hour day-of-month month day-of-week
  */
 export const reconciliationCronHandler = inngest.createFunction(
   {
@@ -27,7 +28,7 @@ export const reconciliationCronHandler = inngest.createFunction(
       limit: 1, // Only one reconciliation at a time
     },
   },
-  { cron: '*/30 * * * * *' }, // Every 30 seconds
+  { cron: '*/30 * * * * *' }, // Every 30 seconds (Inngest supports sub-minute cron)
   async ({ step }) => {
     console.log('Periodic reconciliation started');
 

--- a/src/backend/inngest/functions/reconciliation.ts
+++ b/src/backend/inngest/functions/reconciliation.ts
@@ -1,0 +1,192 @@
+/**
+ * Reconciliation Inngest Functions
+ *
+ * Implements the hybrid triggering strategy for reconciliation:
+ * 1. Event-triggered: Immediate reconciliation after state changes
+ * 2. Cron-triggered: Periodic reconciliation to catch drift
+ */
+
+import { reconciliationService } from '../../services/index.js';
+import { inngest } from '../client.js';
+
+/**
+ * Periodic Reconciliation Cron Job
+ *
+ * Runs every 30 seconds to ensure system consistency.
+ * This is the "backup" reconciliation that catches any drift
+ * that wasn't handled by event-triggered reconciliation.
+ *
+ * Schedule: Every 30 seconds
+ */
+export const reconciliationCronHandler = inngest.createFunction(
+  {
+    id: 'reconciliation-cron',
+    name: 'Periodic Reconciliation',
+    retries: 1,
+    concurrency: {
+      limit: 1, // Only one reconciliation at a time
+    },
+  },
+  { cron: '*/30 * * * * *' }, // Every 30 seconds
+  async ({ step }) => {
+    console.log('Periodic reconciliation started');
+
+    const result = await step.run('reconcile-all', async () => {
+      return await reconciliationService.reconcileAll();
+    });
+
+    console.log('Periodic reconciliation complete', {
+      tasksReconciled: result.tasksReconciled,
+      agentsReconciled: result.agentsReconciled,
+      supervisorsCreated: result.supervisorsCreated,
+      workersCreated: result.workersCreated,
+      infrastructureCreated: result.infrastructureCreated,
+      crashesDetected: result.crashesDetected,
+      errorCount: result.errors.length,
+    });
+
+    return {
+      success: result.success,
+      summary: {
+        tasksReconciled: result.tasksReconciled,
+        agentsReconciled: result.agentsReconciled,
+        supervisorsCreated: result.supervisorsCreated,
+        workersCreated: result.workersCreated,
+        infrastructureCreated: result.infrastructureCreated,
+        crashesDetected: result.crashesDetected,
+        errorCount: result.errors.length,
+      },
+    };
+  }
+);
+
+/**
+ * Event-Triggered Reconciliation
+ *
+ * Handles immediate reconciliation requests triggered by state changes.
+ * This provides faster response than waiting for the cron job.
+ */
+export const reconciliationEventHandler = inngest.createFunction(
+  {
+    id: 'reconciliation-event',
+    name: 'Event-Triggered Reconciliation',
+    retries: 2,
+    concurrency: {
+      limit: 5, // Allow multiple concurrent event-triggered reconciliations
+    },
+  },
+  { event: 'reconcile.requested' },
+  async ({ event, step }) => {
+    const { taskId, agentId, source } = event.data;
+
+    console.log('Event-triggered reconciliation started', { taskId, agentId, source });
+
+    // If specific task or agent is requested, reconcile just that entity
+    if (taskId) {
+      await step.run('reconcile-task', async () => {
+        await reconciliationService.reconcileTask(taskId);
+      });
+
+      return {
+        success: true,
+        type: 'task',
+        entityId: taskId,
+        source,
+      };
+    }
+
+    if (agentId) {
+      await step.run('reconcile-agent', async () => {
+        await reconciliationService.reconcileAgent(agentId);
+      });
+
+      return {
+        success: true,
+        type: 'agent',
+        entityId: agentId,
+        source,
+      };
+    }
+
+    // If no specific entity, run full reconciliation
+    const result = await step.run('reconcile-all', async () => {
+      return await reconciliationService.reconcileAll();
+    });
+
+    return {
+      success: result.success,
+      type: 'full',
+      source,
+      summary: {
+        tasksReconciled: result.tasksReconciled,
+        agentsReconciled: result.agentsReconciled,
+        supervisorsCreated: result.supervisorsCreated,
+        workersCreated: result.workersCreated,
+        infrastructureCreated: result.infrastructureCreated,
+        crashesDetected: result.crashesDetected,
+        errorCount: result.errors.length,
+      },
+    };
+  }
+);
+
+/**
+ * Helper function to trigger immediate reconciliation for a task
+ */
+export async function triggerTaskReconciliation(taskId: string): Promise<void> {
+  try {
+    await inngest.send({
+      name: 'reconcile.requested',
+      data: {
+        taskId,
+        source: 'event',
+        timestamp: Date.now(),
+      },
+    });
+  } catch (error) {
+    console.log('Failed to trigger task reconciliation (Inngest may not be running):', error);
+    // Fall back to direct reconciliation if Inngest is not available
+    await reconciliationService.reconcileTask(taskId);
+  }
+}
+
+/**
+ * Helper function to trigger immediate reconciliation for an agent
+ */
+export async function triggerAgentReconciliation(agentId: string): Promise<void> {
+  try {
+    await inngest.send({
+      name: 'reconcile.requested',
+      data: {
+        agentId,
+        source: 'event',
+        timestamp: Date.now(),
+      },
+    });
+  } catch (error) {
+    console.log('Failed to trigger agent reconciliation (Inngest may not be running):', error);
+    // Fall back to direct reconciliation if Inngest is not available
+    await reconciliationService.reconcileAgent(agentId);
+  }
+}
+
+/**
+ * Helper function to trigger full reconciliation
+ */
+export async function triggerFullReconciliation(
+  source: 'event' | 'manual' = 'manual'
+): Promise<void> {
+  try {
+    await inngest.send({
+      name: 'reconcile.requested',
+      data: {
+        source,
+        timestamp: Date.now(),
+      },
+    });
+  } catch (error) {
+    console.log('Failed to trigger full reconciliation (Inngest may not be running):', error);
+    // Fall back to direct reconciliation if Inngest is not available
+    await reconciliationService.reconcileAll();
+  }
+}

--- a/src/backend/inngest/functions/top-level-task-created.ts
+++ b/src/backend/inngest/functions/top-level-task-created.ts
@@ -1,17 +1,20 @@
-import { startSupervisorForTask } from '../../agents/supervisor/lifecycle.js';
-import { decisionLogAccessor, mailAccessor, taskAccessor } from '../../resource_accessors/index.js';
-import { inngest } from '../client.js';
-
 /**
- * Handle task.top_level.created event by starting a supervisor agent
+ * Handle task.top_level.created event
  *
- * This is the entry point for full automation:
- * 1. Top-level task is created (by human via UI)
- * 2. This handler fires automatically
- * 3. Supervisor is created for the top-level task
- * 4. Supervisor breaks down the task into subtasks
- * 5. Workers are created automatically for each subtask (via task.created handler)
+ * In the reconciliation pattern, event handlers are simple:
+ * they just update state and trigger reconciliation.
+ *
+ * The reconciler is responsible for:
+ * - Creating the supervisor agent
+ * - Setting up worktree and branch
+ * - Managing agent lifecycle
  */
+
+import { TaskState } from '@prisma-gen/client';
+import { taskAccessor } from '../../resource_accessors/index.js';
+import { inngest } from '../client.js';
+import { triggerTaskReconciliation } from './reconciliation.js';
+
 export const topLevelTaskCreatedHandler = inngest.createFunction(
   {
     id: 'top-level-task-created',
@@ -20,12 +23,12 @@ export const topLevelTaskCreatedHandler = inngest.createFunction(
   },
   { event: 'task.top_level.created' },
   async ({ event, step }) => {
-    const { taskId, title } = event.data;
+    const { taskId } = event.data;
 
     console.log(`Top-level task created event received for task ${taskId}`);
 
-    // Step 1: Verify top-level task exists and is ready for supervisor
-    const topLevelTask = await step.run('verify-top-level-task', async () => {
+    // Step 1: Verify task exists and set state to PLANNING
+    const topLevelTask = await step.run('set-planning-state', async () => {
       const task = await taskAccessor.findById(taskId);
       if (!task) {
         throw new Error(`Task with ID '${taskId}' not found`);
@@ -35,57 +38,32 @@ export const topLevelTaskCreatedHandler = inngest.createFunction(
           `Task '${taskId}' is not a top-level task (has parentId: ${task.parentId})`
         );
       }
+
+      // Ensure task is in PLANNING state (may already be from creation)
+      if (task.state !== TaskState.PLANNING) {
+        await taskAccessor.update(taskId, { state: TaskState.PLANNING });
+      }
+
       return {
         id: task.id,
         title: task.title,
-        state: task.state,
+        state: TaskState.PLANNING,
       };
     });
 
-    // Step 2: Start supervisor for the top-level task
-    const supervisorResult = await step.run('start-supervisor', async () => {
-      try {
-        const agentId = await startSupervisorForTask(taskId);
-        console.log(`Started supervisor ${agentId} for top-level task ${taskId}`);
-
-        // Log the supervisor creation
-        await decisionLogAccessor.createManual(
-          agentId,
-          `Supervisor created for top-level task "${title}"`,
-          `Automatic supervisor creation triggered by task.top_level.created event`,
-          JSON.stringify({ taskId, title })
-        );
-
-        return {
-          success: true,
-          agentId,
-          message: `Supervisor ${agentId} started for top-level task ${taskId}`,
-        };
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        console.error(`Failed to start supervisor for top-level task ${taskId}:`, error);
-
-        // Send notification to human about failure
-        await mailAccessor.create({
-          isForHuman: true,
-          subject: `Failed to create supervisor for top-level task: ${title}`,
-          body:
-            `The system failed to automatically create a supervisor for top-level task "${title}".\n\n` +
-            `Task ID: ${taskId}\n` +
-            `Error: ${errorMessage}\n\n` +
-            `Manual intervention may be required.`,
-        });
-
-        throw error;
-      }
+    // Step 2: Trigger reconciliation to create supervisor and infrastructure
+    await step.run('trigger-reconciliation', async () => {
+      await triggerTaskReconciliation(taskId);
     });
 
+    console.log(`Reconciliation triggered for top-level task ${taskId}`);
+
     return {
-      success: supervisorResult.success,
+      success: true,
       taskId,
       taskTitle: topLevelTask.title,
-      supervisorId: supervisorResult.agentId,
-      message: supervisorResult.message,
+      state: topLevelTask.state,
+      message: `Task state set to PLANNING, reconciliation triggered`,
     };
   }
 );

--- a/src/backend/resource_accessors/task.accessor.ts
+++ b/src/backend/resource_accessors/task.accessor.ts
@@ -45,6 +45,8 @@ export interface UpdateTaskInput {
   attempts?: number;
   completedAt?: Date | null;
   failureReason?: string | null;
+  lastReconcileAt?: Date;
+  reconcileFailures?: Prisma.InputJsonValue;
 }
 
 export interface ListTasksFilters {
@@ -440,7 +442,7 @@ export class TaskAccessor {
       where: {
         parentId: taskId,
         state: {
-          notIn: [TaskState.COMPLETED, TaskState.FAILED, TaskState.CANCELLED],
+          notIn: [TaskState.COMPLETED, TaskState.FAILED],
         },
       },
     });
@@ -457,16 +459,13 @@ export class TaskAccessor {
     });
 
     const counts: Record<TaskState, number> = {
-      [TaskState.PLANNING]: 0,
-      [TaskState.PLANNED]: 0,
       [TaskState.PENDING]: 0,
-      [TaskState.ASSIGNED]: 0,
+      [TaskState.PLANNING]: 0,
       [TaskState.IN_PROGRESS]: 0,
       [TaskState.REVIEW]: 0,
       [TaskState.COMPLETED]: 0,
       [TaskState.BLOCKED]: 0,
       [TaskState.FAILED]: 0,
-      [TaskState.CANCELLED]: 0,
     };
 
     for (const child of children) {
@@ -474,6 +473,131 @@ export class TaskAccessor {
     }
 
     return counts;
+  }
+
+  // ============================================
+  // Reconciliation Helpers
+  // ============================================
+
+  /**
+   * Find tasks that need reconciliation:
+   * - Tasks in active states (IN_PROGRESS, REVIEW) without assigned agents
+   * - Tasks in PENDING that should have workers
+   * - Tasks that haven't been reconciled recently
+   */
+  async findTasksNeedingReconciliation(staleMinutes = 5): Promise<TaskWithRelations[]> {
+    const staleThreshold = new Date(Date.now() - staleMinutes * 60 * 1000);
+
+    return await prisma.task.findMany({
+      where: {
+        OR: [
+          // Active tasks without agents
+          {
+            state: { in: [TaskState.IN_PROGRESS, TaskState.REVIEW] },
+            assignedAgentId: null,
+          },
+          // Tasks that haven't been reconciled recently
+          {
+            state: { in: [TaskState.PENDING, TaskState.IN_PROGRESS, TaskState.REVIEW] },
+            lastReconcileAt: {
+              lt: staleThreshold,
+            },
+          },
+          // Tasks that have never been reconciled
+          {
+            state: { in: [TaskState.PENDING, TaskState.IN_PROGRESS, TaskState.REVIEW] },
+            lastReconcileAt: null,
+          },
+        ],
+      },
+      include: fullInclude,
+    });
+  }
+
+  /**
+   * Find top-level tasks in PLANNING state that need supervisors
+   */
+  findTopLevelTasksNeedingSupervisors(): Promise<TaskWithRelations[]> {
+    return prisma.task.findMany({
+      where: {
+        parentId: null, // Top-level only
+        state: TaskState.PLANNING,
+        supervisorAgent: null, // No supervisor assigned
+      },
+      include: fullInclude,
+    });
+  }
+
+  /**
+   * Find leaf tasks in PENDING state that are ready for workers
+   */
+  async findLeafTasksNeedingWorkers(): Promise<TaskWithRelations[]> {
+    const pendingTasks = await prisma.task.findMany({
+      where: {
+        parentId: { not: null }, // Leaf tasks only
+        state: TaskState.PENDING,
+        assignedAgentId: null, // No worker assigned
+      },
+      include: fullInclude,
+    });
+
+    // Filter to only tasks that aren't blocked
+    const readyTasks: TaskWithRelations[] = [];
+    for (const task of pendingTasks) {
+      const isBlocked = await this.isBlocked(task.id);
+      if (!isBlocked) {
+        readyTasks.push(task);
+      }
+    }
+
+    return readyTasks;
+  }
+
+  /**
+   * Update reconciliation timestamp
+   */
+  markReconciled(id: string): Promise<Task> {
+    return prisma.task.update({
+      where: { id },
+      data: { lastReconcileAt: new Date() },
+    });
+  }
+
+  /**
+   * Record a reconciliation failure
+   */
+  async recordReconcileFailure(id: string, error: string, action: string): Promise<Task> {
+    const task = await prisma.task.findUnique({ where: { id } });
+    const existingFailures = (task?.reconcileFailures as unknown[]) ?? [];
+    const newFailure = {
+      timestamp: new Date().toISOString(),
+      error,
+      action,
+    };
+
+    // Keep last 10 failures
+    const failures = [...existingFailures, newFailure].slice(-10) as object[];
+
+    return prisma.task.update({
+      where: { id },
+      data: {
+        reconcileFailures: failures,
+        lastReconcileAt: new Date(),
+      },
+    });
+  }
+
+  /**
+   * Find tasks with missing infrastructure (worktree, branch) that should have it
+   */
+  findTasksWithMissingInfrastructure(): Promise<TaskWithRelations[]> {
+    return prisma.task.findMany({
+      where: {
+        state: TaskState.IN_PROGRESS,
+        OR: [{ worktreePath: null }, { branchName: null }],
+      },
+      include: fullInclude,
+    });
   }
 }
 

--- a/src/backend/routers/api/task.router.ts
+++ b/src/backend/routers/api/task.router.ts
@@ -153,7 +153,7 @@ function calculateTaskSummary(childTasks: TaskWithBasicRelations[]) {
   return {
     total: childTasks.length,
     pending: childTasks.filter((t) => t.state === 'PENDING').length,
-    assigned: childTasks.filter((t) => t.state === 'ASSIGNED').length,
+    planning: childTasks.filter((t) => t.state === 'PLANNING').length,
     inProgress: childTasks.filter((t) => t.state === 'IN_PROGRESS').length,
     review: childTasks.filter((t) => t.state === 'REVIEW').length,
     blocked: childTasks.filter((t) => t.state === 'BLOCKED').length,

--- a/src/backend/routers/mcp/agent.mcp.ts
+++ b/src/backend/routers/mcp/agent.mcp.ts
@@ -37,10 +37,11 @@ async function getStatus(context: McpToolContext, input: unknown): Promise<McpTo
     return createSuccessResponse({
       id: agent.id,
       type: agent.type,
-      state: agent.state,
+      executionState: agent.executionState,
+      desiredExecutionState: agent.desiredExecutionState,
       currentTaskId: agent.currentTaskId,
       tmuxSessionName: agent.tmuxSessionName,
-      lastActiveAt: agent.lastActiveAt,
+      lastHeartbeat: agent.lastHeartbeat,
       createdAt: agent.createdAt,
       updatedAt: agent.updatedAt,
     });

--- a/src/backend/routers/mcp/errors.ts
+++ b/src/backend/routers/mcp/errors.ts
@@ -59,8 +59,9 @@ Error: ${error.message}
 Stack trace:
 ${error.stack || 'N/A'}
 
-Agent state: ${agent.state}
-Last active: ${agent.lastActiveAt}
+Execution state: ${agent.executionState}
+Desired state: ${agent.desiredExecutionState}
+Last heartbeat: ${agent.lastHeartbeat}
   `.trim();
 
   // Send to human if no specific recipient found
@@ -92,8 +93,8 @@ Error: ${error.message}
 Stack trace:
 ${error.stack || 'N/A'}
 
-Agent state: ${agent.state}
-Current task: ${agent.currentTaskId || 'N/A'}
+Execution state: ${agent.executionState}
+Current task: ${agent.currentTaskId ?? 'N/A'}
 
 This tool is marked as critical and requires immediate attention.
   `.trim();

--- a/src/backend/routers/mcp/server.test.ts
+++ b/src/backend/routers/mcp/server.test.ts
@@ -216,7 +216,7 @@ describe('executeMcpTool', () => {
       await executeMcpTool(agent.id, 'mcp__test__heartbeat', {});
 
       expect(mockAgentAccessor.update).toHaveBeenCalledWith(agent.id, {
-        lastActiveAt: expect.any(Date),
+        lastHeartbeat: expect.any(Date),
       });
     });
 

--- a/src/backend/routers/mcp/server.ts
+++ b/src/backend/routers/mcp/server.ts
@@ -130,7 +130,7 @@ async function executeWithRetry<TInput, TOutput>(
       const context: McpToolContext = { agentId };
       const result = await toolEntry.handler(context, toolInput);
       await decisionLogAccessor.createAutomatic(agentId, toolName, 'result', result);
-      await agentAccessor.update(agentId, { lastActiveAt: new Date() });
+      await agentAccessor.update(agentId, { lastHeartbeat: new Date() });
       return { success: true, result: result as McpToolResponse<TOutput> };
     } catch (error) {
       lastError = error instanceof Error ? error : new Error(String(error));

--- a/src/backend/routers/mcp/task.mcp.ts
+++ b/src/backend/routers/mcp/task.mcp.ts
@@ -77,16 +77,13 @@ const ForceCompleteTaskInputSchema = z.object({
  */
 function isValidStateTransition(from: TaskState, to: TaskState): boolean {
   const validTransitions: Record<TaskState, TaskState[]> = {
-    [TaskState.PLANNING]: [TaskState.PLANNED, TaskState.CANCELLED],
-    [TaskState.PLANNED]: [TaskState.IN_PROGRESS, TaskState.CANCELLED],
-    [TaskState.PENDING]: [TaskState.ASSIGNED, TaskState.IN_PROGRESS, TaskState.BLOCKED],
-    [TaskState.ASSIGNED]: [TaskState.IN_PROGRESS, TaskState.PENDING],
+    [TaskState.PENDING]: [TaskState.IN_PROGRESS, TaskState.BLOCKED, TaskState.FAILED],
+    [TaskState.PLANNING]: [TaskState.IN_PROGRESS, TaskState.FAILED],
     [TaskState.IN_PROGRESS]: [TaskState.REVIEW, TaskState.BLOCKED, TaskState.FAILED],
     [TaskState.REVIEW]: [TaskState.COMPLETED, TaskState.IN_PROGRESS, TaskState.BLOCKED],
     [TaskState.BLOCKED]: [TaskState.IN_PROGRESS, TaskState.FAILED, TaskState.PENDING],
     [TaskState.COMPLETED]: [],
     [TaskState.FAILED]: [TaskState.IN_PROGRESS, TaskState.PENDING],
-    [TaskState.CANCELLED]: [],
   };
 
   return validTransitions[from]?.includes(to) ?? false;

--- a/src/backend/services/index.ts
+++ b/src/backend/services/index.ts
@@ -14,6 +14,11 @@ export { createLogger } from './logger.service.js';
 export { notificationService } from './notification.service.js';
 // Rate limiter service
 export { rateLimiter } from './rate-limiter.service.js';
+// Reconciliation service
+export {
+  type ReconciliationResult,
+  reconciliationService,
+} from './reconciliation.service.js';
 // Worktree service
 export {
   type CleanupResult,

--- a/src/backend/services/reconciliation.service.test.ts
+++ b/src/backend/services/reconciliation.service.test.ts
@@ -1,0 +1,1206 @@
+/**
+ * Comprehensive scenario tests for the Reconciliation Service
+ *
+ * These tests verify the core reconciliation logic that maintains system consistency.
+ * The reconciliation service is critical infrastructure - it ensures:
+ * 1. Tasks get supervisors/workers when needed
+ * 2. Crashed agents are detected and handled
+ * 3. State mismatches are resolved
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Hoist mock definitions
+const mockAgentAccessor = vi.hoisted(() => ({
+  findById: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  findSupervisorByTopLevelTaskId: vi.fn(),
+  findPotentiallyCrashedAgents: vi.fn(),
+  findAgentsNeedingReconciliation: vi.fn(),
+  markAsCrashed: vi.fn(),
+  markReconciled: vi.fn(),
+  recordReconcileFailure: vi.fn(),
+}));
+
+const mockTaskAccessor = vi.hoisted(() => ({
+  findById: vi.fn(),
+  update: vi.fn(),
+  findTopLevelTasksNeedingSupervisors: vi.fn(),
+  findLeafTasksNeedingWorkers: vi.fn(),
+  findTasksWithMissingInfrastructure: vi.fn(),
+  isBlocked: vi.fn(),
+  getTopLevelParent: vi.fn(),
+  markReconciled: vi.fn(),
+  recordReconcileFailure: vi.fn(),
+}));
+
+const mockConfigService = vi.hoisted(() => ({
+  getSystemConfig: vi.fn(() => ({
+    agentHeartbeatThresholdMinutes: 5,
+    maxWorkerAttempts: 3,
+    crashLoopThresholdMs: 60_000,
+    maxRapidCrashes: 3,
+  })),
+}));
+
+const mockGitClientFactory = vi.hoisted(() => ({
+  forProject: vi.fn(() => ({
+    getWorktreePath: vi.fn((name: string) => `/tmp/worktrees/${name}`),
+    createWorktree: vi.fn(() =>
+      Promise.resolve({ branchName: 'test-branch', worktreePath: '/tmp/worktrees/test' })
+    ),
+  })),
+}));
+
+vi.mock('../resource_accessors/index.js', () => ({
+  agentAccessor: mockAgentAccessor,
+  taskAccessor: mockTaskAccessor,
+}));
+
+vi.mock('./config.service.js', () => ({
+  configService: mockConfigService,
+}));
+
+vi.mock('../clients/git.client.js', () => ({
+  GitClientFactory: mockGitClientFactory,
+}));
+
+vi.mock('./logger.service.js', () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+// Import after mocking
+import { AgentType, DesiredExecutionState, ExecutionState, TaskState } from '@prisma-gen/client';
+import { createAgent, createProject, createTask } from '../testing/factories.js';
+
+// Import the service after mocks are set up - need dynamic import due to module mocking
+// biome-ignore lint/plugin: vitest requires dynamic import after vi.mock()
+const { reconciliationService } = await import('./reconciliation.service.js');
+
+describe('ReconciliationService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default mock returns - empty arrays/null
+    mockAgentAccessor.findPotentiallyCrashedAgents.mockResolvedValue([]);
+    mockAgentAccessor.findAgentsNeedingReconciliation.mockResolvedValue([]);
+    mockTaskAccessor.findTopLevelTasksNeedingSupervisors.mockResolvedValue([]);
+    mockTaskAccessor.findLeafTasksNeedingWorkers.mockResolvedValue([]);
+    mockTaskAccessor.findTasksWithMissingInfrastructure.mockResolvedValue([]);
+    mockTaskAccessor.markReconciled.mockResolvedValue({});
+    mockAgentAccessor.markReconciled.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ============================================================================
+  // Phase 1: Crash Detection
+  // ============================================================================
+
+  describe('Phase 1: Crash Detection', () => {
+    it('should mark agents with stale heartbeats as crashed', async () => {
+      const staleAgent = createAgent({
+        id: 'stale-agent',
+        type: AgentType.WORKER,
+        executionState: ExecutionState.ACTIVE,
+        desiredExecutionState: DesiredExecutionState.ACTIVE,
+        lastHeartbeat: new Date(Date.now() - 10 * 60 * 1000), // 10 minutes ago
+      });
+
+      mockAgentAccessor.findPotentiallyCrashedAgents.mockResolvedValue([staleAgent]);
+      mockAgentAccessor.markAsCrashed.mockResolvedValue({
+        ...staleAgent,
+        executionState: ExecutionState.CRASHED,
+      });
+
+      const result = await reconciliationService.reconcileAll();
+
+      expect(mockAgentAccessor.markAsCrashed).toHaveBeenCalledWith('stale-agent');
+      expect(result.crashesDetected).toBe(1);
+    });
+
+    it('should not mark agents with recent heartbeats as crashed', async () => {
+      // No stale agents returned
+      mockAgentAccessor.findPotentiallyCrashedAgents.mockResolvedValue([]);
+
+      const result = await reconciliationService.reconcileAll();
+
+      expect(mockAgentAccessor.markAsCrashed).not.toHaveBeenCalled();
+      expect(result.crashesDetected).toBe(0);
+    });
+
+    it('should detect multiple crashed agents in one cycle', async () => {
+      const staleAgents = [
+        createAgent({ id: 'stale-1', type: AgentType.WORKER }),
+        createAgent({ id: 'stale-2', type: AgentType.WORKER }),
+        createAgent({ id: 'stale-3', type: AgentType.SUPERVISOR }),
+      ];
+
+      mockAgentAccessor.findPotentiallyCrashedAgents.mockResolvedValue(staleAgents);
+      mockAgentAccessor.markAsCrashed.mockResolvedValue({});
+
+      const result = await reconciliationService.reconcileAll();
+
+      expect(mockAgentAccessor.markAsCrashed).toHaveBeenCalledTimes(3);
+      expect(result.crashesDetected).toBe(3);
+    });
+
+    it('should continue processing if one crash marking fails', async () => {
+      const staleAgents = [createAgent({ id: 'stale-1' }), createAgent({ id: 'stale-2' })];
+
+      mockAgentAccessor.findPotentiallyCrashedAgents.mockResolvedValue(staleAgents);
+      mockAgentAccessor.markAsCrashed
+        .mockRejectedValueOnce(new Error('Database error'))
+        .mockResolvedValueOnce({});
+
+      const result = await reconciliationService.reconcileAll();
+
+      expect(mockAgentAccessor.markAsCrashed).toHaveBeenCalledTimes(2);
+      expect(result.crashesDetected).toBe(1);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toMatchObject({
+        entity: 'agent',
+        id: 'stale-1',
+        action: 'mark_crashed',
+      });
+    });
+  });
+
+  // ============================================================================
+  // Phase 2: Top-Level Task Reconciliation
+  // ============================================================================
+
+  describe('Phase 2: Top-Level Task Reconciliation', () => {
+    const project = createProject({ id: 'project-1' });
+
+    it('should create supervisor for PLANNING task without one', async () => {
+      const task = {
+        ...createTask({
+          id: 'top-level-1',
+          projectId: project.id,
+          parentId: null,
+          state: TaskState.PLANNING,
+        }),
+        project,
+        parent: null,
+        children: [],
+        assignedAgent: null,
+        supervisorAgent: null,
+        dependsOn: [],
+        dependents: [],
+      };
+
+      const newSupervisor = createAgent({
+        id: 'new-supervisor',
+        type: AgentType.SUPERVISOR,
+        currentTaskId: task.id,
+      });
+
+      mockTaskAccessor.findTopLevelTasksNeedingSupervisors.mockResolvedValue([task]);
+      // First call (during reconcileSingleTopLevelTask) returns null
+      // Second call (after reconciliation to count supervisors) returns the created supervisor
+      mockAgentAccessor.findSupervisorByTopLevelTaskId
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(newSupervisor);
+      mockAgentAccessor.create.mockResolvedValue(newSupervisor);
+
+      const result = await reconciliationService.reconcileAll();
+
+      expect(mockAgentAccessor.create).toHaveBeenCalledWith({
+        type: AgentType.SUPERVISOR,
+        currentTaskId: 'top-level-1',
+        desiredExecutionState: DesiredExecutionState.ACTIVE,
+        executionState: ExecutionState.IDLE,
+      });
+      expect(result.supervisorsCreated).toBe(1);
+    });
+
+    it('should create infrastructure (worktree) for top-level task', async () => {
+      const task = {
+        ...createTask({
+          id: 'top-level-1',
+          projectId: project.id,
+          parentId: null,
+          state: TaskState.PLANNING,
+        }),
+        project,
+        parent: null,
+        children: [],
+        assignedAgent: null,
+        supervisorAgent: null,
+        dependsOn: [],
+        dependents: [],
+      };
+
+      mockTaskAccessor.findTopLevelTasksNeedingSupervisors.mockResolvedValue([task]);
+      mockAgentAccessor.findSupervisorByTopLevelTaskId.mockResolvedValue(null);
+      mockAgentAccessor.create.mockResolvedValue(createAgent({ id: 'new-supervisor' }));
+      mockTaskAccessor.update.mockResolvedValue({});
+
+      await reconciliationService.reconcileAll();
+
+      expect(mockGitClientFactory.forProject).toHaveBeenCalledWith({
+        repoPath: project.repoPath,
+        worktreeBasePath: project.worktreeBasePath,
+      });
+      expect(mockTaskAccessor.update).toHaveBeenCalledWith(
+        'top-level-1',
+        expect.objectContaining({
+          worktreePath: expect.any(String),
+          branchName: expect.any(String),
+        })
+      );
+    });
+
+    it('should not create supervisor if one already exists (healthy)', async () => {
+      // Note: findTopLevelTasksNeedingSupervisors only returns tasks that don't have supervisors
+      // So if a supervisor already exists for a task, the task won't be in the list.
+      // This test verifies that when there are no tasks needing supervisors, none are created.
+
+      // No tasks need supervisors (all have healthy supervisors)
+      mockTaskAccessor.findTopLevelTasksNeedingSupervisors.mockResolvedValue([]);
+
+      const result = await reconciliationService.reconcileAll();
+
+      expect(mockAgentAccessor.create).not.toHaveBeenCalled();
+      expect(result.supervisorsCreated).toBe(0);
+    });
+
+    it('should reset crashed supervisor to trigger restart', async () => {
+      const task = {
+        ...createTask({
+          id: 'top-level-1',
+          projectId: project.id,
+          parentId: null,
+          state: TaskState.PLANNING,
+        }),
+        project,
+        parent: null,
+        children: [],
+        assignedAgent: null,
+        supervisorAgent: null,
+        dependsOn: [],
+        dependents: [],
+      };
+
+      const crashedSupervisor = createAgent({
+        id: 'crashed-supervisor',
+        type: AgentType.SUPERVISOR,
+        executionState: ExecutionState.CRASHED,
+        currentTaskId: task.id,
+      });
+
+      mockTaskAccessor.findTopLevelTasksNeedingSupervisors.mockResolvedValue([task]);
+      mockAgentAccessor.findSupervisorByTopLevelTaskId.mockResolvedValue(crashedSupervisor);
+      mockAgentAccessor.update.mockResolvedValue({});
+
+      await reconciliationService.reconcileAll();
+
+      // Should reset the crashed supervisor instead of creating new one
+      expect(mockAgentAccessor.update).toHaveBeenCalledWith('crashed-supervisor', {
+        desiredExecutionState: DesiredExecutionState.ACTIVE,
+        executionState: ExecutionState.IDLE,
+      });
+      expect(mockAgentAccessor.create).not.toHaveBeenCalled();
+    });
+
+    it('should not reconcile tasks not in PLANNING state', async () => {
+      // Service only looks for PLANNING tasks via findTopLevelTasksNeedingSupervisors
+      // So if we return empty, nothing should happen
+      mockTaskAccessor.findTopLevelTasksNeedingSupervisors.mockResolvedValue([]);
+
+      const result = await reconciliationService.reconcileAll();
+
+      expect(mockAgentAccessor.create).not.toHaveBeenCalled();
+      expect(result.supervisorsCreated).toBe(0);
+    });
+  });
+
+  // ============================================================================
+  // Phase 3: Leaf Task Reconciliation
+  // ============================================================================
+
+  describe('Phase 3: Leaf Task Reconciliation', () => {
+    const project = createProject({ id: 'project-1' });
+    const topLevelTask = createTask({
+      id: 'top-level-1',
+      projectId: project.id,
+      parentId: null,
+      state: TaskState.IN_PROGRESS,
+      branchName: 'top-level-branch',
+    });
+
+    it('should create worker for PENDING unblocked leaf task', async () => {
+      const leafTask = {
+        ...createTask({
+          id: 'leaf-1',
+          projectId: project.id,
+          parentId: topLevelTask.id,
+          state: TaskState.PENDING,
+          assignedAgentId: null,
+        }),
+        project,
+        parent: topLevelTask,
+        children: [],
+        assignedAgent: null,
+        supervisorAgent: null,
+        dependsOn: [],
+        dependents: [],
+      };
+
+      mockTaskAccessor.findLeafTasksNeedingWorkers.mockResolvedValue([leafTask]);
+      mockTaskAccessor.isBlocked.mockResolvedValue(false);
+      mockTaskAccessor.getTopLevelParent.mockResolvedValue(topLevelTask);
+      mockTaskAccessor.update.mockResolvedValue({});
+      mockAgentAccessor.create.mockResolvedValue(
+        createAgent({
+          id: 'new-worker',
+          type: AgentType.WORKER,
+          currentTaskId: leafTask.id,
+        })
+      );
+
+      const result = await reconciliationService.reconcileAll();
+
+      expect(mockAgentAccessor.create).toHaveBeenCalledWith({
+        type: AgentType.WORKER,
+        currentTaskId: 'leaf-1',
+        desiredExecutionState: DesiredExecutionState.ACTIVE,
+        executionState: ExecutionState.IDLE,
+      });
+      expect(mockTaskAccessor.update).toHaveBeenCalledWith(
+        'leaf-1',
+        expect.objectContaining({
+          state: TaskState.IN_PROGRESS,
+          assignedAgentId: 'new-worker',
+        })
+      );
+      expect(result.workersCreated).toBe(1);
+    });
+
+    it('should mark blocked task as BLOCKED', async () => {
+      const blockedTask = {
+        ...createTask({
+          id: 'blocked-1',
+          projectId: project.id,
+          parentId: topLevelTask.id,
+          state: TaskState.PENDING,
+        }),
+        project,
+        parent: topLevelTask,
+        children: [],
+        assignedAgent: null,
+        supervisorAgent: null,
+        dependsOn: [],
+        dependents: [],
+      };
+
+      mockTaskAccessor.findLeafTasksNeedingWorkers.mockResolvedValue([blockedTask]);
+      mockTaskAccessor.isBlocked.mockResolvedValue(true);
+      mockTaskAccessor.update.mockResolvedValue({});
+
+      await reconciliationService.reconcileAll();
+
+      expect(mockTaskAccessor.update).toHaveBeenCalledWith('blocked-1', {
+        state: TaskState.BLOCKED,
+      });
+      expect(mockAgentAccessor.create).not.toHaveBeenCalled();
+    });
+
+    it('should create worker for IN_PROGRESS task without one', async () => {
+      // Note: findLeafTasksNeedingWorkers only returns PENDING tasks,
+      // but the reconcileSingleLeafTask method handles IN_PROGRESS without worker too
+      // This scenario is handled when calling reconcileTask directly or when a task
+      // in the list has state changed during processing
+
+      const orphanedTask = {
+        ...createTask({
+          id: 'orphaned-1',
+          projectId: project.id,
+          parentId: topLevelTask.id,
+          state: TaskState.IN_PROGRESS,
+          assignedAgentId: null, // In progress but no worker!
+        }),
+        project,
+        parent: topLevelTask,
+        children: [],
+        assignedAgent: null,
+        supervisorAgent: null,
+        dependsOn: [],
+        dependents: [],
+      };
+
+      mockTaskAccessor.findById.mockResolvedValue(orphanedTask);
+      mockTaskAccessor.isBlocked.mockResolvedValue(false);
+      mockTaskAccessor.getTopLevelParent.mockResolvedValue(topLevelTask);
+      mockTaskAccessor.update.mockResolvedValue({});
+      mockAgentAccessor.create.mockResolvedValue(
+        createAgent({
+          id: 'new-worker',
+          type: AgentType.WORKER,
+        })
+      );
+
+      // Call reconcileTask directly for this scenario
+      await reconciliationService.reconcileTask('orphaned-1');
+
+      expect(mockAgentAccessor.create).toHaveBeenCalledWith({
+        type: AgentType.WORKER,
+        currentTaskId: 'orphaned-1',
+        desiredExecutionState: DesiredExecutionState.ACTIVE,
+        executionState: ExecutionState.IDLE,
+      });
+    });
+
+    it('should create infrastructure for task with missing worktree', async () => {
+      const taskMissingInfra = {
+        ...createTask({
+          id: 'no-infra-1',
+          projectId: project.id,
+          parentId: topLevelTask.id,
+          state: TaskState.IN_PROGRESS,
+          worktreePath: null, // Missing!
+          branchName: null, // Missing!
+          assignedAgentId: 'some-worker',
+        }),
+        project,
+        parent: topLevelTask,
+        children: [],
+        assignedAgent: null,
+        supervisorAgent: null,
+        dependsOn: [],
+        dependents: [],
+      };
+
+      mockTaskAccessor.findTasksWithMissingInfrastructure.mockResolvedValue([taskMissingInfra]);
+      mockTaskAccessor.findById.mockResolvedValue(taskMissingInfra);
+      mockTaskAccessor.getTopLevelParent.mockResolvedValue({
+        ...topLevelTask,
+        branchName: 'top-level-branch',
+      });
+      mockTaskAccessor.update.mockResolvedValue({});
+
+      const result = await reconciliationService.reconcileAll();
+
+      expect(mockGitClientFactory.forProject).toHaveBeenCalled();
+      expect(mockTaskAccessor.update).toHaveBeenCalledWith(
+        'no-infra-1',
+        expect.objectContaining({
+          worktreePath: expect.any(String),
+          branchName: expect.any(String),
+        })
+      );
+      expect(result.infrastructureCreated).toBeGreaterThan(0);
+    });
+
+    it('should handle multiple leaf tasks in one cycle', async () => {
+      const task1 = {
+        ...createTask({
+          id: 'leaf-1',
+          projectId: project.id,
+          parentId: topLevelTask.id,
+          state: TaskState.PENDING,
+        }),
+        project,
+        parent: topLevelTask,
+        children: [],
+        assignedAgent: null,
+        supervisorAgent: null,
+        dependsOn: [],
+        dependents: [],
+      };
+      const task2 = {
+        ...createTask({
+          id: 'leaf-2',
+          projectId: project.id,
+          parentId: topLevelTask.id,
+          state: TaskState.PENDING,
+        }),
+        project,
+        parent: topLevelTask,
+        children: [],
+        assignedAgent: null,
+        supervisorAgent: null,
+        dependsOn: [],
+        dependents: [],
+      };
+
+      mockTaskAccessor.findLeafTasksNeedingWorkers.mockResolvedValue([task1, task2]);
+      mockTaskAccessor.isBlocked.mockResolvedValue(false);
+      mockTaskAccessor.getTopLevelParent.mockResolvedValue(topLevelTask);
+      mockTaskAccessor.update.mockResolvedValue({});
+      // Mock findById for race condition checks - return tasks without assignedAgentId
+      mockTaskAccessor.findById.mockImplementation((id: string) => {
+        if (id === 'leaf-1') {
+          return Promise.resolve({ ...task1, assignedAgentId: null });
+        }
+        if (id === 'leaf-2') {
+          return Promise.resolve({ ...task2, assignedAgentId: null });
+        }
+        return Promise.resolve(null);
+      });
+      mockAgentAccessor.create
+        .mockResolvedValueOnce(createAgent({ id: 'worker-1' }))
+        .mockResolvedValueOnce(createAgent({ id: 'worker-2' }));
+
+      const result = await reconciliationService.reconcileAll();
+
+      expect(mockAgentAccessor.create).toHaveBeenCalledTimes(2);
+      expect(result.workersCreated).toBe(2);
+    });
+  });
+
+  // ============================================================================
+  // Phase 4: Agent State Reconciliation
+  // ============================================================================
+
+  describe('Phase 4: Agent State Reconciliation', () => {
+    it('should transition IDLE agent to ACTIVE when desired', async () => {
+      const agent = createAgent({
+        id: 'agent-1',
+        executionState: ExecutionState.IDLE,
+        desiredExecutionState: DesiredExecutionState.ACTIVE,
+      });
+
+      mockAgentAccessor.findAgentsNeedingReconciliation.mockResolvedValue([agent]);
+      mockAgentAccessor.update.mockResolvedValue({});
+
+      const result = await reconciliationService.reconcileAll();
+
+      expect(mockAgentAccessor.update).toHaveBeenCalledWith('agent-1', {
+        executionState: ExecutionState.ACTIVE,
+      });
+      expect(result.agentsReconciled).toBe(1);
+    });
+
+    it('should transition ACTIVE agent to IDLE when desired', async () => {
+      const agent = createAgent({
+        id: 'agent-1',
+        executionState: ExecutionState.ACTIVE,
+        desiredExecutionState: DesiredExecutionState.IDLE,
+      });
+
+      mockAgentAccessor.findAgentsNeedingReconciliation.mockResolvedValue([agent]);
+      mockAgentAccessor.update.mockResolvedValue({});
+
+      await reconciliationService.reconcileAll();
+
+      expect(mockAgentAccessor.update).toHaveBeenCalledWith('agent-1', {
+        executionState: ExecutionState.IDLE,
+      });
+    });
+
+    it('should transition ACTIVE agent to PAUSED when desired', async () => {
+      const agent = createAgent({
+        id: 'agent-1',
+        executionState: ExecutionState.ACTIVE,
+        desiredExecutionState: DesiredExecutionState.PAUSED,
+      });
+
+      mockAgentAccessor.findAgentsNeedingReconciliation.mockResolvedValue([agent]);
+      mockAgentAccessor.update.mockResolvedValue({});
+
+      await reconciliationService.reconcileAll();
+
+      expect(mockAgentAccessor.update).toHaveBeenCalledWith('agent-1', {
+        executionState: ExecutionState.PAUSED,
+      });
+    });
+
+    it('should recover CRASHED agent when desired ACTIVE', async () => {
+      const crashedAgent = createAgent({
+        id: 'crashed-1',
+        executionState: ExecutionState.CRASHED,
+        desiredExecutionState: DesiredExecutionState.ACTIVE,
+      });
+
+      mockAgentAccessor.findAgentsNeedingReconciliation.mockResolvedValue([crashedAgent]);
+      mockAgentAccessor.update.mockResolvedValue({});
+
+      await reconciliationService.reconcileAll();
+
+      expect(mockAgentAccessor.update).toHaveBeenCalledWith('crashed-1', {
+        executionState: ExecutionState.ACTIVE,
+      });
+    });
+
+    it('should only mark reconciled if states already match', async () => {
+      const matchedAgent = createAgent({
+        id: 'matched-1',
+        executionState: ExecutionState.ACTIVE,
+        desiredExecutionState: DesiredExecutionState.ACTIVE,
+      });
+
+      mockAgentAccessor.findAgentsNeedingReconciliation.mockResolvedValue([matchedAgent]);
+
+      await reconciliationService.reconcileAll();
+
+      expect(mockAgentAccessor.update).not.toHaveBeenCalled();
+      expect(mockAgentAccessor.markReconciled).toHaveBeenCalledWith('matched-1');
+    });
+
+    it('should handle multiple agents with different state transitions', async () => {
+      const agents = [
+        createAgent({
+          id: 'agent-1',
+          executionState: ExecutionState.IDLE,
+          desiredExecutionState: DesiredExecutionState.ACTIVE,
+        }),
+        createAgent({
+          id: 'agent-2',
+          executionState: ExecutionState.ACTIVE,
+          desiredExecutionState: DesiredExecutionState.PAUSED,
+        }),
+        createAgent({
+          id: 'agent-3',
+          executionState: ExecutionState.PAUSED,
+          desiredExecutionState: DesiredExecutionState.IDLE,
+        }),
+      ];
+
+      mockAgentAccessor.findAgentsNeedingReconciliation.mockResolvedValue(agents);
+      mockAgentAccessor.update.mockResolvedValue({});
+
+      const result = await reconciliationService.reconcileAll();
+
+      expect(mockAgentAccessor.update).toHaveBeenCalledWith('agent-1', {
+        executionState: ExecutionState.ACTIVE,
+      });
+      expect(mockAgentAccessor.update).toHaveBeenCalledWith('agent-2', {
+        executionState: ExecutionState.PAUSED,
+      });
+      expect(mockAgentAccessor.update).toHaveBeenCalledWith('agent-3', {
+        executionState: ExecutionState.IDLE,
+      });
+      expect(result.agentsReconciled).toBe(3);
+    });
+  });
+
+  // ============================================================================
+  // Single Entity Reconciliation (reconcileTask / reconcileAgent)
+  // ============================================================================
+
+  describe('Single Entity Reconciliation', () => {
+    describe('reconcileTask', () => {
+      it('should handle non-existent task gracefully', async () => {
+        mockTaskAccessor.findById.mockResolvedValue(null);
+
+        // Should not throw
+        await expect(reconciliationService.reconcileTask('nonexistent')).resolves.not.toThrow();
+      });
+
+      it('should reconcile top-level task via reconcileSingleTopLevelTask', async () => {
+        const project = createProject({ id: 'project-1' });
+        const task = {
+          ...createTask({
+            id: 'top-level-1',
+            projectId: project.id,
+            parentId: null,
+            state: TaskState.PLANNING,
+          }),
+          project,
+          parent: null,
+          children: [],
+          assignedAgent: null,
+          supervisorAgent: null,
+          dependsOn: [],
+          dependents: [],
+        };
+
+        mockTaskAccessor.findById.mockResolvedValue(task);
+        mockAgentAccessor.findSupervisorByTopLevelTaskId.mockResolvedValue(null);
+        mockAgentAccessor.create.mockResolvedValue(createAgent({ id: 'new-supervisor' }));
+        mockTaskAccessor.update.mockResolvedValue({});
+
+        await reconciliationService.reconcileTask('top-level-1');
+
+        expect(mockAgentAccessor.create).toHaveBeenCalled();
+        expect(mockTaskAccessor.markReconciled).toHaveBeenCalledWith('top-level-1');
+      });
+
+      it('should reconcile leaf task via reconcileSingleLeafTask', async () => {
+        const project = createProject({ id: 'project-1' });
+        const topLevelTask = createTask({ id: 'top-level', parentId: null, branchName: 'main' });
+        const task = {
+          ...createTask({
+            id: 'leaf-1',
+            projectId: project.id,
+            parentId: 'top-level',
+            state: TaskState.PENDING,
+          }),
+          project,
+          parent: topLevelTask,
+          children: [],
+          assignedAgent: null,
+          supervisorAgent: null,
+          dependsOn: [],
+          dependents: [],
+        };
+
+        mockTaskAccessor.findById.mockResolvedValue(task);
+        mockTaskAccessor.isBlocked.mockResolvedValue(false);
+        mockTaskAccessor.getTopLevelParent.mockResolvedValue(topLevelTask);
+        mockTaskAccessor.update.mockResolvedValue({});
+        mockAgentAccessor.create.mockResolvedValue(createAgent({ id: 'new-worker' }));
+
+        await reconciliationService.reconcileTask('leaf-1');
+
+        expect(mockAgentAccessor.create).toHaveBeenCalled();
+        expect(mockTaskAccessor.markReconciled).toHaveBeenCalledWith('leaf-1');
+      });
+
+      it('should record failure on error', async () => {
+        const project = createProject({ id: 'project-1' });
+        const task = {
+          ...createTask({
+            id: 'failing-task',
+            projectId: project.id,
+            parentId: null,
+            state: TaskState.PLANNING,
+          }),
+          project: null, // Will cause error - no project!
+          parent: null,
+          children: [],
+          assignedAgent: null,
+          supervisorAgent: null,
+          dependsOn: [],
+          dependents: [],
+        };
+
+        mockTaskAccessor.findById.mockResolvedValue(task);
+        mockAgentAccessor.findSupervisorByTopLevelTaskId.mockResolvedValue(null);
+        mockAgentAccessor.create.mockResolvedValue(createAgent({ id: 'supervisor' }));
+        mockTaskAccessor.recordReconcileFailure.mockResolvedValue({});
+
+        await reconciliationService.reconcileTask('failing-task');
+
+        expect(mockTaskAccessor.recordReconcileFailure).toHaveBeenCalledWith(
+          'failing-task',
+          expect.stringContaining('no associated project'),
+          'reconcile_task'
+        );
+      });
+    });
+
+    describe('reconcileAgent', () => {
+      it('should handle non-existent agent gracefully', async () => {
+        mockAgentAccessor.findById.mockResolvedValue(null);
+
+        await expect(reconciliationService.reconcileAgent('nonexistent')).resolves.not.toThrow();
+      });
+
+      it('should reconcile agent state mismatch', async () => {
+        const agent = createAgent({
+          id: 'agent-1',
+          executionState: ExecutionState.IDLE,
+          desiredExecutionState: DesiredExecutionState.ACTIVE,
+        });
+
+        mockAgentAccessor.findById.mockResolvedValue(agent);
+        mockAgentAccessor.update.mockResolvedValue({});
+
+        await reconciliationService.reconcileAgent('agent-1');
+
+        expect(mockAgentAccessor.update).toHaveBeenCalledWith('agent-1', {
+          executionState: ExecutionState.ACTIVE,
+        });
+        expect(mockAgentAccessor.markReconciled).toHaveBeenCalledWith('agent-1');
+      });
+
+      it('should record failure on error', async () => {
+        const agent = createAgent({
+          id: 'failing-agent',
+          executionState: ExecutionState.IDLE,
+          desiredExecutionState: DesiredExecutionState.ACTIVE,
+        });
+
+        mockAgentAccessor.findById.mockResolvedValue(agent);
+        mockAgentAccessor.update.mockRejectedValue(new Error('Database error'));
+        mockAgentAccessor.recordReconcileFailure.mockResolvedValue({});
+
+        await reconciliationService.reconcileAgent('failing-agent');
+
+        expect(mockAgentAccessor.recordReconcileFailure).toHaveBeenCalledWith(
+          'failing-agent',
+          'Database error',
+          'reconcile_agent'
+        );
+      });
+    });
+  });
+
+  // ============================================================================
+  // Full Reconciliation Cycle
+  // ============================================================================
+
+  describe('Full Reconciliation Cycle', () => {
+    it('should run all four phases in order', async () => {
+      const callOrder: string[] = [];
+
+      mockAgentAccessor.findPotentiallyCrashedAgents.mockImplementation(() => {
+        callOrder.push('phase1_crash_detection');
+        return Promise.resolve([]);
+      });
+      mockTaskAccessor.findTopLevelTasksNeedingSupervisors.mockImplementation(() => {
+        callOrder.push('phase2_top_level');
+        return Promise.resolve([]);
+      });
+      mockTaskAccessor.findLeafTasksNeedingWorkers.mockImplementation(() => {
+        callOrder.push('phase3_leaf');
+        return Promise.resolve([]);
+      });
+      mockAgentAccessor.findAgentsNeedingReconciliation.mockImplementation(() => {
+        callOrder.push('phase4_agents');
+        return Promise.resolve([]);
+      });
+
+      await reconciliationService.reconcileAll();
+
+      expect(callOrder).toEqual([
+        'phase1_crash_detection',
+        'phase2_top_level',
+        'phase3_leaf',
+        'phase4_agents',
+      ]);
+    });
+
+    it('should return success when no errors occur', async () => {
+      const result = await reconciliationService.reconcileAll();
+
+      expect(result.success).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should return failure when errors occur', async () => {
+      mockAgentAccessor.findPotentiallyCrashedAgents.mockRejectedValue(new Error('Phase 1 failed'));
+
+      const result = await reconciliationService.reconcileAll();
+
+      expect(result.success).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it('should aggregate results from all phases', async () => {
+      const project = createProject({ id: 'project-1' });
+      const topLevelTask = {
+        ...createTask({
+          id: 'top-level-1',
+          projectId: project.id,
+          parentId: null,
+          state: TaskState.PLANNING,
+        }),
+        project,
+        parent: null,
+        children: [],
+        assignedAgent: null,
+        supervisorAgent: null,
+        dependsOn: [],
+        dependents: [],
+      };
+      const leafTask = {
+        ...createTask({
+          id: 'leaf-1',
+          projectId: project.id,
+          parentId: 'top-level-1',
+          state: TaskState.PENDING,
+        }),
+        project,
+        parent: topLevelTask,
+        children: [],
+        assignedAgent: null,
+        supervisorAgent: null,
+        dependsOn: [],
+        dependents: [],
+      };
+
+      // Phase 1: One crashed agent
+      const staleAgent = createAgent({
+        id: 'stale-1',
+        executionState: ExecutionState.ACTIVE,
+      });
+      mockAgentAccessor.findPotentiallyCrashedAgents.mockResolvedValue([staleAgent]);
+      mockAgentAccessor.markAsCrashed.mockResolvedValue({});
+
+      // Phase 2: One top-level task needing supervisor
+      const newSupervisor = createAgent({ id: 'new-supervisor', type: AgentType.SUPERVISOR });
+      mockTaskAccessor.findTopLevelTasksNeedingSupervisors.mockResolvedValue([topLevelTask]);
+      // First call returns null (checking if exists), second returns created supervisor (counting)
+      mockAgentAccessor.findSupervisorByTopLevelTaskId
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(newSupervisor);
+      mockAgentAccessor.create
+        .mockResolvedValueOnce(newSupervisor)
+        .mockResolvedValueOnce(createAgent({ id: 'new-worker', type: AgentType.WORKER }));
+
+      // Phase 3: One leaf task needing worker
+      mockTaskAccessor.findLeafTasksNeedingWorkers.mockResolvedValue([leafTask]);
+      mockTaskAccessor.isBlocked.mockResolvedValue(false);
+      mockTaskAccessor.getTopLevelParent.mockResolvedValue({ ...topLevelTask, branchName: 'main' });
+      mockTaskAccessor.update.mockResolvedValue({});
+
+      // Phase 4: One agent needing state change
+      const agentNeedingReconcile = createAgent({
+        id: 'reconcile-1',
+        executionState: ExecutionState.IDLE,
+        desiredExecutionState: DesiredExecutionState.ACTIVE,
+      });
+      mockAgentAccessor.findAgentsNeedingReconciliation.mockResolvedValue([agentNeedingReconcile]);
+      mockAgentAccessor.update.mockResolvedValue({});
+
+      const result = await reconciliationService.reconcileAll();
+
+      expect(result.crashesDetected).toBe(1);
+      expect(result.supervisorsCreated).toBe(1);
+      expect(result.workersCreated).toBe(1);
+      expect(result.agentsReconciled).toBe(1);
+      expect(result.tasksReconciled).toBe(2); // top-level + leaf
+    });
+
+    it('should continue processing other phases if one phase fails', async () => {
+      // Phase 1 fails
+      mockAgentAccessor.findPotentiallyCrashedAgents.mockRejectedValue(new Error('Phase 1 error'));
+
+      // But phases 2-4 should still run
+      mockTaskAccessor.findTopLevelTasksNeedingSupervisors.mockResolvedValue([]);
+      mockTaskAccessor.findLeafTasksNeedingWorkers.mockResolvedValue([]);
+      mockAgentAccessor.findAgentsNeedingReconciliation.mockResolvedValue([]);
+
+      const result = await reconciliationService.reconcileAll();
+
+      // All phases should have been attempted
+      expect(mockTaskAccessor.findTopLevelTasksNeedingSupervisors).toHaveBeenCalled();
+      expect(mockTaskAccessor.findLeafTasksNeedingWorkers).toHaveBeenCalled();
+      expect(mockAgentAccessor.findAgentsNeedingReconciliation).toHaveBeenCalled();
+
+      // But result should indicate failure
+      expect(result.success).toBe(false);
+    });
+  });
+
+  // ============================================================================
+  // Idempotency Tests
+  // ============================================================================
+
+  describe('Idempotency', () => {
+    it('should produce same result when run twice with no state changes', async () => {
+      // First run
+      const result1 = await reconciliationService.reconcileAll();
+
+      // Second run (no changes in between)
+      const result2 = await reconciliationService.reconcileAll();
+
+      expect(result1).toEqual(result2);
+    });
+
+    it('should not create duplicate supervisors', async () => {
+      const project = createProject({ id: 'project-1' });
+      const task = {
+        ...createTask({
+          id: 'top-level-1',
+          projectId: project.id,
+          parentId: null,
+          state: TaskState.PLANNING,
+        }),
+        project,
+        parent: null,
+        children: [],
+        assignedAgent: null,
+        supervisorAgent: null,
+        dependsOn: [],
+        dependents: [],
+      };
+
+      // First run - no supervisor exists
+      mockTaskAccessor.findTopLevelTasksNeedingSupervisors.mockResolvedValueOnce([task]);
+      mockAgentAccessor.findSupervisorByTopLevelTaskId.mockResolvedValueOnce(null);
+      mockAgentAccessor.create.mockResolvedValueOnce(createAgent({ id: 'supervisor-1' }));
+      mockTaskAccessor.update.mockResolvedValue({});
+
+      await reconciliationService.reconcileAll();
+
+      expect(mockAgentAccessor.create).toHaveBeenCalledTimes(1);
+
+      // Second run - supervisor now exists
+      const createdSupervisor = createAgent({
+        id: 'supervisor-1',
+        type: AgentType.SUPERVISOR,
+        executionState: ExecutionState.ACTIVE,
+      });
+      mockTaskAccessor.findTopLevelTasksNeedingSupervisors.mockResolvedValueOnce([task]);
+      mockAgentAccessor.findSupervisorByTopLevelTaskId.mockResolvedValueOnce(createdSupervisor);
+
+      await reconciliationService.reconcileAll();
+
+      // Should still only have created once
+      expect(mockAgentAccessor.create).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ============================================================================
+  // Edge Cases
+  // ============================================================================
+
+  describe('Edge Cases', () => {
+    it('should handle empty database gracefully', async () => {
+      const result = await reconciliationService.reconcileAll();
+
+      expect(result.success).toBe(true);
+      expect(result.tasksReconciled).toBe(0);
+      expect(result.agentsReconciled).toBe(0);
+      expect(result.supervisorsCreated).toBe(0);
+      expect(result.workersCreated).toBe(0);
+      expect(result.crashesDetected).toBe(0);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should handle task without project when creating infrastructure', async () => {
+      const task = {
+        ...createTask({
+          id: 'no-project-task',
+          parentId: null,
+          state: TaskState.PLANNING,
+        }),
+        project: null, // No project!
+        parent: null,
+        children: [],
+        assignedAgent: null,
+        supervisorAgent: null,
+        dependsOn: [],
+        dependents: [],
+      };
+
+      mockTaskAccessor.findTopLevelTasksNeedingSupervisors.mockResolvedValue([task]);
+      mockAgentAccessor.findSupervisorByTopLevelTaskId.mockResolvedValue(null);
+      mockAgentAccessor.create.mockResolvedValue(createAgent({ id: 'supervisor' }));
+
+      const result = await reconciliationService.reconcileAll();
+
+      // Should have recorded an error for this task
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          entity: 'task',
+          id: 'no-project-task',
+        })
+      );
+    });
+
+    it('should handle leaf task without top-level parent', async () => {
+      const project = createProject({ id: 'project-1' });
+      const orphanedLeaf = {
+        ...createTask({
+          id: 'orphaned-leaf',
+          projectId: project.id,
+          parentId: 'nonexistent-parent',
+          state: TaskState.IN_PROGRESS,
+          worktreePath: null,
+        }),
+        project,
+        parent: null,
+        children: [],
+        assignedAgent: null,
+        supervisorAgent: null,
+        dependsOn: [],
+        dependents: [],
+      };
+
+      mockTaskAccessor.findTasksWithMissingInfrastructure.mockResolvedValue([orphanedLeaf]);
+      mockTaskAccessor.findById.mockResolvedValue(orphanedLeaf);
+      mockTaskAccessor.getTopLevelParent.mockResolvedValue(null); // No parent!
+
+      const result = await reconciliationService.reconcileAll();
+
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          entity: 'task',
+          id: 'orphaned-leaf',
+        })
+      );
+    });
+
+    it('should handle git client errors during infrastructure creation', async () => {
+      const project = createProject({ id: 'project-1' });
+      const task = {
+        ...createTask({
+          id: 'top-level-1',
+          projectId: project.id,
+          parentId: null,
+          state: TaskState.PLANNING,
+        }),
+        project,
+        parent: null,
+        children: [],
+        assignedAgent: null,
+        supervisorAgent: null,
+        dependsOn: [],
+        dependents: [],
+      };
+
+      mockTaskAccessor.findTopLevelTasksNeedingSupervisors.mockResolvedValue([task]);
+      mockAgentAccessor.findSupervisorByTopLevelTaskId.mockResolvedValue(null);
+      mockAgentAccessor.create.mockResolvedValue(createAgent({ id: 'supervisor' }));
+
+      // Make git client fail
+      mockGitClientFactory.forProject.mockReturnValue({
+        getWorktreePath: vi.fn(() => '/tmp/worktrees/test'),
+        createWorktree: vi.fn().mockRejectedValue(new Error('Git worktree creation failed')),
+      });
+
+      const result = await reconciliationService.reconcileAll();
+
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          entity: 'task',
+          id: 'top-level-1',
+          error: expect.stringContaining('Git worktree creation failed'),
+        })
+      );
+    });
+  });
+
+  // ============================================================================
+  // State Matching Logic
+  // ============================================================================
+
+  describe('State Matching Logic', () => {
+    it.each([
+      [ExecutionState.ACTIVE, DesiredExecutionState.ACTIVE, true],
+      [ExecutionState.IDLE, DesiredExecutionState.IDLE, true],
+      [ExecutionState.PAUSED, DesiredExecutionState.PAUSED, true],
+      [ExecutionState.IDLE, DesiredExecutionState.ACTIVE, false],
+      [ExecutionState.ACTIVE, DesiredExecutionState.IDLE, false],
+      [ExecutionState.CRASHED, DesiredExecutionState.ACTIVE, false],
+      [ExecutionState.ACTIVE, DesiredExecutionState.PAUSED, false],
+    ])('should correctly determine match: actual=%s, desired=%s -> %s', async (actual, desired, shouldMatch) => {
+      const agent = createAgent({
+        id: 'test-agent',
+        executionState: actual,
+        desiredExecutionState: desired,
+      });
+
+      mockAgentAccessor.findAgentsNeedingReconciliation.mockResolvedValue([agent]);
+      mockAgentAccessor.update.mockResolvedValue({});
+
+      await reconciliationService.reconcileAll();
+
+      if (shouldMatch) {
+        // States match - should only mark reconciled, not update
+        expect(mockAgentAccessor.update).not.toHaveBeenCalled();
+        expect(mockAgentAccessor.markReconciled).toHaveBeenCalledWith('test-agent');
+      } else {
+        // States don't match - should update or mark reconciled depending on transition
+        // Note: Not all mismatches result in updates (e.g., CRASHED with desired IDLE)
+        const updateCalls = mockAgentAccessor.update.mock.calls;
+        const markReconciledCalls = mockAgentAccessor.markReconciled.mock.calls;
+        expect(updateCalls.length + markReconciledCalls.length).toBeGreaterThan(0);
+      }
+    });
+  });
+});

--- a/src/backend/services/reconciliation.service.ts
+++ b/src/backend/services/reconciliation.service.ts
@@ -1,0 +1,658 @@
+/**
+ * Reconciliation Service
+ *
+ * The core of the reconciliation-based task infrastructure.
+ * Continuously reconciles desired state with actual state,
+ * implementing a self-healing, declarative approach.
+ *
+ * Key principles:
+ * 1. Level-triggered, not edge-triggered - continuously check "is reality correct?"
+ * 2. Separate task state from agent state
+ * 3. Events update state, reconciler acts
+ * 4. Hybrid triggering - events trigger immediate reconciliation; periodic cron catches drift
+ */
+
+import type { Task } from '@prisma-gen/client';
+import { AgentType, DesiredExecutionState, ExecutionState, TaskState } from '@prisma-gen/client';
+import { GitClientFactory } from '../clients/git.client.js';
+import { agentAccessor, taskAccessor } from '../resource_accessors/index.js';
+import type { TaskWithRelations } from '../resource_accessors/task.accessor.js';
+import { configService } from './config.service.js';
+import { createLogger } from './logger.service.js';
+
+const logger = createLogger('reconciliation');
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface ReconciliationResult {
+  success: boolean;
+  tasksReconciled: number;
+  agentsReconciled: number;
+  supervisorsCreated: number;
+  workersCreated: number;
+  infrastructureCreated: number;
+  crashesDetected: number;
+  errors: Array<{ entity: string; id: string; error: string; action: string }>;
+}
+
+export interface TaskReconcileAction {
+  taskId: string;
+  action:
+    | 'create_supervisor'
+    | 'create_worker'
+    | 'create_infrastructure'
+    | 'mark_blocked'
+    | 'unblock'
+    | 'none';
+  reason: string;
+}
+
+export interface AgentReconcileAction {
+  agentId: string;
+  action: 'start' | 'stop' | 'mark_crashed' | 'restart' | 'none';
+  reason: string;
+}
+
+// ============================================================================
+// Reconciliation Service
+// ============================================================================
+
+class ReconciliationService {
+  /**
+   * Main reconciliation loop - runs periodically to ensure system consistency.
+   * This is the primary entry point for the reconciler.
+   */
+  async reconcileAll(): Promise<ReconciliationResult> {
+    const result: ReconciliationResult = {
+      success: true,
+      tasksReconciled: 0,
+      agentsReconciled: 0,
+      supervisorsCreated: 0,
+      workersCreated: 0,
+      infrastructureCreated: 0,
+      crashesDetected: 0,
+      errors: [],
+    };
+
+    logger.info('Starting reconciliation cycle');
+
+    try {
+      // Phase 1: Detect crashed agents
+      const crashResult = await this.detectAndMarkCrashedAgents();
+      result.crashesDetected = crashResult.crashesDetected;
+      result.errors.push(...crashResult.errors);
+
+      // Phase 2: Reconcile top-level tasks (supervisors)
+      const topLevelResult = await this.reconcileTopLevelTasks();
+      result.supervisorsCreated = topLevelResult.supervisorsCreated;
+      result.errors.push(...topLevelResult.errors);
+
+      // Phase 3: Reconcile leaf tasks (workers + infrastructure)
+      const leafResult = await this.reconcileLeafTasks();
+      result.workersCreated = leafResult.workersCreated;
+      result.infrastructureCreated = leafResult.infrastructureCreated;
+      result.errors.push(...leafResult.errors);
+
+      // Phase 4: Reconcile agent execution states
+      const agentResult = await this.reconcileAgentStates();
+      result.agentsReconciled = agentResult.agentsReconciled;
+      result.errors.push(...agentResult.errors);
+
+      // Calculate totals
+      result.tasksReconciled = topLevelResult.tasksReconciled + leafResult.tasksReconciled;
+      result.success = result.errors.length === 0;
+
+      logger.info('Reconciliation cycle complete', {
+        tasksReconciled: result.tasksReconciled,
+        agentsReconciled: result.agentsReconciled,
+        supervisorsCreated: result.supervisorsCreated,
+        workersCreated: result.workersCreated,
+        infrastructureCreated: result.infrastructureCreated,
+        crashesDetected: result.crashesDetected,
+        errorCount: result.errors.length,
+      });
+    } catch (error) {
+      result.success = false;
+      result.errors.push({
+        entity: 'system',
+        id: 'reconciliation',
+        error: error instanceof Error ? error.message : String(error),
+        action: 'reconcile_all',
+      });
+      logger.error('Reconciliation cycle failed', error as Error);
+    }
+
+    return result;
+  }
+
+  /**
+   * Reconcile a single task (called after state changes for immediate reconciliation)
+   */
+  async reconcileTask(taskId: string): Promise<void> {
+    const task = await taskAccessor.findById(taskId);
+    if (!task) {
+      logger.warn('Task not found for reconciliation', { taskId });
+      return;
+    }
+
+    logger.debug('Reconciling single task', { taskId, state: task.state });
+
+    try {
+      if (task.parentId === null) {
+        // Top-level task
+        await this.reconcileSingleTopLevelTask(task);
+      } else {
+        // Leaf task
+        await this.reconcileSingleLeafTask(task);
+      }
+
+      await taskAccessor.markReconciled(taskId);
+    } catch (error) {
+      await taskAccessor.recordReconcileFailure(
+        taskId,
+        error instanceof Error ? error.message : String(error),
+        'reconcile_task'
+      );
+      logger.error('Failed to reconcile task', error as Error, { taskId });
+    }
+  }
+
+  /**
+   * Reconcile a single agent (called after state changes for immediate reconciliation)
+   */
+  async reconcileAgent(agentId: string): Promise<void> {
+    const agent = await agentAccessor.findById(agentId);
+    if (!agent) {
+      logger.warn('Agent not found for reconciliation', { agentId });
+      return;
+    }
+
+    logger.debug('Reconciling single agent', {
+      agentId,
+      executionState: agent.executionState,
+      desiredExecutionState: agent.desiredExecutionState,
+    });
+
+    try {
+      await this.reconcileSingleAgentState(agent);
+      await agentAccessor.markReconciled(agentId);
+    } catch (error) {
+      await agentAccessor.recordReconcileFailure(
+        agentId,
+        error instanceof Error ? error.message : String(error),
+        'reconcile_agent'
+      );
+      logger.error('Failed to reconcile agent', error as Error, { agentId });
+    }
+  }
+
+  // ============================================================================
+  // Phase 1: Crash Detection
+  // ============================================================================
+
+  private async detectAndMarkCrashedAgents(): Promise<{
+    crashesDetected: number;
+    errors: ReconciliationResult['errors'];
+  }> {
+    const errors: ReconciliationResult['errors'] = [];
+    let crashesDetected = 0;
+
+    try {
+      const config = configService.getSystemConfig();
+      const heartbeatThreshold = config.agentHeartbeatThresholdMinutes;
+
+      // Find agents that should be active but haven't sent a heartbeat recently
+      const potentiallyCrashed =
+        await agentAccessor.findPotentiallyCrashedAgents(heartbeatThreshold);
+
+      for (const agent of potentiallyCrashed) {
+        try {
+          logger.warn('Marking agent as crashed (stale heartbeat)', {
+            agentId: agent.id,
+            agentType: agent.type,
+            lastHeartbeat: agent.lastHeartbeat?.toISOString(),
+          });
+
+          await agentAccessor.markAsCrashed(agent.id);
+          crashesDetected++;
+        } catch (error) {
+          errors.push({
+            entity: 'agent',
+            id: agent.id,
+            error: error instanceof Error ? error.message : String(error),
+            action: 'mark_crashed',
+          });
+        }
+      }
+    } catch (error) {
+      errors.push({
+        entity: 'system',
+        id: 'crash_detection',
+        error: error instanceof Error ? error.message : String(error),
+        action: 'detect_crashes',
+      });
+    }
+
+    return { crashesDetected, errors };
+  }
+
+  // ============================================================================
+  // Phase 2: Top-Level Tasks (Supervisors)
+  // ============================================================================
+
+  private async reconcileTopLevelTasks(): Promise<{
+    tasksReconciled: number;
+    supervisorsCreated: number;
+    errors: ReconciliationResult['errors'];
+  }> {
+    const errors: ReconciliationResult['errors'] = [];
+    let tasksReconciled = 0;
+    let supervisorsCreated = 0;
+
+    try {
+      // Find top-level tasks in PLANNING state that need supervisors
+      const tasksNeedingSupervisors = await taskAccessor.findTopLevelTasksNeedingSupervisors();
+
+      for (const task of tasksNeedingSupervisors) {
+        try {
+          await this.reconcileSingleTopLevelTask(task);
+          tasksReconciled++;
+          // Check if we created a supervisor
+          const supervisor = await agentAccessor.findSupervisorByTopLevelTaskId(task.id);
+          if (supervisor) {
+            supervisorsCreated++;
+          }
+        } catch (error) {
+          errors.push({
+            entity: 'task',
+            id: task.id,
+            error: error instanceof Error ? error.message : String(error),
+            action: 'reconcile_top_level',
+          });
+        }
+      }
+    } catch (error) {
+      errors.push({
+        entity: 'system',
+        id: 'top_level_reconciliation',
+        error: error instanceof Error ? error.message : String(error),
+        action: 'reconcile_top_level_tasks',
+      });
+    }
+
+    return { tasksReconciled, supervisorsCreated, errors };
+  }
+
+  private async reconcileSingleTopLevelTask(task: TaskWithRelations): Promise<void> {
+    // Only reconcile tasks in PLANNING state that don't have a supervisor
+    if (task.state !== TaskState.PLANNING) {
+      return;
+    }
+
+    const existingSupervisor = await agentAccessor.findSupervisorByTopLevelTaskId(task.id);
+    if (existingSupervisor) {
+      // Supervisor exists, check if it's healthy
+      if (existingSupervisor.executionState === ExecutionState.CRASHED) {
+        // Supervisor crashed - set desired state to ACTIVE to trigger restart
+        await agentAccessor.update(existingSupervisor.id, {
+          desiredExecutionState: DesiredExecutionState.ACTIVE,
+          executionState: ExecutionState.IDLE, // Reset to IDLE so reconciler will start it
+        });
+        logger.info('Resetting crashed supervisor', {
+          agentId: existingSupervisor.id,
+          taskId: task.id,
+        });
+      }
+      return;
+    }
+
+    // Create supervisor agent
+    logger.info('Creating supervisor for top-level task', { taskId: task.id, title: task.title });
+
+    const supervisor = await agentAccessor.create({
+      type: AgentType.SUPERVISOR,
+      currentTaskId: task.id,
+      desiredExecutionState: DesiredExecutionState.ACTIVE, // We want it to run
+      executionState: ExecutionState.IDLE, // It will be started by agent reconciliation
+    });
+
+    // Create worktree and branch for the top-level task
+    await this.createTopLevelTaskInfrastructure(task, supervisor.id);
+
+    await taskAccessor.markReconciled(task.id);
+  }
+
+  private async createTopLevelTaskInfrastructure(
+    task: TaskWithRelations,
+    _supervisorId: string
+  ): Promise<void> {
+    const project = task.project;
+    if (!project) {
+      throw new Error(`Task ${task.id} has no associated project`);
+    }
+
+    const gitClient = GitClientFactory.forProject({
+      repoPath: project.repoPath,
+      worktreeBasePath: project.worktreeBasePath,
+    });
+
+    const worktreeName = `top-level-${task.id}`;
+    const worktreePath = gitClient.getWorktreePath(worktreeName);
+
+    try {
+      // Create worktree for top-level task
+      const worktreeInfo = await gitClient.createWorktree(worktreeName, project.defaultBranch);
+      const branchName = worktreeInfo.branchName;
+
+      // Update task with infrastructure info
+      await taskAccessor.update(task.id, {
+        worktreePath,
+        branchName,
+      });
+
+      logger.info('Created top-level task infrastructure', {
+        taskId: task.id,
+        worktreePath,
+        branchName,
+      });
+    } catch (error) {
+      logger.error('Failed to create top-level task infrastructure', error as Error, {
+        taskId: task.id,
+      });
+      throw error;
+    }
+  }
+
+  // ============================================================================
+  // Phase 3: Leaf Tasks (Workers + Infrastructure)
+  // ============================================================================
+
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: reconciliation function with necessary error handling
+  private async reconcileLeafTasks(): Promise<{
+    tasksReconciled: number;
+    workersCreated: number;
+    infrastructureCreated: number;
+    errors: ReconciliationResult['errors'];
+  }> {
+    const errors: ReconciliationResult['errors'] = [];
+    let tasksReconciled = 0;
+    let workersCreated = 0;
+    let infrastructureCreated = 0;
+
+    try {
+      // Find leaf tasks that need workers
+      const tasksNeedingWorkers = await taskAccessor.findLeafTasksNeedingWorkers();
+
+      for (const task of tasksNeedingWorkers) {
+        try {
+          const result = await this.reconcileSingleLeafTask(task);
+          tasksReconciled++;
+          if (result.workerCreated) {
+            workersCreated++;
+          }
+          if (result.infrastructureCreated) {
+            infrastructureCreated++;
+          }
+        } catch (error) {
+          errors.push({
+            entity: 'task',
+            id: task.id,
+            error: error instanceof Error ? error.message : String(error),
+            action: 'reconcile_leaf_task',
+          });
+        }
+      }
+
+      // Also check for tasks with missing infrastructure
+      const tasksWithMissingInfra = await taskAccessor.findTasksWithMissingInfrastructure();
+      for (const task of tasksWithMissingInfra) {
+        try {
+          await this.ensureLeafTaskInfrastructure(task);
+          infrastructureCreated++;
+        } catch (error) {
+          errors.push({
+            entity: 'task',
+            id: task.id,
+            error: error instanceof Error ? error.message : String(error),
+            action: 'create_infrastructure',
+          });
+        }
+      }
+    } catch (error) {
+      errors.push({
+        entity: 'system',
+        id: 'leaf_task_reconciliation',
+        error: error instanceof Error ? error.message : String(error),
+        action: 'reconcile_leaf_tasks',
+      });
+    }
+
+    return { tasksReconciled, workersCreated, infrastructureCreated, errors };
+  }
+
+  private async reconcileSingleLeafTask(
+    task: TaskWithRelations
+  ): Promise<{ workerCreated: boolean; infrastructureCreated: boolean }> {
+    let workerCreated = false;
+    let infrastructureCreated = false;
+
+    // Check if task is blocked
+    const isBlocked = await taskAccessor.isBlocked(task.id);
+    if (isBlocked && task.state === TaskState.PENDING) {
+      // Task is blocked, update state if needed
+      await taskAccessor.update(task.id, { state: TaskState.BLOCKED });
+      return { workerCreated, infrastructureCreated };
+    }
+
+    // If task is in PENDING and unblocked, transition to IN_PROGRESS and create worker
+    if (task.state === TaskState.PENDING && !task.assignedAgentId) {
+      // Create worker agent
+      logger.info('Creating worker for leaf task', { taskId: task.id, title: task.title });
+
+      const worker = await agentAccessor.create({
+        type: AgentType.WORKER,
+        currentTaskId: task.id,
+        desiredExecutionState: DesiredExecutionState.ACTIVE,
+        executionState: ExecutionState.IDLE,
+      });
+      workerCreated = true;
+
+      // Update task state and assign agent
+      await taskAccessor.update(task.id, {
+        state: TaskState.IN_PROGRESS,
+        assignedAgentId: worker.id,
+      });
+
+      // Create infrastructure
+      await this.ensureLeafTaskInfrastructure(task);
+      infrastructureCreated = true;
+    }
+
+    // If task is IN_PROGRESS but has no worker, create one
+    if (task.state === TaskState.IN_PROGRESS && !task.assignedAgentId) {
+      logger.info('Creating missing worker for IN_PROGRESS task', {
+        taskId: task.id,
+        title: task.title,
+      });
+
+      const worker = await agentAccessor.create({
+        type: AgentType.WORKER,
+        currentTaskId: task.id,
+        desiredExecutionState: DesiredExecutionState.ACTIVE,
+        executionState: ExecutionState.IDLE,
+      });
+      workerCreated = true;
+
+      await taskAccessor.update(task.id, {
+        assignedAgentId: worker.id,
+      });
+    }
+
+    // Ensure infrastructure exists for IN_PROGRESS tasks
+    if (task.state === TaskState.IN_PROGRESS && !(task.worktreePath && task.branchName)) {
+      await this.ensureLeafTaskInfrastructure(task);
+      infrastructureCreated = true;
+    }
+
+    await taskAccessor.markReconciled(task.id);
+    return { workerCreated, infrastructureCreated };
+  }
+
+  private async ensureLeafTaskInfrastructure(task: TaskWithRelations | Task): Promise<void> {
+    // Get full task with project if not already loaded
+    const fullTask =
+      'project' in task && task.project ? task : await taskAccessor.findById(task.id);
+    if (!fullTask?.project) {
+      throw new Error(`Task ${task.id} has no associated project`);
+    }
+
+    const project = fullTask.project;
+    const gitClient = GitClientFactory.forProject({
+      repoPath: project.repoPath,
+      worktreeBasePath: project.worktreeBasePath,
+    });
+
+    // Get the top-level task's branch as the base
+    const topLevelTask = await taskAccessor.getTopLevelParent(task.id);
+    if (!topLevelTask) {
+      throw new Error(`Task ${task.id} has no top-level parent`);
+    }
+
+    const baseBranch = topLevelTask.branchName ?? project.defaultBranch;
+    const worktreeName = `task-${task.id}`;
+    const worktreePath = gitClient.getWorktreePath(worktreeName);
+
+    try {
+      // Create worktree
+      const worktreeInfo = await gitClient.createWorktree(worktreeName, baseBranch);
+      const branchName = worktreeInfo.branchName;
+
+      // Update task
+      await taskAccessor.update(task.id, {
+        worktreePath,
+        branchName,
+      });
+
+      logger.info('Created leaf task infrastructure', {
+        taskId: task.id,
+        worktreePath,
+        branchName,
+        baseBranch,
+      });
+    } catch (error) {
+      logger.error('Failed to create leaf task infrastructure', error as Error, {
+        taskId: task.id,
+      });
+      throw error;
+    }
+  }
+
+  // ============================================================================
+  // Phase 4: Agent States
+  // ============================================================================
+
+  private async reconcileAgentStates(): Promise<{
+    agentsReconciled: number;
+    errors: ReconciliationResult['errors'];
+  }> {
+    const errors: ReconciliationResult['errors'] = [];
+    let agentsReconciled = 0;
+
+    try {
+      // Find agents that need reconciliation
+      const agentsNeedingReconciliation = await agentAccessor.findAgentsNeedingReconciliation();
+
+      for (const agent of agentsNeedingReconciliation) {
+        try {
+          await this.reconcileSingleAgentState(agent);
+          agentsReconciled++;
+        } catch (error) {
+          errors.push({
+            entity: 'agent',
+            id: agent.id,
+            error: error instanceof Error ? error.message : String(error),
+            action: 'reconcile_agent_state',
+          });
+        }
+      }
+    } catch (error) {
+      errors.push({
+        entity: 'system',
+        id: 'agent_state_reconciliation',
+        error: error instanceof Error ? error.message : String(error),
+        action: 'reconcile_agent_states',
+      });
+    }
+
+    return { agentsReconciled, errors };
+  }
+
+  private async reconcileSingleAgentState(agent: {
+    id: string;
+    type: AgentType;
+    executionState: ExecutionState;
+    desiredExecutionState: DesiredExecutionState;
+  }): Promise<void> {
+    const { id, executionState, desiredExecutionState } = agent;
+
+    // If actual matches desired, nothing to do
+    if (this.statesMatch(executionState, desiredExecutionState)) {
+      await agentAccessor.markReconciled(id);
+      return;
+    }
+
+    logger.debug('Reconciling agent state mismatch', {
+      agentId: id,
+      executionState,
+      desiredExecutionState,
+    });
+
+    // Handle state transitions
+    if (desiredExecutionState === DesiredExecutionState.ACTIVE) {
+      if (executionState === ExecutionState.IDLE || executionState === ExecutionState.CRASHED) {
+        // Need to start the agent
+        // Note: Actual agent starting is handled by the agent lifecycle module
+        // The reconciler just sets the state, the lifecycle module watches for this
+        await agentAccessor.update(id, {
+          executionState: ExecutionState.ACTIVE,
+        });
+        logger.info('Agent marked for activation', { agentId: id });
+      }
+    } else if (desiredExecutionState === DesiredExecutionState.IDLE) {
+      if (executionState === ExecutionState.ACTIVE || executionState === ExecutionState.PAUSED) {
+        // Need to stop the agent
+        await agentAccessor.update(id, {
+          executionState: ExecutionState.IDLE,
+        });
+        logger.info('Agent marked for deactivation', { agentId: id });
+      }
+    } else if (desiredExecutionState === DesiredExecutionState.PAUSED) {
+      if (executionState === ExecutionState.ACTIVE) {
+        await agentAccessor.update(id, {
+          executionState: ExecutionState.PAUSED,
+        });
+        logger.info('Agent marked as paused', { agentId: id });
+      }
+    }
+
+    await agentAccessor.markReconciled(id);
+  }
+
+  private statesMatch(actual: ExecutionState, desired: DesiredExecutionState): boolean {
+    switch (desired) {
+      case DesiredExecutionState.ACTIVE:
+        return actual === ExecutionState.ACTIVE;
+      case DesiredExecutionState.IDLE:
+        return actual === ExecutionState.IDLE;
+      case DesiredExecutionState.PAUSED:
+        return actual === ExecutionState.PAUSED;
+      default:
+        return false;
+    }
+  }
+}
+
+// Export singleton instance
+export const reconciliationService = new ReconciliationService();

--- a/src/backend/services/worktree.service.ts
+++ b/src/backend/services/worktree.service.ts
@@ -133,7 +133,7 @@ export class WorktreeService {
     if (!task) {
       return { isOrphaned: true, reason: 'deleted_top_level_task' };
     }
-    if (task.state === 'COMPLETED' || task.state === 'CANCELLED') {
+    if (task.state === 'COMPLETED' || task.state === 'FAILED') {
       return { isOrphaned: true, reason: 'deleted_top_level_task' };
     }
     return { isOrphaned: false, reason: 'unknown' };

--- a/src/backend/testing/factories.ts
+++ b/src/backend/testing/factories.ts
@@ -1,5 +1,5 @@
 import type { Agent, Mail, Project, Task } from '@prisma-gen/client';
-import { AgentState, AgentType, TaskState } from '@prisma-gen/client';
+import { AgentType, DesiredExecutionState, ExecutionState, TaskState } from '@prisma-gen/client';
 
 let idCounter = 0;
 
@@ -52,6 +52,8 @@ export interface TaskOverrides {
   prUrl?: string | null;
   attempts?: number;
   failureReason?: string | null;
+  lastReconcileAt?: Date | null;
+  reconcileFailures?: object[];
   createdAt?: Date;
   updatedAt?: Date;
   completedAt?: Date | null;
@@ -79,6 +81,8 @@ export function createTask(overrides: TaskOverrides = {}): Task {
     prUrl: overrides.prUrl ?? null,
     attempts: overrides.attempts ?? 0,
     failureReason: overrides.failureReason ?? null,
+    lastReconcileAt: overrides.lastReconcileAt ?? null,
+    reconcileFailures: overrides.reconcileFailures ?? [],
     createdAt: overrides.createdAt ?? now,
     updatedAt: overrides.updatedAt ?? now,
     completedAt: overrides.completedAt ?? null,
@@ -88,13 +92,16 @@ export function createTask(overrides: TaskOverrides = {}): Task {
 export interface AgentOverrides {
   id?: string;
   type?: AgentType;
-  state?: AgentState;
+  executionState?: ExecutionState;
+  desiredExecutionState?: DesiredExecutionState;
   currentTaskId?: string | null;
   tmuxSessionName?: string | null;
   sessionId?: string | null;
+  lastHeartbeat?: Date | null;
+  lastReconcileAt?: Date | null;
+  reconcileFailures?: object[];
   createdAt?: Date;
   updatedAt?: Date;
-  lastActiveAt?: Date;
 }
 
 export function createAgent(overrides: AgentOverrides = {}): Agent {
@@ -103,13 +110,16 @@ export function createAgent(overrides: AgentOverrides = {}): Agent {
   return {
     id,
     type: overrides.type ?? AgentType.WORKER,
-    state: overrides.state ?? AgentState.IDLE,
+    executionState: overrides.executionState ?? ExecutionState.IDLE,
+    desiredExecutionState: overrides.desiredExecutionState ?? DesiredExecutionState.IDLE,
     currentTaskId: overrides.currentTaskId ?? null,
     tmuxSessionName: overrides.tmuxSessionName ?? null,
     sessionId: overrides.sessionId ?? null,
+    lastHeartbeat: overrides.lastHeartbeat ?? now,
+    lastReconcileAt: overrides.lastReconcileAt ?? null,
+    reconcileFailures: overrides.reconcileFailures ?? [],
     createdAt: overrides.createdAt ?? now,
     updatedAt: overrides.updatedAt ?? now,
-    lastActiveAt: overrides.lastActiveAt ?? now,
   };
 }
 

--- a/src/backend/trpc/task.trpc.ts
+++ b/src/backend/trpc/task.trpc.ts
@@ -168,16 +168,13 @@ export const taskRouter = router({
 
       // Initialize all TaskState values for completeness
       const byState: Record<TaskState, number> = {
-        [TaskState.PLANNING]: 0,
-        [TaskState.PLANNED]: 0,
         [TaskState.PENDING]: 0,
-        [TaskState.ASSIGNED]: 0,
+        [TaskState.PLANNING]: 0,
         [TaskState.IN_PROGRESS]: 0,
         [TaskState.REVIEW]: 0,
         [TaskState.BLOCKED]: 0,
         [TaskState.COMPLETED]: 0,
         [TaskState.FAILED]: 0,
-        [TaskState.CANCELLED]: 0,
       };
 
       for (const task of tasks) {


### PR DESCRIPTION
## Summary

- Implements Kubernetes-style reconciliation pattern for task/agent management
- Separates task state from agent execution state with new `ExecutionState` and `DesiredExecutionState` enums
- Adds `ReconciliationService` with level-triggered, self-healing architecture
- Simplifies event handlers to update state and trigger reconciliation
- Hybrid triggering: events for immediate response, cron for drift detection

## Breaking Changes

- `AgentState` enum replaced with `ExecutionState` + `DesiredExecutionState`
- `agent.state` → `agent.executionState`
- `agent.lastActiveAt` → `agent.lastHeartbeat`
- Removed `TaskState.PLANNED`, `TaskState.ASSIGNED`, `TaskState.CANCELLED`

## Test plan

- [x] TypeScript typechecks pass (`pnpm typecheck`)
- [x] Linting passes (`pnpm check:fix`)
- [ ] Run database migrations
- [ ] Test reconciliation loop with agents
- [ ] Verify crash recovery works as expected

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)