### PR TITLE
Improve workspace creation UX with immediate navigation

### DIFF
--- a/src/client/routes/projects/workspaces/detail.tsx
+++ b/src/client/routes/projects/workspaces/detail.tsx
@@ -350,8 +350,9 @@ function WorkspaceChatContent() {
   // A workspace is considered fully ready when:
   // 1. initStatus is READY, AND
   // 2. worktreePath is populated (required for sessions)
+  // Show overlay if initStatus hasn't loaded yet OR if status isn't READY OR if worktreePath missing
   const isInitializing =
-    (initStatus && initStatus.initStatus !== 'READY') || !workspace?.worktreePath;
+    !initStatus || initStatus.initStatus !== 'READY' || !workspace?.worktreePath;
 
   return (
     <div className="relative flex h-full flex-col overflow-hidden">

--- a/src/frontend/components/app-sidebar.tsx
+++ b/src/frontend/components/app-sidebar.tsx
@@ -112,19 +112,19 @@ export function AppSidebar() {
     startCreating(name);
 
     try {
-      // Create workspace (branchName defaults to project's default branch)
+      // Create workspace - returns immediately, initialization happens in background
       // Don't create a session - user will choose workflow in workspace page
       const workspace = await createWorkspace.mutateAsync({
         projectId: selectedProjectId,
         name,
       });
 
-      // Invalidate caches to trigger immediate refetch
+      // Navigate immediately - workspace detail page shows initialization overlay
+      navigate(`/projects/${selectedProjectSlug}/workspaces/${workspace.id}`);
+
+      // Invalidate caches in background (navigation already happened)
       utils.workspace.list.invalidate({ projectId: selectedProjectId });
       utils.workspace.getProjectSummaryState.invalidate({ projectId: selectedProjectId });
-
-      // Navigate to workspace (workflow selection will be shown)
-      navigate(`/projects/${selectedProjectSlug}/workspaces/${workspace.id}`);
     } catch {
       // Clear the creating state on error so the UI doesn't get stuck
       cancelCreating();


### PR DESCRIPTION
## Summary
- Make workspace creation feel instant by returning from the API immediately after creating the DB record
- Navigate to the workspace detail page right away instead of waiting for worktree initialization
- Show the initialization overlay on the detail page while the worktree is being set up in the background

## Problem
Previously, clicking the + button would:
1. Show a spinner in the sidebar
2. Wait for the entire worktree initialization to complete (several seconds)
3. Stop the spinner
4. Navigate to the workspace page

This caused a disconnect where the spinner stopped but the user still had to wait for the redirect.

## Solution
Now the flow is:
1. Click + → brief sidebar spinner (just DB insert)
2. Immediate redirect to workspace detail page
3. "Setting up workspace..." overlay shows with spinner
4. Overlay disappears when worktree is ready

The spinner runs continuously from click to ready-state, providing a unified and intuitive experience.

## Test plan
- [ ] Click + to create a new workspace
- [ ] Verify immediate navigation to workspace detail page
- [ ] Verify initialization overlay shows while workspace is being set up
- [ ] Verify overlay disappears when workspace is ready
- [ ] Verify workspace list in sidebar updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the workspace creation flow to run worktree setup asynchronously, which can introduce timing/race issues around `worktreePath` availability and init failure handling. UI behavior now depends on polling `getInitStatus` to gate session readiness.
> 
> **Overview**
> Workspace creation is changed to return immediately after the DB insert; worktree initialization is kicked off in the background via `initializeWorkspaceWorktree` and failures are logged without failing the API response.
> 
> The workspace detail page now treats missing/unknown init status as initializing (showing the overlay until `READY` *and* `worktreePath` are present), and the sidebar creation flow navigates to the new workspace immediately before cache invalidations complete.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17639181425cba78108bca48e363bf0d3111f9c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->