### PR TITLE
Add tabbed session view for workspaces

### DIFF
--- a/src/app/projects/[slug]/workspaces/[id]/page.tsx
+++ b/src/app/projects/[slug]/workspaces/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { GitBranch, Plus } from 'lucide-react';
+import { GitBranch } from 'lucide-react';
 import { useParams, useRouter } from 'next/navigation';
 import { Suspense, useCallback, useEffect, useMemo, useRef } from 'react';
 
@@ -9,7 +9,7 @@ import {
   ChatInput,
   PermissionPrompt,
   QuestionPrompt,
-  SessionPicker,
+  SessionTabBar,
   useChatWebSocket,
 } from '@/components/chat';
 import { Button } from '@/components/ui/button';
@@ -117,6 +117,13 @@ function WorkspaceChatContent() {
     },
   });
 
+  // Delete session mutation
+  const deleteSession = trpc.session.deleteClaudeSession.useMutation({
+    onSuccess: () => {
+      utils.session.listClaudeSessions.invalidate({ workspaceId });
+    },
+  });
+
   // Get the first session (or most recent) to auto-load
   const initialSessionId = claudeSessions?.[0]?.id;
 
@@ -126,7 +133,6 @@ function WorkspaceChatContent() {
     connected,
     running,
     claudeSessionId,
-    availableSessions,
     pendingPermission,
     pendingQuestion,
     loadingSession,
@@ -142,29 +148,86 @@ function WorkspaceChatContent() {
     messagesEndRef,
   } = useChatWebSocket({ initialSessionId });
 
-  // Load session when sessions are fetched and we have one
+  // Load session when sessions are fetched and we have one with history
   useEffect(() => {
     if (initialSessionId && !claudeSessionId && !loadingSession) {
-      loadSession(initialSessionId);
+      // Find the session and only load if it has an actual Claude session ID
+      // (meaning it has history to load). New sessions won't have one yet.
+      const session = claudeSessions?.find((s) => s.id === initialSessionId);
+      if (session?.claudeSessionId) {
+        loadSession(session.claudeSessionId);
+      }
     }
-  }, [initialSessionId, claudeSessionId, loadingSession, loadSession]);
+  }, [initialSessionId, claudeSessionId, loadingSession, loadSession, claudeSessions]);
 
-  // Handle loading a session
-  const handleLoadSession = useCallback(
+  // Handle selecting a session by TRPC session ID
+  const handleSelectSession = useCallback(
     (sessionId: string) => {
-      loadSession(sessionId);
+      // Find the session and load it using the claudeSessionId
+      const session = claudeSessions?.find((s) => s.id === sessionId);
+      if (session?.claudeSessionId) {
+        loadSession(session.claudeSessionId);
+      } else {
+        // Session exists but has no claudeSessionId - it's a new session with no history
+        // Just clear the chat to show empty state
+        clearChat();
+      }
     },
-    [loadSession]
+    [loadSession, claudeSessions, clearChat]
+  );
+
+  // Handle closing/deleting a session
+  const handleCloseSession = useCallback(
+    (sessionId: string) => {
+      if (!claudeSessions || claudeSessions.length === 0) {
+        return;
+      }
+
+      // Find the session being closed
+      const sessionIndex = claudeSessions.findIndex((s) => s.id === sessionId);
+      if (sessionIndex === -1) {
+        return;
+      }
+
+      const closingSession = claudeSessions[sessionIndex];
+      const isCurrentSession =
+        closingSession.claudeSessionId === claudeSessionId || closingSession.id === claudeSessionId;
+
+      // Delete the session
+      deleteSession.mutate({ id: sessionId });
+
+      // If closing the current session, switch to an adjacent one
+      if (isCurrentSession && claudeSessions.length > 1) {
+        // Prefer next session, fallback to previous
+        const nextSession = claudeSessions[sessionIndex + 1] ?? claudeSessions[sessionIndex - 1];
+        if (nextSession?.claudeSessionId) {
+          loadSession(nextSession.claudeSessionId);
+        } else {
+          clearChat();
+        }
+      } else if (claudeSessions.length === 1) {
+        // Closing the last session
+        clearChat();
+      }
+    },
+    [claudeSessions, claudeSessionId, deleteSession, loadSession, clearChat]
   );
 
   // Handle new chat button - creates a new session for this workspace
   const handleNewChat = useCallback(() => {
-    clearChat();
-    createSession.mutate({
-      workspaceId,
-      workflow: 'explore',
-      model: 'sonnet',
-    });
+    createSession.mutate(
+      {
+        workspaceId,
+        workflow: 'explore',
+        model: 'sonnet',
+      },
+      {
+        onSuccess: () => {
+          // Clear chat after session is created - the new session has no history to load
+          clearChat();
+        },
+      }
+    );
   }, [clearChat, createSession, workspaceId]);
 
   // Determine connection status for indicator
@@ -214,16 +277,18 @@ function WorkspaceChatContent() {
     );
   }
 
