### PR TITLE
Fix tool status indicators overflow when agent makes many tool calls

### DIFF
--- a/src/components/agent-activity/tool-renderers.tsx
+++ b/src/components/agent-activity/tool-renderers.tsx
@@ -232,7 +232,45 @@ export const ToolSequenceGroup = memo(function ToolSequenceGroup({
   }
 
   // Multiple tool calls - render as collapsible group
+  // Count statuses for summary display
+  const statusCounts = {
+    success: pairedCalls.filter((c) => c.status === 'success').length,
+    error: pairedCalls.filter((c) => c.status === 'error').length,
+    pending: pairedCalls.filter((c) => c.status === 'pending').length,
+  };
+
   const renderStatusIndicators = () => {
+    // Show counts instead of individual icons when there are many tool calls
+    const MAX_INDIVIDUAL_ICONS = 8;
+    if (pairedCalls.length > MAX_INDIVIDUAL_ICONS) {
+      return (
+        <>
+          {statusCounts.success > 0 && (
+            <span
+              className="flex items-center gap-0.5"
+              title={`${statusCounts.success} successful`}
+            >
+              <CheckCircle className="h-3.5 w-3.5 shrink-0 text-success" />
+              <span className="text-[10px] text-success">{statusCounts.success}</span>
+            </span>
+          )}
+          {statusCounts.error > 0 && (
+            <span className="flex items-center gap-0.5" title={`${statusCounts.error} failed`}>
+              <AlertCircle className="h-3.5 w-3.5 shrink-0 text-destructive" />
+              <span className="text-[10px] text-destructive">{statusCounts.error}</span>
+            </span>
+          )}
+          {statusCounts.pending > 0 && (
+            <span className="flex items-center gap-0.5" title={`${statusCounts.pending} pending`}>
+              <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
+              <span className="text-[10px] text-muted-foreground">{statusCounts.pending}</span>
+            </span>
+          )}
+        </>
+      );
+    }
+
+    // Show individual icons for small numbers of tool calls
     return pairedCalls.map((call) => {
       const key = `${sequence.id}-status-${call.id}`;
       switch (call.status) {


### PR DESCRIPTION
## Summary
- When an agent makes many tool calls (e.g., 47), each tool was rendered with an individual status icon, causing horizontal overflow in the UI
- Now shows a compact summary with counts (e.g., "✓ 45") when there are more than 8 tool calls
- Preserves individual icons for smaller numbers of tool calls (≤8)

## Test plan
- [ ] Open a workspace with a session where an agent made many tool calls (>8)
- [ ] Verify the tool status indicators show counts instead of overflowing icons
- [ ] Verify sessions with ≤8 tool calls still show individual icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only rendering change that alters how status indicators are displayed for large tool-call groups without affecting tool execution or data handling.
> 
> **Overview**
> Avoids horizontal overflow in `ToolSequenceGroup` by summarizing tool-call statuses as *counts* (success/error/pending) once the group exceeds `MAX_INDIVIDUAL_ICONS` (8), while keeping per-call status icons for smaller groups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fbfea6ecb381d2575b4a43bed28786a4fefdda06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->