### PR TITLE
Add automatic tag creation to npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -63,7 +63,7 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          if git ls-remote --tags origin | grep -q "refs/tags/v$VERSION$"; then
+          if [ -n "$(git ls-remote --tags origin "refs/tags/v$VERSION")" ]; then
             echo "Tag v$VERSION already exists on remote, skipping tag creation"
           else
             git tag -a "v$VERSION" -m "Release v$VERSION"


### PR DESCRIPTION
## Summary
- Adds automatic git tag creation when the npm publish workflow is triggered manually via `workflow_dispatch`
- Tags are created in the format `v{version}` based on `package.json`
- Only runs for non-dry-run manual triggers (release events already have tags)

## Test plan
- [ ] Trigger workflow_dispatch with dry_run=true - verify no tag is created
- [ ] Trigger workflow_dispatch with dry_run=false - verify tag is created and pushed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Workflow now has write access to repo contents and pushes git tags during `workflow_dispatch`, which can affect release history if misconfigured. Logic is simple and gated to non-dry-run manual runs, so overall risk is moderate.
> 
> **Overview**
> Adds automatic `v{package.json version}` tag creation/push to the npm publish GitHub Actions workflow when run via `workflow_dispatch` (non-dry-run), skipping if the tag already exists.
> 
> Updates workflow permissions to `contents: write` to allow pushing tags; release-triggered runs continue to just publish.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85327b67036e090313884caa67f3e215f0b9711d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->