### PR TITLE
Fix pending AskUserQuestion/ExitPlanMode not restored on session resume

### DIFF
--- a/src/backend/routers/websocket/chat.handler.ts
+++ b/src/backend/routers/websocket/chat.handler.ts
@@ -686,6 +686,8 @@ function handleQuestionResponseMessage(
 
   const client = sessionService.getClient(sessionId);
   if (!client) {
+    // Clear stale pending request since client is gone
+    pendingInteractiveRequests.delete(sessionId);
     ws.send(JSON.stringify({ type: 'error', message: 'No active client for session' }));
     return;
   }
@@ -698,6 +700,8 @@ function handleQuestionResponseMessage(
       logger.info('[Chat WS] Answered question', { sessionId, requestId });
     }
   } catch (error) {
+    // Clear stale pending request on failure to prevent infinite retry loop
+    pendingInteractiveRequests.delete(sessionId);
     const errorMessage = error instanceof Error ? error.message : String(error);
     logger.error('[Chat WS] Failed to answer question', {
       sessionId,
@@ -727,6 +731,8 @@ function handlePermissionResponseMessage(
 
   const client = sessionService.getClient(sessionId);
   if (!client) {
+    // Clear stale pending request since client is gone
+    pendingInteractiveRequests.delete(sessionId);
     ws.send(JSON.stringify({ type: 'error', message: 'No active client for session' }));
     return;
   }
@@ -743,6 +749,8 @@ function handlePermissionResponseMessage(
       logger.info('[Chat WS] Responded to permission request', { sessionId, requestId, allow });
     }
   } catch (error) {
+    // Clear stale pending request on failure to prevent infinite retry loop
+    pendingInteractiveRequests.delete(sessionId);
     const errorMessage = error instanceof Error ? error.message : String(error);
     logger.error('[Chat WS] Failed to respond to permission request', {
       sessionId,

--- a/src/components/chat/chat-reducer.test.ts
+++ b/src/components/chat/chat-reducer.test.ts
@@ -1336,6 +1336,7 @@ describe('createActionFromWebSocketMessage', () => {
         gitBranch: 'main',
         running: false,
         settings,
+        pendingInteractiveRequest: null,
       },
     });
   });
@@ -1351,6 +1352,7 @@ describe('createActionFromWebSocketMessage', () => {
         gitBranch: null,
         running: false,
         settings: undefined,
+        pendingInteractiveRequest: null,
       },
     });
   });

--- a/src/components/chat/chat-reducer.test.ts
+++ b/src/components/chat/chat-reducer.test.ts
@@ -798,6 +798,30 @@ describe('chatReducer', () => {
 
       expect(newState.pendingPermission).toEqual(permissionRequest);
     });
+
+    it('should not overwrite existing pending permission request (guard against loss)', () => {
+      const existingRequest: PermissionRequest = {
+        requestId: 'req-first',
+        toolName: 'Bash',
+        toolInput: { command: 'rm -rf /' },
+        timestamp: '2024-01-01T00:00:00.000Z',
+      };
+      const newRequest: PermissionRequest = {
+        requestId: 'req-second',
+        toolName: 'Write',
+        toolInput: { file_path: '/tmp/test.txt' },
+        timestamp: '2024-01-01T00:00:01.000Z',
+      };
+      const state: ChatState = {
+        ...initialState,
+        pendingPermission: existingRequest,
+      };
+      const action: ChatAction = { type: 'WS_PERMISSION_REQUEST', payload: newRequest };
+      const newState = chatReducer(state, action);
+
+      // Should keep the first request, not overwrite with second
+      expect(newState.pendingPermission).toEqual(existingRequest);
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -823,6 +847,30 @@ describe('chatReducer', () => {
       const newState = chatReducer(initialState, action);
 
       expect(newState.pendingQuestion).toEqual(questionRequest);
+    });
+
+    it('should not overwrite existing pending question (guard against loss)', () => {
+      const existingQuestion: UserQuestionRequest = {
+        requestId: 'req-first',
+        questions: [{ question: 'First question?', header: 'Q1', options: [], multiSelect: false }],
+        timestamp: '2024-01-01T00:00:00.000Z',
+      };
+      const newQuestion: UserQuestionRequest = {
+        requestId: 'req-second',
+        questions: [
+          { question: 'Second question?', header: 'Q2', options: [], multiSelect: false },
+        ],
+        timestamp: '2024-01-01T00:00:01.000Z',
+      };
+      const state: ChatState = {
+        ...initialState,
+        pendingQuestion: existingQuestion,
+      };
+      const action: ChatAction = { type: 'WS_USER_QUESTION', payload: newQuestion };
+      const newState = chatReducer(state, action);
+
+      // Should keep the first question, not overwrite with second
+      expect(newState.pendingQuestion).toEqual(existingQuestion);
     });
   });
 

