### PR TITLE
Add chat session startup status indicator

### DIFF
--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -835,6 +835,9 @@ async function handleChatMessage(
 ) {
   switch (message.type) {
     case 'start': {
+      // Notify client that session is starting (Claude CLI spinning up)
+      ws.send(JSON.stringify({ type: 'starting', sessionId }));
+
       // Map planModeEnabled to permissionMode
       const permissionMode = message.planModeEnabled ? 'plan' : 'bypassPermissions';
 
@@ -861,8 +864,11 @@ async function handleChatMessage(
       if (client) {
         client.sendMessage(message.text || '');
       } else {
+        // Notify client that session is starting (Claude CLI spinning up)
+        ws.send(JSON.stringify({ type: 'starting', sessionId }));
         // Auto-start if not running
         const newClient = await getOrCreateChatClient(sessionId, { workingDir });
+        ws.send(JSON.stringify({ type: 'started', sessionId }));
         newClient.sendMessage(message.text || '');
       }
       break;


### PR DESCRIPTION
## Summary
- Add "Starting session..." indicator in chat area during Claude CLI startup (6-7 second delay)
- Simplify status dot to three states: gray (disconnected), green pulsing (busy), green solid (ready)
- Backend sends `starting` message before spawning Claude process for immediate feedback

## Test plan
- [ ] Load /chat page - should show gray dot initially, then green when connected
- [ ] Send first message - should show "Starting session..." with green pulsing dot
- [ ] Wait for Claude to respond - should transition to "Agent is working..." then green solid when done
- [ ] Verify no confusing color transitions (no orange/yellow/blue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)