### PR TITLE
Fix virtualizer scrollToIndex error when scroll element becomes null

### DIFF
--- a/src/components/chat/virtualized-message-list.tsx
+++ b/src/components/chat/virtualized-message-list.tsx
@@ -105,7 +105,13 @@ export const VirtualizedMessageList = memo(function VirtualizedMessageList({
     if (currentCount > prevCount && isNearBottomRef.current && scrollContainerRef.current) {
       isAutoScrollingRef.current = true;
       // Use 'auto' behavior instead of smooth to prevent animation jitter during rapid updates
-      virtualizer.scrollToIndex(currentCount - 1, { align: 'end', behavior: 'auto' });
+      // Wrap in try-catch to handle edge cases where scroll element becomes null during unmount
+      // or rapid component updates (see: https://github.com/TanStack/virtual/issues/696)
+      try {
+        virtualizer.scrollToIndex(currentCount - 1, { align: 'end', behavior: 'auto' });
+      } catch {
+        // Scroll element likely became null during unmount - safe to ignore
+      }
       // Reset flag immediately for instant scroll
       requestAnimationFrame(() => {
         isAutoScrollingRef.current = false;


### PR DESCRIPTION
## Summary
- Wrap `scrollToIndex` call in try-catch to handle race condition where the scroll element becomes null during component unmount or rapid updates
- Fixes intermittent "Cannot read properties of null (reading 'requestAnimationFrame')" console errors

## What happened
The virtualizer's `scrollToIndex` method internally calls `getScrollElement()` which can return `null` if the component unmounts between the ref check and the actual scroll operation. When this happens, it tries to access `element.ownerDocument.defaultView.requestAnimationFrame` on a null element.

This is a known edge case with `@tanstack/react-virtual`: https://github.com/TanStack/virtual/issues/696

## Test plan
- [x] Typecheck passes
- [x] Lint passes
- [ ] Manual testing: verify auto-scroll still works when new messages arrive

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI resilience change: it only adds error handling around auto-scroll and does not affect data or auth flows. Main risk is masking unexpected scrolling bugs, but it’s limited to an edge-case during unmount/rapid updates.
> 
> **Overview**
> Prevents intermittent console/runtime errors during chat auto-scroll by wrapping `virtualizer.scrollToIndex(...)` in a `try/catch` in `virtualized-message-list.tsx`, handling cases where the scroll element becomes `null` during unmount or rapid updates (TanStack virtual edge case).
> 
> Auto-scroll behavior remains the same (`behavior: 'auto'`), but failures are now safely ignored instead of surfacing as crashes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48c48aef6b1d7c146e8a4f9b374e98e42dd50fb2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->