### PR TITLE
Add dark mode support

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from 'next';
 import './globals.css';
 import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
 import { AppSidebar } from '../frontend/components/app-sidebar';
+import { ThemeProvider } from '../frontend/components/theme-provider';
 import { TRPCProvider } from '../frontend/lib/providers';
 
 export const metadata: Metadata = {
@@ -13,14 +14,20 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className={`${GeistSans.variable} ${GeistMono.variable}`}>
+    <html
+      lang="en"
+      className={`${GeistSans.variable} ${GeistMono.variable}`}
+      suppressHydrationWarning
+    >
       <body className="min-h-screen bg-background font-sans antialiased">
-        <TRPCProvider>
-          <SidebarProvider>
-            <AppSidebar />
-            <SidebarInset className="p-3">{children}</SidebarInset>
-          </SidebarProvider>
-        </TRPCProvider>
+        <ThemeProvider>
+          <TRPCProvider>
+            <SidebarProvider>
+              <AppSidebar />
+              <SidebarInset className="p-3">{children}</SidebarInset>
+            </SidebarProvider>
+          </TRPCProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/workspace/file-viewer.tsx
+++ b/src/components/workspace/file-viewer.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { AlertCircle, AlertTriangle, FileCode, Loader2 } from 'lucide-react';
+import { useTheme } from 'next-themes';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import { oneDark, oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism';
 
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { trpc } from '@/frontend/lib/trpc';
@@ -35,10 +36,13 @@ function formatFileSize(bytes: number): string {
 // =============================================================================
 
 export function FileViewer({ workspaceId, filePath }: FileViewerProps) {
+  const { resolvedTheme } = useTheme();
   const { data, isLoading, error } = trpc.workspace.readFile.useQuery({
     workspaceId,
     path: filePath,
   });
+
+  const syntaxTheme = resolvedTheme === 'dark' ? oneDark : oneLight;
 
   if (isLoading) {
     return (
@@ -107,7 +111,7 @@ export function FileViewer({ workspaceId, filePath }: FileViewerProps) {
         ) : (
           <SyntaxHighlighter
             language={data.language}
-            style={oneLight}
+            style={syntaxTheme}
             showLineNumbers
             wrapLines
             customStyle={{

--- a/src/frontend/components/app-sidebar.tsx
+++ b/src/frontend/components/app-sidebar.tsx
@@ -29,6 +29,7 @@ import {
 import { Skeleton } from '@/components/ui/skeleton';
 import { setProjectContext, trpc } from '../lib/trpc';
 import { Logo } from './logo';
+import { ThemeToggle } from './theme-toggle';
 
 const SELECTED_PROJECT_KEY = 'factoryfactory_selected_project_slug';
 
@@ -326,7 +327,10 @@ export function AppSidebar() {
       </SidebarContent>
 
       <SidebarFooter className="border-t border-sidebar-border p-4">
-        <p className="text-xs text-muted-foreground">Phase 7: Production Ready</p>
+        <div className="flex items-center justify-between">
+          <p className="text-xs text-muted-foreground">Phase 7: Production Ready</p>
+          <ThemeToggle />
+        </div>
       </SidebarFooter>
     </Sidebar>
   );

--- a/src/frontend/components/theme-provider.tsx
+++ b/src/frontend/components/theme-provider.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { ThemeProvider as NextThemesProvider } from 'next-themes';
+
+interface ThemeProviderProps {
+  children: React.ReactNode;
+}
+
+export function ThemeProvider({ children }: ThemeProviderProps) {
+  return (
+    <NextThemesProvider
+      attribute="class"
+      defaultTheme="system"
+      enableSystem
+      disableTransitionOnChange
+    >
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/src/frontend/components/theme-toggle.tsx
+++ b/src/frontend/components/theme-toggle.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { Monitor, Moon, Sun } from 'lucide-react';
+import { useTheme } from 'next-themes';
+import { useEffect, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+export function ThemeToggle() {
+  const { setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  // Prevent hydration mismatch by only rendering after mount
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return (
+      <Button variant="ghost" size="icon" disabled>
+        <Sun className="h-4 w-4" />
+        <span className="sr-only">Toggle theme</span>
+      </Button>
+    );
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon">
+          <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+          <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+          <span className="sr-only">Toggle theme</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => setTheme('light')}>
+          <Sun className="mr-2 h-4 w-4" />
+          Light
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme('dark')}>
+          <Moon className="mr-2 h-4 w-4" />
+          Dark
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme('system')}>
+          <Monitor className="mr-2 h-4 w-4" />
+          System
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}


### PR DESCRIPTION
## Summary
- Add ThemeProvider wrapper using next-themes with system preference detection
- Add ThemeToggle dropdown component in sidebar footer (Light/Dark/System options)
- Update FileViewer syntax highlighting to switch between oneLight/oneDark themes

## Test plan
- [ ] Toggle between light/dark/system modes via sidebar footer button
- [ ] Verify theme preference persists across page refresh
- [ ] Change OS theme setting and confirm "System" mode follows it
- [ ] Open a file in FileViewer and verify syntax highlighting adapts to theme
- [ ] Open DiffViewer and verify colors work in both themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)