### PR TITLE
Fix permission mode not applied before initial prompt

### DIFF
--- a/src/backend/claude/process.ts
+++ b/src/backend/claude/process.ts
@@ -559,6 +559,11 @@ export class ClaudeProcess extends EventEmitter {
       args.push('--disallowed-tools', options.disallowedTools.join(','));
     }
 
+    // Permission mode - must be set via CLI args to be active before initial prompt
+    if (options.permissionMode) {
+      args.push('--permission-mode', options.permissionMode);
+    }
+
     return args;
   }
 


### PR DESCRIPTION
## Summary

- Fixes race condition where permission mode was only set asynchronously after Claude CLI process started
- Adds `--permission-mode` flag to CLI arguments so it's active before the initial prompt (`-p`) is processed
- Prevents unexpected permission prompts or hangs when `bypassPermissions` mode should apply

## Test plan

- [ ] Verify `pnpm test` passes
- [ ] Verify `pnpm typecheck` passes
- [ ] Test spawning Claude with `initialPrompt` and `permissionMode: 'bypassPermissions'` - tools should auto-approve without prompts

Fixes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)