### PR TITLE
Fix native module ABI version mismatch when switching Node.js versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "dev": "node scripts/ensure-native-modules.mjs node && tsx src/cli/index.ts serve --dev",
     "build": "tsc -p tsconfig.backend.json && tsc-alias -p tsconfig.backend.json --resolve-full-paths && vite build",
-    "start": "tsx src/cli/index.ts serve",
+    "start": "node scripts/ensure-native-modules.mjs node && tsx src/cli/index.ts serve",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",


### PR DESCRIPTION
## Summary
- Fixed `ensure-native-modules.mjs` to include Node.js ABI version in the cache key (e.g., `node-abi127` for Node 22, `node-abi137` for Node 23)
- Added `ensure-native-modules` check to the `start` script so production runs also verify correct binaries

## Problem
When switching between Node.js major versions, the script would see "we're already on 'node' target" and skip rebuilding, causing `NODE_MODULE_VERSION` mismatch errors like:
```
The module was compiled against NODE_MODULE_VERSION 137. 
This version of Node.js requires NODE_MODULE_VERSION 127.
```

## Solution
Cache keys now include the ABI version, so switching Node.js versions triggers automatic rebuild or cache restore from the version-specific cache.

## Test plan
- [x] Verified `pnpm build` completes without errors
- [x] Verified `pnpm start` runs without native module errors
- [x] Verified cache structure now uses `node-abi127` instead of just `node`
- [x] All 846 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates native-module caching/switching logic and the default `start` path, which can affect runtime startup if the cache/marker logic misbehaves. Scope is limited to local build tooling (no auth/data flow changes).
> 
> **Overview**
> Fixes native module switching to avoid `NODE_MODULE_VERSION` mismatches when changing Node versions by **including the Node ABI (`process.versions.modules`) in the cache key/marker** (e.g., `node-abi127`) and adding marker-aware cache checks/copying.
> 
> Also updates `package.json` so `pnpm start` runs `scripts/ensure-native-modules.mjs node` before launching, ensuring production/normal runs verify the correct native binaries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cdd5f6564a999c7c6e6554944b94c0dee94ed9b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->