### PR TITLE
Add CLI dependency health check on app launch

### DIFF
--- a/src/backend/services/cli-health.service.ts
+++ b/src/backend/services/cli-health.service.ts
@@ -1,0 +1,103 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { type GitHubCLIHealthStatus, githubCLIService } from './github-cli.service';
+import { createLogger } from './logger.service';
+
+const execFileAsync = promisify(execFile);
+const logger = createLogger('cli-health');
+
+export interface ClaudeCLIHealthStatus {
+  isInstalled: boolean;
+  version?: string;
+  error?: string;
+}
+
+export interface CLIHealthStatus {
+  claude: ClaudeCLIHealthStatus;
+  github: GitHubCLIHealthStatus;
+  allHealthy: boolean;
+}
+
+/**
+ * Service for checking CLI dependencies health.
+ * Checks that required CLIs (Claude, GitHub) are installed and configured.
+ */
+class CLIHealthService {
+  private cachedStatus: CLIHealthStatus | null = null;
+  private cacheTimestamp = 0;
+  private readonly CACHE_TTL_MS = 30_000; // Cache for 30 seconds
+
+  /**
+   * Check if Claude CLI is installed.
+   */
+  async checkClaudeCLI(): Promise<ClaudeCLIHealthStatus> {
+    try {
+      const { stdout } = await execFileAsync('claude', ['--version'], { timeout: 5000 });
+      const versionMatch = stdout.match(/claude[- ]?(?:code[- ]?)?(?:v?(\d+\.\d+\.\d+))?/i);
+      const version = versionMatch?.[1] || stdout.trim().split('\n')[0];
+
+      return { isInstalled: true, version };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const isNotFound = message.toLowerCase().includes('enoent') || message.includes('not found');
+
+      return {
+        isInstalled: false,
+        error: isNotFound
+          ? 'Claude CLI is not installed. Install from https://claude.ai/download'
+          : `Failed to check Claude CLI: ${message}`,
+      };
+    }
+  }
+
+  /**
+   * Check health of all required CLIs.
+   * Results are cached for CACHE_TTL_MS to avoid excessive process spawning.
+   */
+  async checkHealth(forceRefresh = false): Promise<CLIHealthStatus> {
+    const now = Date.now();
+
+    // Return cached result if still valid
+    if (!forceRefresh && this.cachedStatus && now - this.cacheTimestamp < this.CACHE_TTL_MS) {
+      return this.cachedStatus;
+    }
+
+    logger.debug('Checking CLI health...');
+
+    // Run checks in parallel
+    const [claude, github] = await Promise.all([
+      this.checkClaudeCLI(),
+      githubCLIService.checkHealth(),
+    ]);
+
+    const status: CLIHealthStatus = {
+      claude,
+      github,
+      allHealthy: claude.isInstalled && github.isInstalled && github.isAuthenticated,
+    };
+
+    // Cache the result
+    this.cachedStatus = status;
+    this.cacheTimestamp = now;
+
+    if (!status.allHealthy) {
+      logger.warn('CLI health check found issues', {
+        claudeInstalled: claude.isInstalled,
+        githubInstalled: github.isInstalled,
+        githubAuthenticated: github.isAuthenticated,
+      });
+    }
+
+    return status;
+  }
+
+  /**
+   * Clear the cached health status.
+   */
+  clearCache(): void {
+    this.cachedStatus = null;
+    this.cacheTimestamp = 0;
+  }
+}
+
+export const cliHealthService = new CLIHealthService();

--- a/src/backend/services/index.ts
+++ b/src/backend/services/index.ts
@@ -4,6 +4,8 @@
  * Central export point for all backend services.
  */
 
+// CLI health service
+export { type CLIHealthStatus, cliHealthService } from './cli-health.service';
 // Configuration service
 export { configService } from './config.service';
 // GitHub CLI service

