### PR TITLE
Fix spinner not showing for subsequent messages in chat session

### DIFF
--- a/src/backend/services/chat-message-handlers.service.ts
+++ b/src/backend/services/chat-message-handlers.service.ts
@@ -246,6 +246,10 @@ class ChatMessageHandlerService {
     // Update state to DISPATCHED - emits message_state_changed event
     messageStateService.updateState(dbSessionId, msg.id, MessageState.DISPATCHED);
 
+    // Notify frontend that agent is working - this ensures the spinner shows
+    // for subsequent messages when client is already running
+    chatConnectionService.forwardToSession(dbSessionId, { type: 'status', running: true });
+
     // Build content and send to Claude
     const content = this.buildMessageContent(msg);
     client.sendMessage(content);


### PR DESCRIPTION
## Summary
- Fix bug where the "Agent is working..." spinner didn't appear when sending subsequent messages to an already open chat session
- Send running status notification when dispatching messages to ensure spinner shows for all messages, not just the first one

## Problem
When sending a message to an existing session where the Claude client was already created but idle, the frontend never received a status update to transition from `ready` to `running`. This caused the spinner to not appear even though the agent was processing the message.

## Solution
Added a `{ type: 'status', running: true }` notification in `dispatchMessage()` to inform the frontend that work is starting whenever a message is dispatched.

## Test plan
- [x] TypeScript compiles without errors
- [x] All existing tests pass
- [ ] Manual test: Send a message, wait for response, send another message - spinner should appear for both

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single websocket `status` notification on message dispatch to keep UI state in sync, without changing queueing or Claude interaction logic.
> 
> **Overview**
> Ensures the frontend spinner reliably appears for *subsequent* queued messages by sending a `{ type: 'status', running: true }` event whenever `dispatchMessage()` hands work to the Claude client, even if the client was already created and idle.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 527b859bb4090da8fe387e5f4cca374028bef024. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->