### PR TITLE
Fix chat component issues from code review

### DIFF
--- a/src/app/chat/error.tsx
+++ b/src/app/chat/error.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { AlertTriangle, RefreshCw } from 'lucide-react';
+import { useEffect } from 'react';
+
+import { Button } from '@/components/ui/button';
+
+interface ChatErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+/**
+ * Error boundary for the chat page.
+ * Catches rendering errors and provides a recovery option.
+ */
+export default function ChatError({ error, reset }: ChatErrorProps) {
+  useEffect(() => {
+    // Log the error for debugging/monitoring - intentional for production error tracking
+    // biome-ignore lint/suspicious/noConsole: Error logging is intentional for debugging
+    console.error('Chat error:', error);
+  }, [error]);
+
+  return (
+    <div className="flex h-full flex-col items-center justify-center p-8">
+      <div className="flex flex-col items-center gap-4 text-center max-w-md">
+        <div className="flex h-16 w-16 items-center justify-center rounded-full bg-destructive/10">
+          <AlertTriangle className="h-8 w-8 text-destructive" />
+        </div>
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold">Something went wrong</h2>
+          <p className="text-sm text-muted-foreground">
+            An error occurred while rendering the chat. This might be due to a malformed message or
+            a temporary issue.
+          </p>
+          {process.env.NODE_ENV === 'development' && (
+            <p className="mt-2 text-xs font-mono text-destructive bg-destructive/10 p-2 rounded">
+              {error.message}
+            </p>
+          )}
+        </div>
+        <Button onClick={reset} className="gap-2">
+          <RefreshCw className="h-4 w-4" />
+          Try Again
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/agent-activity/agent-activity.tsx
+++ b/src/components/agent-activity/agent-activity.tsx
@@ -19,6 +19,7 @@ import {
 import { StatsPanel } from './stats-panel';
 import { MinimalStatus, StatusBar } from './status-bar';
 import { ToolSequenceGroup } from './tool-renderers';
+import type { AgentMetadata, ConnectionState, TokenStats } from './types';
 import { useAgentWebSocket } from './use-agent-websocket';
 
 // =============================================================================
@@ -343,8 +344,6 @@ function findLastThinkingMessageId(messages: ChatMessage[]): string | null {
 // =============================================================================
 // Mock Agent Activity (for Storybook/testing)
 // =============================================================================
-
-import type { AgentMetadata, ConnectionState, TokenStats } from './types';
 
 export interface MockAgentActivityProps {
   /** Pre-loaded messages to display */

--- a/src/components/agent-activity/message-renderers.tsx
+++ b/src/components/agent-activity/message-renderers.tsx
@@ -285,10 +285,15 @@ export function ErrorRenderer({ message, className }: ErrorRendererProps) {
 // Thinking Renderer
 // =============================================================================
 
+/** Default number of characters to show before truncating thinking content */
+const DEFAULT_THINKING_TRUNCATE_LENGTH = 200;
+
 interface ThinkingRendererProps {
   text: string;
   /** The ID of the ChatMessage containing this thinking block (for completion tracking) */
   messageId?: string;
+  /** Number of characters to show before truncating (default: 200) */
+  truncateLength?: number;
   className?: string;
 }
 
@@ -299,13 +304,18 @@ interface ThinkingRendererProps {
  * - If there's subsequent content after this thinking block, it's complete
  * - Only the last thinking block (while agent is running) shows animation
  */
-function ThinkingRenderer({ text, messageId, className }: ThinkingRendererProps) {
+function ThinkingRenderer({
+  text,
+  messageId,
+  truncateLength = DEFAULT_THINKING_TRUNCATE_LENGTH,
+  className,
+}: ThinkingRendererProps) {
   const [isExpanded, setIsExpanded] = React.useState(false);
   const isInProgress = useIsThinkingInProgress(messageId);
 
   // Show truncated version if long
-  const shouldTruncate = text.length > 200;
-  const displayText = shouldTruncate && !isExpanded ? `${text.slice(0, 200)}...` : text;
+  const shouldTruncate = text.length > truncateLength;
+  const displayText = shouldTruncate && !isExpanded ? `${text.slice(0, truncateLength)}...` : text;
 
   return (
     <div

--- a/src/components/agent-activity/use-agent-websocket.ts
+++ b/src/components/agent-activity/use-agent-websocket.ts
@@ -15,6 +15,7 @@ import {
   createEmptyTokenStats,
   updateTokenStatsFromResult,
 } from '@/lib/claude-types';
+import { buildWebSocketUrl } from '@/lib/websocket-config';
 
 // =============================================================================
 // Types
@@ -54,9 +55,10 @@ export interface UseAgentWebSocketReturn {
 // Constants
 // =============================================================================
 
+// Note: Agent activity uses longer delays/attempts than chat since agents
+// may be starting up or restarting
 const MAX_RECONNECT_ATTEMPTS = 5;
 const RECONNECT_DELAY_MS = 3000;
-const WEBSOCKET_PORT = 3001;
 
 // =============================================================================
 // Helper Functions
@@ -211,8 +213,7 @@ export function useAgentWebSocket(options: UseAgentWebSocketOptions): UseAgentWe
     setConnectionState('connecting');
     setError(null);
 
-    const host = typeof window !== 'undefined' ? window.location.hostname : 'localhost';
-    const wsUrl = `ws://${host}:${WEBSOCKET_PORT}/agent-activity?agentId=${encodeURIComponent(agentId)}`;
+    const wsUrl = buildWebSocketUrl('/agent-activity', { agentId });
 
     try {
       const ws = new WebSocket(wsUrl);

--- a/src/components/chat/permission-prompt.tsx
+++ b/src/components/chat/permission-prompt.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ShieldCheck, ShieldX, Terminal } from 'lucide-react';
+import { useEffect, useRef } from 'react';
 
 import { Button } from '@/components/ui/button';
 import type { PermissionRequest } from '@/lib/claude-types';
@@ -67,6 +68,21 @@ function formatToolInput(input: Record<string, unknown>): string {
  * Appears above the chat input as a compact card.
  */
 export function PermissionPrompt({ permission, onApprove }: PermissionPromptProps) {
+  const allowButtonRef = useRef<HTMLButtonElement>(null);
+
+  // Focus the Allow button when the prompt appears for keyboard accessibility
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Only re-focus when requestId changes
+  useEffect(() => {
+    if (!permission) {
+      return;
+    }
+    // Small delay to ensure the element is rendered and focusable
+    const timeoutId = setTimeout(() => {
+      allowButtonRef.current?.focus();
+    }, 100);
+    return () => clearTimeout(timeoutId);
+  }, [permission?.requestId]);
+
   if (!permission) {
     return null;
   }
@@ -83,9 +99,13 @@ export function PermissionPrompt({ permission, onApprove }: PermissionPromptProp
   };
 
   return (
-    <div className="border-b bg-muted/50 p-3">
+    <div
+      className="border-b bg-muted/50 p-3"
+      role="alertdialog"
+      aria-label={`Permission request for ${toolName}`}
+    >
       <div className="flex items-start gap-3">
-        <Terminal className="h-5 w-5 shrink-0 text-muted-foreground mt-0.5" />
+        <Terminal className="h-5 w-5 shrink-0 text-muted-foreground mt-0.5" aria-hidden="true" />
         <div className="flex-1 min-w-0">
           <div className="text-sm font-medium">Permission: {toolName}</div>
           <div
@@ -97,11 +117,11 @@ export function PermissionPrompt({ permission, onApprove }: PermissionPromptProp
         </div>
         <div className="flex gap-2 shrink-0">
           <Button variant="outline" size="sm" onClick={handleDeny} className="gap-1.5">
-            <ShieldX className="h-3.5 w-3.5" />
+            <ShieldX className="h-3.5 w-3.5" aria-hidden="true" />
             Deny
           </Button>
-          <Button size="sm" onClick={handleAllow} className="gap-1.5">
-            <ShieldCheck className="h-3.5 w-3.5" />
+          <Button ref={allowButtonRef} size="sm" onClick={handleAllow} className="gap-1.5">
+            <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
             Allow
           </Button>
         </div>
@@ -115,6 +135,20 @@ export function PermissionPrompt({ permission, onApprove }: PermissionPromptProp
  * Use when more context is needed before approval.
  */
 export function PermissionPromptExpanded({ permission, onApprove }: PermissionPromptProps) {
+  const allowButtonRef = useRef<HTMLButtonElement>(null);
+
+  // Focus the Allow button when the prompt appears for keyboard accessibility
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Only re-focus when requestId changes
+  useEffect(() => {
+    if (!permission) {
+      return;
+    }
+    const timeoutId = setTimeout(() => {
+      allowButtonRef.current?.focus();
+    }, 100);
+    return () => clearTimeout(timeoutId);
+  }, [permission?.requestId]);
+
   if (!permission) {
     return null;
   }
@@ -130,9 +164,13 @@ export function PermissionPromptExpanded({ permission, onApprove }: PermissionPr
   };
 
   return (
-    <div className="border-b bg-muted/50 p-3">
+    <div
+      className="border-b bg-muted/50 p-3"
+      role="alertdialog"
+      aria-label={`Permission request for ${toolName}`}
+    >
       <div className="flex items-start gap-3">
-        <Terminal className="h-5 w-5 shrink-0 text-muted-foreground mt-0.5" />
+        <Terminal className="h-5 w-5 shrink-0 text-muted-foreground mt-0.5" aria-hidden="true" />
         <div className="flex-1 min-w-0 space-y-2">
           <div className="text-sm font-medium">Permission: {toolName}</div>
           <div className="bg-background rounded-md p-2 border">
@@ -143,11 +181,11 @@ export function PermissionPromptExpanded({ permission, onApprove }: PermissionPr
         </div>
         <div className="flex gap-2 shrink-0">
           <Button variant="outline" size="sm" onClick={handleDeny} className="gap-1.5">
-            <ShieldX className="h-3.5 w-3.5" />
+            <ShieldX className="h-3.5 w-3.5" aria-hidden="true" />
             Deny
           </Button>
-          <Button size="sm" onClick={handleAllow} className="gap-1.5">
-            <ShieldCheck className="h-3.5 w-3.5" />
+          <Button ref={allowButtonRef} size="sm" onClick={handleAllow} className="gap-1.5">
+            <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
             Allow
           </Button>
         </div>

--- a/src/components/chat/session-picker.tsx
+++ b/src/components/chat/session-picker.tsx
@@ -58,6 +58,7 @@ function formatDate(dateString: string): string {
       day: 'numeric',
     });
   } catch {
+    // Invalid date string - return as-is rather than crashing
     return dateString;
   }
 }

--- a/src/lib/websocket-config.ts
+++ b/src/lib/websocket-config.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared WebSocket configuration for frontend components.
+ * This centralizes the WebSocket connection settings used by chat and agent-activity hooks.
+ */
+
+/**
+ * Port number for WebSocket connections to the backend.
+ * In development, this matches the BACKEND_PORT env var (defaults to 3001).
+ */
+export const WEBSOCKET_PORT = 3001;
+
+/**
+ * Maximum reconnection attempts before giving up.
+ */
+export const MAX_RECONNECT_ATTEMPTS = 3;
+
+/**
+ * Delay in milliseconds between reconnection attempts.
+ */
+export const RECONNECT_DELAY_MS = 2000;
+
+/**
+ * Constructs a WebSocket URL for the given endpoint with query parameters.
+ * @param endpoint - The WebSocket endpoint path (e.g., '/chat', '/agent-activity')
+ * @param params - Query parameters to append to the URL
+ */
+export function buildWebSocketUrl(endpoint: string, params: Record<string, string>): string {
+  const host = typeof window !== 'undefined' ? window.location.hostname : 'localhost';
+  const queryString = new URLSearchParams(params).toString();
+  return `ws://${host}:${WEBSOCKET_PORT}${endpoint}?${queryString}`;
+}


### PR DESCRIPTION
## Summary
- Fix debug logging leaking to production by using `NODE_ENV` check
- Fix module-level mutable state issue by moving counter to instance-scoped ref
- Add `useEffect` to reset `QuestionPrompt` state when question changes (prevents stale state)
- Simplify redundant key calculation and memoize `groupAdjacentToolCalls` for performance
- Add Next.js error boundary (`error.tsx`) for graceful error recovery in chat
- Extract `WEBSOCKET_PORT` to shared config (`websocket-config.ts`) used by both hooks
- Make `ThinkingRenderer` truncation length configurable via prop
- Add ARIA labels, focus management, and aria-live status announcements for accessibility
- Clear tool input accumulator map when loading new sessions to prevent memory buildup
- Minor cleanup: move misplaced import, add comment to empty catch block

## Test plan
- [ ] Verify chat page loads without console spam in production mode
- [ ] Test loading different sessions clears previous state correctly
- [ ] Test permission and question prompts auto-focus for keyboard accessibility
- [ ] Verify screen readers announce status changes
- [ ] Test error boundary by triggering a render error

🤖 Generated with [Claude Code](https://claude.com/claude-code)