### PR TITLE
Fix spurious warning when archiving workspace

### DIFF
--- a/src/backend/claude/process.ts
+++ b/src/backend/claude/process.ts
@@ -619,14 +619,13 @@ export class ClaudeProcess extends EventEmitter {
 
     // Handle protocol close (stdout EOF)
     this.protocol.on('close', () => {
-      // Process crash or unexpected close
-      logger.warn('Claude protocol closed', {
-        pid: this.process.pid,
-        status: this.status,
-        claudeSessionId: this.claudeSessionId,
-      });
-      // Only emit error if not intentionally stopping and not already exited
+      // Only log warning and emit error if not intentionally stopping and not already exited
       if (this.status !== 'exited' && !this.isIntentionallyStopping) {
+        logger.warn('Claude protocol closed unexpectedly', {
+          pid: this.process.pid,
+          status: this.status,
+          claudeSessionId: this.claudeSessionId,
+        });
         const stderr = this.stderrBuffer.join('');
         logger.error('Claude process closed unexpectedly', {
           pid: this.process.pid,


### PR DESCRIPTION
## Summary
- Move the "Claude protocol closed" warning log inside the conditional that checks for unexpected closures
- Previously logged unconditionally, causing false warnings when intentionally stopping (e.g., archiving a workspace)

## Test plan
- [ ] Archive a workspace and verify no warning is logged
- [ ] Kill a Claude process unexpectedly and verify the warning still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts logging/alerting behavior on `ClaudeProtocol` close events, without changing process lifecycle or protocol behavior.
> 
> **Overview**
> Avoids spurious warnings when intentionally stopping a Claude CLI process. The `ClaudeProtocol` `close` handler now logs `Claude protocol closed unexpectedly` (and emits the associated error) only when the process wasn’t intentionally stopping and hasn’t already exited.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d523ce94135b47dc4acc545c3553ae11d1d32a7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->