### PR TITLE
Fix sidebar Working indicator to show actual session activity

### DIFF
--- a/src/backend/resource_accessors/claude-session.accessor.ts
+++ b/src/backend/resource_accessors/claude-session.accessor.ts
@@ -90,6 +90,18 @@ class ClaudeSessionAccessor {
       orderBy: { updatedAt: 'desc' },
     });
   }
+
+  /**
+   * Find sessions for multiple workspaces in a single query.
+   */
+  findByWorkspaceIds(workspaceIds: string[]): Promise<ClaudeSession[]> {
+    return prisma.claudeSession.findMany({
+      where: {
+        workspaceId: { in: workspaceIds },
+      },
+      orderBy: { updatedAt: 'desc' },
+    });
+  }
 }
 
 export const claudeSessionAccessor = new ClaudeSessionAccessor();

--- a/src/backend/services/session.service.ts
+++ b/src/backend/services/session.service.ts
@@ -123,6 +123,33 @@ class SessionService {
     const process = activeClaudeProcesses.get(sessionId);
     return process?.isRunning() ?? false;
   }
+
+  /**
+   * Check if a session is actively working (not just alive, but processing)
+   */
+  isSessionWorking(sessionId: string): boolean {
+    const process = activeClaudeProcesses.get(sessionId);
+    return process?.getStatus() === 'running';
+  }
+
+  /**
+   * Get working status for all sessions in a workspace.
+   * Returns a map of sessionId -> isWorking
+   */
+  getWorkspaceWorkingStatus(sessionIds: string[]): Map<string, boolean> {
+    const result = new Map<string, boolean>();
+    for (const sessionId of sessionIds) {
+      result.set(sessionId, this.isSessionWorking(sessionId));
+    }
+    return result;
+  }
+
+  /**
+   * Check if any session in the given list is actively working
+   */
+  isAnySessionWorking(sessionIds: string[]): boolean {
+    return sessionIds.some((id) => this.isSessionWorking(id));
+  }
 }
 
 export const sessionService = new SessionService();

--- a/src/backend/services/session.service.ts
+++ b/src/backend/services/session.service.ts
@@ -133,18 +133,6 @@ class SessionService {
   }
 
   /**
-   * Get working status for all sessions in a workspace.
-   * Returns a map of sessionId -> isWorking
-   */
-  getWorkspaceWorkingStatus(sessionIds: string[]): Map<string, boolean> {
-    const result = new Map<string, boolean>();
-    for (const sessionId of sessionIds) {
-      result.set(sessionId, this.isSessionWorking(sessionId));
-    }
-    return result;
-  }
-
-  /**
    * Check if any session in the given list is actively working
    */
   isAnySessionWorking(sessionIds: string[]): boolean {

--- a/src/backend/trpc/session.trpc.ts
+++ b/src/backend/trpc/session.trpc.ts
@@ -148,4 +148,28 @@ export const sessionRouter = router({
     .mutation(({ input }) => {
       return terminalSessionAccessor.delete(input.id);
     }),
+
+  // Working Status
+
+  // Check if any session in a workspace is actively working
+  isWorkspaceWorking: publicProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .query(async ({ input }) => {
+      const sessions = await claudeSessionAccessor.findByWorkspaceId(input.workspaceId);
+      const sessionIds = sessions.map((s) => s.id);
+      return sessionService.isAnySessionWorking(sessionIds);
+    }),
+
+  // Get working status for multiple workspaces at once
+  getWorkspacesWorkingStatus: publicProcedure
+    .input(z.object({ workspaceIds: z.array(z.string()) }))
+    .query(async ({ input }) => {
+      const result: Record<string, boolean> = {};
+      for (const workspaceId of input.workspaceIds) {
+        const sessions = await claudeSessionAccessor.findByWorkspaceId(workspaceId);
+        const sessionIds = sessions.map((s) => s.id);
+        result[workspaceId] = sessionService.isAnySessionWorking(sessionIds);
+      }
+      return result;
+    }),
 });

--- a/src/frontend/components/app-sidebar.tsx
+++ b/src/frontend/components/app-sidebar.tsx
@@ -27,7 +27,6 @@ import {
   SidebarSeparator,
 } from '@/components/ui/sidebar';
 import { Skeleton } from '@/components/ui/skeleton';
-import { cn } from '@/lib/utils';
 import { setProjectContext, trpc } from '../lib/trpc';
 import { Logo } from './logo';
 
@@ -63,6 +62,13 @@ export function AppSidebar() {
   const { data: workspaces } = trpc.workspace.list.useQuery(
     { projectId: selectedProjectId ?? '', status: 'ACTIVE' },
     { enabled: !!selectedProjectId, refetchInterval: 5000 }
+  );
+
+  // Fetch working status for all workspaces
+  const workspaceIds = workspaces?.map((w) => w.id) ?? [];
+  const { data: workingStatus } = trpc.session.getWorkspacesWorkingStatus.useQuery(
+    { workspaceIds },
+    { enabled: workspaceIds.length > 0, refetchInterval: 1000 }
   );
 
   const utils = trpc.useUtils();
@@ -250,15 +256,12 @@ export function AppSidebar() {
                               </div>
                               <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
                                 <span className="truncate">{workspace.name}</span>
-                                <span>·</span>
-                                <span
-                                  className={cn(
-                                    workspace.status === 'ACTIVE' && 'text-green-500',
-                                    workspace.status === 'COMPLETED' && 'text-blue-500'
-                                  )}
-                                >
-                                  {workspace.status === 'ACTIVE' ? 'Working...' : workspace.status}
-                                </span>
+                                {workingStatus?.[workspace.id] && (
+                                  <>
+                                    <span>·</span>
+                                    <span className="text-green-500">Working...</span>
+                                  </>
+                                )}
                               </div>
                             </div>
                           </Link>


### PR DESCRIPTION
## Summary
- Sidebar now shows "Working..." only when a Claude session is actively processing (streaming response, executing tools)
- Previously showed "Working..." for all ACTIVE workspaces regardless of actual session state
- Uses in-memory process status tracking, easily extendable to Redis for multi-server deployments

## Test plan
- [ ] Start a Claude session and verify "Working..." appears while Claude is responding
- [ ] Verify "Working..." disappears when Claude finishes responding and is waiting for input
- [ ] Verify workspaces with no running sessions don't show "Working..."

🤖 Generated with [Claude Code](https://claude.com/claude-code)