### PR TITLE
Fix workspace list stability during create/archive operations

### DIFF
--- a/src/frontend/components/use-workspace-list-state.ts
+++ b/src/frontend/components/use-workspace-list-state.ts
@@ -1,0 +1,171 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type WorkspaceUIState = 'normal' | 'creating' | 'archiving';
+
+export interface WorkspaceListItem {
+  id: string;
+  name: string;
+  branchName?: string | null;
+  prUrl?: string | null;
+  prNumber?: number | null;
+  prState?: string | null;
+  prCiStatus?: string | null;
+  isWorking: boolean;
+  gitStats: {
+    total: number;
+    additions: number;
+    deletions: number;
+    hasUncommitted: boolean;
+  } | null;
+  uiState: WorkspaceUIState;
+}
+
+export interface ServerWorkspace {
+  id: string;
+  name: string;
+  branchName?: string | null;
+  prUrl?: string | null;
+  prNumber?: number | null;
+  prState?: string | null;
+  prCiStatus?: string | null;
+  isWorking: boolean;
+  gitStats: {
+    total: number;
+    additions: number;
+    deletions: number;
+    hasUncommitted: boolean;
+  } | null;
+}
+
+// =============================================================================
+// Hook
+// =============================================================================
+
+/**
+ * Custom hook that manages workspace list state with optimistic updates.
+ * Ensures stable list positions during create/archive operations.
+ *
+ * Key behaviors:
+ * - Creating placeholder appears at the top of the list
+ * - Archiving workspaces stay in their original position (no jumping)
+ * - Automatically clears optimistic states when server data reflects changes
+ */
+export function useWorkspaceListState(serverWorkspaces: ServerWorkspace[] | undefined) {
+  // Track workspace being created (before it has an ID)
+  const [creatingWorkspace, setCreatingWorkspace] = useState<{ name: string } | null>(null);
+
+  // Track workspace being archived (ID + cached data for display)
+  const [archivingWorkspace, setArchivingWorkspace] = useState<{
+    id: string;
+    name: string;
+    branchName?: string | null;
+  } | null>(null);
+
+  // Build the unified workspace list with UI states
+  const workspaceList = useMemo((): WorkspaceListItem[] => {
+    const items: WorkspaceListItem[] = [];
+
+    // Add "creating" placeholder at the top if we're creating a new workspace
+    if (creatingWorkspace) {
+      items.push({
+        id: `creating-${creatingWorkspace.name}`,
+        name: creatingWorkspace.name,
+        branchName: null,
+        prUrl: null,
+        prNumber: null,
+        prState: null,
+        prCiStatus: null,
+        isWorking: false,
+        gitStats: null,
+        uiState: 'creating',
+      });
+    }
+
+    // Add server workspaces with appropriate UI states
+    if (serverWorkspaces) {
+      for (const workspace of serverWorkspaces) {
+        // Check if this workspace is being archived
+        const isArchiving = archivingWorkspace?.id === workspace.id;
+
+        items.push({
+          ...workspace,
+          uiState: isArchiving ? 'archiving' : 'normal',
+        });
+      }
+    }
+
+    // If archiving workspace is no longer in server list but still in archiving state,
+    // we DON'T add it back - it's been successfully archived and removed.
+    // The archivingWorkspace state will be cleared after a brief delay for visual feedback.
+
+    return items;
+  }, [serverWorkspaces, creatingWorkspace, archivingWorkspace]);
+
+  // Check if creating workspace has appeared in the server list
+  const creatingWorkspaceInList = creatingWorkspace
+    ? serverWorkspaces?.some((w) => w.name === creatingWorkspace.name)
+    : false;
+
+  // Clear creating state when workspace appears in list
+  useEffect(() => {
+    if (creatingWorkspace && creatingWorkspaceInList) {
+      setCreatingWorkspace(null);
+    }
+  }, [creatingWorkspace, creatingWorkspaceInList]);
+
+  // Check if archiving workspace has been removed from server list
+  const archivingWorkspaceInList = archivingWorkspace
+    ? serverWorkspaces?.some((w) => w.id === archivingWorkspace.id)
+    : false;
+
+  // Clear archiving state after workspace is removed and a brief delay
+  useEffect(() => {
+    if (!archivingWorkspace || archivingWorkspaceInList) {
+      return;
+    }
+    // Small delay for visual feedback before clearing
+    const timer = setTimeout(() => {
+      setArchivingWorkspace(null);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [archivingWorkspace, archivingWorkspaceInList]);
+
+  // Get existing workspace names (including creating workspace to prevent duplicates)
+  const existingNames = useMemo(() => {
+    const names = serverWorkspaces?.map((w) => w.name) ?? [];
+    if (creatingWorkspace?.name) {
+      names.push(creatingWorkspace.name);
+    }
+    return names;
+  }, [serverWorkspaces, creatingWorkspace?.name]);
+
+  const startCreating = useCallback((name: string) => {
+    setCreatingWorkspace({ name });
+  }, []);
+
+  const startArchiving = useCallback(
+    (id: string) => {
+      const workspace = serverWorkspaces?.find((w) => w.id === id);
+      if (workspace) {
+        setArchivingWorkspace({
+          id: workspace.id,
+          name: workspace.name,
+          branchName: workspace.branchName,
+        });
+      }
+    },
+    [serverWorkspaces]
+  );
+
+  return {
+    workspaceList,
+    existingNames,
+    isCreating: !!creatingWorkspace,
+    startCreating,
+    startArchiving,
+  };
+}


### PR DESCRIPTION
## Summary
- Fix bug where creating workspace placeholder appeared alongside the actual workspace (duplicate entries)
- Fix bug where archived workspace jumped to top of list before disappearing
- Extract workspace list state management into dedicated `useWorkspaceListState` hook for better maintainability

## Changes
- **New file**: `src/frontend/components/use-workspace-list-state.ts` - centralized hook for workspace list state management
- **Modified**: `src/frontend/components/app-sidebar.tsx` - simplified by using the new hook

## How it works
The new hook maintains stable list positions by:
1. Tracking creating/archiving states separately from server data
2. Merging optimistic states into a unified workspace list with `uiState` flags
3. Automatically clearing optimistic states when server data reflects changes
4. Archiving workspaces stay in their original position (no jumping to top)

## Test plan
- [ ] Create a new workspace - should show "Creating workspace..." placeholder at top, then smoothly transition to actual workspace
- [ ] Archive a workspace - should show "Archiving..." state in place, then disappear without jumping
- [ ] Rapid create/archive operations should not cause duplicate entries or visual glitches

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only state management refactor in the sidebar; risk is limited to potential regressions in optimistic list rendering/disable states during create/archive.
> 
> **Overview**
> **Improves workspace list stability during create/archive.** Sidebar workspace rendering now uses a new `useWorkspaceListState` hook that merges server workspaces with optimistic UI states (`creating`/`archiving`) to avoid duplicate “creating” entries and prevent archived items from jumping position.
> 
> `AppSidebar` is simplified by removing ad-hoc pending/archiving bookkeeping and instead driving button disabling, placeholders, and archiving visuals from the hook; create failures now explicitly clear the creating state to avoid a stuck spinner.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d2fbc0d385387dc6c0c78bb003e6db79c4c6b73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->