### PR TITLE
Add Greptile and Bugbot AI code reviewer configs

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -1,0 +1,55 @@
+# Bugbot Configuration
+
+## Project Overview
+
+This is a workspace-based coding environment where users interact with Claude Code through isolated workspaces. The app runs as both a web application and an Electron desktop app.
+
+## Architecture
+
+- **Frontend:** Vite + React Router v7 + TailwindCSS
+- **Backend:** Express + tRPC with WebSocket support
+- **Database:** SQLite + Prisma ORM
+- **Desktop:** Electron wrapper that spawns backend as child process
+
+## Code Review Guidelines
+
+### TypeScript Standards
+
+- Use strict TypeScript - no `any` types without justification
+- Prefer interfaces over type aliases
+- Use path aliases: `@/*` for `src/`, `@prisma-gen/*` for `prisma/generated/`
+- No `.js` extensions needed for backend imports (tsx handles resolution)
+
+### Backend Rules
+
+- All database queries must go through `src/backend/resource_accessors/`
+- tRPC routers live in `src/backend/trpc/`
+- Claude integration code is in `src/backend/claude/`
+- WebSocket handlers: `/chat` for Claude CLI streaming, `/terminal` for PTY sessions
+
+### Frontend Rules
+
+- Routes are explicitly configured in `src/client/router.tsx`
+- Use React Router v7 patterns
+- Component files in `src/client/routes/`
+- Prefer React Query for server state
+
+### Security Concerns
+
+- Check for command injection in terminal/shell operations
+- Validate all user inputs, especially file paths
+- Git worktree operations should be sandboxed to workspace directories
+- WebSocket messages should be validated before processing
+
+### Common Pitfalls
+
+- Don't commit `.env` files or credentials
+- Prisma schema changes require `pnpm db:generate` followed by migration
+- Electron builds have different database paths than web mode
+- Test both web and Electron modes when making backend changes
+
+## Testing
+
+Run tests with `pnpm test` (Vitest)
+Lint with `pnpm check:fix` (Biome)
+Typecheck with `pnpm typecheck`

--- a/greptile.json
+++ b/greptile.json
@@ -1,0 +1,53 @@
+{
+  "triggerOnUpdates": false,
+  "strictness": 2,
+  "commentTypes": ["logic", "syntax"],
+  "ignorePatterns": [
+    "pnpm-lock.yaml",
+    "*.lock",
+    "dist/**",
+    "build/**",
+    "node_modules/**",
+    "prisma/generated/**",
+    "*.min.js",
+    "*.min.css"
+  ],
+  "summarySection": {
+    "included": true,
+    "collapsible": false
+  },
+  "issuesTableSection": {
+    "included": true,
+    "collapsible": false
+  },
+  "sequenceDiagramSection": {
+    "included": true,
+    "collapsible": true,
+    "defaultOpen": false
+  },
+  "files": [
+    {
+      "scope": ["**/*.ts", "**/*.tsx"],
+      "path": "CLAUDE.md",
+      "description": "Project architecture, code patterns, and development conventions."
+    }
+  ],
+  "rules": [
+    {
+      "scope": ["src/backend/**/*.ts"],
+      "instruction": "Backend code uses Express with tRPC. Database queries should go through resource_accessors. No .js extensions needed for imports."
+    },
+    {
+      "scope": ["src/client/**/*.tsx"],
+      "instruction": "Frontend uses React Router v7 with Vite. Routes are configured in src/client/router.tsx. Use path aliases @/* for src/ imports."
+    },
+    {
+      "scope": ["electron/**/*.ts"],
+      "instruction": "Electron main process code. Spawns backend as child process. Uses OS-specific paths for database storage."
+    },
+    {
+      "scope": ["prisma/**/*.prisma"],
+      "instruction": "SQLite database schema. Run pnpm db:generate after schema changes."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `greptile.json` for Greptile AI code reviews with project-specific scoped rules
- Adds `.cursor/BUGBOT.md` for Bugbot with architecture context and security guidelines

## Configuration Details

**Greptile (`greptile.json`):**
- Strictness level 2 (medium)
- Comment types: logic and syntax
- Scoped rules for backend (tRPC/Express), frontend (React Router v7), Electron, and Prisma
- Ignores lock files, dist, node_modules, and generated Prisma code
- References CLAUDE.md as context for TypeScript files

**Bugbot (`.cursor/BUGBOT.md`):**
- Project architecture overview
- TypeScript standards and path alias conventions
- Backend/frontend specific patterns
- Security concerns (command injection, path validation, WebSocket security)
- Testing commands

## Manual Setup Required
After merging, enable the integrations:
1. **Greptile**: Add repo at https://app.greptile.com
2. **Bugbot**: Enable at https://cursor.com/bugbot

## Test plan
- [x] JSON is valid (verified by Biome)
- [ ] Greptile indexing works after enabling
- [ ] Bugbot picks up BUGBOT.md on next PR review

🤖 Generated with [Claude Code](https://claude.com/claude-code)