### PR TITLE
Fix terminal PIDs not being persisted for orphan cleanup

### DIFF
--- a/src/backend/resource_accessors/terminal-session.accessor.ts
+++ b/src/backend/resource_accessors/terminal-session.accessor.ts
@@ -4,6 +4,7 @@ import { prisma } from '../db';
 interface CreateTerminalSessionInput {
   workspaceId: string;
   name?: string;
+  pid?: number;
 }
 
 interface UpdateTerminalSessionInput {
@@ -28,6 +29,7 @@ class TerminalSessionAccessor {
       data: {
         workspaceId: data.workspaceId,
         name: data.name,
+        pid: data.pid,
       },
     });
   }
@@ -55,6 +57,19 @@ class TerminalSessionAccessor {
       where,
       take: filters?.limit,
       orderBy: { updatedAt: 'desc' },
+    });
+  }
+
+  findByName(name: string): Promise<TerminalSession | null> {
+    return prisma.terminalSession.findFirst({
+      where: { name },
+    });
+  }
+
+  async clearPid(name: string): Promise<void> {
+    await prisma.terminalSession.updateMany({
+      where: { name },
+      data: { pid: null },
     });
   }
 

--- a/src/backend/services/terminal.service.ts
+++ b/src/backend/services/terminal.service.ts
@@ -56,6 +56,11 @@ export interface CreateTerminalOptions {
   shell?: string;
 }
 
+export interface CreateTerminalResult {
+  terminalId: string;
+  pid: number;
+}
+
 export interface TerminalOutput {
   terminalId: string;
   data: string;
@@ -184,7 +189,7 @@ class TerminalService {
   /**
    * Create a new terminal instance for a workspace
    */
-  async createTerminal(options: CreateTerminalOptions): Promise<string> {
+  async createTerminal(options: CreateTerminalOptions): Promise<CreateTerminalResult> {
     const { workspaceId, workingDir, cols = 80, rows = 24, shell } = options;
 
     const nodePty = await this.getNodePty();
@@ -283,7 +288,7 @@ class TerminalService {
 
     logger.info('Terminal created', { terminalId, workspaceId, pid: pty.pid });
 
-    return terminalId;
+    return { terminalId, pid: pty.pid };
   }
 
   /**


### PR DESCRIPTION
## Summary
- Terminal PIDs were never stored in the database, making orphan process detection via `findWithPid()` ineffective
- `terminalService.createTerminal()` now returns `{ terminalId, pid }` instead of just `terminalId`
- WebSocket handler persists terminal sessions with PID when terminals are created
- Exit handlers clear PID when terminal process exits

## Test plan
- [x] TypeScript compiles without errors (`pnpm typecheck`)
- [x] All 383 tests pass (`pnpm test`)
- [x] Lint passes (`pnpm check:fix`)

Fixes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)