### PR TITLE
Enforce logger usage and prevent console.log in codebase

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -103,11 +103,10 @@
   "overrides": [
     {
       "includes": [
-        "src/backend/**/*.ts",
+        "src/backend/services/logger.service.ts",
+        "src/lib/debug.ts",
         "src/cli/**/*.ts",
-        "scripts/**/*.ts",
-        "test-*.ts",
-        "src/components/chat/use-chat-websocket.ts"
+        "scripts/**/*.ts"
       ],
       "linter": {
         "rules": {

--- a/src/backend/claude/protocol.ts
+++ b/src/backend/claude/protocol.ts
@@ -9,6 +9,7 @@ import { randomUUID } from 'node:crypto';
 import { EventEmitter } from 'node:events';
 import * as readline from 'node:readline';
 import type { Readable, Writable } from 'node:stream';
+import { createLogger } from '../services/logger.service';
 import {
   type ClaudeContentItem,
   type ClaudeJson,
@@ -23,6 +24,8 @@ import {
   type PermissionMode,
   type StreamEventMessage,
 } from './types';
+
+const logger = createLogger('protocol');
 
 // =============================================================================
 // Exported Types
@@ -331,11 +334,9 @@ export class ClaudeProtocol extends EventEmitter {
       parsed = JSON.parse(trimmed) as ClaudeJson;
     } catch (error) {
       // Log and skip malformed JSON
-      console.error(
-        '[ClaudeProtocol] Failed to parse JSON:',
-        error instanceof Error ? error.message : error
-      );
-      console.error('[ClaudeProtocol] Raw line:', trimmed.slice(0, 200));
+      logger.error('Failed to parse JSON', error as Error, {
+        rawLine: trimmed.slice(0, 200),
+      });
       return;
     }
 

--- a/src/backend/claude/session.ts
+++ b/src/backend/claude/session.ts
@@ -1,7 +1,10 @@
 import { readdir, readFile, stat } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { createLogger } from '../services/logger.service';
 import type { ClaudeContentItem, ClaudeJson, ClaudeMessage } from './types';
+
+const logger = createLogger('session');
 
 /**
  * Represents a message from session history
@@ -127,13 +130,13 @@ export class SessionManager {
           messages.push(...parsedMessages);
         } catch {
           // Skip malformed JSONL lines
-          console.warn(`Skipping malformed JSONL line in session ${sessionId}`);
+          logger.warn('Skipping malformed JSONL line', { sessionId });
         }
       }
     } catch (error) {
       // Return empty array if file doesn't exist or can't be read
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-        console.warn(`Error reading session ${sessionId}:`, error);
+        logger.warn('Error reading session', { sessionId, error });
       }
     }
 
@@ -167,7 +170,7 @@ export class SessionManager {
       }
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-        console.warn(`Error reading session ${sessionId} for model:`, error);
+        logger.warn('Error reading session for model', { sessionId, error });
       }
     }
 
@@ -198,7 +201,7 @@ export class SessionManager {
       }
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-        console.warn(`Error reading session ${sessionId} for thinking mode:`, error);
+        logger.warn('Error reading session for thinking mode', { sessionId, error });
       }
     }
 
@@ -229,7 +232,7 @@ export class SessionManager {
       }
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-        console.warn(`Error reading session ${sessionId} for git branch:`, error);
+        logger.warn('Error reading session for git branch', { sessionId, error });
       }
     }
 
@@ -264,13 +267,13 @@ export class SessionManager {
           });
         } catch {
           // Skip files we can't stat
-          console.warn(`Could not stat session file: ${filePath}`);
+          logger.warn('Could not stat session file', { filePath });
         }
       }
     } catch (error) {
       // Return empty array if project directory doesn't exist
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-        console.warn(`Error listing sessions for ${workingDir}:`, error);
+        logger.warn('Error listing sessions', { workingDir, error });
       }
     }
 

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -1382,13 +1382,15 @@ server.listen(PORT, async () => {
   // Start periodic orphan cleanup
   reconciliationService.startPeriodicCleanup();
 
-  console.log(`Backend server running on http://localhost:${PORT}`);
-  console.log(`Health check: http://localhost:${PORT}/health`);
-  console.log(`Health check (all): http://localhost:${PORT}/health/all`);
-  console.log(`Inngest endpoint: http://localhost:${PORT}/api/inngest`);
-  console.log(`tRPC endpoint: http://localhost:${PORT}/api/trpc`);
-  console.log(`WebSocket chat: ws://localhost:${PORT}/chat`);
-  console.log(`WebSocket terminal: ws://localhost:${PORT}/terminal`);
+  logger.info('Server endpoints available', {
+    server: `http://localhost:${PORT}`,
+    health: `http://localhost:${PORT}/health`,
+    healthAll: `http://localhost:${PORT}/health/all`,
+    inngest: `http://localhost:${PORT}/api/inngest`,
+    trpc: `http://localhost:${PORT}/api/trpc`,
+    wsChat: `ws://localhost:${PORT}/chat`,
+    wsTerminal: `ws://localhost:${PORT}/terminal`,
+  });
 });
 
 // Shared cleanup logic

--- a/src/backend/routers/api/project.router.ts
+++ b/src/backend/routers/api/project.router.ts
@@ -2,8 +2,10 @@ import { Router } from 'express';
 import { z } from 'zod';
 import { projectAccessor } from '../../resource_accessors/index';
 import { configService } from '../../services/config.service';
+import { createLogger } from '../../services/logger.service';
 
 const router = Router();
+const logger = createLogger('api:project');
 
 // ============================================================================
 // Input Schemas
@@ -76,7 +78,7 @@ router.post('/create', async (req, res) => {
       });
     }
 
-    console.error('Error creating project:', error);
+    logger.error('Error creating project', error as Error);
     return res.status(500).json({
       success: false,
       error: {
@@ -115,7 +117,7 @@ router.get('/list', async (req, res) => {
       },
     });
   } catch (error) {
-    console.error('Error listing projects:', error);
+    logger.error('Error listing projects', error as Error);
     return res.status(500).json({
       success: false,
       error: {
@@ -163,7 +165,7 @@ router.get('/:projectId', async (req, res) => {
       },
     });
   } catch (error) {
-    console.error('Error getting project:', error);
+    logger.error('Error getting project', error as Error);
     return res.status(500).json({
       success: false,
       error: {
@@ -235,7 +237,7 @@ router.put('/:projectId', async (req, res) => {
       });
     }
 
-    console.error('Error updating project:', error);
+    logger.error('Error updating project', error as Error);
     return res.status(500).json({
       success: false,
       error: {
@@ -277,7 +279,7 @@ router.delete('/:projectId', async (req, res) => {
       },
     });
   } catch (error) {
-    console.error('Error archiving project:', error);
+    logger.error('Error archiving project', error as Error);
     return res.status(500).json({
       success: false,
       error: {
@@ -319,7 +321,7 @@ router.post('/:projectId/validate', async (req, res) => {
       },
     });
   } catch (error) {
-    console.error('Error validating project:', error);
+    logger.error('Error validating project', error as Error);
     return res.status(500).json({
       success: false,
       error: {

--- a/src/backend/routers/mcp/server.ts
+++ b/src/backend/routers/mcp/server.ts
@@ -1,7 +1,10 @@
 import { decisionLogAccessor } from '../../resource_accessors/index';
+import { createLogger } from '../../services/logger.service';
 import { CRITICAL_TOOLS, isTransientError } from './errors';
 import type { McpToolContext, McpToolRegistryEntry, McpToolResponse } from './types';
 import { McpErrorCode } from './types';
+
+const logger = createLogger('mcp');
 
 /**
  * Global tool registry
@@ -14,10 +17,10 @@ const toolRegistry = new Map<string, McpToolRegistryEntry>();
  */
 export function registerMcpTool(entry: McpToolRegistryEntry): void {
   if (toolRegistry.has(entry.name)) {
-    console.warn(`Tool '${entry.name}' is already registered. Overwriting.`);
+    logger.warn('Tool already registered, overwriting', { tool: entry.name });
   }
   toolRegistry.set(entry.name, entry);
-  console.log(`Registered MCP tool: ${entry.name}`);
+  logger.debug('Registered MCP tool', { tool: entry.name });
 }
 
 /**
@@ -119,7 +122,7 @@ async function handleToolFailure(
 
   // Log critical tool failures
   if (CRITICAL_TOOLS.includes(toolName)) {
-    console.error(`Critical tool failure: ${toolName}`, error);
+    logger.error('Critical tool failure', error, { toolName, agentId });
   }
 
   return {

--- a/src/lib/debug.ts
+++ b/src/lib/debug.ts
@@ -1,0 +1,37 @@
+/**
+ * Debug utility for frontend logging.
+ *
+ * Provides a centralized way to log debug information in development.
+ * All logging is disabled unless explicitly enabled via the DEBUG flag.
+ */
+
+type LogFn = (...args: unknown[]) => void;
+
+interface DebugLogger {
+  log: LogFn;
+  group: (label: string) => void;
+  groupEnd: () => void;
+}
+
+/**
+ * Create a debug logger that only logs when the flag is enabled.
+ * All logging is a no-op when disabled to avoid any runtime overhead.
+ */
+export function createDebugLogger(enabled: boolean): DebugLogger {
+  if (!enabled) {
+    const noop = () => {
+      // Intentional no-op when debug logging is disabled
+    };
+    return {
+      log: noop,
+      group: noop,
+      groupEnd: noop,
+    };
+  }
+
+  return {
+    log: (...args: unknown[]) => console.log(...args),
+    group: (label: string) => console.group(label),
+    groupEnd: () => console.groupEnd(),
+  };
+}


### PR DESCRIPTION
## Summary

- Enforce the existing `noConsole` lint rule by removing the broad override that allowed console everywhere in backend
- Convert all backend console.log/error/warn calls to use the structured logger
- Create a frontend debug utility for websocket debug logging
- Only allow console in files that genuinely need it (logger implementation, CLI tools, scripts)

## Changes

**biome.json**: Narrowed `noConsole` override to only allow console in:
- `src/backend/services/logger.service.ts` (the logger implementation)
- `src/lib/debug.ts` (frontend debug utility)
- `src/cli/**/*.ts` (CLI tools use console for user-facing output)
- `scripts/**/*.ts` (build scripts)

**New file `src/lib/debug.ts`**: Frontend debug utility that wraps console methods and only logs when explicitly enabled via flag

**Backend files converted to logger**:
- `notification.service.ts` - notification logging
- `backend/index.ts` - server startup messages
- `routers/mcp/server.ts` - MCP tool registration
- `routers/api/project.router.ts` - API error logging
- `claude/protocol.ts` - protocol parsing errors
- `claude/session.ts` - session management warnings

**Frontend**: `use-chat-websocket.ts` - converted debug logs to use the new debug utility

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm check:fix` passes (no console lint errors)
- [x] `pnpm test` passes (368 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)