### PR TITLE
Fix chat input and message text overflow issues

### DIFF
--- a/src/components/agent-activity/agent-activity.tsx
+++ b/src/components/agent-activity/agent-activity.tsx
@@ -217,7 +217,7 @@ export function MessageItem({ message }: MessageItemProps) {
   if (message.source === 'user') {
     return (
       <MessageWrapper chatMessage={message}>
-        <div className="rounded-lg bg-primary text-primary-foreground px-3 py-2 inline-block">
+        <div className="rounded-lg bg-primary text-primary-foreground px-3 py-2 inline-block max-w-full break-words">
           {stripThinkingSuffix(message.text)}
         </div>
       </MessageWrapper>

--- a/src/components/agent-activity/message-renderers.tsx
+++ b/src/components/agent-activity/message-renderers.tsx
@@ -118,7 +118,7 @@ export function AssistantMessageRenderer({
   const text = extractTextFromMessage(message);
   if (text) {
     return (
-      <div className={cn('prose prose-sm dark:prose-invert max-w-none', className)}>
+      <div className={cn('prose prose-sm dark:prose-invert max-w-none break-words', className)}>
         <TextRenderer text={text} />
       </div>
     );

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -192,8 +192,9 @@ export function ChatInput({
         if (text && !disabled && !running) {
           onSend(text);
           event.currentTarget.value = '';
-          // Reset textarea height
+          // Reset textarea height and overflow
           event.currentTarget.style.height = 'auto';
+          event.currentTarget.style.overflowY = 'hidden';
         }
       }
     },
@@ -212,16 +213,22 @@ export function ChatInput({
         onSend(text);
         inputRef.current.value = '';
         inputRef.current.style.height = 'auto';
+        inputRef.current.style.overflowY = 'hidden';
         inputRef.current.focus();
       }
     }
   }, [onSend, onStop, inputRef, disabled, running]);
 
   // Auto-resize textarea based on content
+  const maxHeight = 200;
   const handleInput = useCallback((event: React.FormEvent<HTMLTextAreaElement>) => {
     const target = event.currentTarget;
+    // Reset height to auto to get accurate scrollHeight
     target.style.height = 'auto';
-    target.style.height = `${Math.min(target.scrollHeight, 200)}px`;
+    const newHeight = Math.min(target.scrollHeight, maxHeight);
+    target.style.height = `${newHeight}px`;
+    // Show scrollbar only when content exceeds max height
+    target.style.overflowY = target.scrollHeight > maxHeight ? 'auto' : 'hidden';
   }, []);
 
   // Focus input when component mounts or when running state changes to false
@@ -266,7 +273,7 @@ export function ChatInput({
           disabled={isDisabled}
           placeholder={isDisabled ? 'Connecting...' : placeholder}
           className={cn(
-            'min-h-[40px] max-h-[200px]',
+            'min-h-[40px] max-h-[200px] overflow-y-hidden',
             isDisabled && 'opacity-50 cursor-not-allowed'
           )}
           rows={1}

--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -12,7 +12,7 @@ interface MarkdownRendererProps {
 
 export function MarkdownRenderer({ content, className }: MarkdownRendererProps) {
   return (
-    <div className={cn('prose prose-sm dark:prose-invert max-w-none', className)}>
+    <div className={cn('prose prose-sm dark:prose-invert max-w-none break-words', className)}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{


### PR DESCRIPTION
## Summary
- Fix long text in chat messages overflowing the container instead of wrapping by adding `break-words` and `max-w-full` to user messages and prose containers
- Fix chat input textarea showing scrollbar when content doesn't require it by properly managing `overflowY` state during auto-resize and message send

## Test plan
- [ ] Send a message with a very long unbroken string (like a URL) and verify it wraps instead of overflowing
- [ ] Type multi-line content in the chat input and verify the scrollbar only appears when content exceeds max height
- [ ] Send a message and verify the textarea resets properly without a lingering scrollbar

🤖 Generated with [Claude Code](https://claude.ai/code)