### PR TITLE
Remove padding from PR link button in sidebar

### DIFF
--- a/src/frontend/components/app-sidebar.tsx
+++ b/src/frontend/components/app-sidebar.tsx
@@ -372,7 +372,7 @@ export function AppSidebar() {
                                           }
                                         }}
                                         className={cn(
-                                          'text-xs hover:opacity-80 transition-opacity',
+                                          'text-xs hover:opacity-80 transition-opacity p-0',
                                           workspace.prState === 'MERGED'
                                             ? 'text-purple-500'
                                             : 'text-muted-foreground hover:text-foreground'


### PR DESCRIPTION
## Summary
- Removes padding from the PR number button in the workspaces nav bar to prevent accidental clicks when trying to select the workspace row

## Test plan
- [ ] Navigate to a project with workspaces that have PR links
- [ ] Verify the PR link clickable area is now limited to the text itself
- [ ] Confirm clicking near the PR link (but not directly on it) selects the workspace row instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk styling-only change that reduces the clickable area of the PR number button; no logic, data, or API behavior is modified.
> 
> **Overview**
> Tightens the PR number link in `AppSidebar` by removing padding (`p-0`) from the PR button styling so clicks near the PR label are less likely to open GitHub and instead fall through to the workspace row.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f91558f78c58abd87947959ebb10a475e6555dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->