### PR TITLE
Fix empty catch blocks with proper error handling

### DIFF
--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -3,6 +3,7 @@
 import { Brain, ChevronDown, ImagePlus, Loader2, Map as MapIcon, Send, Square } from 'lucide-react';
 import type { ChangeEvent, KeyboardEvent } from 'react';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
 
 import { AttachmentPreview } from '@/components/chat/attachment-preview';
 import { Button } from '@/components/ui/button';
@@ -241,6 +242,7 @@ export const ChatInput = memo(function ChatInput({
 
   // Handle file selection
   const handleFileSelect = useCallback(
+    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: File handling requires multiple checks
     async (event: ChangeEvent<HTMLInputElement>) => {
       const files = event.target.files;
       if (!files || files.length === 0) {
@@ -253,9 +255,9 @@ export const ChatInput = memo(function ChatInput({
         try {
           const attachment = await fileToAttachment(file);
           newAttachments.push(attachment);
-        } catch {
-          // Silently ignore errors for now
-          // TODO: Show error toast/notification for failed uploads
+        } catch (error) {
+          const message = error instanceof Error ? error.message : 'Unknown error';
+          toast.error(`Failed to upload ${file.name}: ${message}`);
         }
       }
 

--- a/src/frontend/components/app-sidebar.tsx
+++ b/src/frontend/components/app-sidebar.tsx
@@ -1,6 +1,7 @@
 import { Archive, Check, GitPullRequest, Kanban, Loader2, Plus, Settings } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router';
+import { toast } from 'sonner';
 import { Badge } from '@/components/ui/badge';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import {
@@ -141,9 +142,11 @@ export function AppSidebar() {
 
       // Navigate to workspace (workflow selection will be shown)
       navigate(`/projects/${selectedProjectSlug}/workspaces/${workspace.id}`);
-    } catch {
+    } catch (error) {
       // Clear the creating state on error so the UI doesn't get stuck
       cancelCreating();
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      toast.error(`Failed to create workspace: ${message}`);
     }
   };
 

--- a/src/frontend/components/kanban/kanban-context.tsx
+++ b/src/frontend/components/kanban/kanban-context.tsx
@@ -14,7 +14,9 @@ function getHiddenColumnsFromStorage(projectId: string): KanbanColumnType[] {
   try {
     const stored = localStorage.getItem(`${STORAGE_KEY_PREFIX}${projectId}`);
     return stored ? JSON.parse(stored) : [];
-  } catch {
+  } catch (error) {
+    // biome-ignore lint/suspicious/noConsole: Intentional error logging for debugging localStorage issues
+    console.warn('Failed to parse hidden columns from localStorage:', error);
     return [];
   }
 }
@@ -25,8 +27,9 @@ function saveHiddenColumnsToStorage(projectId: string, columns: KanbanColumnType
   }
   try {
     localStorage.setItem(`${STORAGE_KEY_PREFIX}${projectId}`, JSON.stringify(columns));
-  } catch {
-    // Ignore errors
+  } catch (error) {
+    // biome-ignore lint/suspicious/noConsole: Intentional error logging for debugging localStorage issues
+    console.warn('Failed to save hidden columns to localStorage:', error);
   }
 }
 


### PR DESCRIPTION
## Summary
- Add toast notification for failed file uploads in chat-input.tsx
- Add toast notification for failed workspace creation in app-sidebar.tsx
- Add console.warn for localStorage errors in kanban-context.tsx

Previously these catch blocks silently swallowed errors, leaving users without feedback when operations failed. Now users will see clear error messages when:
- File uploads fail during chat
- Workspace creation fails in the sidebar
- localStorage operations fail (logged to console for debugging)

## Test plan
- [ ] Trigger a file upload error (e.g., upload a corrupted file or disconnect network during upload) and verify toast appears
- [ ] Trigger a workspace creation error and verify toast appears
- [ ] Verify localStorage errors are logged to console (can test by filling localStorage quota)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to error handling and user/debug feedback (toasts/console warnings) without altering core business logic or data flow.
> 
> **Overview**
> Adds visible error feedback where failures were previously silently ignored. Chat file attachment uploads and sidebar workspace creation now show `sonner` toast errors with the underlying exception message, and Kanban hidden-column localStorage read/write failures now emit `console.warn` logs for debugging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c715134e4464bbd7f4c3957690397f74a83bdc06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->