### PR TITLE
Add MCP terminal output tool with active terminal tracking

### DIFF
--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -1702,6 +1702,17 @@ function handleTerminalUpgrade(
             break;
           }
 
+          case 'set_active': {
+            if (message.terminalId) {
+              logger.debug('Setting active terminal', {
+                workspaceId,
+                terminalId: message.terminalId,
+              });
+              terminalService.setActiveTerminal(workspaceId, message.terminalId);
+            }
+            break;
+          }
+
           default:
             logger.warn('Unknown message type', { type: message.type });
         }

--- a/src/backend/routers/mcp/index.ts
+++ b/src/backend/routers/mcp/index.ts
@@ -1,6 +1,7 @@
 import { createLogger } from '../../services/logger.service';
 import { registerLockTools } from './lock.mcp';
 import { registerSystemTools } from './system.mcp';
+import { registerTerminalTools } from './terminal.mcp';
 
 const logger = createLogger('mcp');
 
@@ -13,6 +14,7 @@ export function initializeMcpTools(): void {
   // Register tool categories
   registerSystemTools();
   registerLockTools();
+  registerTerminalTools();
 
   logger.info('MCP tools initialized successfully');
 }

--- a/src/backend/routers/mcp/terminal.mcp.test.ts
+++ b/src/backend/routers/mcp/terminal.mcp.test.ts
@@ -1,0 +1,307 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock dependencies before importing
+const mockFindById = vi.fn();
+const mockGetTerminal = vi.fn();
+const mockGetTerminalsForWorkspace = vi.fn();
+const mockGetActiveTerminal = vi.fn();
+
+vi.mock('../../resource_accessors/claude-session.accessor', () => ({
+  claudeSessionAccessor: {
+    findById: (...args: unknown[]) => mockFindById(...args),
+  },
+}));
+
+vi.mock('../../services/terminal.service', () => ({
+  terminalService: {
+    getTerminal: (...args: unknown[]) => mockGetTerminal(...args),
+    getTerminalsForWorkspace: (...args: unknown[]) => mockGetTerminalsForWorkspace(...args),
+    getActiveTerminal: (...args: unknown[]) => mockGetActiveTerminal(...args),
+  },
+}));
+
+vi.mock('../../services/logger.service', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+// Import after mocks are set up
+import { executeMcpTool } from './server';
+import { registerTerminalTools } from './terminal.mcp';
+import type { McpToolResponse } from './types';
+import { McpErrorCode } from './types';
+
+// Type for the get_output response
+interface GetTerminalOutputResult {
+  terminals: Array<{
+    terminalId: string;
+    pid: number;
+    output: string;
+    lineCount: number;
+    truncated: boolean;
+    isActive: boolean;
+    createdAt: string;
+    cols: number;
+    rows: number;
+  }>;
+  totalTerminals: number;
+}
+
+// Helper to execute and type the MCP tool
+function executeGetOutput(
+  agentId: string,
+  input: { terminalId?: string; maxLines?: number } = {}
+): Promise<McpToolResponse<GetTerminalOutputResult>> {
+  return executeMcpTool(agentId, 'mcp__terminal__get_output', input) as Promise<
+    McpToolResponse<GetTerminalOutputResult>
+  >;
+}
+
+// Helper to create mock terminal instances
+function createMockTerminal(
+  overrides: Partial<{
+    id: string;
+    workspaceId: string;
+    outputBuffer: string;
+    createdAt: Date;
+    cols: number;
+    rows: number;
+    pid: number;
+  }> = {}
+) {
+  return {
+    id: overrides.id ?? 'term-123',
+    workspaceId: overrides.workspaceId ?? 'workspace-1',
+    outputBuffer: overrides.outputBuffer ?? 'line1\nline2\nline3',
+    createdAt: overrides.createdAt ?? new Date('2024-01-01T00:00:00Z'),
+    cols: overrides.cols ?? 80,
+    rows: overrides.rows ?? 24,
+    pty: {
+      pid: overrides.pid ?? 12_345,
+    },
+    disposables: [],
+  };
+}
+
+describe('terminal.mcp', () => {
+  const mockWorkspaceId = 'workspace-123';
+  const mockAgentId = 'agent-1';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default mock for session lookup
+    mockFindById.mockResolvedValue({
+      workspaceId: mockWorkspaceId,
+      workspace: {
+        worktreePath: '/path/to/worktree',
+      },
+    });
+
+    // Default: no active terminal
+    mockGetActiveTerminal.mockReturnValue(null);
+
+    // Default: no terminals
+    mockGetTerminalsForWorkspace.mockReturnValue([]);
+    mockGetTerminal.mockReturnValue(null);
+
+    // Register tools
+    registerTerminalTools();
+  });
+
+  describe('mcp__terminal__get_output', () => {
+    it('returns empty array when no terminals exist', async () => {
+      const result = await executeGetOutput(mockAgentId);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.terminals).toHaveLength(0);
+        expect(result.data.totalTerminals).toBe(0);
+      }
+    });
+
+    it('returns all terminals when no terminalId specified', async () => {
+      const terminal1 = createMockTerminal({ id: 'term-1', outputBuffer: 'output1' });
+      const terminal2 = createMockTerminal({ id: 'term-2', outputBuffer: 'output2' });
+      mockGetTerminalsForWorkspace.mockReturnValue([terminal1, terminal2]);
+
+      const result = await executeGetOutput(mockAgentId);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.terminals).toHaveLength(2);
+        expect(result.data.totalTerminals).toBe(2);
+        expect(result.data.terminals[0].terminalId).toBe('term-1');
+        expect(result.data.terminals[0].output).toBe('output1');
+        expect(result.data.terminals[1].terminalId).toBe('term-2');
+        expect(result.data.terminals[1].output).toBe('output2');
+      }
+    });
+
+    it('returns specific terminal when terminalId provided', async () => {
+      const terminal = createMockTerminal({ id: 'term-specific', outputBuffer: 'specific output' });
+      mockGetTerminal.mockReturnValue(terminal);
+
+      const result = await executeGetOutput(mockAgentId, { terminalId: 'term-specific' });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.terminals).toHaveLength(1);
+        expect(result.data.terminals[0].terminalId).toBe('term-specific');
+        expect(result.data.terminals[0].output).toBe('specific output');
+      }
+      expect(mockGetTerminal).toHaveBeenCalledWith(mockWorkspaceId, 'term-specific');
+    });
+
+    it('returns active terminal when terminalId is "active"', async () => {
+      const activeTerminal = createMockTerminal({
+        id: 'term-active',
+        outputBuffer: 'active output',
+      });
+      mockGetActiveTerminal.mockReturnValue('term-active');
+      mockGetTerminal.mockReturnValue(activeTerminal);
+
+      const result = await executeGetOutput(mockAgentId, { terminalId: 'active' });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.terminals).toHaveLength(1);
+        expect(result.data.terminals[0].terminalId).toBe('term-active');
+        expect(result.data.terminals[0].isActive).toBe(true);
+      }
+    });
+
+    it('falls back to first terminal when no active set and terminalId is "active"', async () => {
+      const terminal = createMockTerminal({ id: 'term-first', outputBuffer: 'first output' });
+      mockGetActiveTerminal.mockReturnValue(null);
+      mockGetTerminalsForWorkspace.mockReturnValue([terminal]);
+
+      const result = await executeGetOutput(mockAgentId, { terminalId: 'active' });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.terminals).toHaveLength(1);
+        expect(result.data.terminals[0].terminalId).toBe('term-first');
+      }
+    });
+
+    it('truncates output when maxLines specified', async () => {
+      const terminal = createMockTerminal({
+        id: 'term-1',
+        outputBuffer: 'line1\nline2\nline3\nline4\nline5',
+      });
+      mockGetTerminalsForWorkspace.mockReturnValue([terminal]);
+
+      const result = await executeGetOutput(mockAgentId, { maxLines: 2 });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.terminals[0].output).toBe('line4\nline5');
+        expect(result.data.terminals[0].truncated).toBe(true);
+        expect(result.data.terminals[0].lineCount).toBe(2);
+      }
+    });
+
+    it('marks truncated: false when lines are not cut', async () => {
+      const terminal = createMockTerminal({
+        id: 'term-1',
+        outputBuffer: 'line1\nline2',
+      });
+      mockGetTerminalsForWorkspace.mockReturnValue([terminal]);
+
+      const result = await executeGetOutput(mockAgentId, { maxLines: 10 });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.terminals[0].output).toBe('line1\nline2');
+        expect(result.data.terminals[0].truncated).toBe(false);
+      }
+    });
+
+    it('returns WORKSPACE_NOT_FOUND for invalid agentId', async () => {
+      mockFindById.mockResolvedValue(null);
+
+      const result = await executeGetOutput('invalid-agent');
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe(McpErrorCode.WORKSPACE_NOT_FOUND);
+      }
+    });
+
+    it('returns RESOURCE_NOT_FOUND for invalid terminalId', async () => {
+      mockGetTerminal.mockReturnValue(null);
+
+      const result = await executeGetOutput(mockAgentId, { terminalId: 'nonexistent-terminal' });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe(McpErrorCode.RESOURCE_NOT_FOUND);
+        expect(result.error.message).toContain('nonexistent-terminal');
+      }
+    });
+
+    it('returns RESOURCE_NOT_FOUND when active requested but no terminals exist', async () => {
+      mockGetActiveTerminal.mockReturnValue(null);
+      mockGetTerminalsForWorkspace.mockReturnValue([]);
+
+      const result = await executeGetOutput(mockAgentId, { terminalId: 'active' });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe(McpErrorCode.RESOURCE_NOT_FOUND);
+        expect(result.error.message).toContain('active');
+      }
+    });
+
+    it('includes isActive flag correctly for each terminal', async () => {
+      const terminal1 = createMockTerminal({ id: 'term-1' });
+      const terminal2 = createMockTerminal({ id: 'term-2' });
+      mockGetTerminalsForWorkspace.mockReturnValue([terminal1, terminal2]);
+      mockGetActiveTerminal.mockReturnValue('term-2');
+
+      const result = await executeGetOutput(mockAgentId);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.terminals[0].isActive).toBe(false);
+        expect(result.data.terminals[1].isActive).toBe(true);
+      }
+    });
+
+    it('includes terminal metadata in response', async () => {
+      const terminal = createMockTerminal({
+        id: 'term-1',
+        cols: 120,
+        rows: 40,
+        pid: 54_321,
+        createdAt: new Date('2024-06-15T10:30:00Z'),
+      });
+      mockGetTerminalsForWorkspace.mockReturnValue([terminal]);
+
+      const result = await executeGetOutput(mockAgentId);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const t = result.data.terminals[0];
+        expect(t.cols).toBe(120);
+        expect(t.rows).toBe(40);
+        expect(t.pid).toBe(54_321);
+        expect(t.createdAt).toBe('2024-06-15T10:30:00.000Z');
+      }
+    });
+
+    it('returns INVALID_INPUT for invalid maxLines', async () => {
+      const result = await executeGetOutput(mockAgentId, { maxLines: -5 });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe(McpErrorCode.INVALID_INPUT);
+      }
+    });
+  });
+});