-  // Filter available sessions to only show ones for this workspace
-  const workspaceSessions = availableSessions.filter((s) =>
-    claudeSessions?.some((cs) => cs.id === s.sessionId)
-  );
+  // Find the running session ID (session that is currently processing)
+  const runningSessionIdFromDb = running
+    ? claudeSessions?.find((s) => s.claudeSessionId === claudeSessionId || s.id === claudeSessionId)
+        ?.id
+    : undefined;
 
   return (
     <div className="flex h-[calc(100svh-24px)] flex-col overflow-hidden">
       {/* Header */}
-      <div className="flex items-center justify-between border-b px-4 py-3">
-        <div className="flex items-center gap-3">
+      <div className="border-b">
+        {/* Row 1: Branch name and status */}
+        <div className="flex items-center gap-3 px-4 py-2">
           {workspace.branchName ? (
             <div className="flex items-center gap-2">
               <GitBranch className="h-4 w-4 text-muted-foreground" />
@@ -234,22 +299,22 @@ function WorkspaceChatContent() {
           )}
           <StatusDot status={status} />
         </div>
-        <div className="flex items-center gap-2">
-          <SessionPicker
-            sessions={workspaceSessions.length > 0 ? workspaceSessions : availableSessions}
-            currentSessionId={claudeSessionId}
-            onLoadSession={handleLoadSession}
-            disabled={running}
+
+        {/* Row 2: Session tabs */}
+        <div className="px-4 pb-2">
+          <SessionTabBar
+            sessions={claudeSessions ?? []}
+            currentSessionId={
+              claudeSessions?.find(
+                (s) => s.claudeSessionId === claudeSessionId || s.id === claudeSessionId
+              )?.id ?? null
+            }
+            runningSessionId={runningSessionIdFromDb}
+            onSelectSession={handleSelectSession}
+            onCreateSession={handleNewChat}
+            onCloseSession={handleCloseSession}
+            disabled={running || createSession.isPending || deleteSession.isPending}
           />
-          <Button
-            variant="outline"
-            size="icon"
-            onClick={handleNewChat}
-            disabled={running || createSession.isPending}
-            title="New Chat"
-          >
-            <Plus className="h-4 w-4" />
-          </Button>
         </div>
       </div>
 

--- a/src/app/projects/[slug]/workspaces/[id]/page.tsx
+++ b/src/app/projects/[slug]/workspaces/[id]/page.tsx
@@ -190,8 +190,7 @@ function WorkspaceChatContent() {
       }
 
       const closingSession = claudeSessions[sessionIndex];
-      const isCurrentSession =
-        closingSession.claudeSessionId === claudeSessionId || closingSession.id === claudeSessionId;
+      const isCurrentSession = closingSession.claudeSessionId === claudeSessionId;
 
       // Delete the session
       deleteSession.mutate({ id: sessionId });
@@ -279,8 +278,7 @@ function WorkspaceChatContent() {
 
   // Find the running session ID (session that is currently processing)
   const runningSessionIdFromDb = running
-    ? claudeSessions?.find((s) => s.claudeSessionId === claudeSessionId || s.id === claudeSessionId)
-        ?.id
+    ? claudeSessions?.find((s) => s.claudeSessionId === claudeSessionId)?.id
     : undefined;
 
   return (
@@ -305,9 +303,7 @@ function WorkspaceChatContent() {
           <SessionTabBar
             sessions={claudeSessions ?? []}
             currentSessionId={
-              claudeSessions?.find(
-                (s) => s.claudeSessionId === claudeSessionId || s.id === claudeSessionId
-              )?.id ?? null
+              claudeSessions?.find((s) => s.claudeSessionId === claudeSessionId)?.id ?? null
             }
             runningSessionId={runningSessionIdFromDb}
             onSelectSession={handleSelectSession}

--- a/src/components/chat/index.ts
+++ b/src/components/chat/index.ts
@@ -3,6 +3,7 @@ export { ChatInput } from './chat-input';
 export { PermissionPrompt, PermissionPromptExpanded } from './permission-prompt';
 export { QuestionPrompt } from './question-prompt';
 export { SessionPicker } from './session-picker';
+export { SessionTabBar } from './session-tab-bar';
 
 // Hook
 export type { UseChatWebSocketOptions, UseChatWebSocketReturn } from './use-chat-websocket';

--- a/src/components/chat/session-tab-bar.stories.tsx
+++ b/src/components/chat/session-tab-bar.stories.tsx
@@ -1,0 +1,225 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+
+import type { SessionData } from './session-tab-bar';
+import { SessionTabBar } from './session-tab-bar';
+
+const meta = {
+  title: 'Chat/SessionTabBar',
+  component: SessionTabBar,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    sessions: {
+      control: 'object',
+      description: 'Array of sessions to display as tabs',
+    },
+    currentSessionId: {
+      control: 'text',
+      description: 'ID of the currently selected session',
+    },
+    runningSessionId: {
+      control: 'text',
+      description: 'ID of the session that is currently processing',
+    },
+    onSelectSession: {
+      action: 'onSelectSession',
+      description: 'Callback when a session tab is clicked',
+    },
+    onCreateSession: {
+      action: 'onCreateSession',
+      description: 'Callback when the plus button is clicked',
+    },
+    onCloseSession: {
+      action: 'onCloseSession',
+      description: 'Callback when a tab close button is clicked',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Whether the tab bar is disabled',
+    },
+  },
+  args: {
+    onSelectSession: fn(),
+    onCreateSession: fn(),
+    onCloseSession: fn(),
+  },
+} satisfies Meta<typeof SessionTabBar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Helper to create session data
+function createSession(
+  id: string,
+  offsetMinutes: number,
+  options: Partial<SessionData> = {}
+): SessionData {
+  const now = new Date();
+  const createdAt = new Date(now.getTime() - offsetMinutes * 60 * 1000);
+  return {
+    id,
+    claudeSessionId: `claude-${id}`,
+    status: 'IDLE',
+    name: null,
+    createdAt,
+    ...options,
+  };
+}
+
+export const NoSessions: Story = {
+  args: {
+    sessions: [],
+    currentSessionId: null,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'When there are no sessions, a placeholder message is shown with the plus button.',
+      },
+    },
+  },
+};
+
+export const SingleSession: Story = {
+  args: {
+    sessions: [createSession('session-1', 60)],
+    currentSessionId: 'session-1',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'A single session displayed as a tab. Auto-generated name "Session 1" is used.',
+      },
+    },
+  },
+};
+
+export const MultipleSessions: Story = {
+  args: {
+    sessions: [
+      createSession('session-1', 180),
+      createSession('session-2', 120),
+      createSession('session-3', 60),
+    ],
+    currentSessionId: 'session-2',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Multiple sessions with the second one selected. Sessions are numbered by creation order.',
+      },
+    },
+  },
+};
+
+export const WithNamedSessions: Story = {
+  args: {
+    sessions: [
+      createSession('session-1', 180, { name: 'Bug Fix' }),
+      createSession('session-2', 120, { name: 'Feature Work' }),
+      createSession('session-3', 60, { name: 'Refactoring' }),
+    ],
+    currentSessionId: 'session-2',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Sessions can have custom names that override the auto-generated numbering.',
+      },
+    },
+  },
+};
+
+export const RunningSession: Story = {
+  args: {
+    sessions: [
+      createSession('session-1', 180),
+      createSession('session-2', 120, { status: 'RUNNING' }),
+      createSession('session-3', 60),
+    ],
+    currentSessionId: 'session-2',
+    runningSessionId: 'session-2',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A running session shows a pulsing yellow indicator. The tab bar may be disabled during processing.',
+      },
+    },
+  },
+};
+
+export const MixedStatuses: Story = {
+  args: {
+    sessions: [
+      createSession('session-1', 240, { status: 'COMPLETED' }),
+      createSession('session-2', 180, { status: 'FAILED' }),
+      createSession('session-3', 120, { status: 'PAUSED' }),
+      createSession('session-4', 60, { status: 'IDLE' }),
+    ],
+    currentSessionId: 'session-4',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Different session statuses show different indicator colors: green (idle), yellow (running), blue (completed), red (failed), gray (paused).',
+      },
+    },
+  },
+};
+
+export const ManySessions: Story = {
+  args: {
+    sessions: [
+      createSession('session-1', 480),
+      createSession('session-2', 420),
+      createSession('session-3', 360),
+      createSession('session-4', 300),
+      createSession('session-5', 240),
+      createSession('session-6', 180),
+      createSession('session-7', 120),
+      createSession('session-8', 60),
+    ],
+    currentSessionId: 'session-4',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: '400px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'When there are many sessions, the tab bar becomes scrollable. Scroll arrows appear when needed.',
+      },
+    },
+  },
+};
+
+export const DisabledState: Story = {
+  args: {
+    sessions: [
+      createSession('session-1', 180),
+      createSession('session-2', 120),
+      createSession('session-3', 60),
+    ],
+    currentSessionId: 'session-2',
+    disabled: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'The tab bar can be disabled to prevent interaction during loading or processing.',
+      },
+    },
+  },
+};

