### PR TITLE
Preserve newlines in user chat messages

### DIFF
--- a/src/components/agent-activity/agent-activity.tsx
+++ b/src/components/agent-activity/agent-activity.tsx
@@ -37,7 +37,7 @@ export const MessageItem = memo(function MessageItem({ message }: MessageItemPro
   if (message.source === 'user') {
     return (
       <MessageWrapper chatMessage={message}>
-        <div className="rounded-lg bg-primary text-primary-foreground px-3 py-2 inline-block max-w-full break-words text-sm">
+        <div className="rounded-lg bg-primary text-primary-foreground px-3 py-2 inline-block max-w-full break-words text-sm whitespace-pre-wrap">
           {stripThinkingSuffix(message.text)}
         </div>
       </MessageWrapper>


### PR DESCRIPTION
## Summary
Fixes an issue where newlines in user chat messages were being collapsed into spaces when displayed.

## Changes
- Added `whitespace-pre-wrap` CSS class to user message rendering in `agent-activity.tsx`

## Technical Details
Previously, user messages were rendered in a plain `<div>` without whitespace handling, causing HTML's default behavior to collapse newlines into single spaces. This fix adds the `whitespace-pre-wrap` class which:
- Preserves whitespace and newlines (like `white-space: pre`)
- Allows text to wrap at line boundaries (like normal wrapping)

This brings user message display in line with:
- Assistant messages (which use markdown rendering)
- Thinking blocks (which already use `whitespace-pre-wrap`)

## Test Plan
- [ ] Send a multi-line message in the chat
- [ ] Verify that newlines are preserved in the display
- [ ] Verify that long lines still wrap correctly
- [ ] Check that the message styling remains consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that affects how user message text is displayed; main risk is minor layout/wrapping differences for some messages.
> 
> **Overview**
> User chat messages now preserve newlines/whitespace when rendered by adding `whitespace-pre-wrap` to the user message container in `agent-activity.tsx`, preventing multi-line input from being collapsed into a single line while still allowing wrapping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea777167557a3eca33061c9f14a79a3e50b7c9f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->