### PR TITLE
Use short hash branch names instead of workspace-cuid

### DIFF
--- a/src/backend/services/reconciliation.service.ts
+++ b/src/backend/services/reconciliation.service.ts
@@ -55,7 +55,9 @@ class ReconciliationService {
     const worktreeName = `workspace-${workspaceId}`;
     const baseBranch = workspace.branchName ?? project.defaultBranch;
 
-    const worktreeInfo = await gitClient.createWorktree(worktreeName, baseBranch);
+    const worktreeInfo = await gitClient.createWorktree(worktreeName, baseBranch, {
+      branchPrefix: project.githubOwner ?? undefined,
+    });
     const worktreePath = gitClient.getWorktreePath(worktreeName);
 
     await workspaceAccessor.update(workspaceId, {

--- a/src/backend/trpc/workspace.trpc.ts
+++ b/src/backend/trpc/workspace.trpc.ts
@@ -233,7 +233,9 @@ export const workspaceRouter = router({
           }
         }
 
-        const worktreeInfo = await gitClient.createWorktree(worktreeName, baseBranch);
+        const worktreeInfo = await gitClient.createWorktree(worktreeName, baseBranch, {
+          branchPrefix: project.githubOwner ?? undefined,
+        });
         const worktreePath = gitClient.getWorktreePath(worktreeName);
 
         // Update workspace with worktree info


### PR DESCRIPTION
## Summary
- Changes branch naming from `factoryfactory/workspace-{cuid}` to `{github-owner}/{6-char-hash}`
- Adds `generateBranchName()` method to GitClient for short random hashes
- Passes project's `githubOwner` as branch prefix when creating worktrees

## Test plan
- [ ] Create a new workspace and verify branch name follows new format (e.g., `martin-purplefish/a38djnb`)
- [ ] Verify worktree creation still works correctly
- [ ] Check that projects without `githubOwner` get hash-only branch names

🤖 Generated with [Claude Code](https://claude.ai/code)