### PR TITLE
Align workspace spinner indicators to the left

### DIFF
--- a/src/frontend/components/app-sidebar.tsx
+++ b/src/frontend/components/app-sidebar.tsx
@@ -373,6 +373,8 @@ export function AppSidebar() {
                             <div className="flex items-center gap-1.5">
                               {isArchiving || !workspace.branchName ? (
                                 <Loader2 className="h-3 w-3 shrink-0 text-muted-foreground animate-spin" />
+                              ) : isWorking ? (
+                                <Loader2 className="h-3 w-3 shrink-0 text-brand animate-spin" />
                               ) : (
                                 <GitBranch className="h-3 w-3 shrink-0 text-muted-foreground" />
                               )}
@@ -501,12 +503,6 @@ export function AppSidebar() {
                             </div>
                             <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
                               <span className="truncate">{workspace.name}</span>
-                              {isWorking && (
-                                <>
-                                  <span>·</span>
-                                  <Loader2 className="h-3 w-3 animate-spin text-brand shrink-0" />
-                                </>
-                              )}
                             </div>
                           </div>
                         </Link>


### PR DESCRIPTION
## Summary
- Move working status spinner from workspace name to the far left icon position
- Spinner replaces the branch icon when Claude is actively working
- Improves visual alignment when multiple workspaces are running tasks simultaneously

## Changes
- The working status spinner now appears in place of the `GitBranch` icon on the far left
- Removed the redundant spinner that was displayed after the workspace name
- All workspace spinners are now vertically aligned

## Visual Hierarchy
1. **Archiving/No branch** → Gray spinner
2. **Working** → Brand-colored spinner  
3. **Idle** → Branch icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that tweaks sidebar rendering; no data flow or business logic changes.
> 
> **Overview**
> Adjusts workspace rows in `app-sidebar.tsx` so the *working* indicator uses the left icon slot (brand-colored `Loader2`) instead of showing a secondary spinner next to the workspace name.
> 
> Removes the redundant trailing-name spinner, keeping archiving/no-branch as the muted spinner and idle as the `GitBranch` icon for consistent alignment across workspaces.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d6b5c94baea2b8c6b469dfb9c939624a797a724. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->