### PR TITLE
Fix npx migrations and add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,74 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version bump type"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      dry_run:
+        description: "Dry run (show what would happen)"
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Bump version
+        id: bump
+        run: |
+          # Bump version and capture new version
+          NEW_VERSION=$(npm version ${{ github.event.inputs.version }} --no-git-tag-version)
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "New version: $NEW_VERSION"
+
+      - name: Show changes (dry run)
+        if: ${{ github.event.inputs.dry_run == 'true' }}
+        run: |
+          echo "Would create release ${{ steps.bump.outputs.version }}"
+          git diff package.json
+
+      - name: Commit, tag, and push
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        run: |
+          git add package.json
+          git commit -m "chore: release ${{ steps.bump.outputs.version }}"
+          git tag ${{ steps.bump.outputs.version }}
+          git push origin main --tags
+
+      - name: Create GitHub Release
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.bump.outputs.version }}
+          name: ${{ steps.bump.outputs.version }}
+          generate_release_notes: true


### PR DESCRIPTION
## Summary
- Fix migration failure when running `npx factory-factory serve` - the CLI was using `npx prisma migrate deploy` but Prisma is a devDependency
- Use the existing better-sqlite3 migration runner (built for Electron) in the CLI
- Add manual release workflow for version bumping via GitHub Actions UI

## Test plan
- [x] Typecheck passes
- [x] Build succeeds
- [x] `node dist/src/cli/index.js db:migrate -d /tmp/test.db` works
- [ ] Test `npx factory-factory serve` after publishing

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switches CLI database migration execution from `npx prisma migrate deploy` to an in-process better-sqlite3 runner, which could affect how migrations are applied and error-handled across environments. Also introduces an automated workflow that can tag and publish releases to `main`, so misconfiguration could create unintended version bumps/tags.
> 
> **Overview**
> Adds a manual `Release` GitHub Actions workflow that bumps `package.json` version (patch/minor/major), optionally dry-runs, then commits, tags, pushes to `main`, and creates a GitHub Release with autogenerated notes.
> 
> Updates the CLI (`src/cli/index.ts`) to stop shelling out to `npx prisma migrate deploy` and instead run migrations via the internal better-sqlite3 migration runner (`runDbMigrations`) for both `serve` startup and the `db:migrate` command, improving compatibility when Prisma is not installed for end users.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fafcc88e15d3f244ca073f8646b3801cd55730f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->