### PR TITLE
Refactor codebase for improved maintainability

### DIFF
--- a/src/backend/constants/http.ts
+++ b/src/backend/constants/http.ts
@@ -1,0 +1,13 @@
+/**
+ * HTTP status code constants.
+ */
+export const HTTP_STATUS = {
+  OK: 200,
+  CREATED: 201,
+  BAD_REQUEST: 400,
+  NOT_FOUND: 404,
+  INTERNAL_ERROR: 500,
+  SERVICE_UNAVAILABLE: 503,
+} as const;
+
+export type HttpStatus = (typeof HTTP_STATUS)[keyof typeof HTTP_STATUS];

--- a/src/backend/constants/index.ts
+++ b/src/backend/constants/index.ts
@@ -1,0 +1,2 @@
+export { HTTP_STATUS, type HttpStatus } from './http';
+export { WS_READY_STATE, type WsReadyState } from './websocket';

--- a/src/backend/constants/websocket.ts
+++ b/src/backend/constants/websocket.ts
@@ -1,0 +1,12 @@
+/**
+ * WebSocket ready state constants.
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/readyState
+ */
+export const WS_READY_STATE = {
+  CONNECTING: 0,
+  OPEN: 1,
+  CLOSING: 2,
+  CLOSED: 3,
+} as const;
+
+export type WsReadyState = (typeof WS_READY_STATE)[keyof typeof WS_READY_STATE];

--- a/src/backend/routers/api/health.router.ts
+++ b/src/backend/routers/api/health.router.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { HTTP_STATUS } from '../../constants';
 import { prisma } from '../../db';
 import { configService, createLogger, rateLimiter } from '../../services/index';
 
