### PR TITLE
Add explicit PR creation instructions and auto-hide scrollbars

### DIFF
--- a/prompts/workflows/bugfix.md
+++ b/prompts/workflows/bugfix.md
@@ -42,8 +42,12 @@ You are fixing a bug. Follow this workflow to ensure the fix is correct and does
 
 ### 7. Create Pull Request
 - Commit with a descriptive message referencing the bug
-- Push and create a PR
-- Include reproduction steps and fix explanation in the PR
+- Push your branch: `git push -u origin HEAD`
+- Create the PR using the GitHub CLI:
+  ```bash
+  gh pr create --title "Fix: Brief description" --body "Description with reproduction steps and fix explanation"
+  ```
+- Include reproduction steps and fix explanation in the PR body
 
 ## Guidelines
 

--- a/prompts/workflows/feature.md
+++ b/prompts/workflows/feature.md
@@ -39,8 +39,12 @@ You are implementing a new feature. Follow this workflow to deliver high-quality
 
 ### 6. Create Pull Request
 - Commit all changes with descriptive messages
-- Push your branch and create a PR
-- Write a clear PR description explaining the changes
+- Push your branch: `git push -u origin HEAD`
+- Create the PR using the GitHub CLI:
+  ```bash
+  gh pr create --title "Your PR title" --body "Description of changes"
+  ```
+- Include a clear summary, what changed, and how to test it in the PR body
 
 ## Guidelines
 

--- a/src/backend/services/session.service.ts
+++ b/src/backend/services/session.service.ts
@@ -44,6 +44,13 @@ class SessionService {
 
     // Get workflow prompt content
     const workflowPrompt = getWorkflowContent(session.workflow);
+    logger.info('Loaded workflow prompt', {
+      sessionId,
+      workflow: session.workflow,
+      hasPrompt: !!workflowPrompt,
+      promptLength: workflowPrompt?.length ?? 0,
+      promptPreview: workflowPrompt?.slice(0, 200) ?? '(none)',
+    });
 
     // Build process options
     const processOptions: ClaudeProcessOptions = {

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -16,7 +16,7 @@ const ScrollArea = React.forwardRef<
 >(({ className, children, onScroll, viewportRef, ...props }, ref) => (
   <ScrollAreaPrimitive.Root
     ref={ref}
-    className={cn('relative overflow-hidden', className)}
+    className={cn('relative overflow-hidden group/scroll', className)}
     {...props}
   >
     <ScrollAreaPrimitive.Viewport
@@ -40,7 +40,7 @@ const ScrollBar = React.forwardRef<
     ref={ref}
     orientation={orientation}
     className={cn(
-      'flex touch-none select-none transition-colors',
+      'flex touch-none select-none transition-opacity duration-300 opacity-0 hover:opacity-100 group-hover/scroll:opacity-100',
       orientation === 'vertical' && 'h-full w-2.5 border-l border-l-transparent p-[1px]',
       orientation === 'horizontal' && 'h-2.5 flex-col border-t border-t-transparent p-[1px]',
       className


### PR DESCRIPTION
## Summary

- **Workflow prompts**: Updated feature and bugfix workflows to include explicit `gh pr create` commands, so agents actually create PRs instead of just describing what to do
- **Debug logging**: Added workflow prompt logging to help diagnose prompt injection issues
- **UI improvement**: Auto-hide scrollbars in workspace with fade-in on hover

## Changes

### Workflow prompts (`prompts/workflows/`)
The PR creation step was too vague ("Push and create a PR"). Now it explicitly instructs:
```bash
git push -u origin HEAD
gh pr create --title "..." --body "..."
```

### Session service (`src/backend/services/session.service.ts`)
Added logging when loading workflow prompts to help debug injection issues.

### ScrollArea component (`src/components/ui/scroll-area.tsx`)
Scrollbars now auto-hide and fade in on hover using Tailwind's group hover pattern.

## Test plan

- [ ] Start a new workspace with the feature workflow and verify the agent creates a PR
- [ ] Check server logs for "Loaded workflow prompt" message with prompt preview
- [ ] Verify scrollbars in workspace chat area auto-hide and appear on hover

🤖 Generated with [Claude Code](https://claude.ai/code)