### PR TITLE
Remove invalid --thinking CLI flag

### DIFF
--- a/src/backend/claude/process.ts
+++ b/src/backend/claude/process.ts
@@ -559,11 +559,6 @@ export class ClaudeProcess extends EventEmitter {
       args.push('--disallowed-tools', options.disallowedTools.join(','));
     }
 
-    // Extended thinking mode
-    if (options.thinkingEnabled) {
-      args.push('--thinking');
-    }
-
     return args;
   }
 


### PR DESCRIPTION
## Summary
- Removes the invalid `--thinking` CLI flag from the Claude process spawn arguments
- The Claude CLI doesn't support a `--thinking` flag; extended thinking mode is enabled by appending " ultrathink" to user messages
- The frontend already handles this correctly in `use-chat-websocket.ts`

## Test plan
- [ ] Enable thinking mode in the UI
- [ ] Send a message - should no longer crash with "unknown option '--thinking'"
- [ ] Verify thinking mode works (responses should show extended thinking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)