### PR TITLE
Fix AskUserQuestion and ExitPlanMode returning blank responses

### DIFF
--- a/src/backend/claude/index.ts
+++ b/src/backend/claude/index.ts
@@ -138,6 +138,11 @@ export class ClaudeClient extends EventEmitter {
         input: request.input,
       } as PendingInteractiveRequest);
     });
+
+    // Clean up pendingInteractiveRequests when requests time out
+    this.interactiveHandler.on('request_timeout', (requestId) => {
+      this.pendingInteractiveRequests.delete(requestId);
+    });
   }
 
   // ===========================================================================
@@ -395,13 +400,6 @@ export class ClaudeClient extends EventEmitter {
     // Clean up stored request
     this.pendingInteractiveRequests.delete(requestId);
     this.interactiveHandler.deny(requestId, reason);
-  }
-
-  /**
-   * Check if there are pending interactive requests.
-   */
-  hasPendingInteractiveRequests(): boolean {
-    return this.interactiveHandler.getPendingCount() > 0;
   }
 
   // ===========================================================================

--- a/src/backend/claude/permissions.test.ts
+++ b/src/backend/claude/permissions.test.ts
@@ -188,8 +188,12 @@ describe('shouldAutoApprove', () => {
       expect(shouldAutoApprove(mode, 'Read')).toBe(true);
     });
 
