### PR TITLE
Remove redundant terminal heading from terminal panel

### DIFF
--- a/src/components/workspace/terminal-panel.tsx
+++ b/src/components/workspace/terminal-panel.tsx
@@ -259,11 +259,7 @@ export function TerminalPanel({ workspaceId, className }: TerminalPanelProps) {
     return (
       <div className={cn('h-full flex flex-col', className)}>
         {/* Header */}
-        <div className="flex items-center justify-between gap-1.5 px-3 py-2 bg-muted/50 border-b">
-          <div className="flex items-center gap-1.5">
-            <Terminal className="h-4 w-4 text-muted-foreground" />
-            <span className="text-sm font-medium text-muted-foreground">Terminal</span>
-          </div>
+        <div className="flex items-center justify-end gap-1.5 px-3 py-2 bg-muted/50 border-b">
           <TerminalTabBar
             tabs={[]}
             activeTabId={null}
@@ -292,11 +288,7 @@ export function TerminalPanel({ workspaceId, className }: TerminalPanelProps) {
   return (
     <div className={cn('h-full flex flex-col', className)}>
       {/* Header with tabs */}
-      <div className="flex items-center justify-between gap-1.5 px-3 py-2 bg-muted/50 border-b">
-        <div className="flex items-center gap-1.5">
-          <Terminal className="h-4 w-4 text-muted-foreground" />
-          <span className="text-sm font-medium text-muted-foreground">Terminal</span>
-        </div>
+      <div className="flex items-center justify-end gap-1.5 px-3 py-2 bg-muted/50 border-b">
         <TerminalTabBar
           tabs={tabs}
           activeTabId={activeTabId}


### PR DESCRIPTION
## Summary
- Remove the "Terminal" heading from inside the terminal panel since the right panel already has tabs for Terminal and Dev Logs
- The terminal instance tab bar is now right-aligned in the header area

## Test plan
- [ ] Open a workspace and verify the right panel shows Terminal/Dev Logs tabs
- [ ] Verify the terminal section no longer has a redundant "Terminal" label
- [ ] Verify terminal tab bar (for multiple terminal instances) is still visible and functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts header layout and removes redundant text/icon; no behavioral logic or data flow is modified.
> 
> **Overview**
> Removes the redundant "Terminal" icon/label from the `TerminalPanel` header (both empty and non-empty states), relying on the surrounding right-panel tabs instead.
> 
> Updates the header layout to right-align the `TerminalTabBar` (`justify-end`) so the instance tab controls sit flush to the right.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 961e8d8c90fe4e5255957c87cb3fd944d1b461df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->