### PR TITLE
Fix tRPC client shared state causing potential context pollution

### DIFF
--- a/src/app/projects/[slug]/layout.tsx
+++ b/src/app/projects/[slug]/layout.tsx
@@ -2,12 +2,14 @@
 
 import { useParams, useRouter } from 'next/navigation';
 import { useEffect } from 'react';
-import { setProjectContext, trpc } from '../../../frontend/lib/trpc';
+import { useProjectContext } from '../../../frontend/lib/providers';
+import { trpc } from '../../../frontend/lib/trpc';
 
 export default function ProjectLayout({ children }: { children: React.ReactNode }) {
   const params = useParams();
   const router = useRouter();
   const slug = params.slug as string;
+  const { setProjectContext } = useProjectContext();
 
   const {
     data: project,
@@ -24,7 +26,7 @@ export default function ProjectLayout({ children }: { children: React.ReactNode 
       // Clear project context when leaving project pages
       setProjectContext(undefined);
     };
-  }, [project?.id]);
+  }, [project?.id, setProjectContext]);
 
   useEffect(() => {
     if (!(isLoading || project || error)) {

--- a/src/frontend/components/app-sidebar.tsx
+++ b/src/frontend/components/app-sidebar.tsx
@@ -26,7 +26,8 @@ import {
   SidebarSeparator,
 } from '@/components/ui/sidebar';
 import { Skeleton } from '@/components/ui/skeleton';
-import { setProjectContext, trpc } from '../lib/trpc';
+import { useProjectContext } from '../lib/providers';
+import { trpc } from '../lib/trpc';
 import { Logo } from './logo';
 import { ThemeToggle } from './theme-toggle';
 
@@ -51,6 +52,7 @@ export function AppSidebar() {
   const router = useRouter();
   const [selectedProjectSlug, setSelectedProjectSlug] = useState<string>('');
   const [hasCheckedProjects, setHasCheckedProjects] = useState(false);
+  const { setProjectContext } = useProjectContext();
 
   const { data: projects, isLoading: projectsLoading } = trpc.project.list.useQuery({
     isArchived: false,
@@ -126,7 +128,7 @@ export function AppSidebar() {
     if (selectedProjectId) {
       setProjectContext(selectedProjectId);
     }
-  }, [selectedProjectId]);
+  }, [selectedProjectId, setProjectContext]);
 
   useEffect(() => {
     const slugFromPath = getProjectSlugFromPath(pathname);

--- a/src/frontend/lib/providers.tsx
+++ b/src/frontend/lib/providers.tsx
@@ -1,8 +1,24 @@
 'use client';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { useState } from 'react';
-import { trpc, trpcClient } from './trpc';
+import { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
+import { createTrpcClient, trpc } from './trpc';
+
+type ProjectContextValue = {
+  projectId: string | undefined;
+  taskId: string | undefined;
+  setProjectContext: (projectId?: string, taskId?: string) => void;
+};
+
+const ProjectContext = createContext<ProjectContextValue | null>(null);
+
+export function useProjectContext() {
+  const ctx = useContext(ProjectContext);
+  if (!ctx) {
+    throw new Error('useProjectContext must be used within TRPCProvider');
+  }
+  return ctx;
+}
 
 export function TRPCProvider({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
@@ -17,9 +33,40 @@ export function TRPCProvider({ children }: { children: React.ReactNode }) {
       })
   );
 
+  // Use refs for context values to avoid recreating the tRPC client
+  const projectIdRef = useRef<string | undefined>(undefined);
+  const taskIdRef = useRef<string | undefined>(undefined);
+
+  // State to trigger re-renders when context changes (for consumers)
+  const [projectId, setProjectId] = useState<string | undefined>(undefined);
+  const [taskId, setTaskId] = useState<string | undefined>(undefined);
+
+  const setProjectContext = useCallback((newProjectId?: string, newTaskId?: string) => {
+    projectIdRef.current = newProjectId;
+    taskIdRef.current = newTaskId;
+    setProjectId(newProjectId);
+    setTaskId(newTaskId);
+  }, []);
+
+  // Create tRPC client once per provider instance
+  // The getter reads from refs so it always gets fresh values
+  const [trpcClient] = useState(() =>
+    createTrpcClient(() => ({
+      projectId: projectIdRef.current,
+      taskId: taskIdRef.current,
+    }))
+  );
+
+  const contextValue = useMemo(
+    () => ({ projectId, taskId, setProjectContext }),
+    [projectId, taskId, setProjectContext]
+  );
+
   return (
-    <trpc.Provider client={trpcClient} queryClient={queryClient}>
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    </trpc.Provider>
+    <ProjectContext.Provider value={contextValue}>
+      <trpc.Provider client={trpcClient} queryClient={queryClient}>
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      </trpc.Provider>
+    </ProjectContext.Provider>
   );
 }


### PR DESCRIPTION
## Summary
- Fixes singleton tRPC client that used module-level mutable state for project context, which could cause context pollution between concurrent SSR requests
- Creates tRPC client per-provider instance using `useState` instead of module-level singleton
- Replaces module-level `setProjectContext` function with React Context (`useProjectContext` hook)
- Updates all consumers to use the new hook pattern

## Test plan
- [ ] Verify project switching works correctly in the sidebar
- [ ] Verify project-scoped API calls include the correct X-Project-Id header
- [ ] Verify navigating between projects updates the context properly

Fixes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)