### PR TITLE
Skip archive confirmation for workspaces with merged PRs

### DIFF
--- a/src/client/routes/projects/workspaces/detail.tsx
+++ b/src/client/routes/projects/workspaces/detail.tsx
@@ -494,7 +494,14 @@ function WorkspaceChatContent() {
                 variant="ghost"
                 size="icon"
                 className="h-8 w-8 hover:bg-destructive/10 hover:text-destructive"
-                onClick={() => setArchiveDialogOpen(true)}
+                onClick={() => {
+                  // Skip confirmation if PR is already merged
+                  if (workspace.prState === 'MERGED') {
+                    archiveWorkspace.mutate({ id: workspaceId });
+                  } else {
+                    setArchiveDialogOpen(true);
+                  }
+                }}
                 disabled={archiveWorkspace.isPending}
               >
                 {archiveWorkspace.isPending ? (


### PR DESCRIPTION
## Summary
- Skip the confirmation dialog when archiving a workspace that has an associated PR already merged
- Workspaces without a merged PR still show the confirmation dialog

## Test plan
- [ ] Create a workspace with a PR and merge it
- [ ] Click the archive button - should archive immediately without confirmation
- [ ] Create a workspace without a merged PR
- [ ] Click the archive button - should show confirmation dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI behavior change limited to the workspace detail page; risk is mainly accidental immediate archiving when `prState` is incorrectly reported as `MERGED`.
> 
> **Overview**
> Archiving from the workspace detail header now **skips the confirmation dialog** when `workspace.prState === 'MERGED'`, and immediately triggers `archiveWorkspace.mutate`.
> 
> For all other PR states, the existing confirm dialog flow is unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01d16b654c91463eeb71b1414be2eb2e25a2a311. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->