--- a/src/backend/trpc/admin.trpc.ts
+++ b/src/backend/trpc/admin.trpc.ts
@@ -13,6 +13,7 @@ import {
   workspaceAccessor,
 } from '../resource_accessors/index';
 import {
+  cliHealthService,
   configService,
   createLogger,
   rateLimiter,
@@ -115,6 +116,16 @@ export const adminRouter = router({
     rateLimiter.resetUsageStats();
     return { success: true, message: 'API usage statistics reset' };
   }),
+
+  /**
+   * Check CLI dependencies health (Claude CLI, GitHub CLI).
+   * Returns status of each CLI and whether all are healthy.
+   */
+  checkCLIHealth: publicProcedure
+    .input(z.object({ forceRefresh: z.boolean().default(false) }).optional())
+    .query(({ input }) => {
+      return cliHealthService.checkHealth(input?.forceRefresh ?? false);
+    }),
 
   /**
    * Get all active processes (Claude and Terminal)

--- a/src/client/root.tsx
+++ b/src/client/root.tsx
@@ -2,6 +2,7 @@ import { Outlet } from 'react-router';
 import { ResizableLayout } from '@/components/layout/resizable-layout';
 import { Toaster } from '@/components/ui/sonner';
 import { AppSidebar } from '@/frontend/components/app-sidebar';
+import { CLIHealthBanner } from '@/frontend/components/cli-health-banner';
 import { ThemeProvider } from '@/frontend/components/theme-provider';
 import { TRPCProvider } from '@/frontend/lib/providers';
 
@@ -9,9 +10,12 @@ export function Root() {
   return (
     <ThemeProvider>
       <TRPCProvider>
-        <ResizableLayout sidebar={<AppSidebar />}>
-          <Outlet />
-        </ResizableLayout>
+        <div className="flex h-screen flex-col">
+          <CLIHealthBanner />
+          <ResizableLayout sidebar={<AppSidebar />} className="flex-1 overflow-hidden">
+            <Outlet />
+          </ResizableLayout>
+        </div>
         <Toaster />
       </TRPCProvider>
     </ThemeProvider>

--- a/src/components/layout/resizable-layout.tsx
+++ b/src/components/layout/resizable-layout.tsx
@@ -4,6 +4,7 @@ import { createContext, type ReactNode, useContext, useState } from 'react';
 
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
 import { SidebarProvider } from '@/components/ui/sidebar';
+import { cn } from '@/lib/utils';
 
 // Context to allow sidebar component to hide the entire sidebar panel
 interface SidebarVisibilityContextType {
@@ -24,9 +25,10 @@ export function useSidebarVisibility() {
 interface ResizableLayoutProps {
   sidebar: ReactNode;
   children: ReactNode;
+  className?: string;
 }
 
-export function ResizableLayout({ sidebar, children }: ResizableLayoutProps) {
+export function ResizableLayout({ sidebar, children, className }: ResizableLayoutProps) {
   const [isSidebarVisible, setIsSidebarVisible] = useState(true);
 
   return (
@@ -35,7 +37,7 @@ export function ResizableLayout({ sidebar, children }: ResizableLayoutProps) {
         {isSidebarVisible ? (
           <ResizablePanelGroup
             direction="horizontal"
-            className="h-svh w-full"
+            className={cn('h-svh w-full', className)}
             autoSaveId="app-sidebar-layout"
           >
             {/* Left sidebar panel */}
@@ -53,7 +55,12 @@ export function ResizableLayout({ sidebar, children }: ResizableLayoutProps) {
             </ResizablePanel>
           </ResizablePanelGroup>
         ) : (
-          <main className="relative flex min-h-0 h-svh w-full flex-1 flex-col overflow-hidden bg-background">
+          <main
+            className={cn(
+              'relative flex min-h-0 h-svh w-full flex-1 flex-col overflow-hidden bg-background',
+              className
+            )}
+          >
             {children}
           </main>
         )}

