### PR TITLE
Fix slow workspace initialization by decoupling UI from session loading

### DIFF
--- a/src/backend/routers/websocket/chat.handler.ts
+++ b/src/backend/routers/websocket/chat.handler.ts
@@ -355,7 +355,7 @@ async function handleChatMessage(
 
   switch (message.type) {
     case 'start': {
-      ws.send(JSON.stringify({ type: 'starting', sessionId }));
+      ws.send(JSON.stringify({ type: 'starting', dbSessionId: sessionId }));
 
       // Determine model to use
       const sessionOpts = await sessionService.getSessionOptions(sessionId);
@@ -375,7 +375,7 @@ async function handleChatMessage(
         planModeEnabled: message.planModeEnabled,
         model,
       });
-      ws.send(JSON.stringify({ type: 'started', sessionId }));
+      ws.send(JSON.stringify({ type: 'started', dbSessionId: sessionId }));
       break;
     }
 
@@ -419,7 +419,7 @@ async function handleChatMessage(
         });
 
         ws.send(JSON.stringify({ type: 'message_queued', text }));
-        ws.send(JSON.stringify({ type: 'starting', sessionId }));
+        ws.send(JSON.stringify({ type: 'starting', dbSessionId: sessionId }));
 
         // Determine model to use
         const validModels = ['sonnet', 'opus'];
@@ -432,7 +432,7 @@ async function handleChatMessage(
           planModeEnabled: message.planModeEnabled,
           model,
         });
-        ws.send(JSON.stringify({ type: 'started', sessionId }));
+        ws.send(JSON.stringify({ type: 'started', dbSessionId: sessionId }));
 
         // Drain pending messages
         const pending = pendingMessages.get(sessionId);
@@ -454,7 +454,7 @@ async function handleChatMessage(
       // Delegate to sessionService for unified session lifecycle management
       await sessionService.stopClaudeSession(sessionId);
       pendingMessages.delete(sessionId);
-      ws.send(JSON.stringify({ type: 'stopped', sessionId }));
+      ws.send(JSON.stringify({ type: 'stopped', dbSessionId: sessionId }));
       break;
     }
 
@@ -463,9 +463,9 @@ async function handleChatMessage(
       const claudeSessionId = client?.getClaudeSessionId();
       if (claudeSessionId) {
         const history = await SessionManager.getHistory(claudeSessionId, workingDir);
-        ws.send(JSON.stringify({ type: 'history', sessionId, messages: history }));
+        ws.send(JSON.stringify({ type: 'history', dbSessionId: sessionId, messages: history }));
       } else {
-        ws.send(JSON.stringify({ type: 'history', sessionId, messages: [] }));
+        ws.send(JSON.stringify({ type: 'history', dbSessionId: sessionId, messages: [] }));
       }
       break;
     }

--- a/src/client/routes/projects/workspaces/detail.tsx
+++ b/src/client/routes/projects/workspaces/detail.tsx
@@ -240,7 +240,6 @@ function WorkspaceChatContent() {
     workspace,
     workspaceLoading,
     claudeSessions,
-    sessionsLoading,
     workflows,
     recommendedWorkflow,
     initialDbSessionId,
@@ -328,8 +327,8 @@ function WorkspaceChatContent() {
   // Auto-scroll behavior with RAF throttling
   const { onScroll, isNearBottom, scrollToBottom } = useAutoScroll(viewportRef, inputRef);
 
-  // Show loading while fetching workspace and sessions
-  if (workspaceLoading || sessionsLoading) {
+  // Show loading while fetching workspace (but not sessions - they can load in background)
+  if (workspaceLoading) {
     return <Loading message="Loading workspace..." />;
   }
 


### PR DESCRIPTION
## Summary
Fixes the 30+ second delay when creating new workspaces by removing unnecessary coupling between workspace UI rendering and session query completion.

## Problem
The workspace detail page was blocking on **both** `workspaceLoading` AND `sessionsLoading`, which meant:
- Even after the workspace was ready, the UI wouldn't render until sessions loaded
- New workspaces have no sessions, so users waited ~30 seconds to see the UI
- The chat websocket required a session to exist, creating artificial coupling

## Solution
1. **Frontend (`detail.tsx`)**: Only block on `workspaceLoading`, not `sessionsLoading`
   - UI now renders immediately after workspace is ready
   - Session list loads in the background without blocking
   
2. **Backend (`chat.handler.ts`)**: Make `sessionId` optional in chat websocket
   - Updated `ConnectionInfo` type to allow `dbSessionId: string | null`
   - Added null checks for all session-dependent operations
   - Skip file logging when no session exists
   - Return helpful errors for operations that require a session

## Result
- Time-to-interactive drops from **~30 seconds to just a few seconds** (workspace init time)
- Workspace UI appears immediately
- Users can see the workflow selector right away
- Better separation of concerns: workspace ≠ session

## Test Plan
- [x] Create a new workspace - verify UI renders quickly
- [x] Verify workflow selector appears immediately
- [x] Create a session and verify chat works normally
- [x] TypeScript checks pass
- [x] Linting passes
- [x] Dependency cruiser passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes WebSocket session assumptions (allowing `sessionId` to be null) and adds early-rejection paths, which could impact chat startup/telemetry if any clients still assume a session is always present.
> 
> **Overview**
> **Decouples workspace rendering from session availability** to remove long delays on new workspaces.
> 
> On the frontend, the workspace detail page no longer blocks initial render on session loading; it only shows the loading state while `workspaceLoading` is true.
> 
> On the backend, the chat WebSocket now allows connections without a `sessionId` (`dbSessionId: string | null`), skips session-scoped forwarding/file logging when unset, and returns a clear error for message types that require a selected session.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a91b0c3c05dd3b7e3270256ff02b53641c09f55d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->