### PR TITLE
Fix project dropdown and improve projects page UI

### DIFF
--- a/src/app/projects/[slug]/workspaces/[id]/page.tsx
+++ b/src/app/projects/[slug]/workspaces/[id]/page.tsx
@@ -21,6 +21,7 @@ import { ChatInput, PermissionPrompt, QuestionPrompt, useChatWebSocket } from '@
 import { Button } from '@/components/ui/button';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import {
   QuickActionsMenu,
   RightPanel,
@@ -133,15 +134,14 @@ function ToggleRightPanelButton() {
   const { rightPanelVisible, toggleRightPanel } = useWorkspacePanel();
 
   return (
-    <Button
-      variant="ghost"
-      size="icon"
-      onClick={toggleRightPanel}
-      className="h-8 w-8"
-      title={rightPanelVisible ? 'Hide right panel' : 'Show right panel'}
-    >
-      <PanelRight className={cn('h-4 w-4', rightPanelVisible && 'text-primary')} />
-    </Button>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button variant="ghost" size="icon" onClick={toggleRightPanel} className="h-8 w-8">
+          <PanelRight className={cn('h-4 w-4', rightPanelVisible && 'text-primary')} />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{rightPanelVisible ? 'Hide right panel' : 'Show right panel'}</TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -783,35 +783,43 @@ function WorkspaceChatContent() {
             disabled={running || createSession.isPending}
           />
           {availableIdes.length > 0 && (
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8 text-muted-foreground hover:text-foreground"
-              title={`Open in ${availableIdes[0].name}`}
-              onClick={() => openInIde.mutate({ id: workspaceId, ide: availableIdes[0].id })}
-              disabled={openInIde.isPending || !workspace.worktreePath}
-            >
-              {openInIde.isPending ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <AppWindow className="h-4 w-4" />
-              )}
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  onClick={() => openInIde.mutate({ id: workspaceId, ide: availableIdes[0].id })}
+                  disabled={openInIde.isPending || !workspace.worktreePath}
+                >
+                  {openInIde.isPending ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <AppWindow className="h-4 w-4" />
+                  )}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Open in {availableIdes[0].name}</TooltipContent>
+            </Tooltip>
           )}
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8 text-muted-foreground hover:text-foreground"
-            title="Archive workspace"
-            onClick={() => {
-              if (confirm('Are you sure you want to archive this workspace?')) {
-                archiveWorkspace.mutate({ id: workspaceId });
-              }
-            }}
-            disabled={archiveWorkspace.isPending}
-          >
-            <Archive className="h-4 w-4" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 hover:bg-destructive/10 hover:text-destructive"
+                onClick={() => {
+                  if (confirm('Are you sure you want to archive this workspace?')) {
+                    archiveWorkspace.mutate({ id: workspaceId });
+                  }
+                }}
+                disabled={archiveWorkspace.isPending}
+              >
+                <Archive className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Archive</TooltipContent>
+          </Tooltip>
           <ToggleRightPanelButton />
         </div>
       </div>

--- a/src/app/projects/new/page.tsx
+++ b/src/app/projects/new/page.tsx
@@ -24,8 +24,11 @@ export default function NewProjectPage() {
   const { data: projects } = trpc.project.list.useQuery({ isArchived: false });
   const hasExistingProjects = projects && projects.length > 0;
 
+  const utils = trpc.useUtils();
+
   const createProject = trpc.project.create.useMutation({
     onSuccess: (project) => {
+      utils.project.list.invalidate();
       router.push(`/projects/${project.slug}`);
     },
     onError: (err) => {

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -14,6 +14,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { trpc } from '../../frontend/lib/trpc';
 
 export default function ProjectsPage() {
@@ -31,7 +32,7 @@ export default function ProjectsPage() {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center h-full gap-2">
+      <div className="flex items-center justify-center h-full gap-2 p-6">
         <Spinner className="size-5" />
         <span className="text-muted-foreground">Loading projects...</span>
       </div>
@@ -39,7 +40,7 @@ export default function ProjectsPage() {
   }
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 p-6">
       <div className="flex justify-between items-center">
         <div>
           <h1 className="text-2xl font-bold text-foreground">Projects</h1>
@@ -72,8 +73,8 @@ export default function ProjectsPage() {
                 <TableHead>Name</TableHead>
                 <TableHead>Repository Path</TableHead>
                 <TableHead>Default Branch</TableHead>
-                <TableHead>Epics</TableHead>
-                <TableHead>Actions</TableHead>
+                <TableHead>Workspaces</TableHead>
+                <TableHead className="w-[80px]" />
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -94,7 +95,9 @@ export default function ProjectsPage() {
                     {project.defaultBranch}
                   </TableCell>
                   <TableCell className="text-sm text-muted-foreground">
-                    {'_count' in project ? (project._count as { epics: number }).epics : '-'}
+                    {'_count' in project
+                      ? (project._count as { workspaces: number }).workspaces
+                      : '-'}
                   </TableCell>
                   <TableCell>
                     <div className="flex items-center gap-1">
@@ -104,29 +107,28 @@ export default function ProjectsPage() {
                         currentStartupScriptCommand={project.startupScriptCommand}
                         currentStartupScriptPath={project.startupScriptPath}
                       />
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => {
-                          if (confirm('Are you sure you want to archive this project?')) {
-                            archiveMutation.mutate({ id: project.id });
-                          }
-                        }}
-                        disabled={archiveMutation.isPending}
-                        className="text-destructive hover:text-destructive hover:bg-destructive/10"
-                      >
-                        {archiveMutation.isPending ? (
-                          <>
-                            <Spinner className="size-4" />
-                            Archiving...
-                          </>
-                        ) : (
-                          <>
-                            <Archive className="size-4" />
-                            Archive
-                          </>
-                        )}
-                      </Button>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => {
+                              if (confirm('Are you sure you want to archive this project?')) {
+                                archiveMutation.mutate({ id: project.id });
+                              }
+                            }}
+                            disabled={archiveMutation.isPending}
+                            className="hover:bg-destructive/10 hover:text-destructive"
+                          >
+                            {archiveMutation.isPending ? (
+                              <Spinner className="size-4" />
+                            ) : (
+                              <Archive className="size-4" />
+                            )}
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Archive</TooltipContent>
+                      </Tooltip>
                     </div>
                   </TableCell>
                 </TableRow>

--- a/src/backend/resource_accessors/project.accessor.ts
+++ b/src/backend/resource_accessors/project.accessor.ts
@@ -181,7 +181,7 @@ class ProjectAccessor {
     });
   }
 
-  list(filters?: ListProjectsFilters): Promise<Project[]> {
+  list(filters?: ListProjectsFilters) {
     const where: Prisma.ProjectWhereInput = {};
 
     if (filters?.isArchived !== undefined) {
@@ -195,7 +195,11 @@ class ProjectAccessor {
       orderBy: { updatedAt: 'desc' },
       include: {
         _count: {
-          select: { workspaces: true },
+          select: {
+            workspaces: {
+              where: { status: 'ACTIVE' },
+            },
+          },
         },
       },
     });

--- a/src/components/chat/session-tab-bar.tsx
+++ b/src/components/chat/session-tab-bar.tsx
@@ -263,16 +263,15 @@ export function SessionTabBar({
       )}
 
       {/* New session button */}
-      <Button
-        variant="ghost"
-        size="icon"
-        className="h-7 w-7 shrink-0 ml-1"
+      <button
+        type="button"
         onClick={onCreateSession}
         disabled={disabled}
         title="New Session"
+        className="h-7 w-7 shrink-0 ml-1 flex items-center justify-center rounded-md transition-colors text-muted-foreground hover:bg-sidebar-accent hover:text-foreground disabled:opacity-50 disabled:pointer-events-none"
       >
         <Plus className="h-4 w-4" />
-      </Button>
+      </button>
     </div>
   );
 }

--- a/src/components/project/project-settings-dialog.tsx
+++ b/src/components/project/project-settings-dialog.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/components/ui/dialog';
 import { Label } from '@/components/ui/label';
 import { Spinner } from '@/components/ui/spinner';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { trpc } from '@/frontend/lib/trpc';
 
 interface ProjectSettingsDialogProps {
@@ -73,12 +74,16 @@ export function ProjectSettingsDialog({
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>
-        <Button variant="ghost" size="sm">
-          <Settings className="h-4 w-4 mr-1" />
-          Settings
-        </Button>
-      </DialogTrigger>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DialogTrigger asChild>
+            <Button variant="ghost" size="icon">
+              <Settings className="h-4 w-4" />
+            </Button>
+          </DialogTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Settings</TooltipContent>
+      </Tooltip>
       <DialogContent className="sm:max-w-[500px]">
         <DialogHeader>
           <DialogTitle>Project Settings</DialogTitle>

--- a/src/components/workspace/main-view-tab-bar.tsx
+++ b/src/components/workspace/main-view-tab-bar.tsx
@@ -208,7 +208,7 @@ export function MainViewTabBar({
           disabled={disabled}
           className={cn(
             'flex items-center justify-center h-6 w-6 rounded-md',
-            'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
+            'text-muted-foreground hover:bg-sidebar-accent hover:text-foreground',
             'transition-colors disabled:opacity-50 disabled:pointer-events-none'
           )}
           aria-label="New chat session"

--- a/src/components/workspace/quick-actions-menu.tsx
+++ b/src/components/workspace/quick-actions-menu.tsx
@@ -11,6 +11,7 @@ import {
   DropdownMenuLabel,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import type { AppRouter } from '@/frontend/lib/trpc';
 import { trpc } from '@/frontend/lib/trpc';
 
@@ -57,18 +58,22 @@ export function QuickActionsMenu({ onExecuteAgent, disabled = false }: QuickActi
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-8 w-8"
-          disabled={disabled || isLoading || !hasActions}
-          title="Quick Actions"
-        >
-          <Zap className="h-4 w-4" />
-          <span className="sr-only">Quick Actions</span>
-        </Button>
-      </DropdownMenuTrigger>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              disabled={disabled || isLoading || !hasActions}
+            >
+              <Zap className="h-4 w-4" />
+              <span className="sr-only">Quick Actions</span>
+            </Button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Quick Actions</TooltipContent>
+      </Tooltip>
       <DropdownMenuContent align="end" className="w-56">
         <DropdownMenuLabel>Quick Actions</DropdownMenuLabel>
         {agentActions.map((action) => {

--- a/src/components/workspace/terminal-tab-bar.tsx
+++ b/src/components/workspace/terminal-tab-bar.tsx
@@ -2,7 +2,6 @@
 
 import { Plus, Terminal, X } from 'lucide-react';
 
-import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 
 // =============================================================================
@@ -61,7 +60,7 @@ export function TerminalTabBar({
               type="button"
               onClick={() => onCloseTab(tab.id)}
               className={cn(
-                'mr-1 p-0.5 rounded hover:bg-zinc-700 transition-colors',
+                'mr-1 p-0.5 rounded hover:bg-zinc-600/50 transition-colors',
                 'opacity-0 group-hover:opacity-100',
                 activeTabId === tab.id && 'opacity-100'
               )}
@@ -72,15 +71,14 @@ export function TerminalTabBar({
         ))}
       </div>
 
-      <Button
-        variant="ghost"
-        size="icon"
+      <button
+        type="button"
         onClick={onNewTab}
-        className="h-6 w-6 flex-shrink-0"
+        className="h-6 w-6 flex-shrink-0 flex items-center justify-center rounded-md transition-colors text-muted-foreground hover:bg-sidebar-accent hover:text-foreground"
         title="New terminal"
       >
         <Plus className="h-3 w-3" />
-      </Button>
+      </button>
     </div>
   );
 }

--- a/src/frontend/components/app-sidebar.tsx
+++ b/src/frontend/components/app-sidebar.tsx
@@ -204,17 +204,13 @@ export function AppSidebar() {
   return (
     <Sidebar collapsible="none">
       <SidebarHeader className="border-b border-sidebar-border p-4">
-        {selectedProjectSlug ? (
-          <Link href={`/projects/${selectedProjectSlug}/workspaces`}>
-            <Logo
-              iconClassName="size-6"
-              textClassName="text-sm"
-              className="hover:opacity-80 transition-opacity"
-            />
-          </Link>
-        ) : (
-          <Logo iconClassName="size-6" textClassName="text-sm" />
-        )}
+        <Link href="/projects">
+          <Logo
+            iconClassName="size-6"
+            textClassName="text-sm"
+            className="hover:opacity-80 transition-opacity"
+          />
+        </Link>
 
         {projects && projects.length > 0 && (
           <div className="mt-3">


### PR DESCRIPTION
## Summary
- Fix blank dropdown after creating new project by invalidating the project list cache
- Change logo link to always go to /projects page
- Simplify projects table with icon-only buttons and tooltips
- Show active workspace count instead of epic count
- Add padding to projects page

## Test plan
- [ ] Create a new project and verify the dropdown shows the new project (not blank)
- [ ] Click logo in sidebar and verify it goes to /projects
- [ ] Verify settings and archive buttons show tooltips on hover
- [ ] Verify workspace count displays correctly in projects table

🤖 Generated with [Claude Code](https://claude.com/claude-code)