--- a/src/frontend/components/cli-health-banner.tsx
+++ b/src/frontend/components/cli-health-banner.tsx
@@ -1,0 +1,123 @@
+import { AlertTriangle, ExternalLink, RefreshCw, X } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { trpc } from '@/frontend/lib/trpc';
+
+/**
+ * Banner that displays warnings when CLI dependencies are not properly installed.
+ * Shows on app launch and can be dismissed (but will reappear on next launch if issues persist).
+ */
+export function CLIHealthBanner() {
+  const [dismissed, setDismissed] = useState(false);
+
+  const {
+    data: health,
+    isLoading,
+    refetch,
+    isRefetching,
+  } = trpc.admin.checkCLIHealth.useQuery(
+    { forceRefresh: false },
+    {
+      // Check on mount, but don't poll - user can manually refresh
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      staleTime: 60_000, // Consider stale after 1 minute
+    }
+  );
+
+  // Reset dismissed state when health status changes to show new issues
+  const allHealthy = health?.allHealthy;
+  useEffect(() => {
+    if (allHealthy === false) {
+      // Only reset if there are issues
+      setDismissed(false);
+    }
+  }, [allHealthy]);
+
+  if (isLoading || dismissed || !health || health.allHealthy) {
+    return null;
+  }
+
+  const issues: Array<{ title: string; description: string; link?: string }> = [];
+
+  if (!health.claude.isInstalled) {
+    issues.push({
+      title: 'Claude CLI not installed',
+      description: 'Install the Claude CLI to enable AI-powered coding sessions.',
+      link: 'https://claude.ai/download',
+    });
+  }
+
+  if (!health.github.isInstalled) {
+    issues.push({
+      title: 'GitHub CLI not installed',
+      description: 'Install the GitHub CLI (gh) to enable PR management features.',
+      link: 'https://cli.github.com/',
+    });
+  } else if (!health.github.isAuthenticated) {
+    issues.push({
+      title: 'GitHub CLI not authenticated',
+      description: 'Run "gh auth login" in your terminal to authenticate with GitHub.',
+    });
+  }
+
+  if (issues.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="border-b border-yellow-500/20 bg-yellow-500/10 px-4 py-3">
+      <div className="mx-auto max-w-7xl">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="mt-0.5 h-5 w-5 flex-shrink-0 text-yellow-600 dark:text-yellow-500" />
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-yellow-800 dark:text-yellow-200">
+                Some features require additional setup
+              </p>
+              <ul className="space-y-1.5">
+                {issues.map((issue) => (
+                  <li key={issue.title} className="text-sm text-yellow-700 dark:text-yellow-300">
+                    <span className="font-medium">{issue.title}:</span> {issue.description}
+                    {issue.link && (
+                      <a
+                        href={issue.link}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="ml-1.5 inline-flex items-center gap-1 text-yellow-800 underline hover:text-yellow-900 dark:text-yellow-200 dark:hover:text-yellow-100"
+                      >
+                        Install
+                        <ExternalLink className="h-3 w-3" />
+                      </a>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => refetch()}
+              disabled={isRefetching}
+              className="h-8 text-yellow-700 hover:bg-yellow-500/20 hover:text-yellow-800 dark:text-yellow-300 dark:hover:text-yellow-200"
+            >
+              <RefreshCw className={`mr-1.5 h-3.5 w-3.5 ${isRefetching ? 'animate-spin' : ''}`} />
+              Recheck
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => setDismissed(true)}
+              className="h-8 w-8 text-yellow-700 hover:bg-yellow-500/20 hover:text-yellow-800 dark:text-yellow-300 dark:hover:text-yellow-200"
+            >
+              <X className="h-4 w-4" />
+              <span className="sr-only">Dismiss</span>
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Check that Claude CLI and GitHub CLI are installed when the app starts
- Display a warning banner at the top of the app if dependencies are missing
- Banner includes links to install pages and a "Recheck" button

## Test plan
- [ ] Uninstall Claude CLI, start app, verify warning appears
- [ ] Install Claude CLI, click "Recheck", verify warning updates
- [ ] Sign out of gh CLI (`gh auth logout`), start app, verify warning appears
- [ ] Sign back in (`gh auth login`), click "Recheck", verify warning clears
- [ ] Dismiss banner, refresh page, verify banner reappears if issues persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)