### PR TITLE
Navigate to workspace immediately on creation

### DIFF
--- a/src/backend/trpc/workspace.trpc.ts
+++ b/src/backend/trpc/workspace.trpc.ts
@@ -211,7 +211,17 @@ export const workspaceRouter = router({
       // Initialize the worktree in the background so the frontend can navigate
       // immediately. The workspace detail page polls for initialization status
       // and shows an overlay spinner until the workspace is fully ready.
-      initializeWorkspaceWorktree(workspace.id, input.branchName);
+      // The function has internal error handling but we add a catch here to handle
+      // any unexpected errors (e.g., if markFailed throws due to DB issues).
+      initializeWorkspaceWorktree(workspace.id, input.branchName).catch((error) => {
+        logger.error(
+          'Unexpected error during background workspace initialization',
+          error as Error,
+          {
+            workspaceId: workspace.id,
+          }
+        );
+      });
 
       return workspace;
     }),


### PR DESCRIPTION
## Summary

- Run workspace initialization in the background instead of waiting for it to complete
- User is navigated to the workspace detail page immediately after clicking "Create Workspace"
- The workspace detail page shows an overlay spinner until the workspace is fully ready (including startup scripts)

## Test plan

- [ ] Create a new workspace in a project
- [ ] Verify navigation happens immediately (no waiting for initialization)
- [ ] Verify spinner overlay displays on workspace detail page while initializing
- [ ] Verify spinner continues showing while startup script runs (if configured)
- [ ] Verify workspace becomes usable once status is READY

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workspace creation semantics to return before worktree/startup initialization completes, which may expose timing/race issues for clients expecting `worktreePath` to be set immediately. Failures now surface via async state transitions/logging rather than the create response.
> 
> **Overview**
> Workspace `create` now **returns immediately** after inserting the workspace record and triggers `initializeWorkspaceWorktree` *asynchronously* instead of blocking until worktree/startup initialization finishes.
> 
> Adds a defensive `.catch` logger around the background init call, and removes the post-init refetch/return of the initialized workspace, shifting readiness/error reporting to the workspace’s async init status.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d489f95ddfe1a8c25d57a644ac5ecb9b419ab04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->