### PR TITLE
Add dynamic port allocation for backend

### DIFF
--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -238,6 +238,11 @@ export function createServer(requestedPort?: number): ServerInstance {
             environment: configService.getEnvironment(),
           });
 
+          // Output port to stdout for CLI to parse (machine-readable format)
+          // This must be on its own line starting with BACKEND_PORT: for the CLI to detect
+          // biome-ignore lint/suspicious/noConsole: Required for CLI to detect actual backend port
+          console.log(`BACKEND_PORT:${actualPort}`);
+
           try {
             await reconciliationService.cleanupOrphans();
           } catch (error) {

--- a/src/backend/services/port.service.test.ts
+++ b/src/backend/services/port.service.test.ts
@@ -51,7 +51,7 @@ describe('port.service', () => {
       const result = await isPortAvailable(3000);
 
       expect(result).toBe(true);
-      expect(mockServer.listen).toHaveBeenCalledWith(3000, 'localhost');
+      expect(mockServer.listen).toHaveBeenCalledWith(3000);
       expect(mockServer.close).toHaveBeenCalled();
     });
 
@@ -68,7 +68,7 @@ describe('port.service', () => {
       const result = await isPortAvailable(3000);
 
       expect(result).toBe(false);
-      expect(mockServer.listen).toHaveBeenCalledWith(3000, 'localhost');
+      expect(mockServer.listen).toHaveBeenCalledWith(3000);
     });
   });
 

--- a/src/backend/services/port.service.ts
+++ b/src/backend/services/port.service.ts
@@ -11,6 +11,7 @@ const logger = createLogger('port-service');
 
 /**
  * Check if a port is available by attempting to create a server on it.
+ * Checks all interfaces (not just localhost) to match server.listen() behavior.
  */
 export function isPortAvailable(port: number): Promise<boolean> {
   return new Promise((resolve) => {
@@ -21,7 +22,8 @@ export function isPortAvailable(port: number): Promise<boolean> {
     testServer.once('listening', () => {
       testServer.close(() => resolve(true));
     });
-    testServer.listen(port, 'localhost');
+    // Listen on all interfaces (like server.listen does) not just localhost
+    testServer.listen(port);
   });
 }
 


### PR DESCRIPTION
## Summary
Implements dynamic port allocation for the backend, ensuring the frontend always connects to the correct port even when the default backend port is unavailable.

## What Changed
- **Backend**: Outputs `BACKEND_PORT:{port}` to stdout when server starts, allowing the CLI to detect the actual port in use
- **CLI Development Mode**: Captures backend port from stdout and passes it to Vite via `BACKEND_URL` environment variable
- **CLI Production Mode**: Same approach for production server (where backend serves both API and static files)

## How It Works
1. Backend tries the requested port, falls back to next available port if taken
2. Backend outputs `BACKEND_PORT:3002` (or whatever port it actually uses) to stdout
3. CLI parses this line and extracts the actual port number
4. CLI starts frontend with `BACKEND_URL=http://localhost:{actualPort}`
5. Frontend Vite proxy configuration uses the correct backend URL

## Test Plan
- [ ] Start app with default ports available - should work as before
- [ ] Start app with backend port 3001 already in use - backend should use 3002, frontend should connect correctly
- [ ] Test both development mode (`pnpm dev`) and production mode
- [ ] Verify startup logs show correct backend port

🤖 Generated with [Claude Code](https://claude.com/claude-code)