@@ -37,7 +38,7 @@ router.get('/database', async (_req, res) => {
     });
   } catch (error) {
     logger.error('Database health check failed', error as Error);
-    res.status(503).json({
+    res.status(HTTP_STATUS.SERVICE_UNAVAILABLE).json({
       status: 'error',
       timestamp: new Date().toISOString(),
       database: 'disconnected',
@@ -80,7 +81,7 @@ router.get('/all', async (_req, res) => {
     overallStatus = 'degraded';
   }
 
-  res.status(overallStatus === 'error' ? 503 : 200).json({
+  res.status(overallStatus === 'error' ? HTTP_STATUS.SERVICE_UNAVAILABLE : HTTP_STATUS.OK).json({
     status: overallStatus,
     timestamp: new Date().toISOString(),
     checks,

--- a/src/backend/routers/api/mcp.router.ts
+++ b/src/backend/routers/api/mcp.router.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { HTTP_STATUS } from '../../constants';
 import { createLogger } from '../../services/index';
 import { executeMcpTool } from '../mcp/index';
 
@@ -18,25 +19,25 @@ router.post('/execute', async (req, res) => {
     const { agentId, toolName, input } = req.body;
 
     if (!agentId) {
-      return res.status(400).json({
+      return res.status(HTTP_STATUS.BAD_REQUEST).json({
         success: false,
         error: { code: 'INVALID_INPUT', message: 'Missing required field: agentId' },
       });
     }
 
     if (!toolName) {
-      return res.status(400).json({
+      return res.status(HTTP_STATUS.BAD_REQUEST).json({
         success: false,
         error: { code: 'INVALID_INPUT', message: 'Missing required field: toolName' },
       });
     }
 
     const result = await executeMcpTool(agentId, toolName, input || {});
-    const statusCode = result.success ? 200 : 400;
+    const statusCode = result.success ? HTTP_STATUS.OK : HTTP_STATUS.BAD_REQUEST;
     return res.status(statusCode).json(result);
   } catch (error) {
     logger.error('Error executing MCP tool', error as Error);
-    return res.status(500).json({
+    return res.status(HTTP_STATUS.INTERNAL_ERROR).json({
       success: false,
       error: {
         code: 'INTERNAL_ERROR',

--- a/src/backend/routers/websocket/terminal.handler.ts
+++ b/src/backend/routers/websocket/terminal.handler.ts
@@ -8,6 +8,7 @@
 import type { IncomingMessage } from 'node:http';
 import type { Duplex } from 'node:stream';
 import type { WebSocket, WebSocketServer } from 'ws';
+import { WS_READY_STATE } from '../../constants';
 import { terminalSessionAccessor } from '../../resource_accessors/terminal-session.accessor';
 import { workspaceAccessor } from '../../resource_accessors/workspace.accessor';
 import { createLogger } from '../../services/index';
@@ -125,7 +126,7 @@ export function handleTerminalUpgrade(
         }
 
         const unsubOutput = terminalService.onOutput(terminal.id, (output) => {
-          if (ws.readyState === 1) {
+          if (ws.readyState === WS_READY_STATE.OPEN) {
             ws.send(JSON.stringify({ type: 'output', terminalId: terminal.id, data: output }));
           }
         });
@@ -133,7 +134,7 @@ export function handleTerminalUpgrade(
 
         const unsubExit = terminalService.onExit(terminal.id, (exitCode) => {
           logger.info('Terminal process exited', { terminalId: terminal.id, exitCode });
-          if (ws.readyState === 1) {
+          if (ws.readyState === WS_READY_STATE.OPEN) {
             ws.send(JSON.stringify({ type: 'exit', terminalId: terminal.id, exitCode }));
           }
           const exitCleanupMap = terminalListenerCleanup.get(ws);
@@ -202,7 +203,7 @@ export function handleTerminalUpgrade(
 
             logger.debug('Setting up output forwarding', { terminalId });
             const unsubOutput = terminalService.onOutput(terminalId, (output) => {
-              if (ws.readyState === 1) {
+              if (ws.readyState === WS_READY_STATE.OPEN) {
                 logger.debug('Forwarding output to client', {
                   terminalId,
                   outputLen: output.length,
@@ -219,7 +220,7 @@ export function handleTerminalUpgrade(
 
             const unsubExit = terminalService.onExit(terminalId, (exitCode) => {
               logger.info('Terminal process exited', { terminalId, exitCode });
-              if (ws.readyState === 1) {
+              if (ws.readyState === WS_READY_STATE.OPEN) {
                 ws.send(JSON.stringify({ type: 'exit', terminalId, exitCode }));
               }
               const exitCleanupMap = terminalListenerCleanup.get(ws);
@@ -321,7 +322,7 @@ export function handleTerminalUpgrade(
           isParsError,
         });
 
-        if (ws.readyState === 1) {
+        if (ws.readyState === WS_READY_STATE.OPEN) {
           ws.send(JSON.stringify({ type: 'error', message: errorMessage }));
         }
       }

--- a/src/backend/trpc/workspace.trpc.ts
+++ b/src/backend/trpc/workspace.trpc.ts
@@ -90,7 +90,11 @@ export const workspaceRouter = router({
                 workspace.worktreePath,
                 defaultBranch
               );
-            } catch {
+            } catch (error) {
+              logger.debug('Failed to get git stats for workspace', {
+                workspaceId: workspace.id,
+                error: error instanceof Error ? error.message : String(error),
+              });
               gitStatsResults[workspace.id] = null;
             }
           })
@@ -110,8 +114,11 @@ export const workspaceRouter = router({
             reviewCount = prs.filter((pr) => pr.reviewDecision !== 'APPROVED').length;
             cachedReviewCount = { count: reviewCount, fetchedAt: now };
           }
-        } catch {
-          // Silently fail - review count is non-critical
+        } catch (error) {
+          // Review count is non-critical, but log for debugging
+          logger.debug('Failed to fetch review count', {
+            error: error instanceof Error ? error.message : String(error),
+          });
         }
       }
 

--- a/src/backend/trpc/workspace/workspace-helpers.ts
+++ b/src/backend/trpc/workspace/workspace-helpers.ts
@@ -1,0 +1,122 @@
+/**
+ * Workspace validation helpers for tRPC procedures.
+ *
+ * Provides reusable functions to look up workspaces and validate their state.
+ */
+
+import { TRPCError } from '@trpc/server';
+import { workspaceAccessor } from '../../resource_accessors/workspace.accessor';
+
+/**
+ * Find a workspace by ID or throw a NOT_FOUND error.
+ *
+ * @throws TRPCError with NOT_FOUND code if workspace doesn't exist
+ */
+export async function getWorkspaceOrThrow(workspaceId: string) {
+  const workspace = await workspaceAccessor.findById(workspaceId);
+  if (!workspace) {
+    throw new TRPCError({
+      code: 'NOT_FOUND',
+      message: `Workspace not found: ${workspaceId}`,
+    });
+  }
+  return workspace;
+}
+
+/**
+ * Find a workspace with project by ID or throw a NOT_FOUND error.
+ *
+ * @throws TRPCError with NOT_FOUND code if workspace doesn't exist
+ */
+export async function getWorkspaceWithProjectOrThrow(workspaceId: string) {
+  const workspace = await workspaceAccessor.findByIdWithProject(workspaceId);
+  if (!workspace) {
+    throw new TRPCError({
+      code: 'NOT_FOUND',
+      message: `Workspace not found: ${workspaceId}`,
+    });
+  }
+  return workspace;
+}
+
+/**
+ * Result type for workspace with validated worktree.
+ */
+export interface WorkspaceWithWorktree {
+  workspace: NonNullable<Awaited<ReturnType<typeof workspaceAccessor.findById>>>;
+  worktreePath: string;
+}
+
+/**
+ * Find a workspace and validate it has a worktree path.
+ *
+ * @returns Object with workspace and worktreePath, or null if no worktree
+ * @throws TRPCError with NOT_FOUND code if workspace doesn't exist
+ */
+export async function getWorkspaceWithWorktree(
+  workspaceId: string
+): Promise<WorkspaceWithWorktree | null> {
+  const workspace = await getWorkspaceOrThrow(workspaceId);
+
+  if (!workspace.worktreePath) {
+    return null;
+  }
+
+  return { workspace, worktreePath: workspace.worktreePath };
+}
+
+/**
+ * Find a workspace and require it has a worktree path.
+ *
+ * @throws TRPCError with NOT_FOUND if workspace doesn't exist
+ * @throws TRPCError with BAD_REQUEST if workspace has no worktree
+ */
+export async function getWorkspaceWithWorktreeOrThrow(
+  workspaceId: string
+): Promise<WorkspaceWithWorktree> {
+  const workspace = await getWorkspaceOrThrow(workspaceId);
+
+  if (!workspace.worktreePath) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'Workspace has no worktree path',
+    });
+  }
+
+  return { workspace, worktreePath: workspace.worktreePath };
+}
+
+/**
+ * Result type for workspace with project and validated worktree.
+ */
+export interface WorkspaceWithProjectAndWorktree {
+  workspace: NonNullable<Awaited<ReturnType<typeof workspaceAccessor.findByIdWithProject>>>;
+  worktreePath: string;
+}
+
+/**
+ * Find a workspace with project and require it has a worktree path.
+ *
+ * @throws TRPCError with NOT_FOUND if workspace doesn't exist
+ * @throws TRPCError with BAD_REQUEST if workspace has no worktree
+ */
+export async function getWorkspaceWithProjectAndWorktreeOrThrow(
+  workspaceId: string
+): Promise<WorkspaceWithProjectAndWorktree> {
+  const workspace = await workspaceAccessor.findByIdWithProject(workspaceId);
+  if (!workspace) {
+    throw new TRPCError({
+      code: 'NOT_FOUND',
+      message: `Workspace not found: ${workspaceId}`,
+    });
+  }
+
+  if (!workspace.worktreePath) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'Workspace has no worktree path',
+    });
+  }
+
+  return { workspace, worktreePath: workspace.worktreePath };
+}


### PR DESCRIPTION
## Summary

- **Extract workspace validation helpers** - Created `workspace-helpers.ts` with reusable functions to reduce duplication across tRPC procedures (8+ occurrences)
- **Split handleChatMessage** - Extracted 6 focused handler functions, reducing the main function from 218 to 40 lines and removing the biome-ignore comment
- **Unify session lifecycle** - `startClaudeSession()` now uses `createClient()` internally, eliminating dual-path stop logic with fallback to process registry
- **Add typed constants** - Created `HTTP_STATUS` and `WS_READY_STATE` constants to replace magic numbers across router files
- **Improve debugging** - Added debug logging to key silent catch blocks (git stats, review count)

## Test plan

- [x] All 867 tests pass
- [x] TypeScript compiles without errors
- [x] Biome linting passes
- [x] No dependency violations (depcruise)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to refactoring of chat WebSocket message handling and Claude session lifecycle creation/stop paths, which could affect live session startup/teardown behavior. Most other changes are mechanical (status constants, helper extraction, extra debug logging).
> 
> **Overview**
> **Refactors backend maintainability and consistency.** Introduces typed `HTTP_STATUS` and `WS_READY_STATE` constants and replaces magic numbers across API routers and WebSocket handlers.
> 
> **Simplifies session and chat handling.** `SessionService.startClaudeSession()` now delegates to `createClient()` (removing the legacy direct process-spawn path and stop fallback), and `chat.handler.ts` splits the monolithic `handleChatMessage` into focused handlers with shared model validation and message queueing.
> 
> **Reduces duplicated workspace validation in tRPC.** Adds `workspace/workspace-helpers.ts` and updates workspace file/git procedures to use these helpers (including returning “no worktree” cases consistently), plus adds debug logging to previously silent catch blocks in workspace summary aggregation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f189d441cfbef1a63eb31269eab061508127d1f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->