### PR TITLE
Fix code review feedback: remove dead code, dedup interfaces, fix diff stats

### DIFF
--- a/src/backend/services/chat-event-forwarder.service.ts
+++ b/src/backend/services/chat-event-forwarder.service.ts
@@ -50,14 +50,6 @@ class ChatEventForwarderService {
   }
 
   /**
-   * Clean up session state when session is destroyed.
-   */
-  cleanupSession(dbSessionId: string): void {
-    this.clientEventSetup.delete(dbSessionId);
-    this.pendingInteractiveRequests.delete(dbSessionId);
-  }
-
-  /**
    * Get pending interactive request for a session.
    */
   getPendingRequest(dbSessionId: string): PendingInteractiveRequest | undefined {

--- a/src/backend/services/notification.service.ts
+++ b/src/backend/services/notification.service.ts
@@ -6,21 +6,10 @@
  */
 
 import { execCommand, sendLinuxNotification, sendMacNotification } from '../lib/shell';
-import { configService } from './config.service';
+import { configService, type NotificationConfig } from './config.service';
 import { createLogger } from './logger.service';
 
 const logger = createLogger('notification');
-
-/**
- * Notification configuration
- */
-interface NotificationConfig {
-  soundEnabled: boolean;
-  pushEnabled: boolean;
-  soundFile?: string;
-  quietHoursStart?: number; // Hour in 24h format (e.g., 22 for 10 PM)
-  quietHoursEnd?: number; // Hour in 24h format (e.g., 8 for 8 AM)
-}
 
 /**
  * Get notification configuration from centralized config service

--- a/src/backend/services/rate-limiter.service.ts
+++ b/src/backend/services/rate-limiter.service.ts
@@ -5,23 +5,10 @@
  * Implements token bucket algorithm for API rate limiting.
  */
 
-import { configService } from './config.service';
+import { configService, type RateLimiterConfig } from './config.service';
 import { createLogger } from './logger.service';
 
 const logger = createLogger('rate-limiter');
-
-/**
- * Rate limiter configuration
- */
-export interface RateLimiterConfig {
-  // Claude API rate limits
-  claudeRequestsPerMinute: number;
-  claudeRequestsPerHour: number;
-
-  // Queue settings
-  maxQueueSize: number;
-  queueTimeoutMs: number;
-}
 
 /**
  * Request priority levels

--- a/src/frontend/components/app-sidebar.tsx
+++ b/src/frontend/components/app-sidebar.tsx
@@ -322,15 +322,22 @@ export function AppSidebar() {
 
                             {/* Diff stats - tight paired columns */}
                             <span className="w-[4.5rem] flex text-xs tabular-nums shrink-0">
-                              {stats && (stats.additions > 0 || stats.deletions > 0) ? (
-                                <>
-                                  <span className="w-1/2 text-right text-green-600 dark:text-green-400">
-                                    +{stats.additions}
+                              {stats &&
+                              (stats.additions > 0 || stats.deletions > 0 || stats.total > 0) ? (
+                                stats.additions > 0 || stats.deletions > 0 ? (
+                                  <>
+                                    <span className="w-1/2 text-right text-green-600 dark:text-green-400">
+                                      +{stats.additions}
+                                    </span>
+                                    <span className="w-1/2 text-left pl-1 text-red-600 dark:text-red-400">
+                                      -{stats.deletions}
+                                    </span>
+                                  </>
+                                ) : (
+                                  <span className="w-full text-center text-muted-foreground">
+                                    {stats.total} files
                                   </span>
-                                  <span className="w-1/2 text-left pl-1 text-red-600 dark:text-red-400">
-                                    -{stats.deletions}
-                                  </span>
-                                </>
+                                )
                               ) : null}
                             </span>
 


### PR DESCRIPTION
## Summary

- Remove unused `cleanupSession` method from `chat-event-forwarder.service.ts` (cleanup already happens in the exit event handler)
- Show file count for binary/permission-only changes in sidebar diff stats (restores visibility for modified binary files or permission-only changes)
- Remove duplicate `RateLimiterConfig` interface from `rate-limiter.service.ts`, now imported from `config.service.ts`
- Remove duplicate `NotificationConfig` interface from `notification.service.ts`, now imported from `config.service.ts`

## Test plan

- [ ] Verify typecheck passes: `pnpm typecheck`
- [ ] Verify sidebar displays "N files" for workspaces with binary file changes
- [ ] Verify session stopping still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup and UI tweak; behavior changes are limited to sidebar diff display for binary/permission-only changes and removal of an unused session cleanup method already handled on process exit.
> 
> **Overview**
> Removes dead session cleanup code by dropping `ChatEventForwarderService.cleanupSession`, relying on existing `exit` handling to clear per-session forwarding/request state.
> 
> Deduplicates backend config typings by importing `NotificationConfig` and `RateLimiterConfig` from `config.service` instead of redefining them.
> 
> Updates the workspace sidebar diff stats to show an `N files` count when there are changes with no line additions/deletions (e.g., binary or permission-only diffs).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4832782044f97449daca8c780bdc8c6bd2057b97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->