### PR TITLE
Fix Kanban board horizontal scroll accessibility

### DIFF
--- a/src/client/routes/projects/workspaces/list.tsx
+++ b/src/client/routes/projects/workspaces/list.tsx
@@ -67,7 +67,7 @@ export default function WorkspacesListPage() {
   if (viewMode === 'board') {
     return (
       <KanbanProvider projectId={project.id} projectSlug={slug}>
-        <div className="space-y-4 p-6">
+        <div className="flex flex-col h-screen p-6 gap-4">
           <PageHeader title="Workspaces">
             <ToggleGroup
               type="single"
@@ -91,7 +91,9 @@ export default function WorkspacesListPage() {
             </Button>
           </PageHeader>
 
-          <KanbanBoard />
+          <div className="flex-1 min-h-0">
+            <KanbanBoard />
+          </div>
         </div>
       </KanbanProvider>
     );

--- a/src/frontend/components/kanban/kanban-board.tsx
+++ b/src/frontend/components/kanban/kanban-board.tsx
@@ -109,8 +109,8 @@ export function KanbanBoard() {
   }
 
   return (
-    <ScrollArea className="w-full whitespace-nowrap">
-      <div className="flex gap-4 pb-4">
+    <ScrollArea className="w-full h-full whitespace-nowrap">
+      <div className="flex gap-4 pb-4 h-full">
         {KANBAN_COLUMNS.map((column) => (
           <KanbanColumn
             key={column.id}

--- a/src/frontend/components/kanban/kanban-column.tsx
+++ b/src/frontend/components/kanban/kanban-column.tsx
@@ -50,7 +50,7 @@ export function KanbanColumn({ column, workspaces, projectSlug, isHidden }: Kanb
       {/* Column Content */}
       <div
         className={cn(
-          'flex-1 overflow-y-auto p-2 space-y-2 min-h-[200px] rounded-b-lg border border-t-0',
+          'flex-1 overflow-y-auto p-2 space-y-2 min-h-0 rounded-b-lg border border-t-0',
           isEmpty && 'border-dashed'
         )}
       >


### PR DESCRIPTION
## Summary
- Constrain board height to viewport so the horizontal scrollbar stays visible
- Columns now scroll internally when they have many items
- Follows the pattern used by Trello, Linear, and GitHub Projects

## Test plan
- [ ] Navigate to a project's workspaces board view
- [ ] Verify horizontal scrollbar is visible at bottom of viewport
- [ ] Add many workspaces to a column, verify column scrolls internally
- [ ] Test on shorter viewports

🤖 Generated with [Claude Code](https://claude.ai/claude-code)