### PR TITLE
Fix new project page padding and redirect

### DIFF
--- a/src/client/root.tsx
+++ b/src/client/root.tsx
@@ -14,8 +14,15 @@ function RootLayout() {
   const showSidebar = !isLoading && projects && projects.length > 0;
 
   // Redirect to onboarding when no projects exist
+  // Only redirect from top-level paths, not from specific project routes
   useEffect(() => {
-    if (!isLoading && projects?.length === 0 && !pathname.startsWith('/projects/new')) {
+    const isProjectSpecificRoute = /^\/projects\/[^/]+/.test(pathname);
+    if (
+      !isLoading &&
+      projects?.length === 0 &&
+      !pathname.startsWith('/projects/new') &&
+      !isProjectSpecificRoute
+    ) {
       navigate('/projects/new');
     }
   }, [isLoading, projects, pathname, navigate]);

--- a/src/client/routes/projects/new.tsx
+++ b/src/client/routes/projects/new.tsx
@@ -74,7 +74,7 @@ export default function NewProjectPage() {
   // Onboarding view when no projects exist
   if (!hasExistingProjects) {
     return (
-      <div className="flex min-h-[80vh] items-center justify-center">
+      <div className="flex min-h-[80vh] items-center justify-center p-6">
         <div className="w-full max-w-lg space-y-8">
           <div className="flex flex-col items-center space-y-4">
             <Logo iconClassName="size-16" textClassName="text-2xl" className="flex-col gap-3" />
@@ -143,7 +143,7 @@ export default function NewProjectPage() {
 
   // Normal view when projects already exist
   return (
-    <div className="max-w-2xl mx-auto space-y-4">
+    <div className="max-w-2xl mx-auto space-y-4 p-6">
       <div className="flex items-center gap-4">
         <Button variant="ghost" size="icon" asChild>
           <Link to="/projects">


### PR DESCRIPTION
## Summary
- Add `p-6` padding to the new project page to match other pages in the app
- Fix redirect logic in Root that was incorrectly redirecting users back to `/projects/new` after creating a project

## Test plan
- [ ] Create a new project when no projects exist - should navigate to the new project's workspace list
- [ ] Create a new project when projects already exist - should navigate to the new project
- [ ] Verify the new project page has proper padding on both onboarding and normal views

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: limits an existing redirect condition and adds layout padding; changes are isolated to client routing/UI with no data or auth logic.
> 
> **Overview**
> Fixes an incorrect onboarding redirect by updating `RootLayout` to *not* force navigation to `/projects/new` when the user is already on a project-specific route (e.g. `/projects/:slug`).
> 
> Adds consistent `p-6` padding to the `/projects/new` page in both the first-project onboarding view and the normal “Add Project” view to match other pages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86ce5ffa98c220ae1e32c23bdacbd6c0b94e2feb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->