### PR TITLE
Fix logger context allowing overwrite of service/component fields

### DIFF
--- a/src/backend/services/logger.service.ts
+++ b/src/backend/services/logger.service.ts
@@ -104,9 +104,9 @@ class Logger {
       timestamp: this.config.includeTimestamp ? new Date().toISOString() : '',
       message,
       context: {
+        ...context,
         service: this.config.serviceName,
         component: this.component,
-        ...context,
       },
     };
 


### PR DESCRIPTION
## Summary
- Fixed object spread order in logger so built-in `service` and `component` fields cannot be overwritten by user-provided context
- Previously, user context was spread last, which allowed callers to accidentally or maliciously replace tracking fields

Fixes #212

## Test plan
- [x] TypeScript typecheck passes
- [x] All 383 tests pass
- [x] Linter and formatter pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)