### PR TITLE
Remove deprecated API fields and methods

### DIFF
--- a/src/backend/clients/git.client.test.ts
+++ b/src/backend/clients/git.client.test.ts
@@ -217,27 +217,6 @@ describe('GitClient', () => {
       expect(name).toMatch(/^martin-purplefish\/[0-9a-f]{6}$/);
     });
   });
-
-  // ===========================================================================
-  // getBranchName Tests (deprecated)
-  // ===========================================================================
-
-  describe('getBranchName (deprecated)', () => {
-    it('should return legacy format branch name', () => {
-      const name = client.getBranchName('workspace-abc123');
-      expect(name).toBe('factoryfactory/workspace-abc123');
-    });
-
-    it('should handle simple workspace names', () => {
-      const name = client.getBranchName('test');
-      expect(name).toBe('factoryfactory/test');
-    });
-
-    it('should preserve workspace name exactly', () => {
-      const name = client.getBranchName('My-Workspace_123');
-      expect(name).toBe('factoryfactory/My-Workspace_123');
-    });
-  });
 });
 
 // =============================================================================

--- a/src/backend/clients/git.client.ts
+++ b/src/backend/clients/git.client.ts
@@ -148,13 +148,6 @@ export class GitClient {
     return this.generateBranchName(prefix, crypto.randomBytes(6).toString('hex'));
   }
 
-  /**
-   * @deprecated Use generateBranchName instead. This method is kept for backwards compatibility.
-   */
-  getBranchName(worktreeName: string): string {
-    return `factoryfactory/${worktreeName}`;
-  }
-
   async checkWorktreeExists(name: string): Promise<boolean> {
     const worktreePath = this.getWorktreePath(name);
     const result = await gitCommandC(this.baseRepoPath, ['worktree', 'list']);

--- a/src/components/agent-activity/tool-renderers.stories.tsx
+++ b/src/components/agent-activity/tool-renderers.stories.tsx
@@ -5,7 +5,7 @@ import {
   SAMPLE_FILE_CONTENTS,
   SAMPLE_FILE_PATHS,
 } from '@/lib/claude-fixtures';
-import type { ChatMessage, ClaudeMessage, ToolSequence } from '@/lib/claude-types';
+import type { ClaudeMessage, ToolSequence } from '@/lib/claude-types';
 import { ToolCallGroupRenderer, ToolInfoRenderer, ToolSequenceGroup } from './tool-renderers';
 import type { ToolCallInfo } from './types';
 
@@ -582,46 +582,11 @@ export const ToolResultStates: Story = {
 // =============================================================================
 
 /**
- * Helper to create a ChatMessage from a tool use.
- */
-function createToolUseChatMessage(
-  toolName: string,
-  input: Record<string, unknown>,
-  toolId = `toolu_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`
-): ChatMessage {
-  return {
-    id: `msg-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
-    source: 'claude',
-    message: createToolUseClaudeMessage(toolName, input, toolId),
-    timestamp: new Date().toISOString(),
-  };
-}
-
-/**
- * Helper to create a ChatMessage from a tool result.
- */
-function createToolResultChatMessage(
-  toolUseId: string,
-  content: string,
-  isError = false
-): ChatMessage {
-  return {
-    id: `msg-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
-    source: 'claude',
-    message: createToolResultClaudeMessage(toolUseId, content, isError),
-    timestamp: new Date().toISOString(),
-  };
-}
-
-/**
  * Creates a ToolSequence for testing.
  */
 function createToolSequence(
   tools: Array<{ name: string; input: Record<string, unknown>; result?: string; isError?: boolean }>
 ): ToolSequence {
-  const messages: ChatMessage[] = [];
-  const toolNames: string[] = [];
-  const statuses: Array<'pending' | 'success' | 'error'> = [];
   const pairedCalls: Array<{
     id: string;
     name: string;
@@ -632,12 +597,9 @@ function createToolSequence(
 
   for (const tool of tools) {
     const toolId = `toolu_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
-    messages.push(createToolUseChatMessage(tool.name, tool.input, toolId));
-    toolNames.push(tool.name);
 
     const status: 'pending' | 'success' | 'error' =
       tool.result !== undefined ? (tool.isError ? 'error' : 'success') : 'pending';
-    statuses.push(status);
 
     pairedCalls.push({
       id: toolId,
@@ -649,19 +611,12 @@ function createToolSequence(
           ? { content: tool.result, isError: tool.isError ?? false }
           : undefined,
     });
-
-    if (tool.result !== undefined) {
-      messages.push(createToolResultChatMessage(toolId, tool.result, tool.isError));
-    }
   }
 
   return {
     type: 'tool_sequence',
     id: `tool-seq-${Date.now()}`,
     pairedCalls,
-    messages,
-    toolNames,
-    statuses,
   };
 }
 

--- a/src/lib/websocket-config.ts
+++ b/src/lib/websocket-config.ts
@@ -26,12 +26,6 @@ export const RECONNECT_BASE_DELAY_MS = 1000;
 export const RECONNECT_MAX_DELAY_MS = 30_000;
 
 /**
- * Legacy constant for backwards compatibility.
- * @deprecated Use getReconnectDelay() instead for exponential backoff.
- */
-export const RECONNECT_DELAY_MS = 2000;
-
-/**
  * Calculate reconnection delay with exponential backoff and jitter.
  * @param attempt - The current reconnection attempt number (0-indexed)
  * @returns Delay in milliseconds


### PR DESCRIPTION
## Summary
- Remove deprecated `messages`, `toolNames`, `statuses` fields from `ToolSequence` interface (consumers should use `pairedCalls`)
- Remove deprecated `getBranchName()` method from `GitClient` (use `generateBranchName()` instead)
- Remove deprecated `RECONNECT_DELAY_MS` constant from websocket-config (use `getReconnectDelay()` instead)

## Test plan
- [x] All 975 tests pass
- [x] TypeScript typechecking passes
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes deprecated exported API surface (`ToolSequence` legacy fields, `GitClient.getBranchName()`, and `RECONNECT_DELAY_MS`), which can break any remaining consumers still referencing them despite deprecation.
> 
> **Overview**
> Removes deprecated APIs across frontend and backend.
> 
> `ToolSequence` is simplified to only expose `pairedCalls`, with grouping logic updated to stop producing legacy `messages`/`toolNames`/`statuses`, and Storybook fixtures adjusted accordingly.
> 
> Deletes the legacy `GitClient.getBranchName()` method (and its tests) in favor of `generateBranchName()`, and removes the deprecated `RECONNECT_DELAY_MS` constant in favor of `getReconnectDelay()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6834cb2e4f5b04cb5cf0f54904897bd3fbf9d77d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->