### PR TITLE
Include thinking content in UI rendering

### DIFF
--- a/src/backend/claude/session.test.ts
+++ b/src/backend/claude/session.test.ts
@@ -334,7 +334,7 @@ describe('parseHistoryEntry', () => {
       expect(result[0].content).toBe(JSON.stringify({ file_path: '/test.txt' }, null, 2));
     });
 
-    it('should skip thinking content', () => {
+    it('should include thinking content', () => {
       const entry = {
         type: 'assistant',
         timestamp,
@@ -347,12 +347,14 @@ describe('parseHistoryEntry', () => {
         },
       };
       const result = parseHistoryEntry(entry);
-      expect(result).toHaveLength(1);
-      expect(result[0].type).toBe('assistant');
-      expect(result[0].content).toBe('Here is my response');
+      expect(result).toHaveLength(2);
+      expect(result[0].type).toBe('thinking');
+      expect(result[0].content).toBe('Let me think...');
+      expect(result[1].type).toBe('assistant');
+      expect(result[1].content).toBe('Here is my response');
     });
 
-    it('should return empty array when only thinking content exists', () => {
+    it('should return thinking content when only thinking content exists', () => {
       const entry = {
         type: 'assistant',
         timestamp,
@@ -362,7 +364,9 @@ describe('parseHistoryEntry', () => {
         },
       };
       const result = parseHistoryEntry(entry);
-      expect(result).toHaveLength(0);
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe('thinking');
+      expect(result[0].content).toBe('Just thinking...');
     });
 
     it('should parse multiple content items in assistant message', () => {

--- a/src/backend/claude/session.ts
+++ b/src/backend/claude/session.ts
@@ -10,7 +10,7 @@ const logger = createLogger('session');
  * Represents a message from session history
  */
 export interface HistoryMessage {
-  type: 'user' | 'assistant' | 'tool_use' | 'tool_result';
+  type: 'user' | 'assistant' | 'tool_use' | 'tool_result' | 'thinking';
   content: string;
   timestamp: string;
   uuid?: string;
@@ -384,7 +384,9 @@ function parseAssistantContentItem(
       ...meta,
     };
   }
-  // Skip thinking items - not shown in UI
+  if (item.type === 'thinking') {
+    return { type: 'thinking', content: item.thinking, ...meta };
+  }
   return null;
 }
 

--- a/src/components/chat/use-chat-websocket.ts
+++ b/src/components/chat/use-chat-websocket.ts
@@ -272,10 +272,10 @@ function shouldStoreMessage(claudeMsg: ClaudeMessage): boolean {
     return false;
   }
 
-  // Only store content_block_start for tool_use and tool_result
+  // Only store content_block_start for tool_use, tool_result, and thinking
   if (event.type === 'content_block_start' && event.content_block) {
     const blockType = event.content_block.type;
-    return blockType === 'tool_use' || blockType === 'tool_result';
+    return blockType === 'tool_use' || blockType === 'tool_result' || blockType === 'thinking';
   }
 
   // Skip all other stream events (deltas, structural events, text blocks)

--- a/src/lib/claude-types.ts
+++ b/src/lib/claude-types.ts
@@ -305,7 +305,7 @@ export interface SessionInfo {
  * Message from session history.
  */
 export interface HistoryMessage {
-  type: 'user' | 'assistant' | 'tool_use' | 'tool_result';
+  type: 'user' | 'assistant' | 'tool_use' | 'tool_result' | 'thinking';
   content: string;
   timestamp: string;
   uuid?: string;
@@ -526,6 +526,25 @@ export function convertHistoryMessage(msg: HistoryMessage): ChatMessage {
       ...baseMessage,
       source: 'user',
       text: msg.content,
+    };
+  }
+
+  // Thinking messages - create properly structured content block
+  if (msg.type === 'thinking') {
+    const thinkingContent: ThinkingContent = {
+      type: 'thinking',
+      thinking: msg.content,
+    };
+    return {
+      ...baseMessage,
+      source: 'claude',
+      message: {
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [thinkingContent],
+        },
+      },
     };
   }
 


### PR DESCRIPTION
## Summary
- The UI now renders thinking content from Claude, regardless of whether `ultrathink` was used
- Previously, thinking blocks were filtered out at two points in the pipeline, but the `ThinkingRenderer` component was already implemented
- Now thinking content flows through for both real-time streaming and session history replay

## Test plan
- [ ] Start a session with ultrathink enabled and verify thinking content appears during streaming
- [ ] Reload the session and verify thinking persists in history
- [ ] Start a session without ultrathink and verify no breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)