### PR TITLE
Add external link icon to GitHub link and reduce footer padding

### DIFF
--- a/src/frontend/components/app-sidebar.tsx
+++ b/src/frontend/components/app-sidebar.tsx
@@ -1,4 +1,13 @@
-import { Archive, Check, GitPullRequest, Kanban, Loader2, Plus, Settings } from 'lucide-react';
+import {
+  Archive,
+  Check,
+  ExternalLink,
+  GitPullRequest,
+  Kanban,
+  Loader2,
+  Plus,
+  Settings,
+} from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router';
 import { toast } from 'sonner';
@@ -480,16 +489,17 @@ export function AppSidebar() {
         </SidebarGroup>
       </SidebarContent>
 
-      <SidebarFooter className="border-t border-sidebar-border p-4">
+      <SidebarFooter className="border-t border-sidebar-border px-4 py-2">
         <ServerPortInfo />
         <div className="flex items-center justify-between">
           <a
             href="https://github.com/purplefish-ai/factory-factory"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors inline-flex items-center gap-1"
           >
             GitHub
+            <ExternalLink className="h-3 w-3" />
           </a>
           <ThemeToggle />
         </div>


### PR DESCRIPTION
## Summary
- Added ExternalLink icon next to the GitHub link in the sidebar footer for better UX clarity
- Reduced footer vertical padding from `p-4` to `py-2` for tighter spacing

## Test plan
- [ ] Open the app and verify the GitHub link in the bottom left sidebar shows an external link icon
- [ ] Verify the footer spacing looks appropriate (not too much vertical padding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change limited to sidebar footer layout and iconography; no business logic or data flow changes.
> 
> **Overview**
> Tweaks the sidebar footer UI by reducing vertical padding and making the GitHub footer link render as an inline-flex row with a new `ExternalLink` icon next to the label.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0af89efadd32c6a8cd610878e4e5637a9b40d02c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->