### PR TITLE
Fix model dropdown selection being ignored

### DIFF
--- a/src/client/routes/projects/workspaces/detail.tsx
+++ b/src/client/routes/projects/workspaces/detail.tsx
@@ -329,6 +329,7 @@ function WorkspaceChatContent() {
     inputRef,
     selectedDbSessionId,
     setSelectedDbSessionId,
+    selectedModel: chatSettings.selectedModel,
   });
 
   // Ref for scroll handling (virtualized list manages its own content)

--- a/src/client/routes/projects/workspaces/use-workspace-detail.ts
+++ b/src/client/routes/projects/workspaces/use-workspace-detail.ts
@@ -72,8 +72,8 @@ interface UseSessionManagementOptions {
   inputRef: React.RefObject<HTMLTextAreaElement | null>;
   selectedDbSessionId: string | null;
   setSelectedDbSessionId: React.Dispatch<React.SetStateAction<string | null>>;
-  /** Selected model from chat settings (null means use default 'opus') */
-  selectedModel: string | null;
+  /** Selected model from chat settings */
+  selectedModel: string;
 }
 
 /** Minimal mutation interface exposing only the properties we use */
@@ -115,8 +115,6 @@ export function useSessionManagement({
   setSelectedDbSessionId,
   selectedModel,
 }: UseSessionManagementOptions): UseSessionManagementReturn {
-  // Default to 'opus' when no model is selected
-  const model = selectedModel ?? 'opus';
   const navigate = useNavigate();
   const utils = trpc.useUtils();
 
@@ -216,7 +214,7 @@ export function useSessionManagement({
     (workflowId: string) => {
       const chatName = getNextChatName();
       createSession.mutate(
-        { workspaceId, workflow: workflowId, model, name: chatName },
+        { workspaceId, workflow: workflowId, model: selectedModel, name: chatName },
         {
           onSuccess: (session) => {
             // Setting the new session ID triggers WebSocket reconnection automatically
@@ -225,14 +223,14 @@ export function useSessionManagement({
         }
       );
     },
-    [createSession, workspaceId, getNextChatName, setSelectedDbSessionId, model]
+    [createSession, workspaceId, getNextChatName, setSelectedDbSessionId, selectedModel]
   );
 
   const handleNewChat = useCallback(() => {
     const name = getNextChatName();
 
     createSession.mutate(
-      { workspaceId, workflow: 'followup', model, name },
+      { workspaceId, workflow: 'followup', model: selectedModel, name },
       {
         onSuccess: (session) => {
           // Setting the new session ID triggers WebSocket reconnection automatically
@@ -240,12 +238,12 @@ export function useSessionManagement({
         },
       }
     );
-  }, [createSession, workspaceId, getNextChatName, setSelectedDbSessionId, model]);
+  }, [createSession, workspaceId, getNextChatName, setSelectedDbSessionId, selectedModel]);
 
   const handleQuickAction = useCallback(
     (name: string, prompt: string) => {
       createSession.mutate(
-        { workspaceId, workflow: 'followup', name, model },
+        { workspaceId, workflow: 'followup', name, model: selectedModel },
         {
           onSuccess: (session) => {
             // Store the pending prompt to be sent once the session state settles
@@ -256,7 +254,7 @@ export function useSessionManagement({
         }
       );
     },
-    [createSession, workspaceId, setSelectedDbSessionId, model]
+    [createSession, workspaceId, setSelectedDbSessionId, selectedModel]
   );
 
   return {

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -64,11 +64,10 @@ function ModelSelector({
   onChange,
   disabled,
 }: {
-  selectedModel: string | null;
-  onChange: (model: string | null) => void;
+  selectedModel: string;
+  onChange: (model: string) => void;
   disabled?: boolean;
 }) {
-  // Find the display name for the current model (null = default/first model)
   const currentModel = AVAILABLE_MODELS.find((m) => m.value === selectedModel);
   const displayName = currentModel?.displayName ?? AVAILABLE_MODELS[0].displayName;
 
@@ -86,13 +85,7 @@ function ModelSelector({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="w-40">
-        <DropdownMenuRadioGroup
-          value={selectedModel ?? AVAILABLE_MODELS[0].value}
-          onValueChange={(value) => {
-            // If selecting the default (first) model, set to null
-            onChange(value === AVAILABLE_MODELS[0].value ? null : value);
-          }}
-        >
+        <DropdownMenuRadioGroup value={selectedModel} onValueChange={onChange}>
           {AVAILABLE_MODELS.map((model) => (
             <DropdownMenuRadioItem key={model.value} value={model.value}>
               {model.displayName}
@@ -350,7 +343,7 @@ export const ChatInput = memo(function ChatInput({
 
   // Settings change handlers
   const handleModelChange = useCallback(
-    (model: string | null) => {
+    (model: string) => {
       onSettingsChange?.({ selectedModel: model });
     },
     [onSettingsChange]
@@ -402,7 +395,7 @@ export const ChatInput = memo(function ChatInput({
           {/* Left side: Model selector and toggles */}
           <div className="flex items-center gap-1">
             <ModelSelector
-              selectedModel={settings?.selectedModel ?? null}
+              selectedModel={settings?.selectedModel ?? 'opus'}
               onChange={handleModelChange}
               disabled={running}
             />

--- a/src/components/chat/chat-persistence.test.ts
+++ b/src/components/chat/chat-persistence.test.ts
@@ -191,9 +191,9 @@ describe('settings persistence', () => {
       expect(result).toBeNull();
     });
 
-    it('should accept settings with null selectedModel', () => {
+    it('should accept settings with default selectedModel', () => {
       const settings: ChatSettings = {
-        selectedModel: null,
+        selectedModel: 'opus',
         thinkingEnabled: false,
         planModeEnabled: true,
       };

--- a/src/lib/claude-types.ts
+++ b/src/lib/claude-types.ts
@@ -34,7 +34,7 @@ export const AVAILABLE_MODELS: ModelInfo[] = [
  * Chat session settings that persist per-session.
  */
 export interface ChatSettings {
-  selectedModel: string | null; // null = use default (Opus)
+  selectedModel: string;
   thinkingEnabled: boolean;
   planModeEnabled: boolean;
 }
@@ -43,7 +43,7 @@ export interface ChatSettings {
  * Default chat settings for new sessions.
  */
 export const DEFAULT_CHAT_SETTINGS: ChatSettings = {
-  selectedModel: null,
+  selectedModel: 'opus',
   thinkingEnabled: false,
   planModeEnabled: false,
 };


### PR DESCRIPTION
## Summary
- Session creation was hardcoding `model: 'sonnet'` instead of using the selected model from the dropdown
- Now passes `chatSettings.selectedModel` through to `useSessionManagement`
- Defaults to 'opus' when no model is selected (matching documented default)

## Test plan
- [ ] Select Opus in the model dropdown, create a new session, verify it uses Opus
- [ ] Select Sonnet in the model dropdown, create a new session, verify it uses Sonnet
- [ ] With default selection (null), verify new sessions use Opus

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session-creation inputs and the persisted `ChatSettings.selectedModel` shape (removing `null`), which could impact compatibility with existing stored settings or any code paths still expecting `null`. Otherwise behavior is localized to chat settings/session creation.
> 
> **Overview**
> **Session creation now respects the UI-selected model.** `useSessionManagement` takes `selectedModel` from `chatSettings` and uses it for workflow selection, new chats, and quick actions instead of hardcoding `model: 'sonnet'`.
> 
> **Model selection is now always explicit.** `ChatSettings.selectedModel` is changed from `string | null` to `string`, defaults are set to `'opus'`, and the model dropdown no longer uses `null` as a sentinel; related persistence tests were updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 334fd6626f834cddf4be4e6c6a3bfe3b68f308e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->