### PR TITLE
Fix navigation flicker showing empty state briefly

### DIFF
--- a/src/components/chat/use-chat-websocket.ts
+++ b/src/components/chat/use-chat-websocket.ts
@@ -577,7 +577,9 @@ export function useChatWebSocket(options: UseChatWebSocketOptions): UseChatWebSo
       setPendingPermission(null);
       setPendingQuestion(null);
       setStartingSession(false);
-      setLoadingSession(false);
+      // Set loadingSession to true immediately to prevent "No messages yet" flash
+      // while the WebSocket reconnects and loads the new session
+      setLoadingSession(true);
       setRunning(false);
       setQueuedMessages([]);
 
@@ -871,6 +873,9 @@ export function useChatWebSocket(options: UseChatWebSocketOptions): UseChatWebSo
       return;
     }
 
+    // Set loading state immediately to prevent "No messages yet" flash
+    // while WebSocket connection is being established
+    setLoadingSession(true);
     connect();
 
     return () => {


### PR DESCRIPTION
## Summary
- Fixes the navigation flicker when switching workspaces or sessions where "No messages yet" would briefly appear before messages loaded
- Sets `loadingSession` to `true` immediately when detecting a session switch or when establishing a WebSocket connection

## Test plan
- [ ] Switch between workspaces rapidly and verify no "No messages yet" flash
- [ ] Switch between sessions within a workspace and verify loading indicator shows
- [ ] Open a workspace with existing messages and verify smooth loading

Fixes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)