### PR TITLE
Add resizable panels and fix tool call overflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "react-dom": "^19.2.4",
     "react-hook-form": "^7.71.1",
     "react-markdown": "^10.1.0",
+    "react-resizable-panels": "^4.5.3",
     "react-syntax-highlighter": "^16.1.0",
     "recharts": "3.7.0",
     "remark-gfm": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.9)(react@19.2.4)
+      react-resizable-panels:
+        specifier: ^4.5.3
+        version: 4.5.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react-syntax-highlighter:
         specifier: ^16.1.0
         version: 16.1.0(react@19.2.4)
@@ -3985,6 +3988,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-resizable-panels@4.5.3:
+    resolution: {integrity: sha512-N4Uc13yM1S9nfmwH25WIpxlp4/cwh2rqj9bDSxyZJ3S6gOJ9kFsZnPalfqIeBrbUv2SoGVLAbQUaTFceUY7A5Q==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
 
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
@@ -8487,6 +8496,11 @@ snapshots:
       use-sidecar: 1.1.3(@types/react@19.2.9)(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.9
+
+  react-resizable-panels@4.5.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   react-style-singleton@2.2.3(@types/react@19.2.9)(react@19.2.4):
     dependencies:

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import { GeistMono } from 'geist/font/mono';
 import { GeistSans } from 'geist/font/sans';
 import type { Metadata } from 'next';
 import './globals.css';
-import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
+import { ResizableLayout } from '@/components/layout/resizable-layout';
 import { Toaster } from '@/components/ui/sonner';
 import { AppSidebar } from '../frontend/components/app-sidebar';
 import { ThemeProvider } from '../frontend/components/theme-provider';
@@ -23,10 +23,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body className="min-h-screen bg-background font-sans antialiased">
         <ThemeProvider>
           <TRPCProvider>
-            <SidebarProvider>
-              <AppSidebar />
-              <SidebarInset>{children}</SidebarInset>
-            </SidebarProvider>
+            <ResizableLayout sidebar={<AppSidebar />}>{children}</ResizableLayout>
             <Toaster />
           </TRPCProvider>
         </ThemeProvider>

--- a/src/app/projects/[slug]/workspaces/[id]/page.tsx
+++ b/src/app/projects/[slug]/workspaces/[id]/page.tsx
@@ -278,6 +278,12 @@ function ChatContent({
           settings={chatSettings}
           onSettingsChange={updateSettings}
           sessionId={selectedDbSessionId}
+          onHeightChange={() => {
+            // Keep messages scrolled to bottom when input area grows
+            if (isNearBottom) {
+              messagesEndRef.current?.scrollIntoView({ behavior: 'instant' });
+            }
+          }}
         />
       </div>
     </div>
@@ -706,7 +712,7 @@ function WorkspaceChatContent() {
   const runningSessionId = running && selectedDbSessionId ? selectedDbSessionId : undefined;
 
   return (
-    <div className="flex h-[calc(100svh-24px)] flex-col overflow-hidden">
+    <div className="flex h-full flex-col overflow-hidden">
       {/* Header: Branch name, status, and toggle button */}
       <div className="flex items-center justify-between px-4 py-2 border-b">
         <div className="flex items-center gap-3">
@@ -798,9 +804,13 @@ function WorkspaceChatContent() {
       </div>
 
       {/* Main Content Area: Resizable two-column layout */}
-      <ResizablePanelGroup direction="horizontal" className="flex-1 overflow-hidden">
+      <ResizablePanelGroup
+        direction="horizontal"
+        className="flex-1 overflow-hidden"
+        autoSaveId="workspace-main-panel"
+      >
         {/* Left Panel: Session tabs + Main View Content */}
-        <ResizablePanel defaultSize={rightPanelVisible ? '70%' : '100%'} minSize="30%">
+        <ResizablePanel defaultSize="70%" minSize="30%">
           <div className="h-full flex flex-col min-w-0">
             <WorkspaceContentView
               workspaceId={workspaceId}

--- a/src/app/projects/[slug]/workspaces/[id]/page.tsx
+++ b/src/app/projects/[slug]/workspaces/[id]/page.tsx
@@ -217,7 +217,7 @@ function ChatContent({
     <div className="relative flex h-full flex-col overflow-hidden" onClick={handleChatClick}>
       {/* Message List */}
       <ScrollArea className="flex-1 min-h-0" viewportRef={viewportRef} onScroll={handleScroll}>
-        <div ref={contentRef} className="p-4 space-y-2">
+        <div ref={contentRef} className="p-4 space-y-2 min-w-0">
           {messages.length === 0 && !running && !loadingSession && !startingSession && (
             <EmptyState />
           )}

--- a/src/app/projects/[slug]/workspaces/[id]/page.tsx
+++ b/src/app/projects/[slug]/workspaces/[id]/page.tsx
@@ -9,6 +9,7 @@ import {
   GitBranch,
   GitPullRequest,
   Loader2,
+  PanelRight,
   XCircle,
 } from 'lucide-react';
 import { useParams, useRouter } from 'next/navigation';
@@ -23,6 +24,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import {
   QuickActionsMenu,
   RightPanel,
+  useWorkspacePanel,
   WorkspaceContentView,
   WorkspacePanelProvider,
 } from '@/components/workspace';
@@ -113,6 +115,26 @@ function EmptyState() {
         <p className="text-sm">Start a conversation by typing a message below.</p>
       </div>
     </div>
+  );
+}
+
+// =============================================================================
+// Toggle Right Panel Button
+// =============================================================================
+
+function ToggleRightPanelButton() {
+  const { rightPanelVisible, toggleRightPanel } = useWorkspacePanel();
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggleRightPanel}
+      className="h-8 w-8"
+      title={rightPanelVisible ? 'Hide right panel' : 'Show right panel'}
+    >
+      <PanelRight className={cn('h-4 w-4', rightPanelVisible && 'text-primary')} />
+    </Button>
   );
 }
 
@@ -592,6 +614,8 @@ function WorkspaceChatContent() {
     initialDbSessionId,
   } = useWorkspaceData({ workspaceId });
 
+  const { rightPanelVisible } = useWorkspacePanel();
+
   // Manage selected session state here so it's available for useChatWebSocket
   const [selectedDbSessionId, setSelectedDbSessionId] = useState<string | null>(null);
 
@@ -769,13 +793,14 @@ function WorkspaceChatContent() {
           >
             <Archive className="h-4 w-4" />
           </Button>
+          <ToggleRightPanelButton />
         </div>
       </div>
 
       {/* Main Content Area: Resizable two-column layout */}
       <ResizablePanelGroup direction="horizontal" className="flex-1 overflow-hidden">
         {/* Left Panel: Session tabs + Main View Content */}
-        <ResizablePanel defaultSize="70%" minSize="30%">
+        <ResizablePanel defaultSize={rightPanelVisible ? '70%' : '100%'} minSize="30%">
           <div className="h-full flex flex-col min-w-0">
             <WorkspaceContentView
               workspaceId={workspaceId}
@@ -819,14 +844,17 @@ function WorkspaceChatContent() {
           </div>
         </ResizablePanel>
 
-        <ResizableHandle />
-
-        {/* Right Panel: Git/Files + Terminal */}
-        <ResizablePanel defaultSize="30%" minSize="15%" maxSize="50%">
-          <div className="h-full border-l">
-            <RightPanel workspaceId={workspaceId} />
-          </div>
-        </ResizablePanel>
+        {/* Right Panel: Git/Files + Terminal (conditionally rendered) */}
+        {rightPanelVisible && (
+          <>
+            <ResizableHandle />
+            <ResizablePanel defaultSize="30%" minSize="15%" maxSize="50%">
+              <div className="h-full border-l">
+                <RightPanel workspaceId={workspaceId} />
+              </div>
+            </ResizablePanel>
+          </>
+        )}
       </ResizablePanelGroup>
     </div>
   );

--- a/src/app/projects/[slug]/workspaces/[id]/page.tsx
+++ b/src/app/projects/[slug]/workspaces/[id]/page.tsx
@@ -9,7 +9,6 @@ import {
   GitBranch,
   GitPullRequest,
   Loader2,
-  PanelRight,
   XCircle,
 } from 'lucide-react';
 import { useParams, useRouter } from 'next/navigation';
@@ -19,11 +18,11 @@ import { toast } from 'sonner';
 import { GroupedMessageItemRenderer, LoadingIndicator } from '@/components/agent-activity';
 import { ChatInput, PermissionPrompt, QuestionPrompt, useChatWebSocket } from '@/components/chat';
 import { Button } from '@/components/ui/button';
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import {
   QuickActionsMenu,
   RightPanel,
-  useWorkspacePanel,
   WorkspaceContentView,
   WorkspacePanelProvider,
 } from '@/components/workspace';
@@ -114,26 +113,6 @@ function EmptyState() {
         <p className="text-sm">Start a conversation by typing a message below.</p>
       </div>
     </div>
-  );
-}
-
-// =============================================================================
-// Toggle Right Panel Button
-// =============================================================================
-
-function ToggleRightPanelButton() {
-  const { rightPanelVisible, toggleRightPanel } = useWorkspacePanel();
-
-  return (
-    <Button
-      variant="ghost"
-      size="icon"
-      onClick={toggleRightPanel}
-      className="h-8 w-8"
-      title={rightPanelVisible ? 'Hide right panel' : 'Show right panel'}
-    >
-      <PanelRight className={cn('h-4 w-4', rightPanelVisible && 'text-primary')} />
-    </Button>
   );
 }
 
@@ -601,7 +580,6 @@ function WorkspaceChatContent() {
   const router = useRouter();
   const slug = params.slug as string;
   const workspaceId = params.id as string;
-  const { rightPanelVisible } = useWorkspacePanel();
 
   // Fetch workspace and session data
   const {
@@ -791,62 +769,65 @@ function WorkspaceChatContent() {
           >
             <Archive className="h-4 w-4" />
           </Button>
-          <ToggleRightPanelButton />
         </div>
       </div>
 
-      {/* Main Content Area: Two-column layout */}
-      <div className="flex flex-1 overflow-hidden">
+      {/* Main Content Area: Resizable two-column layout */}
+      <ResizablePanelGroup direction="horizontal" className="flex-1 overflow-hidden">
         {/* Left Panel: Session tabs + Main View Content */}
-        <div className="flex-1 flex flex-col min-w-0">
-          <WorkspaceContentView
-            workspaceId={workspaceId}
-            claudeSessions={claudeSessions}
-            workflows={workflows}
-            recommendedWorkflow={recommendedWorkflow}
-            selectedSessionId={selectedDbSessionId}
-            runningSessionId={runningSessionId}
-            running={running}
-            isCreatingSession={createSession.isPending}
-            isDeletingSession={deleteSession.isPending}
-            onWorkflowSelect={handleWorkflowSelect}
-            onSelectSession={handleSelectSession}
-            onCreateSession={handleNewChat}
-            onCloseSession={handleCloseSession}
-          >
-            <ChatContent
-              messages={messages}
+        <ResizablePanel defaultSize="70%" minSize="30%">
+          <div className="h-full flex flex-col min-w-0">
+            <WorkspaceContentView
+              workspaceId={workspaceId}
+              claudeSessions={claudeSessions}
+              workflows={workflows}
+              recommendedWorkflow={recommendedWorkflow}
+              selectedSessionId={selectedDbSessionId}
+              runningSessionId={runningSessionId}
               running={running}
-              loadingSession={loadingSession}
-              startingSession={startingSession}
-              messagesEndRef={messagesEndRef}
-              contentRef={contentRef}
-              viewportRef={viewportRef}
-              handleScroll={handleScroll}
-              isNearBottom={isNearBottom}
-              scrollToBottom={scrollToBottom}
-              pendingPermission={pendingPermission}
-              pendingQuestion={pendingQuestion}
-              approvePermission={approvePermission}
-              answerQuestion={answerQuestion}
-              connected={connected}
-              sendMessage={sendMessage}
-              stopChat={stopChat}
-              inputRef={inputRef}
-              chatSettings={chatSettings}
-              updateSettings={updateSettings}
-              selectedDbSessionId={selectedDbSessionId}
-            />
-          </WorkspaceContentView>
-        </div>
+              isCreatingSession={createSession.isPending}
+              isDeletingSession={deleteSession.isPending}
+              onWorkflowSelect={handleWorkflowSelect}
+              onSelectSession={handleSelectSession}
+              onCreateSession={handleNewChat}
+              onCloseSession={handleCloseSession}
+            >
+              <ChatContent
+                messages={messages}
+                running={running}
+                loadingSession={loadingSession}
+                startingSession={startingSession}
+                messagesEndRef={messagesEndRef}
+                contentRef={contentRef}
+                viewportRef={viewportRef}
+                handleScroll={handleScroll}
+                isNearBottom={isNearBottom}
+                scrollToBottom={scrollToBottom}
+                pendingPermission={pendingPermission}
+                pendingQuestion={pendingQuestion}
+                approvePermission={approvePermission}
+                answerQuestion={answerQuestion}
+                connected={connected}
+                sendMessage={sendMessage}
+                stopChat={stopChat}
+                inputRef={inputRef}
+                chatSettings={chatSettings}
+                updateSettings={updateSettings}
+                selectedDbSessionId={selectedDbSessionId}
+              />
+            </WorkspaceContentView>
+          </div>
+        </ResizablePanel>
 
-        {/* Right Panel (conditionally rendered, fixed width) */}
-        {rightPanelVisible && (
-          <div className="w-[480px] border-l flex-shrink-0">
+        <ResizableHandle />
+
+        {/* Right Panel: Git/Files + Terminal */}
+        <ResizablePanel defaultSize="30%" minSize="15%" maxSize="50%">
+          <div className="h-full border-l">
             <RightPanel workspaceId={workspaceId} />
           </div>
-        )}
-      </div>
+        </ResizablePanel>
+      </ResizablePanelGroup>
     </div>
   );
 }

--- a/src/components/agent-activity/tool-renderers.tsx
+++ b/src/components/agent-activity/tool-renderers.tsx
@@ -107,7 +107,7 @@ export function ToolInfoRenderer({
 
     return (
       <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-        <div className="rounded border bg-muted/30">
+        <div className="rounded border bg-muted/30 min-w-0">
           <CollapsibleTrigger asChild>
             <button className="flex w-full items-center gap-1.5 px-2 py-1 text-left hover:bg-muted/50 transition-colors">
               {isOpen ? (
@@ -133,7 +133,7 @@ export function ToolInfoRenderer({
             </button>
           </CollapsibleTrigger>
           <CollapsibleContent>
-            <div className="border-t px-2 py-1.5">
+            <div className="border-t px-2 py-1.5 overflow-x-auto">
               <ToolInputRenderer name={toolInfo.name} input={toolInfo.input} />
             </div>
           </CollapsibleContent>
@@ -153,7 +153,7 @@ export function ToolInfoRenderer({
       <Collapsible open={isOpen} onOpenChange={setIsOpen}>
         <div
           className={cn(
-            'rounded border',
+            'rounded border min-w-0',
             resultInfo.isError ? 'border-destructive/50 bg-destructive/5' : 'bg-muted/30'
           )}
         >
@@ -179,7 +179,7 @@ export function ToolInfoRenderer({
             </button>
           </CollapsibleTrigger>
           <CollapsibleContent>
-            <div className="border-t px-2 py-1.5">
+            <div className="border-t px-2 py-1.5 overflow-x-auto">
               <ToolResultContentRenderer
                 content={resultInfo.content}
                 isError={resultInfo.isError}
@@ -273,7 +273,7 @@ export function ToolSequenceGroup({ sequence, defaultOpen = false }: ToolSequenc
 
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-      <div className="rounded border bg-muted/20">
+      <div className="rounded border bg-muted/20 min-w-0">
         <CollapsibleTrigger asChild>
           <button className="flex w-full items-center gap-1.5 px-2 py-1.5 text-left hover:bg-muted/50 transition-colors">
             {isOpen ? (
@@ -289,7 +289,7 @@ export function ToolSequenceGroup({ sequence, defaultOpen = false }: ToolSequenc
           </button>
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <div className="border-t space-y-1 p-1.5">
+          <div className="border-t space-y-1 p-1.5 overflow-x-auto">
             {pairedCalls.map((call) => (
               <div key={call.id} className="pl-2">
                 <PairedToolCallRenderer call={call} defaultOpen={false} />
@@ -325,7 +325,7 @@ function PairedToolCallRenderer({ call, defaultOpen = false }: PairedToolCallRen
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>
       <div
         className={cn(
-          'rounded border',
+          'rounded border min-w-0',
           isError ? 'border-destructive/50 bg-destructive/5' : 'bg-muted/30'
         )}
       >
@@ -359,15 +359,15 @@ function PairedToolCallRenderer({ call, defaultOpen = false }: PairedToolCallRen
           </button>
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <div className="border-t px-2 py-1.5 space-y-2">
+          <div className="border-t px-2 py-1.5 space-y-2 overflow-x-auto">
             {/* Tool Input */}
-            <div>
+            <div className="min-w-0">
               <div className="text-[10px] font-medium text-muted-foreground mb-0.5">Input</div>
               <ToolInputRenderer name={call.name} input={call.input} />
             </div>
             {/* Tool Result */}
             {call.result && (
-              <div>
+              <div className="min-w-0">
                 <div className="text-[10px] font-medium text-muted-foreground mb-0.5">Result</div>
                 <ToolResultContentRenderer
                   content={call.result.content}
@@ -396,7 +396,7 @@ function ToolInputRenderer({ name, input }: ToolInputRendererProps) {
   switch (name) {
     case 'Read':
       return (
-        <div className="space-y-1">
+        <div className="space-y-1 w-0 min-w-full">
           <FilePathDisplay path={input.file_path as string} />
           {input.offset !== undefined && (
             <div className="text-xs text-muted-foreground">
@@ -408,7 +408,7 @@ function ToolInputRenderer({ name, input }: ToolInputRendererProps) {
 
     case 'Write':
       return (
-        <div className="space-y-1">
+        <div className="space-y-1 w-0 min-w-full">
           <FilePathDisplay path={input.file_path as string} />
           <div className="rounded bg-muted px-1.5 py-1">
             <pre className="text-xs overflow-x-auto max-h-32 overflow-y-auto">
@@ -420,16 +420,16 @@ function ToolInputRenderer({ name, input }: ToolInputRendererProps) {
 
     case 'Edit':
       return (
-        <div className="space-y-1">
+        <div className="space-y-1 w-0 min-w-full">
           <FilePathDisplay path={input.file_path as string} />
           <div className="grid grid-cols-2 gap-1.5">
-            <div className="rounded bg-destructive/10 px-1.5 py-1">
+            <div className="rounded bg-destructive/10 px-1.5 py-1 min-w-0">
               <div className="text-[10px] font-medium text-destructive mb-0.5">Remove</div>
               <pre className="text-xs overflow-x-auto max-h-16 overflow-y-auto">
                 {truncateContent(input.old_string as string, 200)}
               </pre>
             </div>
-            <div className="rounded bg-success/10 px-1.5 py-1">
+            <div className="rounded bg-success/10 px-1.5 py-1 min-w-0">
               <div className="text-[10px] font-medium text-success mb-0.5">Add</div>
               <pre className="text-xs overflow-x-auto max-h-16 overflow-y-auto">
                 {truncateContent(input.new_string as string, 200)}
@@ -441,7 +441,7 @@ function ToolInputRenderer({ name, input }: ToolInputRendererProps) {
 
     case 'Bash':
       return (
-        <div className="space-y-0.5">
+        <div className="space-y-0.5 w-0 min-w-full">
           <div className="rounded bg-muted px-1.5 py-1 font-mono">
             <pre className="text-xs overflow-x-auto whitespace-pre-wrap">
               {String(input.command ?? '')}
@@ -456,7 +456,7 @@ function ToolInputRenderer({ name, input }: ToolInputRendererProps) {
     case 'Glob':
     case 'Grep':
       return (
-        <div className="space-y-0.5">
+        <div className="space-y-0.5 w-0 min-w-full">
           <div className="font-mono text-xs">{String(input.pattern ?? '')}</div>
           {input.path != null && <FilePathDisplay path={String(input.path)} />}
         </div>
@@ -465,9 +465,11 @@ function ToolInputRenderer({ name, input }: ToolInputRendererProps) {
     default:
       // Generic JSON display for unknown tools
       return (
-        <pre className="text-xs overflow-x-auto max-h-32 overflow-y-auto rounded bg-muted px-1.5 py-1">
-          {JSON.stringify(input, null, 2)}
-        </pre>
+        <div className="w-0 min-w-full">
+          <pre className="text-xs overflow-x-auto max-h-32 overflow-y-auto rounded bg-muted px-1.5 py-1">
+            {JSON.stringify(input, null, 2)}
+          </pre>
+        </div>
       );
   }
 }
@@ -484,20 +486,22 @@ interface ToolResultContentRendererProps {
 function ToolResultContentRenderer({ content, isError }: ToolResultContentRendererProps) {
   if (typeof content === 'string') {
     return (
-      <pre
-        className={cn(
-          'text-xs overflow-x-auto max-h-40 overflow-y-auto rounded px-1.5 py-1',
-          isError ? 'bg-destructive/10 text-destructive' : 'bg-muted'
-        )}
-      >
-        {truncateContent(content, 2000)}
-      </pre>
+      <div className="w-0 min-w-full">
+        <pre
+          className={cn(
+            'text-xs overflow-x-auto max-h-40 overflow-y-auto rounded px-1.5 py-1',
+            isError ? 'bg-destructive/10 text-destructive' : 'bg-muted'
+          )}
+        >
+          {truncateContent(content, 2000)}
+        </pre>
+      </div>
     );
   }
 
   // Handle array of text/image items
   return (
-    <div className="space-y-1">
+    <div className="space-y-1 w-0 min-w-full">
       {content.map((item, index) => {
         const key =
           item.type === 'text' ? `text-${index}-${(item.text ?? '').slice(0, 20)}` : `img-${index}`;
@@ -553,7 +557,7 @@ export function ToolCallGroupRenderer({
 
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-      <div className="rounded border bg-muted/20">
+      <div className="rounded border bg-muted/20 min-w-0">
         <CollapsibleTrigger asChild>
           <button className="flex w-full items-center gap-1.5 px-2 py-1 text-left hover:bg-muted/50 transition-colors">
             {isOpen ? (
@@ -583,7 +587,7 @@ export function ToolCallGroupRenderer({
           </button>
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <div className="border-t divide-y">
+          <div className="border-t divide-y overflow-x-auto">
             {toolCalls.map((toolCall) => (
               <ToolCallItem key={toolCall.id} toolCall={toolCall} />
             ))}
@@ -627,7 +631,7 @@ function ToolCallItem({ toolCall }: ToolCallItemProps) {
         </button>
       </CollapsibleTrigger>
       <CollapsibleContent>
-        <div className="px-4 pb-1.5 space-y-1">
+        <div className="px-4 pb-1.5 space-y-1 overflow-x-auto">
           <ToolInputRenderer name={toolCall.name} input={toolCall.input} />
           {toolCall.result && (
             <ToolResultContentRenderer
@@ -656,10 +660,10 @@ function FilePathDisplay({ path }: { path: string }) {
   const directory = parts.slice(0, -1).join('/');
 
   return (
-    <div className="flex items-center gap-1 text-sm">
+    <div className="flex items-center gap-1 text-sm min-w-0">
       <FileCode className="h-4 w-4 shrink-0 text-muted-foreground" />
-      <span className="text-muted-foreground">{directory}/</span>
-      <span className="font-medium">{filename}</span>
+      <span className="text-muted-foreground truncate">{directory}/</span>
+      <span className="font-medium shrink-0">{filename}</span>
     </div>
   );
 }

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -40,6 +40,8 @@ interface ChatInputProps {
   onSettingsChange?: (settings: Partial<ChatSettings>) => void;
   // Session tracking for auto-focus on new sessions
   sessionId?: string | null;
+  // Called when textarea height changes (for scroll adjustment)
+  onHeightChange?: () => void;
 }
 
 // =============================================================================
@@ -192,6 +194,7 @@ export function ChatInput({
   settings,
   onSettingsChange,
   sessionId,
+  onHeightChange,
 }: ChatInputProps) {
   // Handle key press for Enter to send
   const handleKeyDown = useCallback(
@@ -203,9 +206,6 @@ export function ChatInput({
         if (text && !disabled && !running) {
           onSend(text);
           event.currentTarget.value = '';
-          // Reset textarea height and overflow
-          event.currentTarget.style.height = 'auto';
-          event.currentTarget.style.overflowY = 'hidden';
         }
       }
     },
@@ -223,24 +223,24 @@ export function ChatInput({
       if (text && !disabled) {
         onSend(text);
         inputRef.current.value = '';
-        inputRef.current.style.height = 'auto';
-        inputRef.current.style.overflowY = 'hidden';
         inputRef.current.focus();
       }
     }
   }, [onSend, onStop, inputRef, disabled, running]);
 
-  // Auto-resize textarea based on content
-  const maxHeight = 200;
-  const handleInput = useCallback((event: React.FormEvent<HTMLTextAreaElement>) => {
-    const target = event.currentTarget;
-    // Reset height to auto to get accurate scrollHeight
-    target.style.height = 'auto';
-    const newHeight = Math.min(target.scrollHeight, maxHeight);
-    target.style.height = `${newHeight}px`;
-    // Show scrollbar only when content exceeds max height
-    target.style.overflowY = target.scrollHeight > maxHeight ? 'auto' : 'hidden';
-  }, []);
+  // Watch for textarea height changes (from field-sizing: content) to notify parent
+  useEffect(() => {
+    const textarea = inputRef?.current;
+    if (!(textarea && onHeightChange)) {
+      return;
+    }
+
+    const observer = new ResizeObserver(() => {
+      onHeightChange();
+    });
+    observer.observe(textarea);
+    return () => observer.disconnect();
+  }, [inputRef, onHeightChange]);
 
   // Track previous state to only auto-focus on specific transitions
   const prevRunningRef = useRef(running);
@@ -295,11 +295,10 @@ export function ChatInput({
         <InputGroupTextarea
           ref={inputRef}
           onKeyDown={handleKeyDown}
-          onInput={handleInput}
           disabled={isDisabled}
           placeholder={isDisabled ? 'Connecting...' : placeholder}
           className={cn(
-            'min-h-[40px] max-h-[200px] overflow-y-hidden',
+            'min-h-[40px] max-h-[110px] overflow-y-auto [field-sizing:content]',
             isDisabled && 'opacity-50 cursor-not-allowed'
           )}
           rows={1}

--- a/src/components/layout/resizable-layout.tsx
+++ b/src/components/layout/resizable-layout.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { CSSProperties, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
 import { SidebarProvider } from '@/components/ui/sidebar';
@@ -16,7 +16,6 @@ export function ResizableLayout({ sidebar, children }: ResizableLayoutProps) {
       <ResizablePanelGroup
         direction="horizontal"
         className="h-svh w-full"
-        style={{ '--sidebar-width': '100%' } as CSSProperties}
         autoSaveId="app-sidebar-layout"
       >
         {/* Left sidebar panel */}
@@ -28,7 +27,7 @@ export function ResizableLayout({ sidebar, children }: ResizableLayoutProps) {
 
         {/* Main content panel */}
         <ResizablePanel defaultSize="85%" minSize="50%">
-          <main className="relative flex min-h-0 w-full flex-1 flex-col overflow-y-auto bg-background">
+          <main className="relative flex min-h-0 h-full w-full flex-1 flex-col overflow-hidden bg-background">
             {children}
           </main>
         </ResizablePanel>

--- a/src/components/layout/resizable-layout.tsx
+++ b/src/components/layout/resizable-layout.tsx
@@ -17,6 +17,7 @@ export function ResizableLayout({ sidebar, children }: ResizableLayoutProps) {
         direction="horizontal"
         className="h-svh w-full"
         style={{ '--sidebar-width': '100%' } as CSSProperties}
+        autoSaveId="app-sidebar-layout"
       >
         {/* Left sidebar panel */}
         <ResizablePanel defaultSize="15%" minSize="10%" maxSize="30%">

--- a/src/components/layout/resizable-layout.tsx
+++ b/src/components/layout/resizable-layout.tsx
@@ -3,7 +3,7 @@
 import type { CSSProperties, ReactNode } from 'react';
 
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
-import { TooltipProvider } from '@/components/ui/tooltip';
+import { SidebarProvider } from '@/components/ui/sidebar';
 
 interface ResizableLayoutProps {
   sidebar: ReactNode;
@@ -12,7 +12,7 @@ interface ResizableLayoutProps {
 
 export function ResizableLayout({ sidebar, children }: ResizableLayoutProps) {
   return (
-    <TooltipProvider delayDuration={0}>
+    <SidebarProvider>
       <ResizablePanelGroup
         direction="horizontal"
         className="h-svh w-full"
@@ -33,6 +33,6 @@ export function ResizableLayout({ sidebar, children }: ResizableLayoutProps) {
           </main>
         </ResizablePanel>
       </ResizablePanelGroup>
-    </TooltipProvider>
+    </SidebarProvider>
   );
 }

--- a/src/components/layout/resizable-layout.tsx
+++ b/src/components/layout/resizable-layout.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import type { CSSProperties, ReactNode } from 'react';
+
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
+import { TooltipProvider } from '@/components/ui/tooltip';
+
+interface ResizableLayoutProps {
+  sidebar: ReactNode;
+  children: ReactNode;
+}
+
+export function ResizableLayout({ sidebar, children }: ResizableLayoutProps) {
+  return (
+    <TooltipProvider delayDuration={0}>
+      <ResizablePanelGroup
+        direction="horizontal"
+        className="h-svh w-full"
+        style={{ '--sidebar-width': '100%' } as CSSProperties}
+      >
+        {/* Left sidebar panel */}
+        <ResizablePanel defaultSize="15%" minSize="10%" maxSize="30%">
+          {sidebar}
+        </ResizablePanel>
+
+        <ResizableHandle />
+
+        {/* Main content panel */}
+        <ResizablePanel defaultSize="85%" minSize="50%">
+          <main className="relative flex min-h-0 w-full flex-1 flex-col overflow-y-auto bg-background">
+            {children}
+          </main>
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    </TooltipProvider>
+  );
+}

--- a/src/components/ui/resizable.tsx
+++ b/src/components/ui/resizable.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { GripVertical } from 'lucide-react';
+import type { ComponentProps } from 'react';
+import { Group, Panel, Separator } from 'react-resizable-panels';
+
+import { cn } from '@/lib/utils';
+
+type ResizablePanelGroupProps = Omit<ComponentProps<typeof Group>, 'orientation'> & {
+  /** Alias for orientation to maintain shadcn API compatibility */
+  direction?: 'horizontal' | 'vertical';
+};
+
+const ResizablePanelGroup = ({
+  className,
+  direction = 'horizontal',
+  ...props
+}: ResizablePanelGroupProps) => (
+  <Group
+    orientation={direction}
+    className={cn('flex h-full w-full', direction === 'vertical' && 'flex-col', className)}
+    {...props}
+  />
+);
+
+const ResizablePanel = Panel;
+
+const ResizableHandle = ({
+  withHandle,
+  className,
+  ...props
+}: ComponentProps<typeof Separator> & {
+  withHandle?: boolean;
+}) => (
+  <Separator
+    className={cn(
+      'relative flex items-center justify-center bg-border transition-colors hover:bg-primary/50',
+      'w-px after:absolute after:inset-y-0 after:left-1/2 after:w-4 after:-translate-x-1/2',
+      'data-[orientation=vertical]:h-px data-[orientation=vertical]:w-full',
+      'data-[orientation=vertical]:after:inset-x-0 data-[orientation=vertical]:after:inset-y-auto',
+      'data-[orientation=vertical]:after:left-0 data-[orientation=vertical]:after:h-4 data-[orientation=vertical]:after:w-full',
+      'data-[orientation=vertical]:after:-translate-y-1/2 data-[orientation=vertical]:after:translate-x-0',
+      'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1',
+      '[&[data-orientation=vertical]>div]:rotate-90',
+      className
+    )}
+    {...props}
+  >
+    {withHandle && (
+      <div className="z-10 flex h-4 w-3 items-center justify-center rounded-sm border bg-border">
+        <GripVertical className="h-2.5 w-2.5" />
+      </div>
+    )}
+  </Separator>
+);
+
+export { ResizablePanelGroup, ResizablePanel, ResizableHandle };

--- a/src/components/ui/resizable.tsx
+++ b/src/components/ui/resizable.tsx
@@ -84,13 +84,18 @@ const ResizableHandle = ({
 }) => (
   <Separator
     className={cn(
+      // Base styles
       'relative flex items-center justify-center bg-border transition-colors hover:bg-primary/50',
+      // Horizontal panels: vertical divider line (default)
       'w-px after:absolute after:inset-y-0 after:left-1/2 after:w-4 after:-translate-x-1/2',
-      'data-[orientation=vertical]:h-px data-[orientation=vertical]:w-full',
+      // Vertical panels: horizontal divider line
+      'data-[orientation=vertical]:h-1 data-[orientation=vertical]:w-full',
       'data-[orientation=vertical]:after:inset-x-0 data-[orientation=vertical]:after:inset-y-auto',
       'data-[orientation=vertical]:after:left-0 data-[orientation=vertical]:after:h-4 data-[orientation=vertical]:after:w-full',
       'data-[orientation=vertical]:after:-translate-y-1/2 data-[orientation=vertical]:after:translate-x-0',
+      // Focus styles
       'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1',
+      // Rotate grip icon for vertical orientation
       '[&[data-orientation=vertical]>div]:rotate-90',
       className
     )}

--- a/src/components/ui/resizable.tsx
+++ b/src/components/ui/resizable.tsx
@@ -2,6 +2,7 @@
 
 import { GripVertical } from 'lucide-react';
 import type { ComponentProps } from 'react';
+import { useEffect, useState } from 'react';
 import { Group, Panel, Separator, useDefaultLayout } from 'react-resizable-panels';
 
 import { cn } from '@/lib/utils';
@@ -13,6 +14,15 @@ type ResizablePanelGroupProps = Omit<ComponentProps<typeof Group>, 'orientation'
   autoSaveId?: string;
 };
 
+// Custom hook that safely provides localStorage only on client
+function useClientStorage() {
+  const [storage, setStorage] = useState<Storage | undefined>(undefined);
+  useEffect(() => {
+    setStorage(localStorage);
+  }, []);
+  return storage;
+}
+
 const ResizablePanelGroup = ({
   className,
   direction = 'horizontal',
@@ -21,10 +31,12 @@ const ResizablePanelGroup = ({
   onLayoutChanged: onLayoutChangedProp,
   ...props
 }: ResizablePanelGroupProps) => {
+  const clientStorage = useClientStorage();
+
   // Use the persistence hook when autoSaveId is provided
   const persistence = useDefaultLayout({
     id: autoSaveId ?? '__unused__',
-    storage: autoSaveId && typeof window !== 'undefined' ? localStorage : undefined,
+    storage: autoSaveId ? clientStorage : undefined,
   });
 
   return (

--- a/src/components/ui/resizable.tsx
+++ b/src/components/ui/resizable.tsx
@@ -66,7 +66,9 @@ const ResizablePanelGroup = ({
     <Group
       orientation={direction}
       className={cn('flex h-full w-full', direction === 'vertical' && 'flex-col', className)}
-      defaultLayout={autoSaveId ? persistence.defaultLayout : defaultLayoutProp}
+      defaultLayout={
+        autoSaveId ? (persistence.defaultLayout ?? defaultLayoutProp) : defaultLayoutProp
+      }
       onLayoutChanged={autoSaveId ? persistence.onLayoutChanged : onLayoutChangedProp}
       {...props}
     />

--- a/src/components/ui/resizable.tsx
+++ b/src/components/ui/resizable.tsx
@@ -2,26 +2,41 @@
 
 import { GripVertical } from 'lucide-react';
 import type { ComponentProps } from 'react';
-import { Group, Panel, Separator } from 'react-resizable-panels';
+import { Group, Panel, Separator, useDefaultLayout } from 'react-resizable-panels';
 
 import { cn } from '@/lib/utils';
 
 type ResizablePanelGroupProps = Omit<ComponentProps<typeof Group>, 'orientation'> & {
   /** Alias for orientation to maintain shadcn API compatibility */
   direction?: 'horizontal' | 'vertical';
+  /** Unique ID for persisting layout to localStorage */
+  autoSaveId?: string;
 };
 
 const ResizablePanelGroup = ({
   className,
   direction = 'horizontal',
+  autoSaveId,
+  defaultLayout: defaultLayoutProp,
+  onLayoutChanged: onLayoutChangedProp,
   ...props
-}: ResizablePanelGroupProps) => (
-  <Group
-    orientation={direction}
-    className={cn('flex h-full w-full', direction === 'vertical' && 'flex-col', className)}
-    {...props}
-  />
-);
+}: ResizablePanelGroupProps) => {
+  // Use the persistence hook when autoSaveId is provided
+  const persistence = useDefaultLayout({
+    id: autoSaveId ?? '__unused__',
+    storage: autoSaveId && typeof window !== 'undefined' ? localStorage : undefined,
+  });
+
+  return (
+    <Group
+      orientation={direction}
+      className={cn('flex h-full w-full', direction === 'vertical' && 'flex-col', className)}
+      defaultLayout={autoSaveId ? persistence.defaultLayout : defaultLayoutProp}
+      onLayoutChanged={autoSaveId ? persistence.onLayoutChanged : onLayoutChangedProp}
+      {...props}
+    />
+  );
+};
 
 const ResizablePanel = Panel;
 

--- a/src/components/ui/resizable.tsx
+++ b/src/components/ui/resizable.tsx
@@ -75,38 +75,46 @@ const ResizablePanelGroup = ({
 
 const ResizablePanel = Panel;
 
-const ResizableHandle = ({
-  withHandle,
-  className,
-  ...props
-}: ComponentProps<typeof Separator> & {
+type ResizableHandleProps = ComponentProps<typeof Separator> & {
   withHandle?: boolean;
-}) => (
-  <Separator
-    className={cn(
-      // Base styles
-      'relative flex items-center justify-center bg-border transition-colors hover:bg-primary/50',
-      // Horizontal panels: vertical divider line (default)
-      'w-px after:absolute after:inset-y-0 after:left-1/2 after:w-4 after:-translate-x-1/2',
-      // Vertical panels: horizontal divider line
-      'data-[orientation=vertical]:h-1 data-[orientation=vertical]:w-full',
-      'data-[orientation=vertical]:after:inset-x-0 data-[orientation=vertical]:after:inset-y-auto',
-      'data-[orientation=vertical]:after:left-0 data-[orientation=vertical]:after:h-4 data-[orientation=vertical]:after:w-full',
-      'data-[orientation=vertical]:after:-translate-y-1/2 data-[orientation=vertical]:after:translate-x-0',
-      // Focus styles
-      'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1',
-      // Rotate grip icon for vertical orientation
-      '[&[data-orientation=vertical]>div]:rotate-90',
-      className
-    )}
-    {...props}
-  >
-    {withHandle && (
-      <div className="z-10 flex h-4 w-3 items-center justify-center rounded-sm border bg-border">
-        <GripVertical className="h-2.5 w-2.5" />
-      </div>
-    )}
-  </Separator>
-);
+  /** Direction of the parent panel group - determines handle orientation */
+  direction?: 'horizontal' | 'vertical';
+};
+
+const ResizableHandle = ({ withHandle, className, direction, ...props }: ResizableHandleProps) => {
+  // For horizontal panel groups, the handle is a vertical line
+  // For vertical panel groups, the handle is a horizontal line
+  const isHorizontalHandle = direction === 'vertical';
+
+  return (
+    <Separator
+      className={cn(
+        // Base styles
+        'relative flex items-center justify-center bg-border transition-colors hover:bg-primary/50',
+        // Focus styles
+        'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1',
+        // Orientation-specific styles
+        isHorizontalHandle
+          ? // Horizontal handle (for vertical panel groups)
+            'h-1 w-full after:absolute after:inset-x-0 after:top-1/2 after:h-4 after:-translate-y-1/2'
+          : // Vertical handle (for horizontal panel groups) - default
+            'w-px after:absolute after:inset-y-0 after:left-1/2 after:w-4 after:-translate-x-1/2',
+        className
+      )}
+      {...props}
+    >
+      {withHandle && (
+        <div
+          className={cn(
+            'z-10 flex items-center justify-center rounded-sm border bg-border',
+            isHorizontalHandle ? 'h-3 w-4 rotate-90' : 'h-4 w-3'
+          )}
+        >
+          <GripVertical className="h-2.5 w-2.5" />
+        </div>
+      )}
+    </Separator>
+  );
+};
 
 export { ResizablePanelGroup, ResizablePanel, ResizableHandle };

--- a/src/components/workspace/right-panel.tsx
+++ b/src/components/workspace/right-panel.tsx
@@ -125,7 +125,7 @@ export function RightPanel({ workspaceId, className }: RightPanelProps) {
         </div>
       </ResizablePanel>
 
-      <ResizableHandle />
+      <ResizableHandle direction="vertical" />
 
       {/* Bottom Panel: Terminal */}
       <ResizablePanel defaultSize="40%" minSize="15%">

--- a/src/components/workspace/right-panel.tsx
+++ b/src/components/workspace/right-panel.tsx
@@ -3,6 +3,7 @@
 import { Files, GitBranch } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
 import { cn } from '@/lib/utils';
 
 import { FileBrowserPanel } from './file-browser-panel';
@@ -92,36 +93,40 @@ export function RightPanel({ workspaceId, className }: RightPanelProps) {
   };
 
   return (
-    <div className={cn('h-full flex flex-col', className)}>
-      {/* Top Panel: Git Status / File Browser (60% height) */}
-      <div className="flex-[6] flex flex-col min-h-0">
-        {/* Tab bar */}
-        <div className="flex items-center gap-0.5 p-1 bg-muted/50 border-b">
-          <PanelTab
-            label="Git"
-            icon={<GitBranch className="h-3.5 w-3.5" />}
-            isActive={activeTopTab === 'git'}
-            onClick={() => handleTabChange('git')}
-          />
-          <PanelTab
-            label="Files"
-            icon={<Files className="h-3.5 w-3.5" />}
-            isActive={activeTopTab === 'files'}
-            onClick={() => handleTabChange('files')}
-          />
-        </div>
+    <ResizablePanelGroup direction="vertical" className={cn('h-full', className)}>
+      {/* Top Panel: Git Status / File Browser */}
+      <ResizablePanel defaultSize={60} minSize={20}>
+        <div className="flex flex-col h-full min-h-0">
+          {/* Tab bar */}
+          <div className="flex items-center gap-0.5 p-1 bg-muted/50 border-b">
+            <PanelTab
+              label="Git"
+              icon={<GitBranch className="h-3.5 w-3.5" />}
+              isActive={activeTopTab === 'git'}
+              onClick={() => handleTabChange('git')}
+            />
+            <PanelTab
+              label="Files"
+              icon={<Files className="h-3.5 w-3.5" />}
+              isActive={activeTopTab === 'files'}
+              onClick={() => handleTabChange('files')}
+            />
+          </div>
 
-        {/* Content */}
-        <div className="flex-1 overflow-hidden">
-          {activeTopTab === 'git' && <GitSummaryPanel workspaceId={workspaceId} />}
-          {activeTopTab === 'files' && <FileBrowserPanel workspaceId={workspaceId} />}
+          {/* Content */}
+          <div className="flex-1 overflow-hidden">
+            {activeTopTab === 'git' && <GitSummaryPanel workspaceId={workspaceId} />}
+            {activeTopTab === 'files' && <FileBrowserPanel workspaceId={workspaceId} />}
+          </div>
         </div>
-      </div>
+      </ResizablePanel>
 
-      {/* Bottom Panel: Terminal (40% height) */}
-      <div className="flex-[4] min-h-0 border-t">
+      <ResizableHandle />
+
+      {/* Bottom Panel: Terminal */}
+      <ResizablePanel defaultSize={40} minSize={15}>
         <TerminalPanel workspaceId={workspaceId} className="h-full" />
-      </div>
-    </div>
+      </ResizablePanel>
+    </ResizablePanelGroup>
   );
 }

--- a/src/components/workspace/right-panel.tsx
+++ b/src/components/workspace/right-panel.tsx
@@ -99,7 +99,7 @@ export function RightPanel({ workspaceId, className }: RightPanelProps) {
       autoSaveId="workspace-right-panel"
     >
       {/* Top Panel: Git Status / File Browser */}
-      <ResizablePanel defaultSize={60} minSize={20}>
+      <ResizablePanel defaultSize="60%" minSize="20%">
         <div className="flex flex-col h-full min-h-0">
           {/* Tab bar */}
           <div className="flex items-center gap-0.5 p-1 bg-muted/50 border-b">
@@ -128,7 +128,7 @@ export function RightPanel({ workspaceId, className }: RightPanelProps) {
       <ResizableHandle />
 
       {/* Bottom Panel: Terminal */}
-      <ResizablePanel defaultSize={40} minSize={15}>
+      <ResizablePanel defaultSize="40%" minSize="15%">
         <TerminalPanel workspaceId={workspaceId} className="h-full" />
       </ResizablePanel>
     </ResizablePanelGroup>

--- a/src/components/workspace/right-panel.tsx
+++ b/src/components/workspace/right-panel.tsx
@@ -93,7 +93,11 @@ export function RightPanel({ workspaceId, className }: RightPanelProps) {
   };
 
   return (
-    <ResizablePanelGroup direction="vertical" className={cn('h-full', className)}>
+    <ResizablePanelGroup
+      direction="vertical"
+      className={cn('h-full', className)}
+      autoSaveId="workspace-right-panel"
+    >
       {/* Top Panel: Git Status / File Browser */}
       <ResizablePanel defaultSize={60} minSize={20}>
         <div className="flex flex-col h-full min-h-0">


### PR DESCRIPTION
## Summary

- Add resizable panels for workspace layout (left sidebar and right panel)
- Persist panel sizes to localStorage
- Fix wide tool call content from clipping the chat panel by using `w-0 min-w-full` pattern

## Changes

- Resizable left sidebar with localStorage persistence
- Resizable right panel (Git/Files + Terminal)
- SSR-safe localStorage handling
- Tool call content now scrolls horizontally instead of clipping

## Test plan

- [ ] Resize the left sidebar and verify it persists on refresh
- [ ] Resize the right panel and verify it persists on refresh
- [ ] Expand a tool call with a long file path and verify horizontal scrolling works
- [ ] Toggle right panel visibility

🤖 Generated with [Claude Code](https://claude.ai/code)