### PR TITLE
Fix terminal WebSocket error during React Strict Mode cleanup

### DIFF
--- a/src/components/workspace/use-terminal-websocket.ts
+++ b/src/components/workspace/use-terminal-websocket.ts
@@ -157,7 +157,12 @@ export function useTerminalWebSocket({
     };
 
     ws.onerror = () => {
-      onErrorRef.current?.('WebSocket connection error');
+      // Don't report errors if this was an intentional close (e.g., React Strict Mode unmount)
+      // The browser will still log "WebSocket is closed before connection established" but we
+      // won't propagate it to our error handler
+      if (!intentionalCloseRef.current) {
+        onErrorRef.current?.('WebSocket connection error');
+      }
     };
   }, [workspaceId]);
 


### PR DESCRIPTION
## Summary
Suppress WebSocket connection errors that occur during intentional close events (e.g., React Strict Mode unmount). This prevents false error reports to the user when the hook cleans up and reconnects.

## Test Plan
- Load the page and verify no "WebSocket connection error" is shown in the terminal UI
- Verify the terminal panel still connects successfully
- Verify new terminals can be created and function normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)