### PR TITLE
Add chat input persistence and message queue UI

### DIFF
--- a/src/app/projects/[slug]/workspaces/[id]/page.tsx
+++ b/src/app/projects/[slug]/workspaces/[id]/page.tsx
@@ -171,6 +171,7 @@ interface ChatContentProps {
   inputRef: ReturnType<typeof useChatWebSocket>['inputRef'];
   chatSettings: ReturnType<typeof useChatWebSocket>['chatSettings'];
   updateSettings: ReturnType<typeof useChatWebSocket>['updateSettings'];
+  deleteQueuedMessage: ReturnType<typeof useChatWebSocket>['deleteQueuedMessage'];
   /** Database session ID for detecting session changes (auto-focus) */
   selectedDbSessionId: string | null;
 }
@@ -197,6 +198,7 @@ function ChatContent({
   inputRef,
   chatSettings,
   updateSettings,
+  deleteQueuedMessage,
   selectedDbSessionId,
 }: ChatContentProps) {
   const groupedMessages = useMemo(() => groupAdjacentToolCalls(messages), [messages]);
@@ -241,7 +243,11 @@ function ChatContent({
           )}
 
           {groupedMessages.map((item) => (
-            <GroupedMessageItemRenderer key={item.id} item={item} />
+            <GroupedMessageItemRenderer
+              key={item.id}
+              item={item}
+              onDeleteQueued={deleteQueuedMessage}
+            />
           ))}
 
           {running && <LoadingIndicator className="py-4" />}
@@ -660,6 +666,7 @@ function WorkspaceChatContent() {
     approvePermission,
     answerQuestion,
     updateSettings,
+    deleteQueuedMessage,
     inputRef,
     messagesEndRef,
   } = useChatWebSocket({
@@ -870,6 +877,7 @@ function WorkspaceChatContent() {
                 inputRef={inputRef}
                 chatSettings={chatSettings}
                 updateSettings={updateSettings}
+                deleteQueuedMessage={deleteQueuedMessage}
                 selectedDbSessionId={selectedDbSessionId}
               />
             </WorkspaceContentView>

--- a/src/components/agent-activity/agent-activity.tsx
+++ b/src/components/agent-activity/agent-activity.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+import { X } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Skeleton } from '@/components/ui/skeleton';
 import type { ChatMessage, GroupedMessageItem } from '@/lib/claude-types';
@@ -209,15 +212,42 @@ export function CompactAgentActivity({
 
 export interface MessageItemProps {
   message: ChatMessage;
+  /** Callback when delete button is clicked for a queued message */
+  onDeleteQueued?: (id: string) => void;
 }
 
-export function MessageItem({ message }: MessageItemProps) {
+export function MessageItem({ message, onDeleteQueued }: MessageItemProps) {
   // User messages
   if (message.source === 'user') {
     return (
       <MessageWrapper chatMessage={message}>
-        <div className="rounded-lg bg-primary text-primary-foreground px-3 py-2 inline-block max-w-full break-words text-sm">
-          {stripThinkingSuffix(message.text)}
+        <div className="flex items-start gap-2">
+          <div
+            className={cn(
+              'rounded-lg bg-primary text-primary-foreground px-3 py-2 inline-block max-w-full break-words text-sm',
+              message.queued && 'opacity-70'
+            )}
+          >
+            {stripThinkingSuffix(message.text)}
+          </div>
+          {message.queued && (
+            <div className="flex items-center gap-1 shrink-0">
+              <Badge variant="secondary" className="text-xs">
+                Queued
+              </Badge>
+              {onDeleteQueued && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6 hover:bg-destructive/10 hover:text-destructive"
+                  onClick={() => onDeleteQueued(message.id)}
+                  aria-label="Delete queued message"
+                >
+                  <X className="h-3.5 w-3.5" />
+                </Button>
+              )}
+            </div>
+          )}
         </div>
       </MessageWrapper>
     );
@@ -241,16 +271,21 @@ export function MessageItem({ message }: MessageItemProps) {
 
 export interface GroupedMessageItemRendererProps {
   item: GroupedMessageItem;
+  /** Callback when delete button is clicked for a queued message */
+  onDeleteQueued?: (id: string) => void;
 }
 
 /**
  * Renders either a regular message or a tool sequence group.
  */
-export function GroupedMessageItemRenderer({ item }: GroupedMessageItemRendererProps) {
+export function GroupedMessageItemRenderer({
+  item,
+  onDeleteQueued,
+}: GroupedMessageItemRendererProps) {
   if (isToolSequence(item)) {
     return <ToolSequenceGroup sequence={item} />;
   }
-  return <MessageItem message={item} />;
+  return <MessageItem message={item} onDeleteQueued={onDeleteQueued} />;
 }
 
 // =============================================================================

--- a/src/lib/claude-types.ts
+++ b/src/lib/claude-types.ts
@@ -416,6 +416,8 @@ export interface ChatMessage {
   text?: string; // For user messages
   message?: ClaudeMessage; // For claude messages
   timestamp: string;
+  /** Whether this message is queued to be sent (not yet processed by Claude) */
+  queued?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Persist chat input drafts in localStorage per session (debounced saves)
- Queue messages sent while agent is running, display with "Queued" badge
- Allow deleting queued messages before they're sent
- Auto-send queued messages when agent becomes idle

Closes #253

## Test plan
- [ ] Type text in chat input, switch sessions, switch back - text should persist
- [ ] Send message while agent is working - appears as "Queued" with delete button
- [ ] Delete a queued message - removed from chat
- [ ] Queue message and wait for agent to finish - message auto-sends

🤖 Generated with [Claude Code](https://claude.com/claude-code)