-    it('should auto-approve ExitPlanMode', () => {
-      expect(shouldAutoApprove(mode, 'ExitPlanMode')).toBe(true);
+    it('should NOT auto-approve ExitPlanMode (interactive tool)', () => {
+      expect(shouldAutoApprove(mode, 'ExitPlanMode')).toBe(false);
+    });
+
+    it('should NOT auto-approve AskUserQuestion (interactive tool)', () => {
+      expect(shouldAutoApprove(mode, 'AskUserQuestion')).toBe(false);
     });
 
     it('should auto-approve any arbitrary tool', () => {
@@ -629,9 +633,12 @@ describe('ModeBasedHandler', () => {
       expect(response).toEqual({ behavior: 'allow' });
     });
 
-    it('should auto-approve ExitPlanMode', async () => {
+    it('should NOT auto-approve ExitPlanMode (interactive tool)', async () => {
       const response = await handler.onCanUseTool(exitPlanModeRequest);
-      expect(response).toEqual({ behavior: 'allow' });
+      expect(response).toEqual({
+        behavior: 'deny',
+        message: "Tool 'ExitPlanMode' requires manual approval",
+      });
     });
   });
 

--- a/src/backend/claude/permissions.ts
+++ b/src/backend/claude/permissions.ts
@@ -356,6 +356,7 @@ export class DeferredHandler extends EventEmitter implements PermissionHandler {
         this.timeout > 0
           ? setTimeout(() => {
               this.pendingRequests.delete(requestId);
+              this.emit('request_timeout', requestId, request);
               reject(new Error(`Permission request timed out after ${this.timeout}ms`));
             }, this.timeout)
           : undefined;
@@ -551,6 +552,10 @@ export class DeferredHandler extends EventEmitter implements PermissionHandler {
     event: 'stop_request',
     handler: (request: HookCallbackRequest, requestId: string) => void
   ): this;
+  override on(
+    event: 'request_timeout',
+    handler: (requestId: string, request: CanUseToolRequest | HookCallbackRequest) => void
+  ): this;
   // biome-ignore lint/suspicious/noExplicitAny: EventEmitter requires any[] for generic handler
   override on(event: string, handler: (...args: any[]) => void): this {
     return super.on(event, handler);
@@ -563,6 +568,11 @@ export class DeferredHandler extends EventEmitter implements PermissionHandler {
   ): boolean;
   override emit(event: 'hook_request', request: HookCallbackRequest, requestId: string): boolean;
   override emit(event: 'stop_request', request: HookCallbackRequest, requestId: string): boolean;
+  override emit(
+    event: 'request_timeout',
+    requestId: string,
+    request: CanUseToolRequest | HookCallbackRequest
+  ): boolean;
   // biome-ignore lint/suspicious/noExplicitAny: EventEmitter requires any[] for generic emit
   override emit(event: string, ...args: any[]): boolean;
   // biome-ignore lint/suspicious/noExplicitAny: EventEmitter requires any[] for generic emit

--- a/src/backend/claude/permissions.ts
+++ b/src/backend/claude/permissions.ts
@@ -125,9 +125,22 @@ export function createStopHookResponse(
 }
 
 /**
+ * Interactive tools that require user input, not just permission.
+ * These tools should NEVER be auto-approved because they need actual user responses.
+ * - AskUserQuestion: needs the user's answers to questions
+ * - ExitPlanMode: needs user approval of the proposed plan
+ */
+export const INTERACTIVE_TOOLS = new Set(['AskUserQuestion', 'ExitPlanMode']);
+
+/**
  * Determine if a tool should be auto-approved based on permission mode.
  */
 export function shouldAutoApprove(mode: PermissionMode, toolName: string): boolean {
+  // Interactive tools should NEVER be auto-approved - they require user input, not just permission
+  if (INTERACTIVE_TOOLS.has(toolName)) {
+    return false;
+  }
+
   switch (mode) {
     case 'bypassPermissions':
       return true;

--- a/src/backend/routers/websocket/chat.handler.ts
+++ b/src/backend/routers/websocket/chat.handler.ts
@@ -5,7 +5,7 @@
  * Manages session lifecycle, message forwarding, and tool interception.
  */
 
-import { existsSync, realpathSync } from 'node:fs';
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
 import type { IncomingMessage } from 'node:http';
 import { resolve } from 'node:path';
 import type { Duplex } from 'node:stream';
@@ -131,6 +131,72 @@ function notifyToolResultInterceptors(
     pendingToolNames.delete(typedItem.tool_use_id);
     pendingToolInputs.delete(typedItem.tool_use_id);
   }
+}
+
+/**
+ * Read plan file content for ExitPlanMode requests.
+ */
+function readPlanFileContent(planFile: string | undefined): string | null {
+  if (!(planFile && existsSync(planFile))) {
+    return null;
+  }
+  try {
+    return readFileSync(planFile, 'utf-8');
+  } catch (error) {
+    logger.warn('[Chat WS] Failed to read plan file', {
+      planFile,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+/**
+ * Route interactive tool requests to the appropriate WebSocket message format.
+ */
+function routeInteractiveRequest(
+  dbSessionId: string,
+  request: {
+    requestId: string;
+    toolName: string;
+    toolUseId: string;
+    input: Record<string, unknown>;
+  }
+): void {
+  if (request.toolName === 'AskUserQuestion') {
+    // AskUserQuestion: send as 'user_question' with questions extracted from input
+    const input = request.input as { questions?: unknown[] };
+    forwardToConnections(dbSessionId, {
+      type: 'user_question',
+      requestId: request.requestId,
+      questions: input.questions ?? [],
+    });
+    return;
+  }
+
+  if (request.toolName === 'ExitPlanMode') {
+    // ExitPlanMode: send as 'permission_request' for plan approval
+    const exitPlanInput = request.input as { planFile?: string };
+    const planContent = readPlanFileContent(exitPlanInput.planFile);
+
+    forwardToConnections(dbSessionId, {
+      type: 'permission_request',
+      requestId: request.requestId,
+      toolName: request.toolName,
+      input: request.input,
+      planContent,
+    });
+    return;
+  }
+
+  // Fallback: send as generic interactive_request
+  forwardToConnections(dbSessionId, {
+    type: 'interactive_request',
+    requestId: request.requestId,
+    toolName: request.toolName,
+    toolUseId: request.toolUseId,
+    input: request.input,
+  });
 }
 
 function setupChatClientEvents(
@@ -287,33 +353,7 @@ function setupChatClientEvents(
       data: request,
     });
 
-    // Route different interactive tools to appropriate frontend message types
-    if (request.toolName === 'AskUserQuestion') {
-      // AskUserQuestion: send as 'user_question' with questions extracted from input
-      const input = request.input as { questions?: unknown[] };
-      forwardToConnections(dbSessionId, {
-        type: 'user_question',
-        requestId: request.requestId,
-        questions: input.questions ?? [],
-      });
-    } else if (request.toolName === 'ExitPlanMode') {
-      // ExitPlanMode: send as 'permission_request' for plan approval
-      forwardToConnections(dbSessionId, {
-        type: 'permission_request',
-        requestId: request.requestId,
-        toolName: request.toolName,
-        input: request.input,
-      });
-    } else {
-      // Fallback: send as generic interactive_request
-      forwardToConnections(dbSessionId, {
-        type: 'interactive_request',
-        requestId: request.requestId,
-        toolName: request.toolName,
-        toolUseId: request.toolUseId,
-        input: request.input,
-      });
-    }
+    routeInteractiveRequest(dbSessionId, request);
   });
 
   client.on('exit', (result) => {

--- a/src/backend/routers/websocket/chat.handler.ts
+++ b/src/backend/routers/websocket/chat.handler.ts
@@ -744,10 +744,10 @@ async function handleChatMessage(
       await handleLoadSessionMessage(ws, dbSessionId, workingDir);
       break;
     case 'question_response':
-      await handleQuestionResponseMessage(ws, dbSessionId, message);
+      handleQuestionResponseMessage(ws, dbSessionId, message);
       break;
     case 'permission_response':
-      await handlePermissionResponseMessage(ws, dbSessionId, message);
+      handlePermissionResponseMessage(ws, dbSessionId, message);
       break;
   }
 }

--- a/src/components/chat/chat-reducer.test.ts
+++ b/src/components/chat/chat-reducer.test.ts
@@ -827,10 +827,64 @@ describe('chatReducer', () => {
           timestamp: '2024-01-01T00:00:00.000Z',
         },
       };
-      const action: ChatAction = { type: 'PERMISSION_RESPONSE' };
+      const action: ChatAction = { type: 'PERMISSION_RESPONSE', payload: { allow: true } };
       const newState = chatReducer(state, action);
 
       expect(newState.pendingPermission).toBeNull();
+    });
+
+    it('should disable plan mode when ExitPlanMode is approved', () => {
+      const state: ChatState = {
+        ...initialState,
+        chatSettings: { ...initialState.chatSettings, planModeEnabled: true },
+        pendingPermission: {
+          requestId: 'req-1',
+          toolName: 'ExitPlanMode',
+          toolInput: {},
+          timestamp: '2024-01-01T00:00:00.000Z',
+        },
+      };
+      const action: ChatAction = { type: 'PERMISSION_RESPONSE', payload: { allow: true } };
+      const newState = chatReducer(state, action);
+
+      expect(newState.pendingPermission).toBeNull();
+      expect(newState.chatSettings.planModeEnabled).toBe(false);
+    });
+
+    it('should not disable plan mode when ExitPlanMode is denied', () => {
+      const state: ChatState = {
+        ...initialState,
+        chatSettings: { ...initialState.chatSettings, planModeEnabled: true },
+        pendingPermission: {
+          requestId: 'req-1',
+          toolName: 'ExitPlanMode',
+          toolInput: {},
+          timestamp: '2024-01-01T00:00:00.000Z',
+        },
+      };
+      const action: ChatAction = { type: 'PERMISSION_RESPONSE', payload: { allow: false } };
+      const newState = chatReducer(state, action);
+
+      expect(newState.pendingPermission).toBeNull();
+      expect(newState.chatSettings.planModeEnabled).toBe(true);
+    });
+
+    it('should not affect plan mode for other tools', () => {
+      const state: ChatState = {
+        ...initialState,
+        chatSettings: { ...initialState.chatSettings, planModeEnabled: true },
+        pendingPermission: {
+          requestId: 'req-1',
+          toolName: 'Bash',
+          toolInput: {},
+          timestamp: '2024-01-01T00:00:00.000Z',
+        },
+      };
+      const action: ChatAction = { type: 'PERMISSION_RESPONSE', payload: { allow: true } };
+      const newState = chatReducer(state, action);
+
+      expect(newState.pendingPermission).toBeNull();
+      expect(newState.chatSettings.planModeEnabled).toBe(true);
     });
   });
 

--- a/src/components/chat/chat-reducer.ts
+++ b/src/components/chat/chat-reducer.ts
@@ -532,6 +532,8 @@ function handlePermissionRequestMessage(data: WebSocketMessage): ChatAction | nu
         toolName: data.toolName,
         toolInput: data.toolInput ?? {},
         timestamp: new Date().toISOString(),
+        // Include plan content for ExitPlanMode requests
+        planContent: data.planContent ?? null,
       },
     };
   }

--- a/src/components/chat/use-chat-state.ts
+++ b/src/components/chat/use-chat-state.ts
@@ -561,7 +561,7 @@ export function useChatState(options: UseChatStateOptions): UseChatStateReturn {
     (requestId: string, allow: boolean) => {
       const msg: PermissionResponseMessage = { type: 'permission_response', requestId, allow };
       send(msg);
-      dispatch({ type: 'PERMISSION_RESPONSE' });
+      dispatch({ type: 'PERMISSION_RESPONSE', payload: { allow } });
     },
     [send]
   );

--- a/src/lib/claude-types.ts
+++ b/src/lib/claude-types.ts
@@ -302,6 +302,8 @@ export interface PermissionRequest {
   toolName: string;
   toolInput: Record<string, unknown>;
   timestamp: string;
+  /** Plan content for ExitPlanMode requests (markdown) */
+  planContent?: string | null;
 }
 
 // =============================================================================
@@ -413,6 +415,8 @@ export interface WebSocketMessage {
   requestId?: string;
   toolName?: string;
   toolInput?: Record<string, unknown>;
+  // Plan content for ExitPlanMode permission requests
+  planContent?: string | null;
   // AskUserQuestion fields (Phase 11)
   questions?: AskUserQuestion[];
   // Chat settings


### PR DESCRIPTION
## Summary
- Fix interactive tools (`AskUserQuestion`, `ExitPlanMode`) immediately returning blank responses instead of waiting for user input
- Root cause: `shouldAutoApprove()` returned `true` for these tools, so they were approved with `{ behavior: 'allow' }` and no actual user answers
- Add proper deferred handling to wait for user input before returning tool results

## Changes
- Add `INTERACTIVE_TOOLS` set containing tools that should never be auto-approved
- Add `DeferredHandler` to `ClaudeClient` for interactive tool requests
- Route interactive tools to deferred handler to wait for user input
- Add `interactive_request` event to forward requests to WebSocket frontend
- Add WebSocket handlers for `question_response` and `permission_response` messages
- Store pending requests to retrieve original questions when responding
- Update tests to reflect new expected behavior

## Test plan
- [ ] Start a session and trigger `AskUserQuestion` tool (e.g., ask Claude to help decide something)
- [ ] Verify the question prompt appears in the UI
- [ ] Answer the question and verify Claude receives the actual answer (not blank)
- [ ] Test plan mode with `ExitPlanMode` - verify it waits for approval

Fixes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the tool-permission/interactive-tool flow and WebSocket message protocol; mistakes could cause stuck sessions, missed approvals, or incorrect tool execution. Scope is contained to Claude CLI client + chat WS + UI prompts.
> 
> **Overview**
> **Fixes interactive tools returning blank responses** by treating `AskUserQuestion` and `ExitPlanMode` as *never auto-approvable* via a new `INTERACTIVE_TOOLS` guard.
> 
> `ClaudeClient` now routes these tools through a `DeferredHandler`, emits an `interactive_request` event, stores pending requests for later completion, and exposes `answerQuestion` / `approveInteractiveRequest` / `denyInteractiveRequest` APIs (with cleanup on stop/kill/timeouts).
> 
> The chat WebSocket layer forwards interactive requests to the frontend as `user_question` or `permission_request` (including optional `planContent` read from the plan file for `ExitPlanMode`) and accepts `question_response` / `permission_response` messages to complete the deferred requests. The UI updates its reducer/action payloads accordingly and adds a specialized plan approval prompt for `ExitPlanMode`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82c3acc7238989fffc55b76edf6fc66726fee172. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->