### PR TITLE
Fix kanban board column styling and height

### DIFF
--- a/src/frontend/components/kanban/kanban-board.tsx
+++ b/src/frontend/components/kanban/kanban-board.tsx
@@ -12,7 +12,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
 import { Skeleton } from '@/components/ui/skeleton';
 import type { WorkspaceWithKanban } from './kanban-card';
 import { KANBAN_COLUMNS, KanbanColumn } from './kanban-column';
@@ -109,19 +108,16 @@ export function KanbanBoard() {
   }
 
   return (
-    <ScrollArea className="w-full h-full whitespace-nowrap">
-      <div className="flex gap-4 pb-4 h-full">
-        {KANBAN_COLUMNS.map((column) => (
-          <KanbanColumn
-            key={column.id}
-            column={column}
-            workspaces={workspacesByColumn[column.id]}
-            projectSlug={projectSlug}
-            isHidden={hiddenColumns.includes(column.id)}
-          />
-        ))}
-      </div>
-      <ScrollBar orientation="horizontal" />
-    </ScrollArea>
+    <div className="flex gap-4 pb-4 h-full overflow-x-auto">
+      {KANBAN_COLUMNS.map((column) => (
+        <KanbanColumn
+          key={column.id}
+          column={column}
+          workspaces={workspacesByColumn[column.id]}
+          projectSlug={projectSlug}
+          isHidden={hiddenColumns.includes(column.id)}
+        />
+      ))}
+    </div>
   );
 }

--- a/src/frontend/components/kanban/kanban-board.tsx
+++ b/src/frontend/components/kanban/kanban-board.tsx
@@ -82,11 +82,11 @@ export function KanbanBoard() {
 
   if (isLoading) {
     return (
-      <div className="flex gap-4 overflow-x-auto pb-4">
+      <div className="flex gap-4 pb-4 h-full overflow-x-auto">
         {KANBAN_COLUMNS.map((column) => (
-          <div key={column.id} className="min-w-[280px] space-y-2">
-            <Skeleton className="h-10 w-full" />
-            <Skeleton className="h-[200px] w-full" />
+          <div key={column.id} className="flex flex-col h-full w-[280px] shrink-0">
+            <Skeleton className="h-10 w-full rounded-t-lg rounded-b-none" />
+            <Skeleton className="flex-1 w-full rounded-b-lg rounded-t-none" />
           </div>
         ))}
       </div>

--- a/src/frontend/components/kanban/kanban-column.tsx
+++ b/src/frontend/components/kanban/kanban-column.tsx
@@ -2,7 +2,6 @@
 
 import type { KanbanColumn as KanbanColumnType } from '@prisma-gen/browser';
 import { Badge } from '@/components/ui/badge';
-import { cn } from '@/lib/utils';
 import { KanbanCard, type WorkspaceWithKanban } from './kanban-card';
 
 interface ColumnConfig {
@@ -38,7 +37,7 @@ export function KanbanColumn({ column, workspaces, projectSlug, isHidden }: Kanb
   return (
     <div className="flex flex-col h-full w-[280px] shrink-0 overflow-hidden">
       {/* Column Header */}
-      <div className="flex items-center justify-between px-2 py-3 border-b bg-muted/30 rounded-t-lg">
+      <div className="flex items-center justify-between px-2 py-3 bg-muted/30 rounded-t-lg">
         <div className="flex items-center gap-2">
           <h3 className="font-semibold text-sm">{column.label}</h3>
           <Badge variant="secondary" className="h-5 min-w-5 justify-center text-xs">
@@ -48,12 +47,7 @@ export function KanbanColumn({ column, workspaces, projectSlug, isHidden }: Kanb
       </div>
 
       {/* Column Content */}
-      <div
-        className={cn(
-          'flex-1 overflow-y-auto p-2 space-y-2 min-h-0 rounded-b-lg border border-t-0',
-          isEmpty && 'border-dashed'
-        )}
-      >
+      <div className="flex-1 overflow-y-auto p-2 space-y-2 min-h-0 rounded-b-lg bg-muted/30">
         {isEmpty ? (
           <div className="flex items-center justify-center h-[150px] text-muted-foreground text-sm">
             {column.description}


### PR DESCRIPTION
## Summary
- Columns now extend to the bottom of the page, even when empty
- Removed white background from column content area, unified with `bg-muted/30` to match headers
- Removed border separator between column header and content
- Updated skeleton loader to match the new full-height layout

## Screenshots
Before 

<img width="1660" height="982" alt="Pasted Graphic 46" src="https://github.com/user-attachments/assets/dd313763-6db3-4355-bf6d-dc18cc0da062" />

After 

<img width="1673" height="983" alt="image" src="https://github.com/user-attachments/assets/7d6ffcd8-2f4c-4c57-85db-2997a8848644" />

