### PR TITLE
Show archive button in yellow for closed/merged PRs

### DIFF
--- a/src/frontend/components/app-sidebar.tsx
+++ b/src/frontend/components/app-sidebar.tsx
@@ -396,7 +396,7 @@ export function AppSidebar() {
                                 formatRelativeTime(workspace.lastActivityAt)}
                             </span>
 
-                            {/* Archive button (hover) */}
+                            {/* Archive button (hover, or always visible in yellow for closed/merged PRs) */}
                             {!isArchivingItem && (
                               <Tooltip>
                                 <TooltipTrigger asChild>
@@ -408,7 +408,13 @@ export function AppSidebar() {
                                       setWorkspaceToArchive(workspace.id);
                                       setArchiveDialogOpen(true);
                                     }}
-                                    className="shrink-0 ml-1 p-0.5 rounded opacity-0 group-hover/menu-item:opacity-100 transition-opacity text-muted-foreground hover:text-foreground hover:bg-muted"
+                                    className={cn(
+                                      'shrink-0 ml-1 p-0.5 rounded transition-opacity',
+                                      workspace.prState === 'MERGED' ||
+                                        workspace.prState === 'CLOSED'
+                                        ? 'opacity-100 text-yellow-500 hover:text-yellow-400 hover:bg-yellow-500/10'
+                                        : 'opacity-0 group-hover/menu-item:opacity-100 text-muted-foreground hover:text-foreground hover:bg-muted'
+                                    )}
                                   >
                                     <Archive className="h-3 w-3" />
                                   </button>


### PR DESCRIPTION
## Summary
- Display the archive button in yellow and always visible when a workspace's PR is closed or merged
- Previously the archive button only appeared on hover for all workspaces
- This visual cue makes it easier to identify workspaces ready for cleanup

## Test plan
- [ ] Open a project with workspaces that have merged PRs
- [ ] Verify the archive button is always visible in yellow for merged PRs
- [ ] Verify the archive button is always visible in yellow for closed PRs
- [ ] Verify the archive button still only appears on hover for workspaces with open PRs or no PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts conditional styling/visibility of an existing button based on PR state, with no backend or data-flow changes.
> 
> **Overview**
> In the workspace list sidebar, the archive icon is now **always visible and highlighted in yellow** when a workspace’s PR is `CLOSED` or `MERGED`, instead of only appearing on hover.
> 
> Workspaces without a closed/merged PR keep the prior behavior (archive button hidden until hover), and the click behavior/dialog flow is unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0df32c28cc42e3aa72e759d788c971f7e2e2e89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->