### PR TITLE
Stop running Claude process before deleting session

### DIFF
--- a/src/backend/trpc/session.trpc.ts
+++ b/src/backend/trpc/session.trpc.ts
@@ -111,9 +111,13 @@ export const sessionRouter = router({
     }),
 
   // Delete a claude session
-  deleteClaudeSession: publicProcedure.input(z.object({ id: z.string() })).mutation(({ input }) => {
-    return claudeSessionAccessor.delete(input.id);
-  }),
+  deleteClaudeSession: publicProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ input }) => {
+      // Stop process first to prevent orphaned Claude processes
+      await sessionService.stopClaudeSession(input.id);
+      return claudeSessionAccessor.delete(input.id);
+    }),
 
   // Terminal Sessions
 


### PR DESCRIPTION
## Summary
- Fixes deleteClaudeSession to stop the running Claude process before deleting the database record
- Prevents orphaned processes that consume resources and can't be managed through the API

## Details
The `deleteClaudeSession` endpoint was only deleting the database record without stopping the running process first. This caused:
- Orphaned Claude processes continuing to consume memory/CPU
- Processes that can't be stopped through the API since their session records no longer exist
- Exit handlers attempting to update deleted records

The fix calls `sessionService.stopClaudeSession(input.id)` before deletion. This is safe because `stopClaudeSession` is idempotent - it handles cases where the process isn't running or is already being stopped.

## Test plan
- [x] TypeScript type checking passes
- [x] All 383 tests pass
- [x] Linting passes

Fixes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)