### PR TITLE
Add real-time thinking display for extended thinking mode

### DIFF
--- a/src/client/routes/projects/workspaces/detail.tsx
+++ b/src/client/routes/projects/workspaces/detail.tsx
@@ -100,6 +100,7 @@ interface ChatContentProps {
   setInputDraft: ReturnType<typeof useChatWebSocket>['setInputDraft'];
   queuedMessages: ReturnType<typeof useChatWebSocket>['queuedMessages'];
   removeQueuedMessage: ReturnType<typeof useChatWebSocket>['removeQueuedMessage'];
+  latestThinking: ReturnType<typeof useChatWebSocket>['latestThinking'];
   /** Database session ID for detecting session changes (auto-focus) */
   selectedDbSessionId: string | null;
 }
@@ -133,6 +134,7 @@ const ChatContent = memo(function ChatContent({
   setInputDraft,
   queuedMessages,
   removeQueuedMessage,
+  latestThinking,
   selectedDbSessionId,
 }: ChatContentProps) {
   // Group adjacent tool calls for display (memoized)
@@ -185,6 +187,7 @@ const ChatContent = memo(function ChatContent({
             onScroll={onScroll}
             messagesEndRef={messagesEndRef}
             isNearBottom={isNearBottom}
+            latestThinking={latestThinking}
           />
         </KeyboardStateProvider>
       </div>
@@ -290,6 +293,7 @@ function WorkspaceChatContent() {
     chatSettings,
     inputDraft,
     queuedMessages,
+    latestThinking,
     sendMessage,
     stopChat,
     approvePermission,
@@ -529,6 +533,7 @@ function WorkspaceChatContent() {
                 setInputDraft={setInputDraft}
                 queuedMessages={queuedMessages}
                 removeQueuedMessage={removeQueuedMessage}
+                latestThinking={latestThinking}
                 selectedDbSessionId={selectedDbSessionId}
               />
             </WorkspaceContentView>

--- a/src/components/chat/chat-reducer.ts
+++ b/src/components/chat/chat-reducer.ts
@@ -336,7 +336,7 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
     case 'WS_STARTING':
       return { ...state, startingSession: true };
     case 'WS_STARTED':
-      return { ...state, startingSession: false, running: true };
+      return { ...state, startingSession: false, running: true, latestThinking: null };
     case 'WS_STOPPED':
       return { ...state, running: false, stopping: false, startingSession: false };
 
@@ -414,6 +414,7 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
         running: false,
         queuedMessages: [],
         toolUseIdToIndex: new Map(),
+        latestThinking: null,
       };
     case 'SESSION_LOADING_START':
       return { ...state, loadingSession: true };

--- a/src/components/chat/index.ts
+++ b/src/components/chat/index.ts
@@ -3,6 +3,7 @@
 // Types
 export type { ChatMessage } from '@/lib/claude-types';
 export { ChatInput } from './chat-input';
+export { LatestThinking } from './latest-thinking';
 export { PermissionPrompt, PermissionPromptExpanded } from './permission-prompt';
 export { QuestionPrompt } from './question-prompt';
 export { QueuedMessages } from './queued-messages';

--- a/src/components/chat/latest-thinking.tsx
+++ b/src/components/chat/latest-thinking.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { Loader2 } from 'lucide-react';
+import { memo, useEffect, useRef } from 'react';
+import { cn } from '@/lib/utils';
+
+// =============================================================================
+// Props
+// =============================================================================
+
+interface LatestThinkingProps {
+  /** Current accumulated thinking content */
+  thinking: string | null;
+  /** Whether the agent is actively running */
+  running: boolean;
+  /** Optional className for additional styling */
+  className?: string;
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * Displays the latest thinking content from extended thinking mode.
+ * Shown below messages while the agent is running and has thinking content.
+ * Auto-scrolls to keep the latest thinking visible.
+ */
+export const LatestThinking = memo(function LatestThinking({
+  thinking,
+  running,
+  className,
+}: LatestThinkingProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Auto-scroll to bottom when thinking updates
+  useEffect(() => {
+    if (scrollRef.current && thinking) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [thinking]);
+
+  // Don't render if no thinking or not running
+  if (!(thinking && running)) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        'rounded-md border border-dashed border-muted-foreground/30 bg-muted/30 p-3',
+        className
+      )}
+    >
+      <div className="flex items-center gap-2 mb-2">
+        <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
+        <span className="text-xs font-medium text-muted-foreground">Thinking</span>
+      </div>
+      <div
+        ref={scrollRef}
+        className="text-sm text-muted-foreground italic max-h-32 overflow-y-auto whitespace-pre-wrap"
+      >
+        {thinking}
+      </div>
+    </div>
+  );
+});

--- a/src/components/chat/use-chat-websocket.ts
+++ b/src/components/chat/use-chat-websocket.ts
@@ -50,6 +50,8 @@ export interface UseChatWebSocketReturn {
   inputDraft: string;
   // Message queue state
   queuedMessages: QueuedMessage[];
+  // Latest thinking content from extended thinking mode
+  latestThinking: string | null;
   // Actions
   sendMessage: (text: string) => void;
   stopChat: () => void;
@@ -149,6 +151,7 @@ export function useChatWebSocket(options: UseChatWebSocketOptions): UseChatWebSo
     chatSettings: chat.chatSettings,
     inputDraft: chat.inputDraft,
     queuedMessages: chat.queuedMessages,
+    latestThinking: chat.latestThinking,
     // Actions from chat
     sendMessage: chat.sendMessage,
     stopChat: chat.stopChat,

--- a/src/components/chat/virtualized-message-list.tsx
+++ b/src/components/chat/virtualized-message-list.tsx
@@ -5,6 +5,7 @@ import { Loader2 } from 'lucide-react';
 import { memo, useCallback, useEffect, useRef } from 'react';
 import { GroupedMessageItemRenderer, LoadingIndicator } from '@/components/agent-activity';
 import type { GroupedMessageItem } from '@/lib/claude-types';
+import { LatestThinking } from './latest-thinking';
 
 // =============================================================================
 // Types
@@ -23,6 +24,8 @@ interface VirtualizedMessageListProps {
   messagesEndRef?: React.RefObject<HTMLDivElement | null>;
   /** Whether user is near bottom of scroll - used to gate auto-scroll */
   isNearBottom?: boolean;
+  /** Latest accumulated thinking content from extended thinking mode */
+  latestThinking?: string | null;
 }
 
 // =============================================================================
@@ -71,6 +74,7 @@ export const VirtualizedMessageList = memo(function VirtualizedMessageList({
   onScroll,
   messagesEndRef,
   isNearBottom = true,
+  latestThinking,
 }: VirtualizedMessageListProps) {
   const prevMessageCountRef = useRef(messages.length);
   const isAutoScrollingRef = useRef(false);
@@ -176,6 +180,11 @@ export const VirtualizedMessageList = memo(function VirtualizedMessageList({
           );
         })}
       </div>
+
+      {/* Latest thinking from extended thinking mode */}
+      {latestThinking && running && (
+        <LatestThinking thinking={latestThinking} running={running} className="mb-4" />
+      )}
 
       {/* Loading indicators after messages */}
       {running && <LoadingIndicator className="py-4" />}


### PR DESCRIPTION
## Summary

- Add accumulation of `thinking_delta` events that were previously being filtered out
- Create `LatestThinking` component to display thinking content below messages
- Show thinking in a muted gray box with auto-scroll while agent is running
- Automatically clear thinking when a new message starts

Previously, extended thinking mode wasn't displaying thinking content because only the initial `content_block_start` event was stored (with empty content), while the actual `thinking_delta` events containing the text were filtered out.

## Test plan

- [ ] Enable extended thinking mode (toggle in chat input)
- [ ] Send a message that triggers thinking + tool calls
- [ ] Verify thinking content appears below messages in gray
- [ ] Verify thinking updates in real-time as agent thinks
- [ ] Verify thinking clears when agent stops or new message starts
- [ ] Run `pnpm test` - all 867 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes WebSocket stream-event handling and chat reducer state transitions, which could affect session switching/reset behavior and UI rendering during active runs.
> 
> **Overview**
> Adds support for **real-time extended thinking output** by capturing `thinking_delta` stream events in `use-chat-state` and accumulating them in new chat state `latestThinking` via `THINKING_DELTA`/`THINKING_CLEAR` reducer actions.
> 
> Introduces a `LatestThinking` UI component and threads `latestThinking` through `useChatWebSocket` into `VirtualizedMessageList`/workspace chat to render a scrolling “Thinking” box while running; clears thinking on `message_start`, `WS_STARTED`, session switches, and chat resets (with new reducer tests to prevent stale flashes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a383d1595b28fcf5169981a455e3188432efc090. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->