--- a/src/components/chat/chat-reducer.test.ts
+++ b/src/components/chat/chat-reducer.test.ts
@@ -799,7 +799,9 @@ describe('chatReducer', () => {
       expect(newState.pendingPermission).toEqual(permissionRequest);
     });
 
-    it('should not overwrite existing pending permission request (guard against loss)', () => {
+    it('should overwrite existing pending permission request with newer one (matches backend behavior)', () => {
+      // Backend always overwrites stored request with the new one, so frontend must match
+      // to prevent responding to an old request while backend has the new one stored
       const existingRequest: PermissionRequest = {
         requestId: 'req-first',
         toolName: 'Bash',
@@ -819,8 +821,8 @@ describe('chatReducer', () => {
       const action: ChatAction = { type: 'WS_PERMISSION_REQUEST', payload: newRequest };
       const newState = chatReducer(state, action);
 
-      // Should keep the first request, not overwrite with second
-      expect(newState.pendingPermission).toEqual(existingRequest);
+      // Should overwrite with the new request to match backend state
+      expect(newState.pendingPermission).toEqual(newRequest);
     });
   });
 
@@ -849,7 +851,8 @@ describe('chatReducer', () => {
       expect(newState.pendingQuestion).toEqual(questionRequest);
     });
 
-    it('should not overwrite existing pending question (guard against loss)', () => {
+    it('should overwrite existing pending question with newer one (matches backend behavior)', () => {
+      // Backend always overwrites stored request with the new one, so frontend must match
       const existingQuestion: UserQuestionRequest = {
         requestId: 'req-first',
         questions: [{ question: 'First question?', header: 'Q1', options: [], multiSelect: false }],
@@ -869,8 +872,8 @@ describe('chatReducer', () => {
       const action: ChatAction = { type: 'WS_USER_QUESTION', payload: newQuestion };
       const newState = chatReducer(state, action);
 
-      // Should keep the first question, not overwrite with second
-      expect(newState.pendingQuestion).toEqual(existingQuestion);
+      // Should overwrite with the new question to match backend state
+      expect(newState.pendingQuestion).toEqual(newQuestion);
     });
   });
 

--- a/src/components/chat/chat-reducer.test.ts
+++ b/src/components/chat/chat-reducer.test.ts
@@ -824,6 +824,29 @@ describe('chatReducer', () => {
       // Should overwrite with the new request to match backend state
       expect(newState.pendingPermission).toEqual(newRequest);
     });
+
+    it('should clear pendingQuestion when permission request arrives', () => {
+      const existingQuestion: UserQuestionRequest = {
+        requestId: 'req-q1',
+        questions: [{ question: 'Which?', header: 'Q', options: [], multiSelect: false }],
+        timestamp: '2024-01-01T00:00:00.000Z',
+      };
+      const permissionRequest: PermissionRequest = {
+        requestId: 'req-p1',
+        toolName: 'Bash',
+        toolInput: { command: 'ls' },
+        timestamp: '2024-01-01T00:00:01.000Z',
+      };
+      const state: ChatState = {
+        ...initialState,
+        pendingQuestion: existingQuestion,
+      };
+      const action: ChatAction = { type: 'WS_PERMISSION_REQUEST', payload: permissionRequest };
+      const newState = chatReducer(state, action);
+
+      expect(newState.pendingPermission).toEqual(permissionRequest);
+      expect(newState.pendingQuestion).toBeNull();
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -874,6 +897,29 @@ describe('chatReducer', () => {
 
       // Should overwrite with the new question to match backend state
       expect(newState.pendingQuestion).toEqual(newQuestion);
+    });
+
+    it('should clear pendingPermission when question request arrives', () => {
+      const existingPermission: PermissionRequest = {
+        requestId: 'req-p1',
+        toolName: 'Bash',
+        toolInput: { command: 'ls' },
+        timestamp: '2024-01-01T00:00:00.000Z',
+      };
+      const questionRequest: UserQuestionRequest = {
+        requestId: 'req-q1',
+        questions: [{ question: 'Which?', header: 'Q', options: [], multiSelect: false }],
+        timestamp: '2024-01-01T00:00:01.000Z',
+      };
+      const state: ChatState = {
+        ...initialState,
+        pendingPermission: existingPermission,
+      };
+      const action: ChatAction = { type: 'WS_USER_QUESTION', payload: questionRequest };
+      const newState = chatReducer(state, action);
+
+      expect(newState.pendingQuestion).toEqual(questionRequest);
+      expect(newState.pendingPermission).toBeNull();
     });
   });
 

--- a/src/components/chat/chat-reducer.ts
+++ b/src/components/chat/chat-reducer.ts
@@ -401,6 +401,7 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
             questions: (input.questions ?? []) as UserQuestionRequest['questions'],
             timestamp: pendingReq.timestamp,
           };
+          pendingPermission = null; // Clear opposite type to prevent both modals showing
         } else {
           // Restore permission request (ExitPlanMode or other)
           pendingPermission = {
@@ -410,6 +411,7 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
             timestamp: pendingReq.timestamp,
             planContent: pendingReq.planContent,
           };
+          pendingQuestion = null; // Clear opposite type to prevent both modals showing
         }
       }
 

--- a/src/components/chat/chat-reducer.ts
+++ b/src/components/chat/chat-reducer.ts
@@ -430,11 +430,11 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
 
     // Permission and question requests
     // Always accept new requests (overwriting existing) to match backend behavior.
-    // Backend always stores the latest request, so frontend must show the same one.
+    // Clear opposite type to prevent both modals showing simultaneously.
     case 'WS_PERMISSION_REQUEST':
-      return { ...state, pendingPermission: action.payload };
+      return { ...state, pendingPermission: action.payload, pendingQuestion: null };
     case 'WS_USER_QUESTION':
-      return { ...state, pendingQuestion: action.payload };
+      return { ...state, pendingQuestion: action.payload, pendingPermission: null };
     case 'PERMISSION_RESPONSE': {
       // If ExitPlanMode was approved, disable plan mode in settings
       const shouldDisablePlanMode =

--- a/src/components/chat/chat-reducer.ts
+++ b/src/components/chat/chat-reducer.ts
@@ -418,6 +418,7 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
         gitBranch: action.payload.gitBranch,
         running: action.payload.running,
         loadingSession: false,
+        startingSession: false, // Clear to allow queue draining after session loads
         toolUseIdToIndex: new Map(),
         pendingPermission,
         pendingQuestion,

--- a/src/components/chat/chat-reducer.ts
+++ b/src/components/chat/chat-reducer.ts
@@ -330,6 +330,7 @@ function handleToolInputUpdate(
 // Reducer
 // =============================================================================
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Reducer handles many action types by design
 export function chatReducer(state: ChatState, action: ChatAction): ChatState {
   switch (action.type) {
     // WebSocket status messages
@@ -426,9 +427,18 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
     }
 
     // Permission and question requests
+    // Guard: Don't overwrite existing pending request to prevent losing unresponded requests
     case 'WS_PERMISSION_REQUEST':
+      if (state.pendingPermission !== null) {
+        // Already have a pending permission request - ignore new one to prevent loss
+        return state;
+      }
       return { ...state, pendingPermission: action.payload };
     case 'WS_USER_QUESTION':
+      if (state.pendingQuestion !== null) {
+        // Already have a pending question - ignore new one to prevent loss
+        return state;
+      }
       return { ...state, pendingQuestion: action.payload };
     case 'PERMISSION_RESPONSE': {
       // If ExitPlanMode was approved, disable plan mode in settings

--- a/src/components/chat/chat-reducer.ts
+++ b/src/components/chat/chat-reducer.ts
@@ -429,18 +429,11 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
     }
 
     // Permission and question requests
-    // Guard: Don't overwrite existing pending request to prevent losing unresponded requests
+    // Always accept new requests (overwriting existing) to match backend behavior.
+    // Backend always stores the latest request, so frontend must show the same one.
     case 'WS_PERMISSION_REQUEST':
-      if (state.pendingPermission !== null) {
-        // Already have a pending permission request - ignore new one to prevent loss
-        return state;
-      }
       return { ...state, pendingPermission: action.payload };
     case 'WS_USER_QUESTION':
-      if (state.pendingQuestion !== null) {
-        // Already have a pending question - ignore new one to prevent loss
-        return state;
-      }
       return { ...state, pendingQuestion: action.payload };
     case 'PERMISSION_RESPONSE': {
       // If ExitPlanMode was approved, disable plan mode in settings

--- a/src/components/chat/chat-reducer.ts
+++ b/src/components/chat/chat-reducer.ts
@@ -384,10 +384,12 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
           ? [...historyMessages, ...optimisticUserMessages]
           : historyMessages;
 
-      // Restore pending interactive request if present
+      // Restore pending interactive request if present from backend.
+      // Only overwrite existing state if backend has something to restore,
+      // otherwise preserve any pending state that may have arrived during loading (race condition fix).
       const pendingReq = action.payload.pendingInteractiveRequest;
-      let pendingPermission: PermissionRequest | null = null;
-      let pendingQuestion: UserQuestionRequest | null = null;
+      let pendingPermission: PermissionRequest | null = state.pendingPermission;
+      let pendingQuestion: UserQuestionRequest | null = state.pendingQuestion;
 
       if (pendingReq) {
         if (pendingReq.toolName === 'AskUserQuestion') {

--- a/src/components/chat/chat-reducer.ts
+++ b/src/components/chat/chat-reducer.ts
@@ -15,6 +15,7 @@ import type {
   ChatSettings,
   ClaudeMessage,
   HistoryMessage,
+  PendingInteractiveRequest,
   PermissionRequest,
   QueuedMessage,
   SessionInfo,
@@ -76,14 +77,7 @@ export type ChatAction =
         gitBranch: string | null;
         running: boolean;
         settings?: ChatSettings;
-        pendingInteractiveRequest?: {
-          requestId: string;
-          toolName: string;
-          toolUseId: string;
-          input: Record<string, unknown>;
-          planContent: string | null;
-          timestamp: string;
-        } | null;
+        pendingInteractiveRequest?: PendingInteractiveRequest | null;
       };
     }
   | { type: 'WS_PERMISSION_REQUEST'; payload: PermissionRequest }

--- a/src/components/chat/use-chat-state.ts
+++ b/src/components/chat/use-chat-state.ts
@@ -559,6 +559,10 @@ export function useChatState(options: UseChatStateOptions): UseChatStateReturn {
 
   const approvePermission = useCallback(
     (requestId: string, allow: boolean) => {
+      // Validate requestId matches pending permission to prevent stale responses
+      if (stateRef.current.pendingPermission?.requestId !== requestId) {
+        return;
+      }
       const msg: PermissionResponseMessage = { type: 'permission_response', requestId, allow };
       send(msg);
       dispatch({ type: 'PERMISSION_RESPONSE', payload: { allow } });
@@ -568,6 +572,10 @@ export function useChatState(options: UseChatStateOptions): UseChatStateReturn {
 
   const answerQuestion = useCallback(
     (requestId: string, answers: Record<string, string | string[]>) => {
+      // Validate requestId matches pending question to prevent stale responses
+      if (stateRef.current.pendingQuestion?.requestId !== requestId) {
+        return;
+      }
       const msg: QuestionResponseMessage = { type: 'question_response', requestId, answers };
       send(msg);
       dispatch({ type: 'QUESTION_RESPONSE' });

--- a/src/lib/claude-types.ts
+++ b/src/lib/claude-types.ts
@@ -294,19 +294,13 @@ export interface UserQuestionRequest {
 // Pending Interactive Request Types
 // =============================================================================
 
-/**
- * Pending interactive request stored for session restore.
- * When a user navigates away and returns, we need to restore the modal.
- */
-export interface PendingInteractiveRequest {
-  requestId: string;
-  toolName: string;
-  toolUseId: string;
-  input: Record<string, unknown>;
-  /** Plan content for ExitPlanMode requests */
-  planContent: string | null;
-  timestamp: string;
-}
+// Import and re-export from shared module (used by both frontend and backend)
+import type { PendingInteractiveRequest as PendingInteractiveRequestType } from '@/shared/pending-request-types';
+
+export type { PendingInteractiveRequest } from '@/shared/pending-request-types';
+
+// Alias for use within this file
+type PendingInteractiveRequest = PendingInteractiveRequestType;
 
 // =============================================================================
 // Permission Request Types (Phase 9)

--- a/src/lib/claude-types.ts
+++ b/src/lib/claude-types.ts
@@ -291,6 +291,24 @@ export interface UserQuestionRequest {
 }
 
 // =============================================================================
+// Pending Interactive Request Types
+// =============================================================================
+
+/**
+ * Pending interactive request stored for session restore.
+ * When a user navigates away and returns, we need to restore the modal.
+ */
+export interface PendingInteractiveRequest {
+  requestId: string;
+  toolName: string;
+  toolUseId: string;
+  input: Record<string, unknown>;
+  /** Plan content for ExitPlanMode requests */
+  planContent: string | null;
+  timestamp: string;
+}
+
+// =============================================================================
 // Permission Request Types (Phase 9)
 // =============================================================================
 
@@ -424,14 +442,7 @@ export interface WebSocketMessage {
   // Message queued acknowledgment
   text?: string;
   // Pending interactive request for session restore
-  pendingInteractiveRequest?: {
-    requestId: string;
-    toolName: string;
-    toolUseId: string;
-    input: Record<string, unknown>;
-    planContent: string | null;
-    timestamp: string;
-  } | null;
+  pendingInteractiveRequest?: PendingInteractiveRequest | null;
 }
 
 // =============================================================================

--- a/src/lib/claude-types.ts
+++ b/src/lib/claude-types.ts
@@ -423,6 +423,15 @@ export interface WebSocketMessage {
   settings?: ChatSettings;
   // Message queued acknowledgment
   text?: string;
+  // Pending interactive request for session restore
+  pendingInteractiveRequest?: {
+    requestId: string;
+    toolName: string;
+    toolUseId: string;
+    input: Record<string, unknown>;
+    planContent: string | null;
+    timestamp: string;
+  } | null;
 }
 
 // =============================================================================

--- a/src/shared/pending-request-types.ts
+++ b/src/shared/pending-request-types.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared types for pending interactive requests.
+ * Used by both frontend and backend for session restore functionality.
+ */
+
+/**
+ * Pending interactive request stored for session restore.
+ * When a user navigates away and returns, we need to restore the modal.
+ */
+export interface PendingInteractiveRequest {
+  requestId: string;
+  toolName: string;
+  toolUseId: string;
+  input: Record<string, unknown>;
+  /** Plan content for ExitPlanMode requests */
+  planContent: string | null;
+  timestamp: string;
+}


### PR DESCRIPTION
## Summary

- Fix bug where navigating away from a session with a pending interactive request (AskUserQuestion or ExitPlanMode) and returning would not show the modal
- Store pending interactive requests in memory by session ID on the backend
- Include pending request in `session_loaded` response when loading a session  
- Restore `pendingPermission`/`pendingQuestion` state in the frontend reducer
- Clear pending requests when user responds or process exits

## Test plan

- [ ] Start a session and trigger plan mode (use `EnterPlanMode` tool)
- [ ] Wait for the plan approval modal to appear
- [ ] Navigate away to another workspace or project
- [ ] Return to the original session
- [ ] Verify the plan approval modal appears again
- [ ] Same test with AskUserQuestion modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the WebSocket `session_loaded` payload and the frontend reducer’s session-loading logic, which could affect reconnect/session-switch behavior. The change is scoped to in-memory UI state restoration and request response handling (no auth or persistent data changes).
> 
> **Overview**
> Fixes a reconnection/session-resume bug by **persisting pending interactive requests** (e.g. `AskUserQuestion`, `ExitPlanMode`) in the backend and returning them in the `session_loaded` WebSocket payload.
> 
> Updates the frontend to **restore the appropriate modal state** from `pendingInteractiveRequest`, handle race conditions during session loading, and prevent stale permission/question responses via requestId checks; adds shared `PendingInteractiveRequest` types and expanded reducer tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 173b4837e37e83ca9dacf1734f69f8005aea8de3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->