### PR TITLE
Add message queuing for chat while agent is busy

### DIFF
--- a/src/app/projects/[slug]/workspaces/[id]/page.tsx
+++ b/src/app/projects/[slug]/workspaces/[id]/page.tsx
@@ -17,7 +17,13 @@ import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'rea
 import { toast } from 'sonner';
 
 import { GroupedMessageItemRenderer, LoadingIndicator } from '@/components/agent-activity';
-import { ChatInput, PermissionPrompt, QuestionPrompt, useChatWebSocket } from '@/components/chat';
+import {
+  ChatInput,
+  PermissionPrompt,
+  QuestionPrompt,
+  QueuedMessages,
+  useChatWebSocket,
+} from '@/components/chat';
 import { Button } from '@/components/ui/button';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -173,6 +179,8 @@ interface ChatContentProps {
   updateSettings: ReturnType<typeof useChatWebSocket>['updateSettings'];
   inputDraft: ReturnType<typeof useChatWebSocket>['inputDraft'];
   setInputDraft: ReturnType<typeof useChatWebSocket>['setInputDraft'];
+  queuedMessages: ReturnType<typeof useChatWebSocket>['queuedMessages'];
+  removeQueuedMessage: ReturnType<typeof useChatWebSocket>['removeQueuedMessage'];
   /** Database session ID for detecting session changes (auto-focus) */
   selectedDbSessionId: string | null;
 }
