### PR TITLE
Add image upload support to chat interface

### DIFF
--- a/src/backend/claude/index.ts
+++ b/src/backend/claude/index.ts
@@ -13,6 +13,7 @@ import type { ControlResponseBody } from './protocol';
 import { type HistoryMessage, SessionManager } from './session';
 import {
   type AssistantMessage,
+  type ClaudeContentItem,
   type ClaudeJson,
   type ControlRequest,
   type HookCallbackRequest,
@@ -167,9 +168,9 @@ export class ClaudeClient extends EventEmitter {
   /**
    * Send a user message to Claude.
    *
-   * @param content - The message content to send
+   * @param content - The message content to send (string or content array with images)
    */
-  sendMessage(content: string): void {
+  sendMessage(content: string | ClaudeContentItem[]): void {
     if (!this.process) {
       throw new Error('ClaudeClient not initialized');
     }

--- a/src/backend/routers/websocket/chat.handler.ts
+++ b/src/backend/routers/websocket/chat.handler.ts
@@ -11,6 +11,7 @@ import { resolve } from 'node:path';
 import type { Duplex } from 'node:stream';
 import type { WebSocket, WebSocketServer } from 'ws';
 import { type ClaudeClient, SessionManager } from '../../claude/index';
+import type { ClaudeContentItem } from '../../claude/types';
 import { interceptorRegistry } from '../../interceptors';
 import { claudeSessionAccessor } from '../../resource_accessors/claude-session.accessor';
 import { configService, createLogger, sessionService } from '../../services/index';
@@ -29,7 +30,7 @@ export interface ConnectionInfo {
 }
 
 export interface PendingMessage {
-  text: string;
+  content: string | ClaudeContentItem[];
   sentAt: Date;
 }
 
@@ -186,7 +187,7 @@ function setupChatClientEvents(
         count: pending.length,
       });
       for (const msg of pending) {
-        client.sendMessage(msg.text);
+        client.sendMessage(msg.content);
       }
     }
 
@@ -330,6 +331,7 @@ async function handleChatMessage(
   message: {
     type: string;
     text?: string;
+    content?: string | ClaudeContentItem[];
     workingDir?: string;
     systemPrompt?: string;
     model?: string;
@@ -380,15 +382,21 @@ async function handleChatMessage(
     }
 
     case 'user_input': {
-      const text = message.text || '';
-      if (!text.trim()) {
+      // Support both text and content array formats
+      const messageContent = message.content || message.text;
+      if (!messageContent) {
+        break;
+      }
+
+      // For text-only messages, ensure it's not empty
+      if (typeof messageContent === 'string' && !messageContent.trim()) {
         break;
       }
 
       // Check if client exists and is running via sessionService
       const existingClient = sessionService.getClient(sessionId);
       if (existingClient?.isRunning()) {
-        existingClient.sendMessage(text);
+        existingClient.sendMessage(messageContent);
       } else {
         let queue = pendingMessages.get(sessionId);
         if (!queue) {
@@ -411,15 +419,17 @@ async function handleChatMessage(
           break;
         }
 
-        queue.push({ text, sentAt: new Date() });
+        queue.push({ content: messageContent, sentAt: new Date() });
 
         logger.info('[Chat WS] Queued message for pending session', {
           sessionId,
           queueLength: queue.length,
         });
 
-        ws.send(JSON.stringify({ type: 'message_queued', text }));
-        ws.send(JSON.stringify({ type: 'starting', dbSessionId: sessionId }));
+        const displayText =
+          typeof messageContent === 'string' ? messageContent : '[Image message]';
+        ws.send(JSON.stringify({ type: 'message_queued', text: displayText }));
+        ws.send(JSON.stringify({ type: 'starting', dbSessionId: sessionId });
 
         // Determine model to use
         const validModels = ['sonnet', 'opus'];
@@ -443,7 +453,7 @@ async function handleChatMessage(
             count: pending.length,
           });
           for (const msg of pending) {
-            newClient.sendMessage(msg.text);
+            newClient.sendMessage(msg.content);
           }
         }
       }

--- a/src/components/agent-activity/agent-activity.tsx
+++ b/src/components/agent-activity/agent-activity.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { memo } from 'react';
+import { AttachmentPreview } from '@/components/chat/attachment-preview';
 import type { ChatMessage, GroupedMessageItem } from '@/lib/claude-types';
 import { isToolSequence, THINKING_SUFFIX } from '@/lib/claude-types';
 import { AssistantMessageRenderer, MessageWrapper } from './message-renderers';
@@ -36,9 +37,18 @@ export const MessageItem = memo(function MessageItem({ message }: MessageItemPro
   // User messages
   if (message.source === 'user') {
     return (
-      <MessageWrapper>
-        <div className="rounded bg-primary dark:bg-transparent dark:border dark:border-border text-primary-foreground dark:text-foreground px-3 py-2 inline-block max-w-full break-words text-sm text-left whitespace-pre-wrap">
-          {stripThinkingSuffix(message.text)}
+      <MessageWrapper chatMessage={message}>
+        <div className="inline-block max-w-full space-y-2">
+          {/* Attachments */}
+          {message.attachments && message.attachments.length > 0 && (
+            <AttachmentPreview attachments={message.attachments} readOnly />
+          )}
+          {/* Text */}
+          {message.text && (
+            <div className="rounded bg-primary dark:bg-transparent dark:border dark:border-border text-primary-foreground dark:text-foreground px-3 py-2 inline-block max-w-full break-words text-sm text-left whitespace-pre-wrap">
+              {stripThinkingSuffix(message.text)}
+            </div>
+          )}
         </div>
       </MessageWrapper>
     );

--- a/src/components/chat/attachment-preview.tsx
+++ b/src/components/chat/attachment-preview.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { X } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import type { MessageAttachment } from '@/lib/claude-types';
+import { formatFileSize } from '@/lib/image-utils';
+import { cn } from '@/lib/utils';
+
+interface AttachmentPreviewProps {
+  attachments: MessageAttachment[];
+  onRemove?: (id: string) => void;
+  className?: string;
+  /** If true, remove button is hidden (for display-only mode) */
+  readOnly?: boolean;
+}
+
+/**
+ * Preview component for image attachments in chat.
+ * Shows thumbnails with file info and optional remove button.
+ */
+export function AttachmentPreview({
+  attachments,
+  onRemove,
+  className,
+  readOnly = false,
+}: AttachmentPreviewProps) {
+  if (attachments.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={cn('flex flex-wrap gap-2', className)}>
+      {attachments.map((attachment) => (
+        <div
+          key={attachment.id}
+          className="relative flex items-center gap-2 rounded-lg border bg-muted/50 p-2 pr-3 hover:bg-muted/80 transition-colors"
+        >
+          {/* Thumbnail */}
+          <div className="relative h-12 w-12 flex-shrink-0 overflow-hidden rounded">
+            <img
+              src={`data:${attachment.type};base64,${attachment.data}`}
+              alt={attachment.name}
+              className="h-full w-full object-cover"
+            />
+          </div>
+
+          {/* File info */}
+          <div className="flex flex-col gap-0.5 min-w-0">
+            <span className="text-xs font-medium text-foreground truncate max-w-[150px]">
+              {attachment.name}
+            </span>
+            <span className="text-xs text-muted-foreground">{formatFileSize(attachment.size)}</span>
+          </div>
+
+          {/* Remove button */}
+          {!readOnly && onRemove && (
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => onRemove(attachment.id)}
+              className="h-5 w-5 rounded-full hover:bg-destructive/20 hover:text-destructive ml-1"
+              aria-label="Remove attachment"
+            >
+              <X className="h-3 w-3" />
+            </Button>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/claude-types.ts
+++ b/src/lib/claude-types.ts
@@ -110,6 +110,19 @@ export interface ImageItem {
 }
 
 /**
+ * Image content block for user messages (base64 encoded).
+ * Used when users upload images in chat.
+ */
+export interface ImageContent {
+  type: 'image';
+  source: {
+    type: 'base64';
+    media_type: string;
+    data: string;
+  };
+}
+
+/**
  * Value type for tool_result content field.
  */
 export type ToolResultContentValue = string | Array<TextItem | ImageItem>;
@@ -127,7 +140,12 @@ export interface ToolResultContent {
 /**
  * Union of all content item types that can appear in a message.
  */
-export type ClaudeContentItem = TextContent | ThinkingContent | ToolUseContent | ToolResultContent;
+export type ClaudeContentItem =
+  | TextContent
+  | ThinkingContent
+  | ToolUseContent
+  | ToolResultContent
+  | ImageContent;
 
 // =============================================================================
 // Stream Event Types
@@ -408,12 +426,24 @@ export interface WebSocketMessage {
 // =============================================================================
 
 /**
+ * Attachment data for uploaded files in chat.
+ */
+export interface MessageAttachment {
+  id: string;
+  name: string;
+  type: string; // MIME type
+  size: number;
+  data: string; // base64 encoded
+}
+
+/**
  * A message queued to be sent when the agent becomes idle.
  */
 export interface QueuedMessage {
   id: string;
   text: string;
   timestamp: string;
+  attachments?: MessageAttachment[];
 }
 
 // =============================================================================
@@ -429,6 +459,7 @@ export interface ChatMessage {
   text?: string; // For user messages
   message?: ClaudeMessage; // For claude messages
   timestamp: string;
+  attachments?: MessageAttachment[]; // For user uploaded images/files
 }
 
 /**
@@ -499,6 +530,13 @@ export function isToolUseContent(item: ClaudeContentItem): item is ToolUseConten
  */
 export function isToolResultContent(item: ClaudeContentItem): item is ToolResultContent {
   return item.type === 'tool_result';
+}
+
+/**
+ * Type guard to check if a content item is ImageContent.
+ */
+export function isImageContent(item: ClaudeContentItem): item is ImageContent {
+  return item.type === 'image' && 'source' in item;
 }
 
 /**

--- a/src/lib/image-utils.ts
+++ b/src/lib/image-utils.ts
@@ -1,0 +1,84 @@
+import type { MessageAttachment } from './claude-types';
+
+/**
+ * Supported image MIME types for upload.
+ */
+export const SUPPORTED_IMAGE_TYPES = [
+  'image/png',
+  'image/jpeg',
+  'image/jpg',
+  'image/gif',
+  'image/webp',
+] as const;
+
+/**
+ * Maximum file size for image uploads (10MB).
+ */
+export const MAX_IMAGE_SIZE = 10 * 1024 * 1024;
+
+/**
+ * Generate a unique ID for an attachment.
+ */
+export function generateAttachmentId(): string {
+  return `att-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+}
+
+/**
+ * Check if a file is a supported image type.
+ */
+export function isSupportedImageType(type: string): boolean {
+  return SUPPORTED_IMAGE_TYPES.includes(type as (typeof SUPPORTED_IMAGE_TYPES)[number]);
+}
+
+/**
+ * Convert a File to a base64 encoded string.
+ */
+export function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result as string;
+      // Remove the data URL prefix (e.g., "data:image/png;base64,")
+      const base64 = result.split(',')[1];
+      resolve(base64);
+    };
+    reader.onerror = () => reject(new Error('Failed to read file'));
+    reader.readAsDataURL(file);
+  });
+}
+
+/**
+ * Convert a File to a MessageAttachment.
+ */
+export async function fileToAttachment(file: File): Promise<MessageAttachment> {
+  if (!isSupportedImageType(file.type)) {
+    throw new Error(`Unsupported file type: ${file.type}`);
+  }
+
+  if (file.size > MAX_IMAGE_SIZE) {
+    throw new Error(`File too large: ${(file.size / 1024 / 1024).toFixed(2)}MB (max 10MB)`);
+  }
+
+  const base64 = await fileToBase64(file);
+
+  return {
+    id: generateAttachmentId(),
+    name: file.name,
+    type: file.type,
+    size: file.size,
+    data: base64,
+  };
+}
+
+/**
+ * Format file size for display.
+ */
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}


### PR DESCRIPTION
## Summary
Implements support for uploading images during chat sessions, allowing users to share diagrams and other visual content with Claude.

Fixes #285

## What Changed

### Frontend
- Added `ImageContent` type to `ClaudeContentItem` union for user messages
- Added `MessageAttachment` type for tracking uploaded files (base64 + metadata)
- Created `image-utils.ts` with utilities for:
  - File validation (10MB limit)
  - Supported formats: PNG, JPEG, GIF, WebP
  - Base64 encoding
  - File size formatting
- Created `AttachmentPreview` component for displaying image thumbnails with file info and optional remove button
- Updated `ChatInput` component with:
  - File picker button (📷 icon)
  - Attachment preview section
  - Multi-file selection support
- Updated chat state to accept and queue messages with attachments
- Messages sent as content arrays when images are attached
- Updated `MessageItem` to display attachments in user message bubbles

### Backend
- Updated `chat.handler.ts` to accept content arrays in `user_input` messages
- Updated `ClaudeClient.sendMessage` to accept `string | ClaudeContentItem[]`
- Updated `PendingMessage` type to store content arrays
- Forwards image content to Claude CLI protocol unchanged

## How to Test

1. Start the app: `pnpm dev`
2. Navigate to a workspace chat
3. Click the image upload button (📷 icon) next to the chat input
4. Select one or more images (PNG, JPEG, GIF, or WebP)
5. See preview thumbnails appear above the input
6. Optionally add text with the images
7. Send the message
8. Verify images appear in the chat history
9. Verify Claude can see and respond to the images

## Screenshots
<!-- Add screenshots if available -->

## Technical Notes

- Images are base64 encoded for transmission to match Claude's API format
- The protocol already supported content arrays with images (used by tool results)
- Queue system maintains attachments for messages sent while agent is busy
- Type-safe implementation with full TypeScript support

🤖 Generated with Claude Code