--- a/src/components/chat/session-tab-bar.tsx
+++ b/src/components/chat/session-tab-bar.tsx
@@ -1,0 +1,279 @@
+'use client';
+
+import type { SessionStatus } from '@prisma-gen/client';
+import { ChevronLeft, ChevronRight, Plus, X } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface SessionData {
+  id: string;
+  claudeSessionId?: string | null;
+  status: SessionStatus;
+  name?: string | null;
+  createdAt: Date;
+}
+
+interface SessionTabBarProps {
+  sessions: SessionData[];
+  currentSessionId: string | null;
+  runningSessionId?: string | null;
+  onSelectSession: (sessionId: string) => void;
+  onCreateSession: () => void;
+  onCloseSession: (sessionId: string) => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/**
+ * Gets the display name for a session based on its index.
+ */
+function getSessionDisplayName(session: SessionData, index: number): string {
+  if (session.name) {
+    return session.name;
+  }
+  return `Session ${index + 1}`;
+}
+
+// =============================================================================
+// Sub-Components
+// =============================================================================
+
+interface SessionTabProps {
+  session: SessionData;
+  displayName: string;
+  isActive: boolean;
+  isRunning: boolean;
+  onSelect: () => void;
+  onClose: () => void;
+  disabled?: boolean;
+}
+
+function SessionTab({
+  session,
+  displayName,
+  isActive,
+  isRunning,
+  onSelect,
+  onClose,
+  disabled,
+}: SessionTabProps) {
+  const handleClose = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      onClose();
+    },
+    [onClose]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (disabled) {
+        return;
+      }
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        onSelect();
+      }
+    },
+    [disabled, onSelect]
+  );
+
+  return (
+    <div
+      role="tab"
+      tabIndex={disabled ? -1 : 0}
+      onClick={disabled ? undefined : onSelect}
+      onKeyDown={handleKeyDown}
+      aria-selected={isActive}
+      aria-disabled={disabled}
+      className={cn(
+        'group relative flex items-center gap-2 px-3 py-1.5 text-sm font-medium cursor-pointer',
+        'rounded-md transition-all whitespace-nowrap',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+        isActive
+          ? 'bg-background text-foreground shadow-md border border-border'
+          : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
+        disabled && 'pointer-events-none opacity-50 cursor-default'
+      )}
+    >
+      {/* Status indicator */}
+      <div
+        className={cn(
+          'h-2 w-2 rounded-full shrink-0',
+          isRunning && 'bg-yellow-500 animate-pulse',
+          !isRunning && session.status === 'RUNNING' && 'bg-yellow-500 animate-pulse',
+          !isRunning && session.status === 'IDLE' && 'bg-green-500',
+          !isRunning && session.status === 'PAUSED' && 'bg-gray-400',
+          !isRunning && session.status === 'COMPLETED' && 'bg-blue-500',
+          !isRunning && session.status === 'FAILED' && 'bg-red-500'
+        )}
+      />
+
+      <span className="truncate max-w-[120px]">{displayName}</span>
+
+      {/* Close button - visible on hover */}
+      <button
+        type="button"
+        onClick={handleClose}
+        disabled={disabled}
+        className={cn(
+          'ml-1 rounded p-0.5 opacity-0 transition-opacity',
+          'hover:bg-muted-foreground/20 focus-visible:opacity-100',
+          'group-hover:opacity-100',
+          disabled && 'pointer-events-none'
+        )}
+        aria-label={`Close ${displayName}`}
+      >
+        <X className="h-3 w-3" />
+      </button>
+    </div>
+  );
+}
+
+// =============================================================================
+// Main Component
+// =============================================================================
+
+export function SessionTabBar({
+  sessions,
+  currentSessionId,
+  runningSessionId,
+  onSelectSession,
+  onCreateSession,
+  onCloseSession,
+  disabled = false,
+  className,
+}: SessionTabBarProps) {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const [showLeftArrow, setShowLeftArrow] = useState(false);
+  const [showRightArrow, setShowRightArrow] = useState(false);
+
+  // Sort sessions by creation date (oldest first for consistent numbering)
+  const sortedSessions = [...sessions].sort(
+    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+  );
+
+  // Check for overflow and update arrow visibility
+  const updateScrollArrows = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) {
+      return;
+    }
+
+    const { scrollLeft, scrollWidth, clientWidth } = container;
+    setShowLeftArrow(scrollLeft > 0);
+    setShowRightArrow(scrollLeft + clientWidth < scrollWidth - 1);
+  }, []);
+
+  // Update arrows on mount and when sessions change
+  // biome-ignore lint/correctness/useExhaustiveDependencies: We intentionally trigger on sessions.length changes to detect overflow
+  useEffect(() => {
+    updateScrollArrows();
+    window.addEventListener('resize', updateScrollArrows);
+    return () => window.removeEventListener('resize', updateScrollArrows);
+  }, [updateScrollArrows, sessions.length]);
+
+  // Scroll handlers
+  const scrollLeft = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (container) {
+      container.scrollBy({ left: -150, behavior: 'smooth' });
+    }
+  }, []);
+
+  const scrollRight = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (container) {
+      container.scrollBy({ left: 150, behavior: 'smooth' });
+    }
+  }, []);
+
+  // Handle scroll event
+  const handleScroll = useCallback(() => {
+    updateScrollArrows();
+  }, [updateScrollArrows]);
+
+  return (
+    <div className={cn('flex items-center gap-1 bg-muted rounded-lg p-1', className)}>
+      {/* Left scroll arrow */}
+      {showLeftArrow && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 shrink-0"
+          onClick={scrollLeft}
+          disabled={disabled}
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </Button>
+      )}
+
+      {/* Scrollable tab container */}
+      <div
+        ref={scrollContainerRef}
+        role="tablist"
+        onScroll={handleScroll}
+        className="flex items-center gap-1 overflow-x-auto scrollbar-none"
+        style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
+      >
+        {sortedSessions.length === 0 ? (
+          <div className="px-3 py-1.5 text-sm text-muted-foreground">No sessions</div>
+        ) : (
+          sortedSessions.map((session, index) => {
+            const isActive = session.id === currentSessionId;
+            const isRunning =
+              session.id === runningSessionId || session.claudeSessionId === runningSessionId;
+
+            return (
+              <SessionTab
+                key={session.id}
+                session={session}
+                displayName={getSessionDisplayName(session, index)}
+                isActive={isActive}
+                isRunning={isRunning}
+                onSelect={() => onSelectSession(session.id)}
+                onClose={() => onCloseSession(session.id)}
+                disabled={disabled}
+              />
+            );
+          })
+        )}
+      </div>
+
+      {/* Right scroll arrow */}
+      {showRightArrow && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 shrink-0"
+          onClick={scrollRight}
+          disabled={disabled}
+        >
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+      )}
+
+      {/* New session button */}
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-7 w-7 shrink-0 ml-1"
+        onClick={onCreateSession}
+        disabled={disabled}
+        title="New Session"
+      >
+        <Plus className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}

