### PR TITLE
Simplify sidebar navigation layout

### DIFF
--- a/src/frontend/components/app-sidebar.tsx
+++ b/src/frontend/components/app-sidebar.tsx
@@ -106,7 +106,7 @@ export function AppSidebar() {
     ? [
         {
           href: `/projects/${selectedProjectSlug}/epics`,
-          label: 'Top Tasks',
+          label: 'Epics',
           icon: FolderKanban,
         },
         {

--- a/src/frontend/components/app-sidebar.tsx
+++ b/src/frontend/components/app-sidebar.tsx
@@ -18,7 +18,6 @@ import {
   SidebarFooter,
   SidebarGroup,
   SidebarGroupContent,
-  SidebarGroupLabel,
   SidebarHeader,
   SidebarMenu,
   SidebarMenuBadge,
@@ -89,10 +88,18 @@ export function AppSidebar() {
     }
   }, [projectsLoading, projects, selectedProjectSlug, pathname, router]);
 
-  const handleProjectChange = (slug: string) => {
-    setSelectedProjectSlug(slug);
-    localStorage.setItem(SELECTED_PROJECT_KEY, slug);
-    router.push(`/projects/${slug}/epics`);
+  const handleProjectChange = (value: string) => {
+    if (value === '__manage__') {
+      router.push('/projects');
+      return;
+    }
+    if (value === '__create__') {
+      router.push('/projects/new');
+      return;
+    }
+    setSelectedProjectSlug(value);
+    localStorage.setItem(SELECTED_PROJECT_KEY, value);
+    router.push(`/projects/${value}/epics`);
   };
 
   const projectNavItems = selectedProjectSlug
@@ -158,9 +165,6 @@ export function AppSidebar() {
 
         {projects && projects.length > 0 && (
           <div className="mt-3">
-            <label htmlFor="project-select" className="text-xs text-muted-foreground block mb-1">
-              Project
-            </label>
             <Select value={selectedProjectSlug} onValueChange={handleProjectChange}>
               <SelectTrigger id="project-select" className="w-full">
                 <SelectValue placeholder="Select a project" />
@@ -171,14 +175,14 @@ export function AppSidebar() {
                     {project.name}
                   </SelectItem>
                 ))}
+                <SelectItem value="__create__" className="text-muted-foreground">
+                  + Create project
+                </SelectItem>
+                <SelectItem value="__manage__" className="text-muted-foreground">
+                  Manage projects...
+                </SelectItem>
               </SelectContent>
             </Select>
-            <Link
-              href="/projects"
-              className="text-xs text-sidebar-primary hover:text-sidebar-primary/80 mt-1 inline-block"
-            >
-              Manage projects
-            </Link>
           </div>
         )}
       </SidebarHeader>
@@ -186,7 +190,6 @@ export function AppSidebar() {
       <SidebarContent>
         {projectNavItems.length > 0 && (
           <SidebarGroup>
-            <SidebarGroupLabel>Project</SidebarGroupLabel>
             <SidebarGroupContent>
               <SidebarMenu>
                 {projectNavItems.map((item) => {
@@ -217,7 +220,6 @@ export function AppSidebar() {
         <SidebarSeparator />
 
         <SidebarGroup>
-          <SidebarGroupLabel>System</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
               {globalNavItems.map((item) => {


### PR DESCRIPTION
## Summary
- Remove redundant "Project" label from dropdown and "Project"/"System" section headers
- Move "Create project" and "Manage projects" options into the project dropdown
- Keep horizontal separator between project navigation and admin section

## Test plan
- [ ] Verify sidebar renders without "Project" and "System" labels
- [ ] Verify project dropdown shows "Create project" and "Manage projects" options
- [ ] Verify clicking "Create project" navigates to /projects/new
- [ ] Verify clicking "Manage projects" navigates to /projects
- [ ] Verify project selection still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)