### PR TITLE
Add migration for UserSettings table

### DIFF
--- a/prisma/migrations/20260130134009_add_user_settings/migration.sql
+++ b/prisma/migrations/20260130134009_add_user_settings/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "UserSettings" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "userId" TEXT NOT NULL DEFAULT 'default',
+    "preferredIde" TEXT NOT NULL DEFAULT 'cursor',
+    "customIdeCommand" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserSettings_userId_key" ON "UserSettings"("userId");
+
+-- CreateIndex
+CREATE INDEX "UserSettings_userId_idx" ON "UserSettings"("userId");


### PR DESCRIPTION
## Summary
- Adds the missing Prisma migration for the UserSettings table
- The model was added to schema.prisma but the migration file was not committed
- Creates table with IDE preference settings (preferredIde, customIdeCommand)

## Test plan
- [x] `pnpm prisma migrate status` shows database is in sync
- [ ] Fresh database can run all migrations successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)