### PR TITLE
Fix toggle visibility and change default model to Opus

### DIFF
--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -115,7 +115,7 @@ function ThinkingToggle({
             onPressedChange={onPressedChange}
             disabled={disabled}
             size="sm"
-            className="h-6 w-6 p-0"
+            className="h-6 w-6 p-0 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground"
             aria-label="Toggle thinking mode"
           >
             <Brain className="h-3.5 w-3.5" />
@@ -150,7 +150,7 @@ function PlanModeToggle({
             onPressedChange={onPressedChange}
             disabled={disabled}
             size="sm"
-            className="h-6 w-6 p-0"
+            className="h-6 w-6 p-0 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground"
             aria-label="Toggle plan mode"
           >
             <MapIcon className="h-3.5 w-3.5" />

--- a/src/lib/claude-types.ts
+++ b/src/lib/claude-types.ts
@@ -23,18 +23,18 @@ export interface ModelInfo {
 
 /**
  * Available models using Claude CLI aliases.
- * Sonnet is the default (when selectedModel is null).
+ * Opus is the default (when selectedModel is null).
  */
 export const AVAILABLE_MODELS: ModelInfo[] = [
-  { value: 'sonnet', displayName: 'Sonnet' },
   { value: 'opus', displayName: 'Opus' },
+  { value: 'sonnet', displayName: 'Sonnet' },
 ];
 
 /**
  * Chat session settings that persist per-session.
  */
 export interface ChatSettings {
-  selectedModel: string | null; // null = use default (Sonnet)
+  selectedModel: string | null; // null = use default (Opus)
   thinkingEnabled: boolean;
   planModeEnabled: boolean;
 }


### PR DESCRIPTION
## Summary
- Fixed thinking and plan mode toggles to show clear visual feedback when active (they were nearly invisible in dark mode)
- Changed the default model from Sonnet to Opus

## Test plan
- [ ] Toggle the thinking mode button and verify it shows a visible active state
- [ ] Toggle the plan mode button and verify it shows a visible active state
- [ ] Verify the model dropdown defaults to "Opus" for new sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)