### PR TITLE
Fix chat appearing empty after navigating back from file viewer

### DIFF
--- a/src/components/workspace/main-view-content.tsx
+++ b/src/components/workspace/main-view-content.tsx
@@ -21,20 +21,18 @@ export function MainViewContent({ workspaceId, children, className }: MainViewCo
 
   const activeTab = tabs.find((tab) => tab.id === activeTabId);
 
-  if (!activeTab) {
-    // Fallback to chat if no active tab found
-    return <div className={cn('h-full', className)}>{children}</div>;
-  }
+  // Determine what's visible
+  const showChat = !activeTab || activeTab.type === 'chat';
+  const filePath = activeTab?.type === 'file' ? activeTab.path : undefined;
+  const diffPath = activeTab?.type === 'diff' ? activeTab.path : undefined;
 
   return (
     <div className={cn('h-full', className)}>
-      {activeTab.type === 'chat' && children}
-      {activeTab.type === 'file' && activeTab.path && (
-        <FileViewer workspaceId={workspaceId} filePath={activeTab.path} />
-      )}
-      {activeTab.type === 'diff' && activeTab.path && (
-        <DiffViewer workspaceId={workspaceId} filePath={activeTab.path} />
-      )}
+      {/* Always render chat children but hide when not active.
+          This prevents unmounting/remounting which causes state loss. */}
+      <div className={cn('h-full', !showChat && 'hidden')}>{children}</div>
+      {filePath && <FileViewer workspaceId={workspaceId} filePath={filePath} />}
+      {diffPath && <DiffViewer workspaceId={workspaceId} filePath={diffPath} />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Fix bug where chat content appears empty when navigating from file browser back to chat tab
- Keep chat component mounted (but hidden) when viewing files instead of unmounting it
- This preserves chat state including messages, scroll position, and WebSocket connection

## Test plan
- [ ] Open a workspace with an active chat session with some messages
- [ ] Click on a file in the file browser to open it in a tab
- [ ] Click back on the Chat tab
- [ ] Verify the chat messages are still visible (previously they would be empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change limited to `MainViewContent`; main concern is potential layout/CSS issues from keeping the chat mounted while hidden.
> 
> **Overview**
> Fixes chat state loss when switching between chat and file/diff tabs by **keeping the chat children always mounted** and toggling visibility via `hidden` instead of conditionally rendering.
> 
> Simplifies tab rendering by deriving `showChat`, `filePath`, and `diffPath` from the active tab (and treating missing `activeTab` as chat).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b575f96c04019a59386b7ed45b92ae5d5fd5393. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->