--- a/src/components/chat/session-tab-bar.tsx
+++ b/src/components/chat/session-tab-bar.tsx
@@ -231,8 +231,7 @@ export function SessionTabBar({
         ) : (
           sortedSessions.map((session, index) => {
             const isActive = session.id === currentSessionId;
-            const isRunning =
-              session.id === runningSessionId || session.claudeSessionId === runningSessionId;
+            const isRunning = session.id === runningSessionId;
 
             return (
               <SessionTab


### PR DESCRIPTION
## Summary

- Replace `SessionPicker` dropdown with horizontal `SessionTabBar` component
- Each tab shows session name, status indicator, and close button
- Horizontal scrolling with arrow buttons when tabs overflow
- Plus button to create new sessions
- Proper handling of sessions without history (newly created)

## Changes

**New files:**
- `src/components/chat/session-tab-bar.tsx` - New tabbed session selector component
- `src/components/chat/session-tab-bar.stories.tsx` - Storybook stories

**Modified files:**
- `src/app/projects/[slug]/workspaces/[id]/page.tsx` - Use SessionTabBar, add delete mutation, restructure header
- `src/components/chat/index.ts` - Export new component

## Test plan

- [ ] Create workspace with multiple sessions
- [ ] Verify tabs display correctly with auto-generated names
- [ ] Test tab switching loads correct session
- [ ] Test close button deletes session and switches appropriately
- [ ] Test new session creation via + button
- [ ] Verify running session indicator displays correctly
- [ ] Test overflow scrolling with many tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)