### PR TITLE
Auto-focus chat input when entering workspace with active chat tab

### DIFF
--- a/src/client/routes/projects/workspaces/detail.tsx
+++ b/src/client/routes/projects/workspaces/detail.tsx
@@ -312,6 +312,7 @@ function WorkspaceChatContent() {
 
   // Auto-focus chat input when entering workspace with active chat tab
   const hasFocusedOnEntryRef = useRef(false);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: inputRef is a stable ref object
   useEffect(() => {
     if (
       !hasFocusedOnEntryRef.current &&
@@ -323,7 +324,7 @@ function WorkspaceChatContent() {
       // Use setTimeout to ensure the input is mounted and ready
       setTimeout(() => inputRef.current?.focus(), 0);
     }
-  }, [selectedDbSessionId, activeTabId, loadingSession, inputRef]);
+  }, [selectedDbSessionId, activeTabId, loadingSession]);
 
   // Show loading while fetching workspace (but not sessions - they can load in background)
   if (workspaceLoading) {

--- a/src/client/routes/projects/workspaces/detail.tsx
+++ b/src/client/routes/projects/workspaces/detail.tsx
@@ -315,7 +315,8 @@ function WorkspaceChatContent() {
   // biome-ignore lint/correctness/useExhaustiveDependencies: inputRef is a stable ref object
   useEffect(() => {
     if (
-      !hasFocusedOnEntryRef.current &&
+      !(hasFocusedOnEntryRef.current || workspaceLoading) &&
+      workspace &&
       selectedDbSessionId &&
       activeTabId === 'chat' &&
       !loadingSession
@@ -324,7 +325,7 @@ function WorkspaceChatContent() {
       // Use setTimeout to ensure the input is mounted and ready
       setTimeout(() => inputRef.current?.focus(), 0);
     }
-  }, [selectedDbSessionId, activeTabId, loadingSession]);
+  }, [selectedDbSessionId, activeTabId, loadingSession, workspaceLoading, workspace]);
 
   // Show loading while fetching workspace (but not sessions - they can load in background)
   if (workspaceLoading) {

--- a/src/client/routes/projects/workspaces/detail.tsx
+++ b/src/client/routes/projects/workspaces/detail.tsx
@@ -227,7 +227,7 @@ function WorkspaceChatContent() {
     maxSessions,
   } = useWorkspaceData({ workspaceId: workspaceId });
 
-  const { rightPanelVisible } = useWorkspacePanel();
+  const { rightPanelVisible, activeTabId } = useWorkspacePanel();
 
   // Query init status to show initialization overlay
   const { data: initStatus } = trpc.workspace.getInitStatus.useQuery(
@@ -309,6 +309,21 @@ function WorkspaceChatContent() {
 
   // Auto-scroll behavior with RAF throttling
   const { onScroll, isNearBottom, scrollToBottom } = useAutoScroll(viewportRef);
+
+  // Auto-focus chat input when entering workspace with active chat tab
+  const hasFocusedOnEntryRef = useRef(false);
+  useEffect(() => {
+    if (
+      !hasFocusedOnEntryRef.current &&
+      selectedDbSessionId &&
+      activeTabId === 'chat' &&
+      !loadingSession
+    ) {
+      hasFocusedOnEntryRef.current = true;
+      // Use setTimeout to ensure the input is mounted and ready
+      setTimeout(() => inputRef.current?.focus(), 0);
+    }
+  }, [selectedDbSessionId, activeTabId, loadingSession, inputRef]);
 
   // Show loading while fetching workspace (but not sessions - they can load in background)
   if (workspaceLoading) {


### PR DESCRIPTION
## Summary
- Auto-focuses the chat input when entering a workspace that has an active chat session and the chat tab is selected
- Allows users to start typing immediately without needing to click the input field

## Test plan
- [ ] Navigate to a workspace with an existing chat session
- [ ] Verify the chat input is automatically focused when the chat tab is active
- [ ] Verify focus is not stolen when entering with a file/diff tab active

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX change limited to input focus behavior in `WorkspaceDetail`; main concern is unintended focus-stealing, mitigated by tab/session/loading guards and one-time execution.
> 
> **Overview**
> When entering a workspace with an existing selected chat session, the chat input is now automatically focused *only* if the active workspace tab is `chat`.
> 
> This wires `activeTabId` from `useWorkspacePanel()` into `WorkspaceDetail` and adds a one-time `useEffect` that waits for workspace/session readiness (and not `loadingSession`) before calling `inputRef.current?.focus()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9872164b0f1a9a63c878a3a65bdf0ce1e054842. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->