### PR TITLE
Update logo to match reference design

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
-# FACTORY FACTORY
-
 <p align="center">
-  <img src="public/logo.svg" alt="Factory Factory Logo" width="80" height="80">
+  <img src="public/logo-full.svg" alt="Factory Factory" width="300" height="200">
 </p>
 
 Autonomous software development orchestration system that uses AI agents to execute tasks.

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,7 +1,7 @@
 <svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
   <!-- White background -->
   <rect width="32" height="32" rx="6" fill="white"/>
-  <!-- Outer square: scaled to fit -->
+  <!-- Outer square: 24x24 -->
   <rect
     x="4"
     y="4"
@@ -10,17 +10,15 @@
     stroke="#1a1a1a"
     stroke-width="2.5"
     fill="none"
-    rx="1"
   />
-  <!-- Inner square: concentric -->
+  <!-- Inner square: 12x12 centered (half size) -->
   <rect
-    x="8"
-    y="8"
-    width="16"
-    height="16"
+    x="10"
+    y="10"
+    width="12"
+    height="12"
     stroke="#1a1a1a"
     stroke-width="2.5"
     fill="none"
-    rx="1"
   />
 </svg>

--- a/public/logo-full.svg
+++ b/public/logo-full.svg
@@ -1,8 +1,8 @@
 <svg width="300" height="200" viewBox="0 0 300 200" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <!-- Outer square -->
-  <rect x="110" y="20" width="90" height="90" stroke="currentColor" stroke-width="6" fill="none" rx="2"/>
-  <!-- Inner square -->
-  <rect x="90" y="40" width="70" height="70" stroke="currentColor" stroke-width="6" fill="none" rx="2"/>
+  <!-- Outer square: 74x74 inset so stroke fits -->
+  <rect x="113" y="23" width="74" height="74" stroke="currentColor" stroke-width="6" fill="none"/>
+  <!-- Inner square: 37x37 centered (half size) -->
+  <rect x="131.5" y="41.5" width="37" height="37" stroke="currentColor" stroke-width="6" fill="none"/>
   <!-- Text: FACTORY (light) FACTORY (bold) -->
   <text x="150" y="150" text-anchor="middle" font-family="var(--font-geist-sans), system-ui, sans-serif" fill="currentColor">
     <tspan font-size="20" font-weight="300" letter-spacing="0.1em">FACTORY</tspan>

--- a/public/logo-full.svg
+++ b/public/logo-full.svg
@@ -1,10 +1,10 @@
 <svg width="300" height="200" viewBox="0 0 300 200" fill="none" xmlns="http://www.w3.org/2000/svg">
   <!-- Outer square: 74x74 inset so stroke fits -->
-  <rect x="113" y="23" width="74" height="74" stroke="currentColor" stroke-width="6" fill="none"/>
+  <rect x="113" y="23" width="74" height="74" stroke="#1a1a1a" stroke-width="6" fill="none"/>
   <!-- Inner square: 37x37 centered (half size) -->
-  <rect x="131.5" y="41.5" width="37" height="37" stroke="currentColor" stroke-width="6" fill="none"/>
+  <rect x="131.5" y="41.5" width="37" height="37" stroke="#1a1a1a" stroke-width="6" fill="none"/>
   <!-- Text: FACTORY (light) FACTORY (bold) -->
-  <text x="150" y="150" text-anchor="middle" font-family="var(--font-geist-sans), system-ui, sans-serif" fill="currentColor">
+  <text x="150" y="150" text-anchor="middle" font-family="'Geist Sans', system-ui, -apple-system, sans-serif" fill="#1a1a1a">
     <tspan font-size="20" font-weight="300" letter-spacing="0.1em">FACTORY</tspan>
     <tspan font-size="20" font-weight="700" letter-spacing="0.1em" dx="8">FACTORY</tspan>
   </text>

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,24 +1,22 @@
 <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <!-- Outer square: 80x80 at (0, 0) -->
+  <!-- Outer square: 74x74 inset by 3 so stroke fits in viewBox -->
   <rect
-    x="0"
-    y="0"
-    width="80"
-    height="80"
+    x="3"
+    y="3"
+    width="74"
+    height="74"
     stroke="currentColor"
     stroke-width="6"
     fill="none"
-    rx="2"
   />
-  <!-- Inner square: 60x60 at (10, 10) - concentric -->
+  <!-- Inner square: 37x37 centered (half size of outer) -->
   <rect
-    x="10"
-    y="10"
-    width="60"
-    height="60"
+    x="21.5"
+    y="21.5"
+    width="37"
+    height="37"
     stroke="currentColor"
     stroke-width="6"
     fill="none"
-    rx="2"
   />
 </svg>

--- a/src/app/icon.svg
+++ b/src/app/icon.svg
@@ -1,7 +1,7 @@
 <svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
   <!-- White background -->
   <rect width="32" height="32" rx="6" fill="white"/>
-  <!-- Outer square: scaled to fit -->
+  <!-- Outer square: 24x24 -->
   <rect
     x="4"
     y="4"
@@ -10,17 +10,15 @@
     stroke="#1a1a1a"
     stroke-width="2.5"
     fill="none"
-    rx="1"
   />
-  <!-- Inner square: concentric -->
+  <!-- Inner square: 12x12 centered (half size) -->
   <rect
-    x="8"
-    y="8"
-    width="16"
-    height="16"
+    x="10"
+    y="10"
+    width="12"
+    height="12"
     stroke="#1a1a1a"
     stroke-width="2.5"
     fill="none"
-    rx="1"
   />
 </svg>

--- a/src/frontend/components/logo.tsx
+++ b/src/frontend/components/logo.tsx
@@ -12,27 +12,17 @@ function LogoIcon({ className }: LogoIconProps) {
       xmlns="http://www.w3.org/2000/svg"
       className={cn('size-8', className)}
     >
-      {/* Outer square: 80x80 at (0, 0) */}
+      {/* Outer square: 74x74 inset by 3 so stroke fits in viewBox */}
+      <rect x="3" y="3" width="74" height="74" stroke="currentColor" strokeWidth="6" fill="none" />
+      {/* Inner square: 37x37 centered (half size of outer) */}
       <rect
-        x="0"
-        y="0"
-        width="80"
-        height="80"
+        x="21.5"
+        y="21.5"
+        width="37"
+        height="37"
         stroke="currentColor"
         strokeWidth="6"
         fill="none"
-        rx="2"
-      />
-      {/* Inner square: 60x60 at (10, 10) - concentric */}
-      <rect
-        x="10"
-        y="10"
-        width="60"
-        height="60"
-        stroke="currentColor"
-        strokeWidth="6"
-        fill="none"
-        rx="2"
       />
     </svg>
   );


### PR DESCRIPTION
## Summary
- Update logo proportions to match reference image (2x2 inner square inside 4x4 outer square)
- Remove rounded corners for sharp edges
- Fix outer stroke clipping by insetting the rectangle so full stroke width is visible

## Test plan
- [ ] Verify logo renders correctly in the UI
- [ ] Check favicon displays properly in browser tab
- [ ] Confirm logo-full.svg renders with proper proportions

🤖 Generated with [Claude Code](https://claude.com/claude-code)