### PR TITLE
Fix plan mode ExitPlanMode approval flow

### DIFF
--- a/src/backend/claude/permissions.test.ts
+++ b/src/backend/claude/permissions.test.ts
@@ -294,7 +294,7 @@ describe('Helper Functions', () => {
   describe('createAllowResponse', () => {
     it('should return correct structure without updatedInput', () => {
       const response = createAllowResponse();
-      expect(response).toEqual({ behavior: 'allow' });
+      expect(response).toEqual({ behavior: 'allow', updatedInput: {} });
     });
 
     it('should return correct structure with updatedInput', () => {
@@ -306,10 +306,10 @@ describe('Helper Functions', () => {
       });
     });
 
-    it('should not include updatedInput key when undefined', () => {
+    it('should include empty updatedInput when undefined', () => {
       const response = createAllowResponse(undefined);
-      expect(response).toEqual({ behavior: 'allow' });
-      expect('updatedInput' in response).toBe(false);
+      expect(response).toEqual({ behavior: 'allow', updatedInput: {} });
+      expect('updatedInput' in response).toBe(true);
     });
   });
 
@@ -430,17 +430,17 @@ describe('AutoApproveHandler', () => {
   describe('onCanUseTool', () => {
     it('should approve all tool requests', async () => {
       const response = await handler.onCanUseTool(canUseToolRequest);
-      expect(response).toEqual({ behavior: 'allow' });
+      expect(response).toEqual({ behavior: 'allow', updatedInput: {} });
     });
 
     it('should approve Bash tool requests', async () => {
       const response = await handler.onCanUseTool(bashToolRequest);
-      expect(response).toEqual({ behavior: 'allow' });
+      expect(response).toEqual({ behavior: 'allow', updatedInput: {} });
     });
 
     it('should approve Write tool requests', async () => {
       const response = await handler.onCanUseTool(writeToolRequest);
-      expect(response).toEqual({ behavior: 'allow' });
+      expect(response).toEqual({ behavior: 'allow', updatedInput: {} });
     });
   });
 
@@ -543,7 +543,7 @@ describe('ModeBasedHandler', () => {
 
     it('should auto-approve read-only tools', async () => {
       const response = await handler.onCanUseTool(canUseToolRequest);
-      expect(response).toEqual({ behavior: 'allow' });
+      expect(response).toEqual({ behavior: 'allow', updatedInput: {} });
     });
 
     it('should deny non-read-only tools with message', async () => {
@@ -570,6 +570,7 @@ describe('ModeBasedHandler', () => {
 
       const response = await handler.onCanUseTool(bashToolRequest);
       expect(onAsk).toHaveBeenCalledWith(bashToolRequest);
+      // Response is whatever onAsk returns (not transformed by createAllowResponse)
       expect(response).toEqual({ behavior: 'allow' });
     });
 
@@ -587,12 +588,12 @@ describe('ModeBasedHandler', () => {
 
     it('should auto-approve read-only tools', async () => {
       const response = await handler.onCanUseTool(canUseToolRequest);
-      expect(response).toEqual({ behavior: 'allow' });
+      expect(response).toEqual({ behavior: 'allow', updatedInput: {} });
     });
 
     it('should auto-approve Write tool', async () => {
       const response = await handler.onCanUseTool(writeToolRequest);
-      expect(response).toEqual({ behavior: 'allow' });
+      expect(response).toEqual({ behavior: 'allow', updatedInput: {} });
     });
 
     it('should deny Bash tool', async () => {
@@ -609,7 +610,7 @@ describe('ModeBasedHandler', () => {
 
     it('should auto-approve all tools except ExitPlanMode', async () => {
       const response = await handler.onCanUseTool(bashToolRequest);
-      expect(response).toEqual({ behavior: 'allow' });
+      expect(response).toEqual({ behavior: 'allow', updatedInput: {} });
     });
 
     it('should deny ExitPlanMode', async () => {
@@ -626,12 +627,12 @@ describe('ModeBasedHandler', () => {
 
     it('should auto-approve all tools', async () => {
       const response = await handler.onCanUseTool(bashToolRequest);
-      expect(response).toEqual({ behavior: 'allow' });
+      expect(response).toEqual({ behavior: 'allow', updatedInput: {} });
     });
 
     it('should auto-approve ExitPlanMode', async () => {
       const response = await handler.onCanUseTool(exitPlanModeRequest);
-      expect(response).toEqual({ behavior: 'allow' });
+      expect(response).toEqual({ behavior: 'allow', updatedInput: {} });
     });
   });
 
@@ -706,7 +707,7 @@ describe('ModeBasedHandler', () => {
       // After changing mode, allow Bash
       handler.setMode('bypassPermissions');
       response = await handler.onCanUseTool(bashToolRequest);
-      expect(response).toEqual({ behavior: 'allow' });
+      expect(response).toEqual({ behavior: 'allow', updatedInput: {} });
     });
   });
 });
@@ -785,7 +786,7 @@ describe('DeferredHandler', () => {
 
       handler.approve('tool-123');
       const response = await promise;
-      expect(response).toEqual({ behavior: 'allow' });
+      expect(response).toEqual({ behavior: 'allow', updatedInput: {} });
     });
 
     it('should resolve pending permission request with updated input', async () => {

--- a/src/backend/claude/permissions.ts
+++ b/src/backend/claude/permissions.ts
@@ -76,11 +76,12 @@ export interface PermissionHandler {
 
 /**
  * Create an allow response for can_use_tool requests.
+ * Note: updatedInput must always be present for Claude CLI schema validation.
  */
 export function createAllowResponse(updatedInput?: Record<string, unknown>): AllowResponseData {
   return {
     behavior: 'allow',
-    ...(updatedInput && { updatedInput }),
+    updatedInput: updatedInput ?? {},
   };
 }
 

--- a/src/backend/claude/permissions.ts
+++ b/src/backend/claude/permissions.ts
@@ -266,6 +266,14 @@ export class ModeBasedHandler implements PermissionHandler {
   getMode(): PermissionMode {
     return this.mode;
   }
+
+  /**
+   * Set or update the onAsk callback.
+   * This allows setting up deferred approval after construction.
+   */
+  setOnAsk(callback: (request: CanUseToolRequest) => Promise<ControlResponseBody>): void {
+    this.onAsk = callback;
+  }
 }
 
 // =============================================================================

--- a/src/backend/routers/websocket/chat.handler.ts
+++ b/src/backend/routers/websocket/chat.handler.ts
@@ -300,7 +300,7 @@ function setupChatClientEvents(
       type: 'permission_request',
       requestId,
       toolName: request.tool_name,
-      input: request.input,
+      toolInput: request.input, // Frontend expects 'toolInput', not 'input'
     });
   });
 }


### PR DESCRIPTION
## Summary

- Fixes plan mode to properly defer ExitPlanMode to UI for user approval
- Previously, ExitPlanMode was immediately denied because `ModeBasedHandler` had no `onAsk` callback
- Now the permission request is deferred and forwarded to the frontend

## Changes

- Add `setOnAsk()` method to `ModeBasedHandler` for post-construction callback setup
- Add `pendingPermissions` map and `approvePermission()`/`denyPermission()` methods to `ClaudeClient`
- Wire up `onAsk` callback in `create()` when plan mode is enabled
- Add `deferred_permission_request` event forwarding in WebSocket handler
- Add `permission_response` message handler to resolve pending approvals

## How it works

1. Plan mode enabled → `permissionMode: 'plan'`
2. Agent calls ExitPlanMode → Not auto-approved
3. `onAsk` callback triggered → Creates pending promise, emits `deferred_permission_request`
4. WebSocket forwards to frontend → Frontend shows permission prompt
5. User approves/denies → Frontend sends `permission_response`
6. Backend resolves promise → Claude continues or retries

## Test plan

- [x] TypeScript check passes
- [x] All 867 tests pass
- [x] Linting passes
- [ ] Manual test: Enable plan mode, verify ExitPlanMode shows approval UI

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes permission-gating and WebSocket message flow for tool execution in plan mode; incorrect wiring could allow/deny `ExitPlanMode` unexpectedly or leave requests unresolved.
> 
> **Overview**
> Fixes plan mode so `ExitPlanMode` is no longer immediately denied when no `onAsk` handler is present, by deferring the decision to the UI.
> 
> `ClaudeClient.create()` now wires a deferred `ModeBasedHandler.setOnAsk()` callback in plan mode, tracks pending approvals, emits `deferred_permission_request`, and exposes `approvePermission()`/`denyPermission()` to resolve the CLI control request.
> 
> WebSocket chat handling forwards these deferred permission prompts to the frontend and adds a `permission_response` message to apply the user’s allow/deny. Separately, `createAllowResponse()` now always includes `updatedInput: {}` (and tests updated) to match Claude CLI schema expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66e440fd7437ce9e946b6fb2aa75ebee6df6fcd4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->