### PR TITLE
Add merge queue support to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   push:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   checks:


### PR DESCRIPTION
## Summary
- Adds `merge_group` event trigger to CI workflow to support GitHub merge queues
- This allows CI to run on temporary merge commits when PRs are added to the merge queue

## Test plan
- [ ] Verify CI triggers on pull requests (existing behavior)
- [ ] Enable merge queue in repo settings and verify CI runs on merge queue entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)