### PR TITLE
Fix workspace creation failing with invalid branch reference

### DIFF
--- a/src/backend/trpc/workspace.trpc.ts
+++ b/src/backend/trpc/workspace.trpc.ts
@@ -221,6 +221,18 @@ export const workspaceRouter = router({
         const worktreeName = `workspace-${workspace.id}`;
         const baseBranch = input.branchName ?? project.defaultBranch;
 
+        // Validate that the base branch exists before attempting to create worktree
+        const branchExists = await gitClient.branchExists(baseBranch);
+        if (!branchExists) {
+          // Also check if it's a remote branch (origin/branchName)
+          const remoteBranchExists = await gitClient.branchExists(`origin/${baseBranch}`);
+          if (!remoteBranchExists) {
+            throw new Error(
+              `Branch '${baseBranch}' does not exist. Please specify an existing branch or leave empty to use the default branch '${project.defaultBranch}'.`
+            );
+          }
+        }
+
         const worktreeInfo = await gitClient.createWorktree(worktreeName, baseBranch);
         const worktreePath = gitClient.getWorktreePath(worktreeName);
 

--- a/src/frontend/components/app-sidebar.tsx
+++ b/src/frontend/components/app-sidebar.tsx
@@ -82,11 +82,10 @@ export function AppSidebar() {
     }
     const name = generateWorkspaceName();
 
-    // Create workspace
+    // Create workspace (branchName defaults to project's default branch)
     const workspace = await createWorkspace.mutateAsync({
       projectId: selectedProjectId,
       name,
-      branchName: name,
     });
 
     // Create a Claude session for the workspace


### PR DESCRIPTION
## Summary
- Fixed sidebar incorrectly passing generated workspace name as `branchName` parameter (which should be the base branch like `main`, not the workspace name)
- Added validation to check if specified base branch exists before creating worktree, with helpful error message

## Test plan
- [x] Click the + button next to Workspaces in the sidebar to create a new workspace
- [x] Verify workspace creation succeeds without "invalid reference" error
- [x] TypeScript and lint checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)