### PR TITLE
Add visual indicator for closed PRs

### DIFF
--- a/src/frontend/components/app-sidebar.tsx
+++ b/src/frontend/components/app-sidebar.tsx
@@ -360,13 +360,17 @@ export function AppSidebar() {
                                         className={`shrink-0 flex items-center gap-1 text-xs px-1.5 py-0.5 rounded-full transition-colors ${
                                           workspace.prState === 'MERGED'
                                             ? 'bg-purple-500/25 text-purple-700 dark:text-purple-300 hover:bg-purple-500/35'
-                                            : 'bg-purple-500/15 text-purple-600 dark:text-purple-400 hover:bg-purple-500/25'
+                                            : workspace.prState === 'CLOSED'
+                                              ? 'bg-gray-500/20 text-gray-500 dark:text-gray-400 hover:bg-gray-500/30'
+                                              : 'bg-purple-500/15 text-purple-600 dark:text-purple-400 hover:bg-purple-500/25'
                                         }`}
                                       >
                                         <GitPullRequest className="h-3 w-3" />
                                         <span>#{workspace.prNumber}</span>
                                         {workspace.prState === 'MERGED' ? (
                                           <CheckCircle2 className="h-3 w-3 text-purple-500" />
+                                        ) : workspace.prState === 'CLOSED' ? (
+                                          <XCircle className="h-3 w-3 text-gray-400" />
                                         ) : (
                                           <>
                                             {workspace.prCiStatus === 'SUCCESS' && (
@@ -387,13 +391,15 @@ export function AppSidebar() {
                                         PR #{workspace.prNumber}
                                         {workspace.prState === 'MERGED'
                                           ? ' · Merged'
-                                          : workspace.prCiStatus === 'SUCCESS'
-                                            ? ' · CI passed'
-                                            : workspace.prCiStatus === 'FAILURE'
-                                              ? ' · CI failed'
-                                              : workspace.prCiStatus === 'PENDING'
-                                                ? ' · CI running'
-                                                : ''}
+                                          : workspace.prState === 'CLOSED'
+                                            ? ' · Closed'
+                                            : workspace.prCiStatus === 'SUCCESS'
+                                              ? ' · CI passed'
+                                              : workspace.prCiStatus === 'FAILURE'
+                                                ? ' · CI failed'
+                                                : workspace.prCiStatus === 'PENDING'
+                                                  ? ' · CI running'
+                                                  : ''}
                                       </p>
                                       <p className="text-xs text-muted-foreground">
                                         Click to open on GitHub

--- a/src/frontend/components/kanban/kanban-card.stories.tsx
+++ b/src/frontend/components/kanban/kanban-card.stories.tsx
@@ -1,0 +1,223 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import type { WorkspaceWithKanban } from './kanban-card';
+import { KanbanCard } from './kanban-card';
+
+const meta = {
+  title: 'Kanban/KanbanCard',
+  component: KanbanCard,
+  parameters: {
+    layout: 'centered',
+    nextjs: {
+      appDirectory: true,
+    },
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="w-[280px]">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof KanbanCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const baseWorkspace: WorkspaceWithKanban = {
+  id: 'ws-1',
+  name: 'Add user authentication',
+  description: 'Implement OAuth2 login flow',
+  branchName: 'feature/auth',
+  projectId: 'proj-1',
+  worktreePath: '/path/to/worktree',
+  prUrl: null,
+  prNumber: null,
+  prState: 'NONE',
+  prReviewState: null,
+  prCiStatus: 'UNKNOWN',
+  prUpdatedAt: null,
+  status: 'ACTIVE',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  kanbanColumn: 'IN_PROGRESS',
+  isWorking: false,
+  initStatus: 'READY',
+  initErrorMessage: null,
+  initStartedAt: null,
+  initCompletedAt: null,
+  initRetryCount: 0,
+  githubIssueNumber: null,
+  githubIssueUrl: null,
+  hasHadSessions: true,
+  cachedKanbanColumn: 'IN_PROGRESS',
+  stateComputedAt: new Date(),
+};
+
+export const NoPR: Story = {
+  args: {
+    workspace: baseWorkspace,
+    projectSlug: 'my-project',
+  },
+};
+
+export const DraftPR: Story = {
+  args: {
+    workspace: {
+      ...baseWorkspace,
+      prUrl: 'https://github.com/example/repo/pull/42',
+      prNumber: 42,
+      prState: 'DRAFT',
+    },
+    projectSlug: 'my-project',
+  },
+};
+
+export const OpenPR: Story = {
+  args: {
+    workspace: {
+      ...baseWorkspace,
+      prUrl: 'https://github.com/example/repo/pull/43',
+      prNumber: 43,
+      prState: 'OPEN',
+      prCiStatus: 'PENDING',
+    },
+    projectSlug: 'my-project',
+  },
+};
+
+export const ChangesRequested: Story = {
+  args: {
+    workspace: {
+      ...baseWorkspace,
+      name: 'Fix login validation',
+      prUrl: 'https://github.com/example/repo/pull/44',
+      prNumber: 44,
+      prState: 'CHANGES_REQUESTED',
+      prCiStatus: 'SUCCESS',
+    },
+    projectSlug: 'my-project',
+  },
+};
+
+export const Approved: Story = {
+  args: {
+    workspace: {
+      ...baseWorkspace,
+      name: 'Add password reset flow',
+      prUrl: 'https://github.com/example/repo/pull/45',
+      prNumber: 45,
+      prState: 'APPROVED',
+      prCiStatus: 'SUCCESS',
+    },
+    projectSlug: 'my-project',
+  },
+};
+
+export const Merged: Story = {
+  args: {
+    workspace: {
+      ...baseWorkspace,
+      name: 'Implement MFA support',
+      prUrl: 'https://github.com/example/repo/pull/46',
+      prNumber: 46,
+      prState: 'MERGED',
+      kanbanColumn: 'MERGED',
+    },
+    projectSlug: 'my-project',
+  },
+};
+
+export const Closed: Story = {
+  args: {
+    workspace: {
+      ...baseWorkspace,
+      name: 'Deprecated feature branch',
+      prUrl: 'https://github.com/example/repo/pull/47',
+      prNumber: 47,
+      prState: 'CLOSED',
+      kanbanColumn: 'DONE',
+    },
+    projectSlug: 'my-project',
+  },
+};
+
+export const Working: Story = {
+  args: {
+    workspace: {
+      ...baseWorkspace,
+      name: 'Active coding session',
+      isWorking: true,
+      prState: 'OPEN',
+      prUrl: 'https://github.com/example/repo/pull/48',
+      prNumber: 48,
+    },
+    projectSlug: 'my-project',
+  },
+};
+
+export const Initializing: Story = {
+  args: {
+    workspace: {
+      ...baseWorkspace,
+      name: 'New workspace',
+      initStatus: 'INITIALIZING',
+      branchName: null,
+    },
+    projectSlug: 'my-project',
+  },
+};
+
+export const AllPRStates: Story = {
+  decorators: [
+    () => (
+      <div className="flex flex-wrap gap-4">
+        <div className="w-[280px]">
+          <KanbanCard
+            workspace={{ ...baseWorkspace, prState: 'DRAFT', prNumber: 1, prUrl: '#' }}
+            projectSlug="demo"
+          />
+        </div>
+        <div className="w-[280px]">
+          <KanbanCard
+            workspace={{ ...baseWorkspace, prState: 'OPEN', prNumber: 2, prUrl: '#' }}
+            projectSlug="demo"
+          />
+        </div>
+        <div className="w-[280px]">
+          <KanbanCard
+            workspace={{
+              ...baseWorkspace,
+              prState: 'CHANGES_REQUESTED',
+              prNumber: 3,
+              prUrl: '#',
+            }}
+            projectSlug="demo"
+          />
+        </div>
+        <div className="w-[280px]">
+          <KanbanCard
+            workspace={{ ...baseWorkspace, prState: 'APPROVED', prNumber: 4, prUrl: '#' }}
+            projectSlug="demo"
+          />
+        </div>
+        <div className="w-[280px]">
+          <KanbanCard
+            workspace={{ ...baseWorkspace, prState: 'MERGED', prNumber: 5, prUrl: '#' }}
+            projectSlug="demo"
+          />
+        </div>
+        <div className="w-[280px]">
+          <KanbanCard
+            workspace={{ ...baseWorkspace, prState: 'CLOSED', prNumber: 6, prUrl: '#' }}
+            projectSlug="demo"
+          />
+        </div>
+      </div>
+    ),
+  ],
+  args: {
+    workspace: baseWorkspace,
+    projectSlug: 'demo',
+  },
+};

--- a/src/frontend/components/kanban/kanban-card.tsx
+++ b/src/frontend/components/kanban/kanban-card.tsx
@@ -79,7 +79,9 @@ export function KanbanCard({ workspace, projectSlug }: KanbanCardProps) {
                   workspace.prState === 'APPROVED' &&
                     'bg-green-500/10 text-green-700 dark:text-green-400 border-green-500/30',
                   workspace.prState === 'MERGED' &&
-                    'bg-purple-500/10 text-purple-700 dark:text-purple-400 border-purple-500/30'
+                    'bg-purple-500/10 text-purple-700 dark:text-purple-400 border-purple-500/30',
+                  workspace.prState === 'CLOSED' &&
+                    'bg-gray-500/10 text-gray-500 dark:text-gray-400 border-gray-500/30'
                 )}
               >
                 {prBadge.label}


### PR DESCRIPTION
## Summary
- Show closed PRs with gray styling to distinguish them from merged (purple) PRs
- Kanban card: gray badge for CLOSED state
- Sidebar: gray background, XCircle icon, "Closed" tooltip

## Test plan
- [ ] View a workspace with a closed PR in the sidebar - should show gray badge with X icon
- [ ] View a workspace with a closed PR on the kanban board - should show gray "Closed" badge
- [ ] Run Storybook (`pnpm storybook`) and check the new KanbanCard stories showing all PR states

🤖 Generated with [Claude Code](https://claude.com/claude-code)