### PR TITLE
Fix workflow prompt not being loaded for Claude sessions

### DIFF
--- a/src/backend/claude/process.ts
+++ b/src/backend/claude/process.ts
@@ -200,10 +200,21 @@ export class ClaudeProcess extends EventEmitter {
   static async spawn(options: ClaudeProcessOptions): Promise<ClaudeProcess> {
     const args = ClaudeProcess.buildArgs(options);
 
-    logger.info('Spawning Claude process', {
+    // Log the full command for debugging
+    const fullCommand = ['claude', ...args]
+      .map((arg) => (arg.includes(' ') ? `"${arg}"` : arg))
+      .join(' ');
+    logger.info('Spawning Claude process - full command', {
+      command: fullCommand,
       workingDir: options.workingDir,
-      args: args.join(' '),
+    });
+    logger.info('Spawning Claude process - options', {
+      hasSystemPrompt: !!options.systemPrompt,
+      systemPromptLength: options.systemPrompt?.length ?? 0,
+      systemPromptPreview: options.systemPrompt?.slice(0, 500) ?? '(none)',
       resumeClaudeSessionId: options.resumeClaudeSessionId,
+      model: options.model,
+      permissionMode: options.permissionMode,
     });
 
     const childProcess = spawn('claude', args, {

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -958,7 +958,7 @@ async function handleChatMessage(
         requestedModel && validModels.includes(requestedModel) ? requestedModel : sessionOpts.model;
 
       await getOrCreateChatClient(dbSessionId, {
-        workingDir: message.workingDir || sessionOpts.workingDir,
+        workingDir: sessionOpts.workingDir,
         resumeClaudeSessionId: sessionOpts.resumeClaudeSessionId,
         systemPrompt: sessionOpts.systemPrompt,
         model,
@@ -1025,11 +1025,24 @@ async function handleChatMessage(
           break;
         }
 
+        // Map planModeEnabled to permissionMode (default to bypassPermissions for auto-start)
+        const permissionMode = message.planModeEnabled ? 'plan' : 'bypassPermissions';
+
+        // Validate model value - only allow known models, fallback to session model
+        const validModels = ['sonnet', 'opus'];
+        const requestedModel = message.selectedModel || message.model;
+        const model =
+          requestedModel && validModels.includes(requestedModel)
+            ? requestedModel
+            : sessionOpts.model;
+
         const newClient = await getOrCreateChatClient(dbSessionId, {
           workingDir: sessionOpts.workingDir,
           resumeClaudeSessionId: sessionOpts.resumeClaudeSessionId,
           systemPrompt: sessionOpts.systemPrompt,
-          model: sessionOpts.model,
+          model,
+          thinkingEnabled: message.thinkingEnabled,
+          permissionMode,
         });
         ws.send(JSON.stringify({ type: 'started', dbSessionId }));
 

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -29,6 +29,7 @@ import {
   rateLimiter,
   reconciliationService,
   schedulerService,
+  sessionService,
 } from './services/index';
 import { terminalService } from './services/terminal.service';
 import { appRouter, createContext } from './trpc/index';
@@ -939,27 +940,27 @@ async function handleChatMessage(
       // Notify client that session is starting (Claude CLI spinning up)
       ws.send(JSON.stringify({ type: 'starting', dbSessionId }));
 
+      // Get session options from database (includes workflow prompt)
+      const sessionOpts = await sessionService.getSessionOptions(dbSessionId);
+      if (!sessionOpts) {
+        logger.error('[Chat WS] Failed to get session options', { dbSessionId });
+        ws.send(JSON.stringify({ type: 'error', message: 'Session not found' }));
+        break;
+      }
+
       // Map planModeEnabled to permissionMode
       const permissionMode = message.planModeEnabled ? 'plan' : 'bypassPermissions';
 
-      // Validate model value - only allow known models, fallback to default
+      // Validate model value - only allow known models, fallback to session model
       const validModels = ['sonnet', 'opus'];
       const requestedModel = message.selectedModel || message.model;
       const model =
-        requestedModel && validModels.includes(requestedModel) ? requestedModel : undefined;
-
-      // Look up resumeClaudeSessionId from database
-      // The frontend no longer tracks claudeSessionId - it's a backend-only concern
-      const dbSession = await claudeSessionAccessor.findById(dbSessionId);
-      if (!dbSession) {
-        logger.warn('[Chat WS] Session not found during start', { dbSessionId });
-      }
-      const resumeClaudeSessionId = dbSession?.claudeSessionId ?? undefined;
+        requestedModel && validModels.includes(requestedModel) ? requestedModel : sessionOpts.model;
 
       await getOrCreateChatClient(dbSessionId, {
-        workingDir: message.workingDir || workingDir,
-        resumeClaudeSessionId,
-        systemPrompt: message.systemPrompt,
+        workingDir: message.workingDir || sessionOpts.workingDir,
+        resumeClaudeSessionId: sessionOpts.resumeClaudeSessionId,
+        systemPrompt: sessionOpts.systemPrompt,
         model,
         thinkingEnabled: message.thinkingEnabled,
         permissionMode,
@@ -1016,8 +1017,20 @@ async function handleChatMessage(
         // Notify client that session is starting (Claude CLI spinning up)
         ws.send(JSON.stringify({ type: 'starting', dbSessionId }));
 
-        // Auto-start if not running
-        const newClient = await getOrCreateChatClient(dbSessionId, { workingDir });
+        // Auto-start if not running - load session options including workflow prompt
+        const sessionOpts = await sessionService.getSessionOptions(dbSessionId);
+        if (!sessionOpts) {
+          logger.error('[Chat WS] Failed to get session options for auto-start', { dbSessionId });
+          ws.send(JSON.stringify({ type: 'error', message: 'Session not found' }));
+          break;
+        }
+
+        const newClient = await getOrCreateChatClient(dbSessionId, {
+          workingDir: sessionOpts.workingDir,
+          resumeClaudeSessionId: sessionOpts.resumeClaudeSessionId,
+          systemPrompt: sessionOpts.systemPrompt,
+          model: sessionOpts.model,
+        });
         ws.send(JSON.stringify({ type: 'started', dbSessionId }));
 
         // Send queued messages now that client is ready


### PR DESCRIPTION
## Summary

- Fix bug where workflow prompts (system prompts) were not being passed to Claude sessions
- The auto-start code path was missing workflow loading, causing agents to not receive their workflow instructions
- Add `getSessionOptions()` helper as single source of truth for session configuration

## Root Cause

There were two code paths that could start a Claude session:
1. **Explicit start** (when frontend sends `start` message) - was loading workflow from `message.systemPrompt` (frontend)
2. **Auto-start** (when user sends message before session is running) - was only passing `{ workingDir }`, **missing workflow prompt entirely**

## Changes

- **session.service.ts**: Add `getSessionOptions()` helper that loads session config from database including workflow prompt via `getWorkflowContent(session.workflow)`
- **index.ts**: Update both start paths to use the new helper
- **process.ts**: Add detailed logging showing full command and system prompt details

## Test plan

- [x] TypeScript compiles
- [x] All 402 tests pass
- [ ] Manual test: Start session, verify logs show `hasSystemPrompt: true` with workflow content
- [ ] Manual test: Verify agent follows workflow instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)