### PR TITLE
Fix README logo readability on light backgrounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="public/logo-full-dark.svg" alt="Factory Factory" width="400">
+  <img src="public/logo-full.svg" alt="Factory Factory" width="400">
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
- Switch README to use light mode logo (`logo-full.svg`) instead of dark mode variant (`logo-full-dark.svg`)
- The dark mode logo has white text that's hard to read on GitHub's white background

## Test plan
- [ ] View README on GitHub to verify logo text is now readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change: updates the README image reference and does not affect runtime code or behavior.
> 
> **Overview**
> Updates the README header logo to use `public/logo-full.svg` instead of the dark variant so the logo remains readable on light backgrounds (e.g., GitHub’s default theme).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bde3e1c58534656c2ee3f7f3b0abcc478fb3f960. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->