### PR TITLE
Move worktreePath from Task to Agent model

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -76,7 +76,6 @@ model Task {
 
   // Execution tracking (for leaf tasks)
   assignedAgentId   String?
-  worktreePath      String?
   branchName        String?
   prUrl             String?     // Draft PR URL, created after first commit
   attempts          Int         @default(0)
@@ -136,6 +135,7 @@ model Agent {
   // Session management
   tmuxSessionName         String?
   sessionId               String?             // Claude Code CLI session ID for resume
+  worktreePath            String?             // Git worktree path for this agent's workspace
 
   // Health tracking
   lastHeartbeat           DateTime?           // Last agent heartbeat (set by agent itself)

--- a/src/backend/agents/supervisor/supervisor.agent.ts
+++ b/src/backend/agents/supervisor/supervisor.agent.ts
@@ -151,10 +151,11 @@ export async function createSupervisor(
     resumeSessionId: options?.resumeSessionId,
   });
 
-  // Update agent with session info
+  // Update agent with session info and worktree path
   await agentAccessor.update(agent.id, {
     sessionId: sessionContext.sessionId,
     tmuxSessionName: sessionContext.tmuxSessionName,
+    worktreePath: worktreeInfo.path,
   });
 
   console.log(`Created supervisor ${agent.id} for task ${taskId}`);

--- a/src/backend/resource_accessors/agent.accessor.ts
+++ b/src/backend/resource_accessors/agent.accessor.ts
@@ -9,6 +9,7 @@ interface CreateAgentInput {
   currentTaskId?: string;
   tmuxSessionName?: string;
   sessionId?: string;
+  worktreePath?: string;
   executionState?: ExecutionState;
   desiredExecutionState?: DesiredExecutionState;
 }
@@ -17,6 +18,7 @@ interface UpdateAgentInput {
   currentTaskId?: string | null;
   tmuxSessionName?: string | null;
   sessionId?: string | null;
+  worktreePath?: string | null;
   executionState?: ExecutionState;
   desiredExecutionState?: DesiredExecutionState;
   lastHeartbeat?: Date | null;
@@ -41,6 +43,7 @@ class AgentAccessor {
         currentTaskId: data.currentTaskId,
         tmuxSessionName: data.tmuxSessionName,
         sessionId: data.sessionId,
+        worktreePath: data.worktreePath,
         executionState: data.executionState ?? ExecutionState.IDLE,
         desiredExecutionState: data.desiredExecutionState ?? DesiredExecutionState.IDLE,
       },

--- a/src/backend/resource_accessors/task.accessor.ts
+++ b/src/backend/resource_accessors/task.accessor.ts
@@ -40,7 +40,6 @@ export interface UpdateTaskInput {
   description?: string;
   state?: TaskState;
   assignedAgentId?: string | null;
-  worktreePath?: string | null;
   branchName?: string | null;
   prUrl?: string | null;
   attempts?: number;
@@ -422,7 +421,9 @@ export class TaskAccessor {
   /**
    * Get tasks in REVIEW state, ordered by submission time
    */
-  getReviewQueue(parentId: string): Promise<Task[]> {
+  getReviewQueue(
+    parentId: string
+  ): Promise<(Task & { assignedAgent: import('@prisma-gen/client').Agent | null })[]> {
     return prisma.task.findMany({
       where: {
         parentId,
@@ -577,13 +578,14 @@ export class TaskAccessor {
   }
 
   /**
-   * Find tasks with missing infrastructure (worktree, branch) that should have it
+   * Find tasks with missing infrastructure (branch) that should have it
+   * Note: worktreePath is now on Agent, so we only check branchName here
    */
   findTasksWithMissingInfrastructure(): Promise<TaskWithRelations[]> {
     return prisma.task.findMany({
       where: {
         state: TaskState.IN_PROGRESS,
-        OR: [{ worktreePath: null }, { branchName: null }],
+        branchName: null,
       },
       include: fullInclude,
     });

--- a/src/backend/routers/mcp/agent.mcp.ts
+++ b/src/backend/routers/mcp/agent.mcp.ts
@@ -100,7 +100,7 @@ async function getTask(context: McpToolContext, input: unknown): Promise<McpTool
       description: task.description,
       state: task.state,
       parentId: task.parentId,
-      worktreePath: task.worktreePath,
+      worktreePath: agent.worktreePath,
       branchName: task.branchName,
       prUrl: task.prUrl,
       createdAt: task.createdAt,

--- a/src/backend/routers/mcp/task.mcp.ts
+++ b/src/backend/routers/mcp/task.mcp.ts
@@ -524,12 +524,13 @@ async function validateWorkerForPR(
     };
   }
 
-  if (!task.worktreePath) {
+  // worktreePath is now on the agent
+  if (!agent.worktreePath) {
     return {
       success: false,
       error: createErrorResponse(
         McpErrorCode.INVALID_AGENT_STATE,
-        'Task does not have a worktree path'
+        'Agent does not have a worktree path'
       ),
     };
   }
@@ -542,7 +543,7 @@ async function validateWorkerForPR(
         id: task.id,
         parentId: task.parentId,
         branchName: task.branchName,
-        worktreePath: task.worktreePath,
+        worktreePath: agent.worktreePath,
         title: task.title,
       },
       topLevelTask: { id: topLevelTask.id },
@@ -759,10 +760,10 @@ async function getPRStatus(context: McpToolContext, input: unknown): Promise<Mcp
       return createErrorResponse(McpErrorCode.INVALID_AGENT_STATE, 'Task does not have a PR URL');
     }
 
-    // Get PR status
+    // Get PR status (worktreePath is on the agent)
     let prStatus: PRStatus;
     try {
-      prStatus = await githubClient.getPRStatus(task.prUrl, task.worktreePath || undefined);
+      prStatus = await githubClient.getPRStatus(task.prUrl, agent.worktreePath || undefined);
     } catch (error) {
       return createErrorResponse(
         McpErrorCode.INTERNAL_ERROR,
@@ -918,7 +919,7 @@ async function listTasks(context: McpToolContext, input: unknown): Promise<McpTo
         state: t.state,
         assignedAgentId: t.assignedAgentId,
         prUrl: t.prUrl,
-        worktreePath: t.worktreePath,
+        worktreePath: t.assignedAgent?.worktreePath ?? null,
         branchName: t.branchName,
         createdAt: t.createdAt,
         updatedAt: t.updatedAt,
@@ -969,7 +970,7 @@ async function getReviewQueue(context: McpToolContext, input: unknown): Promise<
         title: t.title,
         description: t.description,
         prUrl: t.prUrl,
-        worktreePath: t.worktreePath,
+        worktreePath: t.assignedAgent?.worktreePath ?? null,
         branchName: t.branchName,
         assignedAgentId: t.assignedAgentId,
         submittedAt: t.updatedAt,

--- a/src/backend/services/reconciliation.service.test.ts
+++ b/src/backend/services/reconciliation.service.test.ts
@@ -205,12 +205,15 @@ describe('ReconciliationService', () => {
       });
 
       mockTaskAccessor.findTopLevelTasksNeedingSupervisors.mockResolvedValue([task]);
-      // First call (during reconcileSingleTopLevelTask) returns null
-      // Second call (after reconciliation to count supervisors) returns the created supervisor
+      // First call: check if supervisor exists (returns null → create one)
+      // Second call: find supervisor to update worktreePath
+      // Third call: count supervisors after reconciliation
       mockAgentAccessor.findSupervisorByTopLevelTaskId
         .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(newSupervisor)
         .mockResolvedValueOnce(newSupervisor);
       mockAgentAccessor.create.mockResolvedValue(newSupervisor);
+      mockAgentAccessor.update.mockResolvedValue({});
 
       const result = await reconciliationService.reconcileAll();
 
@@ -240,9 +243,15 @@ describe('ReconciliationService', () => {
         dependents: [],
       };
 
+      const newSupervisor = createAgent({ id: 'new-supervisor', type: AgentType.SUPERVISOR });
       mockTaskAccessor.findTopLevelTasksNeedingSupervisors.mockResolvedValue([task]);
-      mockAgentAccessor.findSupervisorByTopLevelTaskId.mockResolvedValue(null);
-      mockAgentAccessor.create.mockResolvedValue(createAgent({ id: 'new-supervisor' }));
+      // First call: check if exists, Second call: find for worktreePath update, Third call: count
+      mockAgentAccessor.findSupervisorByTopLevelTaskId
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(newSupervisor)
+        .mockResolvedValueOnce(newSupervisor);
+      mockAgentAccessor.create.mockResolvedValue(newSupervisor);
+      mockAgentAccessor.update.mockResolvedValue({});
       mockTaskAccessor.update.mockResolvedValue({});
 
       await reconciliationService.reconcileAll();
@@ -251,11 +260,18 @@ describe('ReconciliationService', () => {
         repoPath: project.repoPath,
         worktreeBasePath: project.worktreeBasePath,
       });
+      // Task only gets branchName (worktreePath is now on Agent)
       expect(mockTaskAccessor.update).toHaveBeenCalledWith(
         'top-level-1',
         expect.objectContaining({
-          worktreePath: expect.any(String),
           branchName: expect.any(String),
+        })
+      );
+      // Agent gets worktreePath
+      expect(mockAgentAccessor.update).toHaveBeenCalledWith(
+        'new-supervisor',
+        expect.objectContaining({
+          worktreePath: expect.any(String),
         })
       );
     });
@@ -486,15 +502,23 @@ describe('ReconciliationService', () => {
         branchName: 'top-level-branch',
       });
       mockTaskAccessor.update.mockResolvedValue({});
+      mockAgentAccessor.update.mockResolvedValue({});
 
       const result = await reconciliationService.reconcileAll();
 
       expect(mockGitClientFactory.forProject).toHaveBeenCalled();
+      // Task only gets branchName (worktreePath is now on Agent)
       expect(mockTaskAccessor.update).toHaveBeenCalledWith(
         'no-infra-1',
         expect.objectContaining({
-          worktreePath: expect.any(String),
           branchName: expect.any(String),
+        })
+      );
+      // Agent gets worktreePath
+      expect(mockAgentAccessor.update).toHaveBeenCalledWith(
+        'some-worker',
+        expect.objectContaining({
+          worktreePath: expect.any(String),
         })
       );
       expect(result.infrastructureCreated).toBeGreaterThan(0);
@@ -931,13 +955,15 @@ describe('ReconciliationService', () => {
       // Phase 2: One top-level task needing supervisor
       const newSupervisor = createAgent({ id: 'new-supervisor', type: AgentType.SUPERVISOR });
       mockTaskAccessor.findTopLevelTasksNeedingSupervisors.mockResolvedValue([topLevelTask]);
-      // First call returns null (checking if exists), second returns created supervisor (counting)
+      // First call: check if exists, Second call: find for worktreePath update, Third call: count
       mockAgentAccessor.findSupervisorByTopLevelTaskId
         .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(newSupervisor)
         .mockResolvedValueOnce(newSupervisor);
       mockAgentAccessor.create
         .mockResolvedValueOnce(newSupervisor)
         .mockResolvedValueOnce(createAgent({ id: 'new-worker', type: AgentType.WORKER }));
+      mockAgentAccessor.update.mockResolvedValue({});
 
       // Phase 3: One leaf task needing worker
       mockTaskAccessor.findLeafTasksNeedingWorkers.mockResolvedValue([leafTask]);

--- a/src/backend/services/reconciliation.service.test.ts
+++ b/src/backend/services/reconciliation.service.test.ts
@@ -460,21 +460,20 @@ describe('ReconciliationService', () => {
       });
     });
 
-    it('should create infrastructure for task with missing worktree', async () => {
+    it('should create infrastructure for task with missing branch', async () => {
       const taskMissingInfra = {
         ...createTask({
           id: 'no-infra-1',
           projectId: project.id,
           parentId: topLevelTask.id,
           state: TaskState.IN_PROGRESS,
-          worktreePath: null, // Missing!
           branchName: null, // Missing!
           assignedAgentId: 'some-worker',
         }),
         project,
         parent: topLevelTask,
         children: [],
-        assignedAgent: null,
+        assignedAgent: createAgent({ id: 'some-worker', worktreePath: null }), // Agent with no worktreePath
         supervisorAgent: null,
         dependsOn: [],
         dependents: [],
@@ -1100,7 +1099,7 @@ describe('ReconciliationService', () => {
           projectId: project.id,
           parentId: 'nonexistent-parent',
           state: TaskState.IN_PROGRESS,
-          worktreePath: null,
+          branchName: null, // Missing branch (worktreePath is now on Agent)
         }),
         project,
         parent: null,

--- a/src/backend/services/reconciliation.service.ts
+++ b/src/backend/services/reconciliation.service.ts
@@ -455,7 +455,11 @@ class ReconciliationService {
 
     for (const task of tasksWithMissingInfra) {
       try {
-        await this.ensureLeafTaskInfrastructure(task);
+        const { worktreePath } = await this.ensureLeafTaskInfrastructure(task);
+        // Update the agent with worktreePath if one exists
+        if (task.assignedAgentId) {
+          await agentAccessor.update(task.assignedAgentId, { worktreePath });
+        }
         infrastructureCreated++;
       } catch (error) {
         errors.push({

--- a/src/backend/testing/factories.ts
+++ b/src/backend/testing/factories.ts
@@ -47,7 +47,6 @@ export interface TaskOverrides {
   description?: string | null;
   state?: TaskState;
   assignedAgentId?: string | null;
-  worktreePath?: string | null;
   branchName?: string | null;
   prUrl?: string | null;
   attempts?: number;
@@ -76,7 +75,6 @@ export function createTask(overrides: TaskOverrides = {}): Task {
     description: overrides.description ?? null,
     state: overrides.state ?? defaultState,
     assignedAgentId: overrides.assignedAgentId ?? null,
-    worktreePath: overrides.worktreePath ?? null,
     branchName: overrides.branchName ?? null,
     prUrl: overrides.prUrl ?? null,
     attempts: overrides.attempts ?? 0,
@@ -97,6 +95,7 @@ export interface AgentOverrides {
   currentTaskId?: string | null;
   tmuxSessionName?: string | null;
   sessionId?: string | null;
+  worktreePath?: string | null;
   lastHeartbeat?: Date | null;
   lastReconcileAt?: Date | null;
   reconcileFailures?: object[];
@@ -115,6 +114,7 @@ export function createAgent(overrides: AgentOverrides = {}): Agent {
     currentTaskId: overrides.currentTaskId ?? null,
     tmuxSessionName: overrides.tmuxSessionName ?? null,
     sessionId: overrides.sessionId ?? null,
+    worktreePath: overrides.worktreePath ?? null,
     lastHeartbeat: overrides.lastHeartbeat ?? now,
     lastReconcileAt: overrides.lastReconcileAt ?? null,
     reconcileFailures: overrides.reconcileFailures ?? [],


### PR DESCRIPTION
## Summary
- Moves `worktreePath` field from the Task model to the Agent model
- Agent now owns all execution resources (tmuxSessionName, sessionId, worktreePath)
- Task retains deliverables (branchName, prUrl)

This aligns with the conceptual separation where agents own their runtime resources and tasks own the artifacts they produce.

## Changes
- Updated Prisma schema to move `worktreePath` field
- Updated resource accessors (agent.accessor.ts, task.accessor.ts)
- Updated agent creation code (supervisor.agent.ts, worker.agent.ts)
- Updated reconciliation service to set worktreePath on agent
- Updated all MCP routers to read worktreePath from agent
- Updated test factories

## Test plan
- [ ] Verify typecheck passes
- [ ] Verify build succeeds
- [ ] Create a new top-level task and verify supervisor gets worktreePath
- [ ] Verify worker agents get worktreePath assigned

🤖 Generated with [Claude Code](https://claude.com/claude-code)