### PR TITLE
Remove default timeout on permission requests

### DIFF
--- a/src/backend/claude/permissions.ts
+++ b/src/backend/claude/permissions.ts
@@ -301,7 +301,7 @@ interface PendingPermissionRequest {
  * Options for DeferredHandler configuration.
  */
 export interface DeferredHandlerOptions {
-  /** Timeout in milliseconds for pending requests. Default: 300000 (5 minutes) */
+  /** Timeout in milliseconds for pending requests. Default: 0 (no timeout) */
   timeout?: number;
 }
 


### PR DESCRIPTION
## Summary
- Removes the 5-minute default timeout on permission requests in `DeferredHandler`
- Users can now take as long as needed to respond to permission prompts without getting timeout errors

## Context
The previous 5-minute timeout was causing "Permission request timed out after 300000ms" errors when users simply hadn't responded yet (e.g., thinking, researching, or stepped away).

Setting the default timeout to `0` disables the timeout while still allowing callers to specify a custom timeout if needed.

## Test plan
- [ ] Start a session and trigger a permission request (e.g., plan mode)
- [ ] Wait longer than 5 minutes without responding
- [ ] Verify no timeout error occurs
- [ ] Respond to the permission request and verify it works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime behavior of `DeferredHandler` so permission/hook requests no longer auto-reject after 5 minutes, which could leave requests pending indefinitely if a caller doesn’t explicitly set a timeout or cancel them.
> 
> **Overview**
> **Removes the default 5-minute timeout** for `DeferredHandler` pending permission/hook requests by defaulting `timeout` to `0` (no timeout).
> 
> Updates the option docs/commentary to reflect the new default, while still allowing callers to pass an explicit timeout when desired.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf25061ec443e5fa28a636fbd0fd5d219981e1ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->