### PR TITLE
Update light mode user message styling to match dark mode

### DIFF
--- a/src/components/agent-activity/agent-activity.tsx
+++ b/src/components/agent-activity/agent-activity.tsx
@@ -48,7 +48,7 @@ export const MessageItem = memo(function MessageItem({ message }: MessageItemPro
           {/* Text */}
           {message.text && (
             <div className="relative inline-block max-w-full">
-              <div className="rounded bg-primary dark:bg-transparent dark:border dark:border-border text-primary-foreground dark:text-foreground px-3 py-2 break-words text-sm text-left whitespace-pre-wrap">
+              <div className="rounded bg-background border border-border px-3 py-2 break-words text-sm text-left whitespace-pre-wrap">
                 {userText}
               </div>
               {userText && <CopyMessageButton textContent={userText} />}


### PR DESCRIPTION
## Summary
- Update user message styling in light mode to use border instead of colored background
- Matches existing dark mode pattern for visual consistency

## Changes
- Changed user messages from `bg-primary` with `text-primary-foreground` to `bg-background` with `border border-border`
- Both light and dark modes now use the same border-based styling approach

## Visual Impact
User messages will now have:
- Same background color as the chat container
- A border to distinguish them from other content
- Consistent appearance across both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely presentational CSS class change for user message bubbles; no behavioral or data-flow impact.
> 
> **Overview**
> Updates user message bubble styling in `agent-activity.tsx` to use `bg-background` with `border border-border` instead of the previous `bg-primary`/foreground color pairing, aligning light-mode appearance with the existing border-based dark-mode pattern.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02861ea7fa9866d4f2bd9a403ce8d33e56179bd0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->