### PR TITLE
Fix queued messages disappearing when switching sessions

### DIFF
--- a/src/components/chat/use-chat-state.ts
+++ b/src/components/chat/use-chat-state.ts
@@ -336,9 +336,6 @@ export function useChatState(options: UseChatStateOptions): UseChatStateReturn {
     if (prevDbSessionId !== null && prevDbSessionId !== newDbSessionId) {
       debug.log('Session switch detected', { from: prevDbSessionId, to: newDbSessionId });
 
-      // Persist queue clear for the old session to prevent stale messages on refresh
-      persistQueue(prevDbSessionId, []);
-
       // Dispatch session switch to reset reducer state
       dispatch({ type: 'SESSION_SWITCH_START' });
 


### PR DESCRIPTION
## Summary
Fixes queued messages disappearing when switching between chat session tabs.

## Problem
When switching between chat session tabs, queued messages were being cleared from sessionStorage. This meant that if you had messages queued in Session A, switched to Session B, and then came back to Session A, your queued messages would be gone.

## Root Cause
The session switching logic in `use-chat-state.ts` was calling `persistQueue(prevDbSessionId, [])` to clear the queue from sessionStorage. This was originally intended to prevent stale messages on refresh, but it had the side effect of losing queued messages when switching between active sessions.

## Solution
Removed the `persistQueue(prevDbSessionId, [])` call when switching sessions. The queue is still cleared from the reducer state (via `SESSION_SWITCH_START`), ensuring the UI shows the correct queue for each session, but the queued messages remain in sessionStorage so they can be restored when navigating back.

## What Changed
- **Before**: Queued messages were cleared from sessionStorage when switching sessions
- **After**: Queued messages persist in sessionStorage per session and are restored when returning to that session

## Test Plan
- [x] All existing tests pass (172 total across chat modules)
  - use-chat-state.test.ts: 39 tests ✓
  - chat-persistence.test.ts: 58 tests ✓
  - chat-reducer.test.ts: 75 tests ✓
- [x] Manual testing: Queue a message in Session A, switch to Session B, return to Session A → messages still displayed
- [x] Verify messages are still correctly dispatched when agent becomes idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes an over-aggressive persistence write during session switching, affecting only client-side queue storage and restoration behavior.
> 
> **Overview**
> Queued messages are no longer wiped from sessionStorage when switching between `dbSessionId`s in `use-chat-state.ts`, preventing queued messages from disappearing when you return to a previous chat session.
> 
> Session switches still reset in-memory reducer state via `SESSION_SWITCH_START`, but persistence for the previous session’s queue is left intact so it can be reloaded on return.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c930f8742c601fe92d455b2a4602e749db08d0f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->