### PR TITLE
Add Quick Actions feature for workspace toolbar

### DIFF
--- a/prompts/quick-actions/review.md
+++ b/prompts/quick-actions/review.md
@@ -1,0 +1,11 @@
+---
+name: Review
+description: Review the current changes
+type: agent
+icon: eye
+---
+Please review the recent changes in this workspace. Run `git diff` to see the changes, then provide a thorough code review focusing on:
+1. Code quality and best practices
+2. Potential bugs or edge cases
+3. Performance considerations
+4. Suggestions for improvement

--- a/prompts/quick-actions/simplify.md
+++ b/prompts/quick-actions/simplify.md
@@ -1,0 +1,7 @@
+---
+name: Simplify
+description: Simplify and refine recent code changes
+type: agent
+icon: sparkles
+---
+Run /code-simplifier to simplify and refine the recently modified code.

--- a/src/backend/prompts/quick-actions.ts
+++ b/src/backend/prompts/quick-actions.ts
@@ -1,0 +1,209 @@
+/**
+ * Quick action loader.
+ *
+ * Quick actions are defined by markdown files in prompts/quick-actions/.
+ * Each file has YAML frontmatter with metadata (name, description, type, icon, script).
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { basename, join, resolve } from 'node:path';
+import { createLogger } from '../services/logger.service';
+
+const logger = createLogger('quick-actions');
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type QuickActionType = 'script' | 'agent';
+
+export interface QuickAction {
+  /** Action ID (filename without .md extension) */
+  id: string;
+  /** Display name from frontmatter */
+  name: string;
+  /** Description from frontmatter */
+  description: string;
+  /** Type of action: 'script' runs a command, 'agent' creates a Claude session */
+  type: QuickActionType;
+  /** Lucide icon name (optional) */
+  icon?: string;
+  /** For script actions: the command to run */
+  script?: string;
+  /** For agent actions: the prompt content (markdown after frontmatter) */
+  content?: string;
+}
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+// Path to quick-actions directory (relative to this file's location)
+// From src/backend/prompts/ → src/backend → src → project root
+const QUICK_ACTIONS_DIR = resolve(import.meta.dirname, '../../..', 'prompts/quick-actions');
+
+// =============================================================================
+// Frontmatter Parser
+// =============================================================================
+
+interface Frontmatter {
+  name?: string;
+  description?: string;
+  type?: string;
+  icon?: string;
+  script?: string;
+}
+
+/**
+ * Parse simple YAML frontmatter from markdown content.
+ * Only handles basic key: value pairs, not nested structures.
+ */
+function parseFrontmatter(content: string): { frontmatter: Frontmatter; body: string } {
+  const frontmatterRegex = /^---\r?\n([\s\S]*?)\r?\n---\r?\n/;
+  const match = content.match(frontmatterRegex);
+
+  if (!match) {
+    return { frontmatter: {}, body: content };
+  }
+
+  const frontmatterText = match[1];
+  const body = content.slice(match[0].length);
+  const frontmatter: Frontmatter = {};
+
+  // Parse each line as key: value
+  for (const line of frontmatterText.split('\n')) {
+    const colonIndex = line.indexOf(':');
+    if (colonIndex === -1) {
+      continue;
+    }
+
+    const key = line.slice(0, colonIndex).trim();
+    const value = line.slice(colonIndex + 1).trim();
+
+    switch (key) {
+      case 'name':
+        frontmatter.name = value;
+        break;
+      case 'description':
+        frontmatter.description = value;
+        break;
+      case 'type':
+        frontmatter.type = value;
+        break;
+      case 'icon':
+        frontmatter.icon = value;
+        break;
+      case 'script':
+        frontmatter.script = value;
+        break;
+    }
+  }
+
+  return { frontmatter, body };
+}
+
+// =============================================================================
+// Quick Action Loading
+// =============================================================================
+
+/**
+ * Load a single quick action file.
+ */
+function loadQuickActionFile(filePath: string): QuickAction | null {
+  try {
+    const content = readFileSync(filePath, 'utf-8');
+    const id = basename(filePath, '.md');
+    const { frontmatter, body } = parseFrontmatter(content);
+
+    // Validate and default the type
+    let type: QuickActionType = 'agent';
+    if (frontmatter.type === 'script') {
+      type = 'script';
+    } else if (frontmatter.type && frontmatter.type !== 'agent') {
+      logger.warn('Unknown quick action type, defaulting to agent', {
+        filePath,
+        type: frontmatter.type,
+      });
+    }
+
+    return {
+      id,
+      name: frontmatter.name ?? id,
+      description: frontmatter.description ?? '',
+      type,
+      icon: frontmatter.icon,
+      script: type === 'script' ? frontmatter.script : undefined,
+      content: type === 'agent' ? body.trim() : undefined,
+    };
+  } catch (error) {
+    logger.warn('Failed to load quick action file', { filePath, error: String(error) });
+    return null;
+  }
+}
+
+// Cached quick actions (loaded once at startup)
+let cachedQuickActions: QuickAction[] | null = null;
+
+/**
+ * Load all quick actions from the quick-actions directory.
+ * Results are cached after first call.
+ */
+function loadQuickActions(): QuickAction[] {
+  if (cachedQuickActions !== null) {
+    logger.debug('Returning cached quick actions', { count: cachedQuickActions.length });
+    return cachedQuickActions;
+  }
+
+  logger.info('Loading quick actions from disk', { dir: QUICK_ACTIONS_DIR });
+
+  try {
+    const files = readdirSync(QUICK_ACTIONS_DIR).filter((f) => f.endsWith('.md'));
+    logger.info('Found quick action files', { files });
+    cachedQuickActions = files
+      .map((file) => loadQuickActionFile(join(QUICK_ACTIONS_DIR, file)))
+      .filter((a): a is QuickAction => a !== null);
+    logger.info('Loaded quick actions', {
+      count: cachedQuickActions.length,
+      ids: cachedQuickActions.map((a) => a.id),
+    });
+    return cachedQuickActions;
+  } catch (error) {
+    // Directory doesn't exist or can't be read
+    logger.error('Failed to load quick actions', { dir: QUICK_ACTIONS_DIR, error: String(error) });
+    cachedQuickActions = [];
+    return cachedQuickActions;
+  }
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * List all available quick actions.
+ */
+export function listQuickActions(): QuickAction[] {
+  return loadQuickActions();
+}
+
+/**
+ * Get a quick action by ID.
+ */
+export function getQuickAction(id: string): QuickAction | null {
+  return loadQuickActions().find((a) => a.id === id) ?? null;
+}
+
+/**
+ * Get quick action prompt content by ID.
+ * Returns null if action not found or is a script action.
+ */
+export function getQuickActionContent(id: string): string | null {
+  return getQuickAction(id)?.content ?? null;
+}
+
+/**
+ * Clear the quick action cache (useful for testing or hot reloading).
+ */
+export function clearQuickActionCache(): void {
+  cachedQuickActions = null;
+}

--- a/src/backend/trpc/session.trpc.ts
+++ b/src/backend/trpc/session.trpc.ts
@@ -1,5 +1,6 @@
 import { SessionStatus } from '@prisma-gen/client';
 import { z } from 'zod';
+import { getQuickAction, listQuickActions } from '../prompts/quick-actions';
 import { DEFAULT_FIRST_SESSION, DEFAULT_FOLLOWUP, listWorkflows } from '../prompts/workflows';
 import { claudeSessionAccessor } from '../resource_accessors/claude-session.accessor';
 import { terminalSessionAccessor } from '../resource_accessors/terminal-session.accessor';
@@ -20,6 +21,16 @@ export const sessionRouter = router({
       const workspace = await workspaceAccessor.findById(input.workspaceId);
       return workspace?.hasHadSessions ? DEFAULT_FOLLOWUP : DEFAULT_FIRST_SESSION;
     }),
+
+  // Quick Actions
+
+  // List all available quick actions
+  listQuickActions: publicProcedure.query(() => listQuickActions()),
+
+  // Get a specific quick action by ID
+  getQuickAction: publicProcedure
+    .input(z.object({ id: z.string() }))
+    .query(({ input }) => getQuickAction(input.id)),
 
   // Claude Sessions
 

--- a/src/components/workspace/index.ts
+++ b/src/components/workspace/index.ts
@@ -5,6 +5,7 @@ export * from './file-viewer';
 export * from './git-summary-panel';
 export * from './main-view-content';
 export * from './main-view-tab-bar';
+export * from './quick-actions-menu';
 export * from './right-panel';
 export * from './terminal-instance';
 export * from './terminal-panel';

--- a/src/components/workspace/quick-actions-menu.tsx
+++ b/src/components/workspace/quick-actions-menu.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import type { inferRouterOutputs } from '@trpc/server';
+import { Check, Eye, type LucideIcon, Play, Sparkles, Terminal, Zap } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import type { AppRouter } from '@/frontend/lib/trpc';
+import { trpc } from '@/frontend/lib/trpc';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+type RouterOutputs = inferRouterOutputs<AppRouter>;
+type QuickAction = NonNullable<RouterOutputs['session']['listQuickActions']>[number];
+
+interface QuickActionsMenuProps {
+  onExecuteAgent: (action: QuickAction) => void;
+  disabled?: boolean;
+}
+
+// =============================================================================
+// Icon Mapping
+// =============================================================================
+
+const ICON_MAP: Record<string, LucideIcon> = {
+  zap: Zap,
+  sparkles: Sparkles,
+  eye: Eye,
+  play: Play,
+  terminal: Terminal,
+  check: Check,
+};
+
+function getActionIcon(iconName?: string): LucideIcon {
+  return (iconName && ICON_MAP[iconName]) || Zap;
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+export function QuickActionsMenu({ onExecuteAgent, disabled = false }: QuickActionsMenuProps) {
+  const { data: quickActions, isLoading } = trpc.session.listQuickActions.useQuery();
+
+  // Only show agent actions for now (script actions not yet implemented)
+  const agentActions = quickActions?.filter((a) => a.type === 'agent') ?? [];
+
+  const hasActions = agentActions.length > 0;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          disabled={disabled || isLoading || !hasActions}
+          title="Quick Actions"
+        >
+          <Zap className="h-4 w-4" />
+          <span className="sr-only">Quick Actions</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuLabel>Quick Actions</DropdownMenuLabel>
+        {agentActions.map((action) => {
+          const Icon = getActionIcon(action.icon ?? undefined);
+          return (
+            <DropdownMenuItem
+              key={action.id}
+              onClick={() => onExecuteAgent(action)}
+              className="cursor-pointer"
+            >
+              <Icon className="mr-2 h-4 w-4" />
+              <div className="flex flex-col">
+                <span>{action.name}</span>
+                <span className="text-xs text-muted-foreground">{action.description}</span>
+              </div>
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a Quick Actions menu to the workspace toolbar that allows users to trigger predefined actions
- Actions are defined as markdown files with YAML frontmatter in `prompts/quick-actions/`
- Agent actions create a Claude session with a predefined prompt
- Backend loader with caching, tRPC endpoints, and React component integration

## Test plan
- [ ] Verify quick actions load from `prompts/quick-actions/` directory
- [ ] Test clicking an agent action creates a new session with the correct prompt
- [ ] Verify the menu is disabled when a session is running or being created
- [ ] Check that script-type actions are filtered from the UI (not implemented yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)