### PR TITLE
Fix workflow and quick action loading in production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "dev": "node scripts/ensure-native-modules.mjs node && tsx src/cli/index.ts serve --dev",
-    "build": "tsc -p tsconfig.backend.json && tsc-alias -p tsconfig.backend.json --resolve-full-paths && vite build",
+    "build": "tsc -p tsconfig.backend.json && tsc-alias -p tsconfig.backend.json --resolve-full-paths && cp -r prompts dist/ && vite build",
     "start": "node scripts/ensure-native-modules.mjs node && tsx src/cli/index.ts serve",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
## Summary
- Fixed workflow and quick action loading errors in production build by copying prompts directory to dist/

## Problem
The server was failing to load workflows and quick actions when running from built files, causing users not to see workflow types when creating new workspaces. Error logs showed:
```
Failed to load quick actions: ENOENT: no such file or directory, scandir '/path/to/dist/prompts/quick-actions'
Failed to load workflows: ENOENT: no such file or directory, scandir '/path/to/dist/prompts/workflows'
```

## Solution
Updated the build script in package.json to copy the `prompts/` directory to `dist/` after TypeScript compilation:
```bash
cp -r prompts dist/
```

## Test plan
- [x] Build completes successfully with prompts directory copied
- [x] Server loads workflows and quick actions from dist/prompts/
- [x] Workflow types appear when creating new workspaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)