### PR TITLE
Add isWorking() method to distinguish active vs idle Claude process

### DIFF
--- a/src/backend/claude/index.ts
+++ b/src/backend/claude/index.ts
@@ -277,10 +277,19 @@ export class ClaudeClient extends EventEmitter {
   }
 
   /**
-   * Check if the Claude process is still running.
+   * Check if the Claude process is still running (alive but may be idle).
    */
   isRunning(): boolean {
     return this.process?.isRunning() ?? false;
+  }
+
+  /**
+   * Check if the Claude process is actively working (processing a request).
+   * Returns true only when status is 'running', false for 'ready' (idle) or 'exited'.
+   * Use this to determine if the UI should show a "thinking" indicator.
+   */
+  isWorking(): boolean {
+    return this.process?.getStatus() === 'running';
   }
 
   // ===========================================================================

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -1056,9 +1056,12 @@ async function handleChatMessage(
 
       const targetSessionId = dbSession.claudeSessionId ?? null;
 
-      // Check if there's an active Claude client running for this session
+      // Check if there's an active Claude client actively working for this session
+      // Use isWorking() instead of isRunning() to distinguish between:
+      // - 'running' status: Claude is actively processing a request
+      // - 'ready' status: Process is alive but idle (not "thinking")
       const existingClient = chatClients.get(dbSessionId);
-      const running = existingClient?.isRunning() ?? false;
+      const running = existingClient?.isWorking() ?? false;
 
       if (targetSessionId) {
         const [history, model, thinkingEnabled, gitBranch] = await Promise.all([

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -1253,9 +1253,9 @@ function handleChatUpgrade(
       });
     }
 
-    // Get running status from chatClients
+    // Get working status from chatClients (actively processing, not just alive)
     const client = chatClients.get(dbSessionId);
-    const isRunning = client?.isRunning() ?? false;
+    const isRunning = client?.isWorking() ?? false;
 
     // Send initial status
     const initialStatus = {


### PR DESCRIPTION
## Summary
- Added `isWorking()` method to `ClaudeClient` that returns true only when actively processing a request (status is 'running')
- Updated `handleChatMessage` to use `isWorking()` instead of `isRunning()` for checking if Claude is busy
- This fixes UI incorrectly showing "thinking" indicators when the process is idle but alive

## Test plan
- [ ] Verify UI shows correct thinking/processing state when Claude is working
- [ ] Verify UI shows idle state when Claude process is alive but not processing
- [ ] Verify existing behavior unchanged when process is not running

🤖 Generated with [Claude Code](https://claude.com/claude-code)