### PR TITLE
Add Tailwind Typography plugin for proper markdown styling

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -23,11 +23,13 @@
     "src/backend/trpc/procedures/index.ts"
   ],
   "ignoreDependencies": [
+    "@electron/rebuild",
     "autoprefixer",
     "tw-animate-css",
     "@tailwindcss/typography",
     "@prisma/client",
     "@radix-ui/react-accordion",
+    "@radix-ui/react-alert-dialog",
     "@radix-ui/react-aspect-ratio",
     "@radix-ui/react-avatar",
     "@radix-ui/react-context-menu",

--- a/knip.json
+++ b/knip.json
@@ -23,12 +23,11 @@
     "src/backend/trpc/procedures/index.ts"
   ],
   "ignoreDependencies": [
-    "@electron/rebuild",
     "autoprefixer",
     "tw-animate-css",
+    "@tailwindcss/typography",
     "@prisma/client",
     "@radix-ui/react-accordion",
-    "@radix-ui/react-alert-dialog",
     "@radix-ui/react-aspect-ratio",
     "@radix-ui/react-avatar",
     "@radix-ui/react-context-menu",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tailwindcss/postcss": "^4.1.18",
+    "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-query": "^5.90.20",
     "@tanstack/react-virtual": "^3.13.18",
     "@trpc/client": "^11.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.1.18
         version: 4.1.18
+      '@tailwindcss/typography':
+        specifier: ^0.5.19
+        version: 0.5.19(tailwindcss@4.1.18)
       '@tanstack/react-query':
         specifier: ^5.90.20
         version: 5.90.20(react@19.2.4)
@@ -2227,6 +2230,11 @@ packages:
   '@tailwindcss/postcss@4.1.18':
     resolution: {integrity: sha512-Ce0GFnzAOuPyfV5SxjXGn0CubwGcuDB0zcdaPuCSzAa/2vII24JTkH+I6jcbXLb1ctjZMZZI6OjDaLPJQL1S0g==}
 
+  '@tailwindcss/typography@0.5.19':
+    resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
+
   '@tailwindcss/vite@4.1.18':
     resolution: {integrity: sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA==}
     peerDependencies:
@@ -3396,6 +3404,11 @@ packages:
 
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   cssom@0.3.8:
     resolution: {integrity: sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==}
@@ -5763,6 +5776,10 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
@@ -9129,6 +9146,11 @@ snapshots:
       postcss: 8.5.6
       tailwindcss: 4.1.18
 
+  '@tailwindcss/typography@0.5.19(tailwindcss@4.1.18)':
+    dependencies:
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 4.1.18
+
   '@tailwindcss/vite@4.1.18(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@tailwindcss/node': 4.1.18
@@ -10646,6 +10668,8 @@ snapshots:
     optional: true
 
   css.escape@1.5.1: {}
+
+  cssesc@3.0.0: {}
 
   cssom@0.3.8:
     optional: true
@@ -13626,6 +13650,11 @@ snapshots:
 
   possible-typed-array-names@1.1.0:
     optional: true
+
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
 
   postcss-value-parser@4.2.0: {}
 

--- a/src/client/globals.css
+++ b/src/client/globals.css
@@ -1,4 +1,5 @@
 @plugin 'tailwindcss-animate';
+@plugin '@tailwindcss/typography';
 @import 'tailwindcss';
 @import 'tw-animate-css';
 


### PR DESCRIPTION
## Summary
- Installed `@tailwindcss/typography` plugin for Tailwind v4
- Configured the plugin via `@plugin` directive in globals.css
- Updated knip.json to ignore the typography package (loaded via CSS directive)

This fixes markdown rendering in chat messages so that headings, lists, code blocks, and other markdown elements display with proper styling in both light and dark modes.

## Test plan
- [x] Verify numbered lists render with proper numbering (1. 2. 3.)
- [x] Verify bullet lists render with bullets
- [x] Verify headings (h1-h6) have proper sizing
- [x] Verify code blocks have background styling
- [x] Verify dark mode works correctly with `prose-invert`
- [x] All 877 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a Tailwind CSS plugin and related build/config entries, with impact limited to styling and dependency graph changes.
> 
> **Overview**
> Enables Tailwind’s typography utilities by adding `@tailwindcss/typography` as a dependency and loading it via `@plugin` in `src/client/globals.css`.
> 
> Updates tooling config (`knip.json`) to ignore the new package since it’s referenced through CSS, and refreshes `pnpm-lock.yaml` for the added dependency and its transitive packages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec60dd8f8379c61b2ccc616364ae289f62209bd8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->