--- a/src/backend/routers/mcp/terminal.mcp.ts
+++ b/src/backend/routers/mcp/terminal.mcp.ts
@@ -1,0 +1,196 @@
+import { z } from 'zod';
+import { claudeSessionAccessor } from '../../resource_accessors/claude-session.accessor';
+import type { TerminalInstance } from '../../services/terminal.service';
+import { terminalService } from '../../services/terminal.service';
+import { createErrorResponse, createSuccessResponse, registerMcpTool } from './server';
+import type { McpToolContext, McpToolResponse } from './types';
+import { McpErrorCode } from './types';
+
+// ============================================================================
+// Input Schemas
+// ============================================================================
+
+const GetTerminalOutputInputSchema = z.object({
+  terminalId: z
+    .string()
+    .optional()
+    .describe(
+      'Terminal ID to get output from. Use "active" for the currently active terminal, or omit to get all terminals.'
+    ),
+  maxLines: z.number().int().positive().optional().describe('Limit output to the last N lines'),
+});
+
+// ============================================================================
+// Result Types
+// ============================================================================
+
+interface TerminalOutputInfo {
+  terminalId: string;
+  pid: number;
+  output: string;
+  lineCount: number;
+  truncated: boolean;
+  isActive: boolean;
+  createdAt: string;
+  cols: number;
+  rows: number;
+}
+
+interface GetTerminalOutputResult {
+  terminals: TerminalOutputInfo[];
+  totalTerminals: number;
+}
+
+// ============================================================================
+// Workspace Resolution
+// ============================================================================
+
+async function resolveWorkspaceId(agentId: string): Promise<string | null> {
+  try {
+    const session = await claudeSessionAccessor.findById(agentId);
+    if (!session?.workspace) {
+      return null;
+    }
+    return session.workspaceId;
+  } catch {
+    return null;
+  }
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+function truncateToLastNLines(
+  output: string,
+  maxLines: number
+): { output: string; truncated: boolean } {
+  const lines = output.split('\n');
+  if (lines.length <= maxLines) {
+    return { output, truncated: false };
+  }
+  return {
+    output: lines.slice(-maxLines).join('\n'),
+    truncated: true,
+  };
+}
+
+function getActiveOrFirstTerminal(workspaceId: string): TerminalInstance | null {
+  const activeTerminalId = terminalService.getActiveTerminal(workspaceId);
+  if (activeTerminalId) {
+    return terminalService.getTerminal(workspaceId, activeTerminalId);
+  }
+  // Fall back to first available terminal
+  const allTerminals = terminalService.getTerminalsForWorkspace(workspaceId);
+  return allTerminals.length > 0 ? allTerminals[0] : null;
+}
+
+function formatTerminalOutput(
+  terminal: TerminalInstance,
+  maxLines: number | undefined,
+  activeTerminalId: string | null
+): TerminalOutputInfo {
+  let output = terminal.outputBuffer;
+  let truncated = false;
+
+  if (maxLines) {
+    const result = truncateToLastNLines(output, maxLines);
+    output = result.output;
+    truncated = result.truncated;
+  }
+
+  return {
+    terminalId: terminal.id,
+    pid: terminal.pty.pid,
+    output,
+    lineCount: output.split('\n').length,
+    truncated,
+    isActive: terminal.id === activeTerminalId,
+    createdAt: terminal.createdAt.toISOString(),
+    cols: terminal.cols,
+    rows: terminal.rows,
+  };
+}
+
+// ============================================================================
+// Tool Implementations
+// ============================================================================
+
+async function getTerminalOutput(
+  context: McpToolContext,
+  input: unknown
+): Promise<McpToolResponse<GetTerminalOutputResult>> {
+  try {
+    const parsed = GetTerminalOutputInputSchema.parse(input);
+
+    // Resolve workspace from agent
+    const workspaceId = await resolveWorkspaceId(context.agentId);
+    if (!workspaceId) {
+      return createErrorResponse(
+        McpErrorCode.WORKSPACE_NOT_FOUND,
+        'Could not resolve workspace for agent'
+      );
+    }
+
+    const activeTerminalId = terminalService.getActiveTerminal(workspaceId);
+
+    // Get terminals based on request
+    const terminals = getTerminalsForRequest(workspaceId, parsed.terminalId);
+    if (terminals === null) {
+      const errorMessage =
+        parsed.terminalId === 'active'
+          ? 'No active terminal found in workspace'
+          : `Terminal '${parsed.terminalId}' not found in workspace`;
+      return createErrorResponse(McpErrorCode.RESOURCE_NOT_FOUND, errorMessage);
+    }
+
+    const results = terminals.map((terminal) =>
+      formatTerminalOutput(terminal, parsed.maxLines, activeTerminalId)
+    );
+
+    return createSuccessResponse({
+      terminals: results,
+      totalTerminals: results.length,
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return createErrorResponse(McpErrorCode.INVALID_INPUT, 'Invalid input', error.issues);
+    }
+    throw error;
+  }
+}
+
+function getTerminalsForRequest(
+  workspaceId: string,
+  terminalId: string | undefined
+): TerminalInstance[] | null {
+  if (terminalId === 'active') {
+    const terminal = getActiveOrFirstTerminal(workspaceId);
+    return terminal ? [terminal] : null;
+  }
+
+  if (terminalId) {
+    const terminal = terminalService.getTerminal(workspaceId, terminalId);
+    return terminal ? [terminal] : null;
+  }
+
+  // Get all terminals
+  return terminalService.getTerminalsForWorkspace(workspaceId);
+}
+
+// ============================================================================
+// Tool Registration
+// ============================================================================
+
+export function registerTerminalTools(): void {
+  registerMcpTool({
+    name: 'mcp__terminal__get_output',
+    description:
+      'Read terminal output from the workspace. Returns buffered output (up to 100KB per terminal). ' +
+      'Use terminalId="active" to get the terminal the user is currently viewing, ' +
+      'provide a specific terminalId, or omit to get all terminals. ' +
+      'Use maxLines to limit output to the last N lines.',
+    handler: getTerminalOutput,
+    schema: GetTerminalOutputInputSchema,
+  });
+}

--- a/src/components/workspace/use-terminal-websocket.ts
+++ b/src/components/workspace/use-terminal-websocket.ts
@@ -33,6 +33,7 @@ interface UseTerminalWebSocketReturn {
   sendInput: (terminalId: string, data: string) => void;
   resize: (terminalId: string, cols: number, rows: number) => void;
   destroy: (terminalId: string) => void;
+  setActive: (terminalId: string) => void;
 }
 
 // =============================================================================
@@ -209,11 +210,19 @@ export function useTerminalWebSocket({
     }
   }, []);
 
+  // Set the active terminal (for MCP tools to know which terminal the user is viewing)
+  const setActive = useCallback((terminalId: string) => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify({ type: 'set_active', terminalId }));
+    }
+  }, []);
+
   return {
     connected,
     create,
     sendInput,
     resize,
     destroy,
+    setActive,
   };
 }


### PR DESCRIPTION
## Summary
- Adds new MCP tool `mcp__terminal__get_output` for reading terminal output from workspace terminals
- Implements active terminal tracking so agents can get output from the user's currently viewed terminal
- Frontend sends `set_active` messages when switching tabs, creating terminals, closing tabs, or restoring terminals
- When closing the active terminal, automatically sets the next available terminal as active

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm check:fix` passes  
- [x] `pnpm test` passes (475 tests including 13 new tests for terminal MCP tool)
- [ ] Manual: Open workspace, create multiple terminals, switch tabs - verify active updates
- [ ] Manual: Close active tab - verify new tab becomes active
- [ ] Manual: Test MCP tool via curl with `terminalId="active"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)