### PR TITLE
Replace phase label with GitHub repo link in sidebar footer

### DIFF
--- a/src/frontend/components/app-sidebar.tsx
+++ b/src/frontend/components/app-sidebar.tsx
@@ -482,7 +482,14 @@ export function AppSidebar() {
       <SidebarFooter className="border-t border-sidebar-border p-4">
         <ServerPortInfo />
         <div className="flex items-center justify-between">
-          <p className="text-xs text-muted-foreground">Phase 7: Production Ready</p>
+          <a
+            href="https://github.com/purplefish-ai/factory-factory"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            GitHub
+          </a>
           <ThemeToggle />
         </div>
       </SidebarFooter>


### PR DESCRIPTION
## Summary
- Replaced "Phase 7: Production Ready" text with a GitHub link in the sidebar footer
- Link opens https://github.com/purplefish-ai/factory-factory in a new tab
- Added subtle hover effect for better UX

## Test plan
- [ ] Verify the GitHub link appears in the bottom left of the sidebar
- [ ] Click the link and confirm it opens the GitHub repo in a new tab
- [ ] Verify the hover state changes the text color

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that replaces static footer text with an external link; no app logic or data flow changes.
> 
> **Overview**
> Replaces the sidebar footer's "Phase 7: Production Ready" label with a **GitHub** link to `https://github.com/purplefish-ai/factory-factory`, opening in a new tab with proper `noopener noreferrer` and a subtle hover color transition.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e8b1b6d846cb9330dd37cc8de35d77f9d3b6e2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->