### PR TITLE
Fix WebSocket URL using ws:// on HTTPS pages

### DIFF
--- a/src/lib/websocket-config.ts
+++ b/src/lib/websocket-config.ts
@@ -53,11 +53,14 @@ export function getReconnectDelay(attempt: number): number {
 
 /**
  * Constructs a WebSocket URL for the given endpoint with query parameters.
+ * Uses wss:// when the page is served over HTTPS, ws:// otherwise.
  * @param endpoint - The WebSocket endpoint path (e.g., '/chat', '/agent-activity')
  * @param params - Query parameters to append to the URL
  */
 export function buildWebSocketUrl(endpoint: string, params: Record<string, string>): string {
   const host = typeof window !== 'undefined' ? window.location.hostname : 'localhost';
+  const protocol =
+    typeof window !== 'undefined' && window.location.protocol === 'https:' ? 'wss:' : 'ws:';
   const queryString = new URLSearchParams(params).toString();
-  return `ws://${host}:${WEBSOCKET_PORT}${endpoint}?${queryString}`;
+  return `${protocol}//${host}:${WEBSOCKET_PORT}${endpoint}?${queryString}`;
 }


### PR DESCRIPTION
## Summary
- Fix `buildWebSocketUrl` to use `wss://` protocol when the page is served over HTTPS
- Previously hardcoded `ws://` caused WebSocket connections to fail on HTTPS deployments due to browser mixed content security policies

## Test plan
- [ ] Verify WebSocket connections work on HTTP (uses `ws://`)
- [ ] Verify WebSocket connections work on HTTPS (uses `wss://`)
- [ ] All existing tests pass

Fixes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)