### PR TITLE
Add agent concurrency limits to prevent resource exhaustion

### DIFF
--- a/src/backend/resource_accessors/agent.accessor.ts
+++ b/src/backend/resource_accessors/agent.accessor.ts
@@ -113,6 +113,29 @@ class AgentAccessor {
   }
 
   /**
+   * Count active agents by type.
+   * Used for enforcing concurrency limits.
+   * Counts agents that are ACTIVE or IDLE with desiredExecutionState=ACTIVE
+   * (i.e., agents that are running or about to start running)
+   */
+  countActiveByType(type: AgentType): Promise<number> {
+    return prisma.agent.count({
+      where: {
+        type,
+        OR: [
+          // Currently active agents
+          { executionState: ExecutionState.ACTIVE },
+          // Agents that are starting up (idle but want to be active)
+          {
+            executionState: ExecutionState.IDLE,
+            desiredExecutionState: DesiredExecutionState.ACTIVE,
+          },
+        ],
+      },
+    });
+  }
+
+  /**
    * Find agent by their current task ID
    * Works for both supervisors (top-level tasks) and workers (leaf tasks)
    */

--- a/src/backend/services/config.service.ts
+++ b/src/backend/services/config.service.ts
@@ -48,6 +48,10 @@ interface SystemConfig {
   healthCheckIntervalMs: number;
   agentHeartbeatThresholdMinutes: number;
 
+  // Agent concurrency limits
+  maxConcurrentWorkers: number;
+  maxConcurrentSupervisors: number;
+
   // Crash recovery settings
   maxWorkerAttempts: number;
   crashLoopThresholdMs: number;
@@ -170,6 +174,10 @@ function loadSystemConfig(): SystemConfig {
       process.env.AGENT_HEARTBEAT_THRESHOLD_MINUTES || '7',
       10
     ),
+
+    // Agent concurrency limits
+    maxConcurrentWorkers: Number.parseInt(process.env.MAX_CONCURRENT_WORKERS || '10', 10),
+    maxConcurrentSupervisors: Number.parseInt(process.env.MAX_CONCURRENT_SUPERVISORS || '5', 10),
 
     // Crash recovery settings
     maxWorkerAttempts: Number.parseInt(process.env.MAX_WORKER_ATTEMPTS || '5', 10),


### PR DESCRIPTION
## Summary
- Implements GitHub issue #96: Adds enforcement of concurrency limits (maxConcurrentWorkers: 10, maxConcurrentSupervisors: 5) in the reconciliation service
- Adds `countActiveByType()` method to count agents that are ACTIVE or starting up (IDLE with desiredExecutionState=ACTIVE)
- Tasks that can't be assigned due to limits stay in their current state and are picked up on the next reconciliation cycle when capacity is available
- Extracts `checkWorkerLimit()` helper to avoid code duplication
- Documents single-threaded reconciliation assumption for TOCTOU safety

## Test plan
- [x] Run `pnpm test` - all 238 tests pass
- [x] Run `pnpm typecheck` - no errors
- [ ] Verify concurrency limits are respected when many tasks are queued
- [ ] Confirm skipped counts appear in reconciliation logs

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)