### PR TITLE
Fix admin page padding and agent status text consistency

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -387,7 +387,7 @@ export default function AdminDashboardPage() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 p-6">
       <PageHeader title="Admin Dashboard" description="System monitoring and management" />
 
       <ApiUsageSection

--- a/src/app/projects/[slug]/workspaces/[id]/page.tsx
+++ b/src/app/projects/[slug]/workspaces/[id]/page.tsx
@@ -249,7 +249,7 @@ function ChatContent({
           {startingSession && !running && (
             <div className="flex items-center gap-2 text-muted-foreground py-4">
               <Loader2 className="h-4 w-4 animate-spin" />
-              <span className="text-xs">Starting agent...</span>
+              <span className="text-sm">Starting agent...</span>
             </div>
           )}
 


### PR DESCRIPTION
## Summary
- Add `p-6` padding to admin page to match other pages like the projects page
- Change "Starting agent..." text from `text-xs` to `text-sm` to match the "Agent is working..." indicator for visual consistency

## Test plan
- [ ] Verify admin page has proper padding
- [ ] Verify "Starting agent..." and "Agent is working..." text are the same size

🤖 Generated with [Claude Code](https://claude.com/claude-code)