### PR TITLE
Make sidebar fixed height with scrollable content area

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -137,7 +137,7 @@ const SidebarProvider = React.forwardRef<
               } as React.CSSProperties
             }
             className={cn(
-              'group/sidebar-wrapper flex min-h-svh w-full has-[[data-variant=inset]]:bg-sidebar',
+              'group/sidebar-wrapper flex h-svh w-full has-[[data-variant=inset]]:bg-sidebar',
               className
             )}
             ref={ref}
@@ -319,7 +319,7 @@ const SidebarInset = React.forwardRef<HTMLDivElement, React.ComponentProps<'main
       <main
         ref={ref}
         className={cn(
-          'relative flex w-full flex-1 flex-col bg-background',
+          'relative flex min-h-0 w-full flex-1 flex-col overflow-y-auto bg-background',
           'md:peer-data-[variant=inset]:m-2 md:peer-data-[state=collapsed]:peer-data-[variant=inset]:ml-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow',
           className
         )}


### PR DESCRIPTION
## Summary
- Change `SidebarProvider` from `min-h-svh` to `h-svh` to fix layout at viewport height
- Add `min-h-0` and `overflow-y-auto` to `SidebarInset` so main content scrolls independently
- Sidebar now stays visible at full height while body content scrolls

## Test plan
- [ ] Verify sidebar remains visible when scrolling page content
- [ ] Test with long content that exceeds viewport height
- [ ] Verify mobile behavior still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)