@@ -201,6 +209,8 @@ function ChatContent({
   updateSettings,
   inputDraft,
   setInputDraft,
+  queuedMessages,
+  removeQueuedMessage,
   selectedDbSessionId,
 }: ChatContentProps) {
   const groupedMessages = useMemo(() => groupAdjacentToolCalls(messages), [messages]);
@@ -276,8 +286,9 @@ function ChatContent({
         </div>
       )}
 
-      {/* Input Section with Prompts */}
+      {/* Input Section with Queue and Prompts */}
       <div className="border-t">
+        <QueuedMessages messages={queuedMessages} onRemove={removeQueuedMessage} />
         <PermissionPrompt permission={pendingPermission} onApprove={approvePermission} />
         <QuestionPrompt question={pendingQuestion} onAnswer={answerQuestion} />
 
@@ -289,7 +300,7 @@ function ChatContent({
           stopping={stopping}
           inputRef={inputRef}
           placeholder={
-            stopping ? 'Stopping...' : running ? 'Claude is thinking...' : 'Type a message...'
+            stopping ? 'Stopping...' : running ? 'Message will be queued...' : 'Type a message...'
           }
           settings={chatSettings}
           onSettingsChange={updateSettings}
@@ -662,12 +673,14 @@ function WorkspaceChatContent() {
     startingSession,
     chatSettings,
     inputDraft,
+    queuedMessages,
     sendMessage,
     stopChat,
     approvePermission,
     answerQuestion,
     updateSettings,
     setInputDraft,
+    removeQueuedMessage,
     inputRef,
     messagesEndRef,
   } = useChatWebSocket({
@@ -880,6 +893,8 @@ function WorkspaceChatContent() {
                 updateSettings={updateSettings}
                 inputDraft={inputDraft}
                 setInputDraft={setInputDraft}
+                queuedMessages={queuedMessages}
+                removeQueuedMessage={removeQueuedMessage}
                 selectedDbSessionId={selectedDbSessionId}
               />
             </WorkspaceContentView>

--- a/src/components/chat/index.ts
+++ b/src/components/chat/index.ts
@@ -2,6 +2,7 @@
 export { ChatInput } from './chat-input';
 export { PermissionPrompt, PermissionPromptExpanded } from './permission-prompt';
 export { QuestionPrompt } from './question-prompt';
+export { QueuedMessages } from './queued-messages';
 export { SessionPicker } from './session-picker';
 export { SessionTabBar } from './session-tab-bar';
 

--- a/src/components/chat/queued-messages.tsx
+++ b/src/components/chat/queued-messages.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { Clock, X } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import type { QueuedMessage } from '@/lib/claude-types';
+
+interface QueuedMessagesProps {
+  messages: QueuedMessage[];
+  onRemove: (id: string) => void;
+}
+
+/**
+ * Displays the queue of pending messages waiting to be sent to the agent.
+ * Each message can be removed before it is sent.
+ */
+export function QueuedMessages({ messages, onRemove }: QueuedMessagesProps) {
+  if (messages.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="border-t border-dashed px-4 py-2 bg-muted/30">
+      <div className="flex items-center gap-2 text-xs text-muted-foreground mb-2">
+        <Clock className="h-3 w-3" />
+        <span>Queued ({messages.length})</span>
+      </div>
+      <div className="space-y-1">
+        {messages.map((msg) => (
+          <div key={msg.id} className="flex items-start gap-2 py-1 group">
+            <div className="flex-1 text-sm truncate text-muted-foreground" title={msg.text}>
+              {msg.text}
+            </div>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-5 w-5 opacity-0 group-hover:opacity-100 transition-opacity"
+              onClick={() => onRemove(msg.id)}
+              aria-label="Remove queued message"
+            >
+              <X className="h-3 w-3" />
+            </Button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/claude-types.ts
+++ b/src/lib/claude-types.ts
@@ -404,6 +404,19 @@ export interface WebSocketMessage {
 }
 
 // =============================================================================
+// Queued Message Types
+// =============================================================================
+
+/**
+ * A message queued to be sent when the agent becomes idle.
+ */
+export interface QueuedMessage {
+  id: string;
+  text: string;
+  timestamp: string;
+}
+
+// =============================================================================
 // UI Chat Message Types
 // =============================================================================
 

--- a/src/lib/queue-storage.test.ts
+++ b/src/lib/queue-storage.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for queue-storage module.
+ *
+ * Note: These tests verify the JSON serialization logic and error handling.
+ * The actual sessionStorage integration is verified through manual testing
+ * since the project doesn't have jsdom configured for browser API testing.
+ */
+import { describe, expect, it } from 'vitest';
+
+import type { QueuedMessage } from './claude-types';
+
+// Since the actual storage functions use sessionStorage which isn't available in Node.js,
+// we test the serialization/deserialization logic that those functions rely on.
+
+describe('queue-storage serialization', () => {
+  describe('QueuedMessage JSON round-trip', () => {
+    it('should serialize and deserialize a single message', () => {
+      const message: QueuedMessage = {
+        id: 'msg-123',
+        text: 'Hello, world!',
+        timestamp: '2024-01-01T00:00:00.000Z',
+      };
+
+      const serialized = JSON.stringify([message]);
+      const deserialized = JSON.parse(serialized) as QueuedMessage[];
+
+      expect(deserialized).toHaveLength(1);
+      expect(deserialized[0]).toEqual(message);
+    });
+
+    it('should serialize and deserialize multiple messages in order', () => {
+      const messages: QueuedMessage[] = [
+        { id: 'msg-1', text: 'First', timestamp: '2024-01-01T00:00:00.000Z' },
+        { id: 'msg-2', text: 'Second', timestamp: '2024-01-01T00:00:01.000Z' },
+        { id: 'msg-3', text: 'Third', timestamp: '2024-01-01T00:00:02.000Z' },
+      ];
+
+      const serialized = JSON.stringify(messages);
+      const deserialized = JSON.parse(serialized) as QueuedMessage[];
+
+      expect(deserialized).toHaveLength(3);
+      expect(deserialized[0].text).toBe('First');
+      expect(deserialized[1].text).toBe('Second');
+      expect(deserialized[2].text).toBe('Third');
+    });
+
+    it('should handle empty array', () => {
+      const messages: QueuedMessage[] = [];
+
+      const serialized = JSON.stringify(messages);
+      const deserialized = JSON.parse(serialized) as QueuedMessage[];
+
+      expect(deserialized).toEqual([]);
+    });
+
+    it('should handle special characters in text', () => {
+      const message: QueuedMessage = {
+        id: 'msg-special',
+        text: 'Hello "world" with \'quotes\' and\nnewlines\tand\ttabs',
+        timestamp: '2024-01-01T00:00:00.000Z',
+      };
+
+      const serialized = JSON.stringify([message]);
+      const deserialized = JSON.parse(serialized) as QueuedMessage[];
+
+      expect(deserialized[0].text).toBe(message.text);
+    });
+
+    it('should handle unicode characters', () => {
+      const message: QueuedMessage = {
+        id: 'msg-unicode',
+        text: 'Hello 世界 🌍 مرحبا',
+        timestamp: '2024-01-01T00:00:00.000Z',
+      };
+
+      const serialized = JSON.stringify([message]);
+      const deserialized = JSON.parse(serialized) as QueuedMessage[];
+
+      expect(deserialized[0].text).toBe(message.text);
+    });
+
+    it('should handle very long text', () => {
+      const longText = 'a'.repeat(10_000);
+      const message: QueuedMessage = {
+        id: 'msg-long',
+        text: longText,
+        timestamp: '2024-01-01T00:00:00.000Z',
+      };
+
+      const serialized = JSON.stringify([message]);
+      const deserialized = JSON.parse(serialized) as QueuedMessage[];
+
+      expect(deserialized[0].text).toBe(longText);
+      expect(deserialized[0].text.length).toBe(10_000);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should throw on invalid JSON parse', () => {
+      expect(() => JSON.parse('invalid json{')).toThrow();
+    });
+
+    it('should return empty array as default fallback pattern', () => {
+      // This demonstrates the pattern used in loadQueue for error handling
+      const loadQueuePattern = (stored: string | null): QueuedMessage[] => {
+        if (!stored) {
+          return [];
+        }
+        try {
+          return JSON.parse(stored) as QueuedMessage[];
+        } catch {
+          return [];
+        }
+      };
+
+      expect(loadQueuePattern(null)).toEqual([]);
+      expect(loadQueuePattern('invalid')).toEqual([]);
+      expect(loadQueuePattern('[]')).toEqual([]);
+      expect(loadQueuePattern('[{"id":"1","text":"test","timestamp":""}]')).toHaveLength(1);
+    });
+  });
+
+  describe('storage key format', () => {
+    it('should use correct key prefix pattern', () => {
+      const QUEUE_KEY_PREFIX = 'chat-queue-';
+      const dbSessionId = 'session-abc-123';
+
+      const key = `${QUEUE_KEY_PREFIX}${dbSessionId}`;
+
+      expect(key).toBe('chat-queue-session-abc-123');
+    });
+
+    it('should handle different session ID formats', () => {
+      const QUEUE_KEY_PREFIX = 'chat-queue-';
+
+      const uuidStyle = `${QUEUE_KEY_PREFIX}550e8400-e29b-41d4-a716-446655440000`;
+      const numericStyle = `${QUEUE_KEY_PREFIX}12345`;
+      const mixedStyle = `${QUEUE_KEY_PREFIX}session_2024_01_abc`;
+
+      expect(uuidStyle).toBe('chat-queue-550e8400-e29b-41d4-a716-446655440000');
+      expect(numericStyle).toBe('chat-queue-12345');
+      expect(mixedStyle).toBe('chat-queue-session_2024_01_abc');
+    });
+  });
+});

--- a/src/lib/queue-storage.ts
+++ b/src/lib/queue-storage.ts
@@ -1,0 +1,64 @@
+/**
+ * Session-storage based queue persistence for chat messages.
+ * Messages are stored per-session to persist across page reloads.
+ */
+
+import type { QueuedMessage } from './claude-types';
+
+const QUEUE_KEY_PREFIX = 'chat-queue-';
+
+/**
+ * Validate that an object has the required QueuedMessage shape.
+ */
+function isValidQueuedMessage(obj: unknown): obj is QueuedMessage {
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    typeof (obj as QueuedMessage).id === 'string' &&
+    typeof (obj as QueuedMessage).text === 'string' &&
+    typeof (obj as QueuedMessage).timestamp === 'string'
+  );
+}
+
+/**
+ * Load queued messages from sessionStorage for a specific session.
+ */
+export function loadQueue(dbSessionId: string): QueuedMessage[] {
+  if (typeof window === 'undefined') {
+    return [];
+  }
+  try {
+    const stored = sessionStorage.getItem(`${QUEUE_KEY_PREFIX}${dbSessionId}`);
+    if (!stored) {
+      return [];
+    }
+    const parsed: unknown = JSON.parse(stored);
+    // Validate the parsed data has the expected shape
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    // Filter out any malformed entries
+    return parsed.filter(isValidQueuedMessage);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Persist queued messages to sessionStorage for a specific session.
+ * Clears storage if queue is empty.
+ */
+export function persistQueue(dbSessionId: string | null, messages: QueuedMessage[]): void {
+  if (typeof window === 'undefined' || !dbSessionId) {
+    return;
+  }
+  try {
+    if (messages.length === 0) {
+      sessionStorage.removeItem(`${QUEUE_KEY_PREFIX}${dbSessionId}`);
+    } else {
+      sessionStorage.setItem(`${QUEUE_KEY_PREFIX}${dbSessionId}`, JSON.stringify(messages));
+    }
+  } catch {
+    // Silently ignore storage errors (quota exceeded, etc.)
+  }
+}


### PR DESCRIPTION
## Summary
- Users can now queue messages while Claude is processing, improving UX for multi-turn workflows
- Messages are persisted to sessionStorage and sent automatically when the agent becomes idle
- Separate stop button provides clear distinction between sending messages and stopping the agent

## Test plan
- [ ] Send a message while agent is idle - should send immediately
- [ ] Send a message while agent is running - should appear in queue UI
- [ ] Queue multiple messages - should display with count and remove buttons
- [ ] Hover over truncated queued message - should show full text in tooltip
- [ ] Remove a queued message - should disappear from queue
- [ ] Wait for agent to finish - queued messages should be sent one at a time
- [ ] Refresh page with queued messages - queue should persist
- [ ] Switch sessions - old session queue should be cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)