### PR TITLE
Fix CLI build command and remove PostgreSQL references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: Lint, Type Check, Dependencies & Dead Code
     runs-on: ubuntu-latest
     env:
-      DATABASE_URL: "postgresql://user:pass@localhost:5432/db"
+      DATABASE_URL: "file:./test.db"
     steps:
       - uses: actions/checkout@v4
 
@@ -46,7 +46,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     env:
-      DATABASE_URL: "postgresql://user:pass@localhost:5432/db"
+      DATABASE_URL: "file:./test.db"
     steps:
       - uses: actions/checkout@v4
 
@@ -75,7 +75,7 @@ jobs:
       contents: read
       pull-requests: write
     env:
-      DATABASE_URL: "postgresql://user:pass@localhost:5432/db"
+      DATABASE_URL: "file:./test.db"
     steps:
       - uses: actions/checkout@v4
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,28 +1,9 @@
 # FactoryFactory Docker Compose Configuration
-# Production-ready multi-service deployment
+# SQLite-based deployment (no external database required)
 
 version: '3.8'
 
 services:
-  # PostgreSQL Database
-  postgres:
-    image: postgres:15-alpine
-    container_name: factoryfactory-db
-    restart: unless-stopped
-    environment:
-      POSTGRES_USER: ${POSTGRES_USER:-factoryfactory}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-factoryfactory_dev}
-      POSTGRES_DB: ${POSTGRES_DB:-factoryfactory}
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-    ports:
-      - "5432:5432"
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-factoryfactory}"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-
   # Backend API Server (production profile)
   backend:
     build:
@@ -32,15 +13,10 @@ services:
     restart: unless-stopped
     profiles:
       - production
-    depends_on:
-      postgres:
-        condition: service_healthy
     environment:
       - NODE_ENV=production
-      - DATABASE_URL=postgresql://${POSTGRES_USER:-factoryfactory}:${POSTGRES_PASSWORD:-factoryfactory_dev}@postgres:5432/${POSTGRES_DB:-factoryfactory}
+      - DATABASE_PATH=/data/factoryfactory.db
       - BACKEND_PORT=3001
-      - INNGEST_EVENT_KEY=${INNGEST_EVENT_KEY}
-      - INNGEST_SIGNING_KEY=${INNGEST_SIGNING_KEY}
       - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:3000}
       - LOG_LEVEL=${LOG_LEVEL:-info}
       # Rate limiting
@@ -59,6 +35,7 @@ services:
     ports:
       - "3001:3001"
     volumes:
+      - data:/data
       - worktrees:/tmp/factoryfactory/worktrees
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3001/health"]
@@ -91,18 +68,6 @@ services:
       retries: 3
       start_period: 10s
 
-  # Inngest Dev Server (dev profile only)
-  inngest:
-    image: inngest/inngest:latest
-    container_name: factoryfactory-inngest
-    restart: unless-stopped
-    profiles:
-      - dev
-    environment:
-      - INNGEST_DEV=true
-    ports:
-      - "8288:8288"
-
   # Nginx Reverse Proxy (production profile)
   nginx:
     image: nginx:alpine
@@ -126,7 +91,7 @@ services:
       retries: 3
 
 volumes:
-  postgres_data:
+  data:
     driver: local
   worktrees:
     driver: local

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,7 +46,7 @@ FactoryFactory orchestrates multiple AI agents to autonomously implement softwar
 │  └──────────────────────────────────────────────────────────────┘  │
 │                                                                   │
 │  ┌────────────┐    ┌────────────┐    ┌────────────┐              │
-│  │ PostgreSQL │    │    Git     │    │   Claude   │              │
+│  │   SQLite   │    │    Git     │    │   Claude   │              │
 │  │  Database  │    │ Worktrees  │    │    Code    │              │
 │  └────────────┘    └────────────┘    └────────────┘              │
 └─────────────────────────────────────────────────────────────────┘
@@ -446,7 +446,7 @@ IDLE ←→ BUSY ←→ WAITING
 | API | tRPC | Type-safe API calls |
 | Backend | Express.js | HTTP server |
 | Events | Inngest | Event processing |
-| Database | PostgreSQL | Persistent storage |
+| Database | SQLite | Persistent storage |
 | ORM | Prisma | Database access |
 | AI | Claude Code CLI | Agent intelligence |
 | Process | tmux | Agent terminals |

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -36,7 +36,7 @@ FactoryFactory is an autonomous multi-agent software development system that use
 └─────────────────────────┼───────────────────────────────────┘
                           │
 ┌─────────────────────────▼─────────────────────────────────┐
-│                  PostgreSQL Database                       │
+│                    SQLite Database                         │
 │  - Epics    - Tasks    - Agents    - Mail                 │
 └────────────────────────────────────────────────────────────┘
 
@@ -54,7 +54,7 @@ FactoryFactory is an autonomous multi-agent software development system that use
 ### Core
 - **Next.js 14+**: App Router, React Server Components
 - **TypeScript**: Full type safety
-- **PostgreSQL**: Primary database
+- **SQLite**: Primary database (zero-config, file-based)
 - **Prisma**: ORM and migrations
 
 ### Backend
@@ -81,8 +81,8 @@ FactoryFactory is an autonomous multi-agent software development system that use
 ### Environment Variables
 
 ```bash
-# Database
-DATABASE_URL="postgresql://user:password@localhost:5432/factoryfactory"
+# Database (SQLite - optional, defaults to ~/factory-factory/data.db)
+DATABASE_PATH="/path/to/data.db"
 
 # Claude API
 CLAUDE_API_KEY="sk-..."


### PR DESCRIPTION
## Summary
- Fix `ff build` command to run actual build commands (tsc, tsc-alias, next build) instead of nonexistent pnpm scripts
- Update CI workflow, docker-compose, and documentation to use SQLite instead of PostgreSQL
- Rebrand CLI banner to "🔲 FACTORY **FACTORY**" with bold styling

## Changes
- **src/cli/index.ts**: Fix build command, update branding
- **.github/workflows/ci.yml**: Use SQLite `file:./test.db` format
- **docker-compose.yml**: Remove PostgreSQL service, use SQLite volume
- **docs/**: Update DESIGN.md, ARCHITECTURE.md, DEPLOYMENT_GUIDE.md for SQLite

## Test plan
- [x] `pnpm typecheck` passes
- [x] `ff serve --dev` starts successfully with auto-created database
- [x] Backend health endpoint responds OK
- [x] Frontend loads correctly

🤖 Generated with [Claude Code](https://claude.ai/code)