### PR TITLE
Fix workspace initialization requiring page refresh

### DIFF
--- a/src/client/routes/projects/workspaces/detail.tsx
+++ b/src/client/routes/projects/workspaces/detail.tsx
@@ -258,19 +258,27 @@ function WorkspaceChatContent() {
       }
     );
 
-  // When init status becomes READY, refetch workspace to get updated worktreePath
+  // When init status becomes READY, refetch workspace to get updated worktreePath.
+  // Also handles edge case where init is already READY on first load but workspace
+  // data is stale (missing worktreePath).
   const prevInitStatusRef = useRef<string | undefined>(undefined);
   useEffect(() => {
     const currentStatus = workspaceInitStatus?.status;
     const prevStatus = prevInitStatusRef.current;
 
-    // Refetch workspace when transitioning to READY (worktreePath now available)
-    if (prevStatus && prevStatus !== 'READY' && currentStatus === 'READY') {
-      utils.workspace.get.invalidate({ id: workspaceId });
+    if (currentStatus === 'READY') {
+      // Invalidate on status transition to READY, or if status was already READY
+      // on first load but workspace is missing worktreePath (stale data)
+      const isTransitionToReady = prevStatus !== undefined && prevStatus !== 'READY';
+      const isStaleOnFirstLoad = prevStatus === undefined && !workspace?.worktreePath;
+
+      if (isTransitionToReady || isStaleOnFirstLoad) {
+        utils.workspace.get.invalidate({ id: workspaceId });
+      }
     }
 
     prevInitStatusRef.current = currentStatus;
-  }, [workspaceInitStatus?.status, workspaceId, utils.workspace.get]);
+  }, [workspaceInitStatus?.status, workspaceId, utils, workspace?.worktreePath]);
 
   // Manage selected session state here so it's available for useChatWebSocket
   const [selectedDbSessionId, setSelectedDbSessionId] = useState<string | null>(null);


### PR DESCRIPTION
## Summary
- Fix issue where users had to refresh the page after workspace initialization completed
- Add effect to invalidate workspace query when init status transitions to READY

## Problem
When creating a workspace, users would see "Workspace is initializing... Please wait for the worktree to be created." and had to refresh the page after initialization completed. This happened because:
1. The workspace is created with `worktreePath: null`
2. Background initialization sets `worktreePath` when complete
3. The `workspace.get` query only polled every 30 seconds
4. Even though `getInitStatus` polled every 1 second and correctly removed the overlay, the main workspace data was stale

## Solution
Added an effect that watches the init status and invalidates the `workspace.get` query when the status transitions to READY. This causes an immediate refetch of the workspace data with the now-populated `worktreePath`.

## Test plan
- [ ] Create a new workspace
- [ ] Verify the initialization overlay appears
- [ ] Wait for initialization to complete
- [ ] Verify the workflow selector becomes enabled without needing to refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/data-fetching change that only alters tRPC query invalidation timing; main risk is extra refetches or missed edge cases around status transitions.
> 
> **Overview**
> Fixes a stale workspace detail view after background initialization by invalidating/refetching `trpc.workspace.get` when `getInitStatus` becomes `READY`.
> 
> Adds a small `useEffect` (tracking previous status) to trigger invalidation on the transition to `READY` and on first-load cases where status is already `READY` but `worktreePath` is still missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ece86ab82e860f118817f1c274b01a358e32c44. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->