### PR TITLE
Make sidebar workspace list denser with tighter tabular layout

### DIFF
--- a/src/client/routes/projects/workspaces/detail.tsx
+++ b/src/client/routes/projects/workspaces/detail.tsx
@@ -1,4 +1,15 @@
-import { AppWindow, Archive, ArrowDown, Check, GitBranch, Loader2, PanelRight } from 'lucide-react';
+import {
+  AppWindow,
+  Archive,
+  ArrowDown,
+  Check,
+  CheckCircle2,
+  Circle,
+  GitBranch,
+  Loader2,
+  PanelRight,
+  XCircle,
+} from 'lucide-react';
 import { memo, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 
@@ -397,16 +408,28 @@ function WorkspaceChatContent() {
               href={workspace.prUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className={`text-xs hover:opacity-80 transition-opacity ${
+              className={`flex items-center gap-1 text-xs hover:opacity-80 transition-opacity ${
                 workspace.prState === 'MERGED'
                   ? 'text-purple-500'
                   : 'text-muted-foreground hover:text-foreground'
               }`}
             >
               #{workspace.prNumber}
-              <span className="inline-block w-3.5 ml-0.5">
-                {workspace.prState === 'MERGED' && <Check className="h-3 w-3 inline" />}
-              </span>
+              {workspace.prState === 'MERGED' ? (
+                <Check className="h-3 w-3" />
+              ) : (
+                <>
+                  {workspace.prCiStatus === 'SUCCESS' && (
+                    <CheckCircle2 className="h-3 w-3 text-green-500" />
+                  )}
+                  {workspace.prCiStatus === 'FAILURE' && (
+                    <XCircle className="h-3 w-3 text-red-500" />
+                  )}
+                  {workspace.prCiStatus === 'PENDING' && (
+                    <Circle className="h-3 w-3 text-yellow-500 animate-pulse" />
+                  )}
+                </>
+              )}
             </a>
           )}
         </div>

--- a/src/frontend/components/app-sidebar.tsx
+++ b/src/frontend/components/app-sidebar.tsx
@@ -342,7 +342,7 @@ export function AppSidebar() {
                             </span>
 
                             {/* PR number - fixed width */}
-                            <span className="w-12 shrink-0 text-right">
+                            <span className="w-14 shrink-0 text-right">
                               {workspace.prNumber &&
                                 workspace.prState !== 'NONE' &&
                                 workspace.prUrl && (


### PR DESCRIPTION
## Summary
- Shrink fixed column widths for diff stats, PR numbers, and timestamps to give more space to workspace names
- Add fixed-width spacer for PR checkmark to prevent layout shift when PRs are merged
- Keep original row height (h-8) for comfortable padding

## Test plan
- [ ] Verify workspace names have more room to display
- [ ] Check that columns stay aligned across different workspaces
- [ ] Confirm merged PR checkmarks don't cause layout shifts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only spacing/icon tweaks to sidebar workspace rows and workspace header PR badge; minimal risk beyond potential layout regressions in edge cases (long names, missing stats/PR).
> 
> **Overview**
> Makes the sidebar workspace rows denser by shrinking fixed-width columns (status dot, diff stats, PR, timestamp), right-aligning PR/timestamps, and slightly adjusting spacing so workspace names have more room.
> 
> Stabilizes PR rendering by reserving space for the merged checkmark in the sidebar and simplifying the workspace detail header PR link to a smaller, text-first badge with compact CI/merged icons.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5ff1e6b06932c00f0bbc40589c8d89b9f32be0f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->