### PR TITLE
Add fetch and rebase quick action

### DIFF
--- a/prompts/quick-actions/fetch-rebase.md
+++ b/prompts/quick-actions/fetch-rebase.md
@@ -1,0 +1,15 @@
+---
+name: Fetch & Rebase
+description: Fetch latest from origin and rebase onto main
+type: agent
+icon: git-branch
+---
+Please fetch the latest changes from origin and rebase the current branch onto origin/main. Follow these steps:
+
+1. Check for uncommitted changes with `git status`
+2. If there are uncommitted changes, stash them with `git stash`
+3. Fetch the latest changes with `git fetch origin`
+4. Rebase onto origin/main with `git rebase origin/main`
+5. If the stash was created, pop it back with `git stash pop`
+
+If there are any conflicts during the rebase, help me resolve them. Provide clear feedback about what happened during each step.

--- a/src/components/workspace/quick-actions-menu.tsx
+++ b/src/components/workspace/quick-actions-menu.tsx
@@ -1,7 +1,16 @@
 'use client';
 
 import type { inferRouterOutputs } from '@trpc/server';
-import { Check, Eye, type LucideIcon, Play, Sparkles, Terminal, Zap } from 'lucide-react';
+import {
+  Check,
+  Eye,
+  GitBranch,
+  type LucideIcon,
+  Play,
+  Sparkles,
+  Terminal,
+  Zap,
+} from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -38,6 +47,7 @@ const ICON_MAP: Record<string, LucideIcon> = {
   play: Play,
   terminal: Terminal,
   check: Check,
+  'git-branch': GitBranch,
 };
 
 function getActionIcon(iconName?: string | null): LucideIcon {


### PR DESCRIPTION
## Summary
Adds a new "Fetch & Rebase" quick action to help users sync their branch with origin/main.

## Changes
- Added `prompts/quick-actions/fetch-rebase.md` with agent-type quick action
- Added GitBranch icon to quick-actions-menu.tsx icon map

## Features
The quick action guides Claude to:
- Check for uncommitted changes
- Stash changes if present
- Fetch latest from origin
- Rebase current branch onto origin/main
- Restore stashed changes
- Help resolve any conflicts that arise

## Test plan
- [ ] Start dev server to load new quick action
- [ ] Click Quick Actions (⚡) button in workspace
- [ ] Verify "Fetch & Rebase" appears with git branch icon
- [ ] Execute action and verify Claude follows the rebase workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)