### PR TITLE
Fix chat scroll pushing tab bar off page and stuck running indicator

### DIFF
--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -1052,6 +1052,10 @@ async function handleChatMessage(
 
       const targetSessionId = dbSession.claudeSessionId ?? null;
 
+      // Check if there's an active Claude client running for this session
+      const existingClient = chatClients.get(dbSessionId);
+      const running = existingClient?.isRunning() ?? false;
+
       if (targetSessionId) {
         const [history, model, thinkingEnabled, gitBranch] = await Promise.all([
           SessionManager.getHistory(targetSessionId, workingDir),
@@ -1072,6 +1076,7 @@ async function handleChatMessage(
             type: 'session_loaded',
             messages: history,
             gitBranch,
+            running,
             settings: {
               selectedModel,
               thinkingEnabled,
@@ -1087,6 +1092,7 @@ async function handleChatMessage(
             type: 'session_loaded',
             messages: [],
             gitBranch: null,
+            running,
             settings: {
               selectedModel: null,
               thinkingEnabled: false,

--- a/src/components/chat/use-chat-websocket.ts
+++ b/src/components/chat/use-chat-websocket.ts
@@ -431,6 +431,7 @@ function handleSessionLoadedMessage(data: WebSocketMessage, ctx: MessageHandlerC
     debug.group('📚 Session loaded from history');
     debug.log('Total messages:', chatMessages.length);
     debug.log('Git branch:', data.gitBranch);
+    debug.log('Running:', data.running);
     debug.log(
       'Message types:',
       chatMessages.map((m) =>
@@ -447,6 +448,9 @@ function handleSessionLoadedMessage(data: WebSocketMessage, ctx: MessageHandlerC
   if (data.settings) {
     ctx.setChatSettings(data.settings);
   }
+  // Set running status from backend - this ensures UI accurately reflects
+  // whether the agent is currently processing for this session
+  ctx.setRunning(data.running ?? false);
   ctx.setLoadingSession(false);
 }
 

--- a/src/components/workspace/workspace-content-view.tsx
+++ b/src/components/workspace/workspace-content-view.tsx
@@ -82,10 +82,12 @@ export function WorkspaceContentView({
   }
 
   // Show tab bar + chat content when sessions exist
+  // Wrap in a flex container with min-h-0 to enable proper overflow handling
+  // Without this, the ScrollArea in ChatContent cannot calculate its height correctly
   return (
-    <>
-      {/* Tab bar */}
-      <div className="border-b">
+    <div className="flex flex-col h-full min-h-0">
+      {/* Tab bar - flex-shrink-0 ensures it stays visible */}
+      <div className="border-b flex-shrink-0">
         <MainViewTabBar
           sessions={claudeSessions}
           currentSessionId={selectedSessionId}
@@ -98,9 +100,9 @@ export function WorkspaceContentView({
       </div>
 
       {/* Main View Content (children = ChatContent) */}
-      <MainViewContent workspaceId={workspaceId} className="flex-1">
+      <MainViewContent workspaceId={workspaceId} className="flex-1 min-h-0">
         {children}
       </MainViewContent>
-    </>
+    </div>
   );
 }

--- a/src/frontend/components/app-sidebar.tsx
+++ b/src/frontend/components/app-sidebar.tsx
@@ -361,11 +361,19 @@ export function AppSidebar() {
                                 workspace.prUrl && (
                                   <Tooltip>
                                     <TooltipTrigger asChild>
-                                      <a
-                                        href={workspace.prUrl}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        onClick={(e) => e.stopPropagation()}
+                                      <button
+                                        type="button"
+                                        onClick={(e) => {
+                                          e.preventDefault();
+                                          e.stopPropagation();
+                                          if (workspace.prUrl) {
+                                            window.open(
+                                              workspace.prUrl,
+                                              '_blank',
+                                              'noopener,noreferrer'
+                                            );
+                                          }
+                                        }}
                                         className="shrink-0 flex items-center gap-1 text-xs px-1.5 py-0.5 rounded-full bg-purple-500/15 text-purple-600 dark:text-purple-400 hover:bg-purple-500/25 transition-colors"
                                       >
                                         <GitPullRequest className="h-3 w-3" />
@@ -379,7 +387,7 @@ export function AppSidebar() {
                                         {workspace.prCiStatus === 'PENDING' && (
                                           <Circle className="h-3 w-3 text-yellow-500 animate-pulse" />
                                         )}
-                                      </a>
+                                      </button>
                                     </TooltipTrigger>
                                     <TooltipContent side="right">
                                       <p>


### PR DESCRIPTION
## Summary
- Fix tab bar being pushed off page when chat content scrolls by wrapping WorkspaceContentView in a proper flex container with `min-h-0`
- Fix "Agent is working" indicator getting stuck by including `running` status in `session_loaded` WebSocket message
- Fix nested `<a>` tags hydration error in sidebar by changing PR badge from `<a>` to `<button>`

## Test plan
- [ ] Open a workspace with a chat session and scroll down - tab bar should stay visible
- [ ] Switch between chat sessions - "Agent is working" should only show when actually running
- [ ] Refresh page while agent is idle - loading indicator should not appear
- [ ] Click PR badge in sidebar - should open GitHub in new tab without hydration errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)