### PR TITLE
Group copy and cancel buttons for queued messages

### DIFF
--- a/src/components/agent-activity/agent-activity.tsx
+++ b/src/components/agent-activity/agent-activity.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { X } from 'lucide-react';
+import { Copy, X } from 'lucide-react';
 import { memo } from 'react';
 import { AttachmentPreview } from '@/components/chat/attachment-preview';
 import type { ChatMessage, GroupedMessageItem } from '@/lib/claude-types';
@@ -56,38 +56,69 @@ export const MessageItem = memo(function MessageItem({
             isQueued && 'opacity-50'
           )}
         >
-          {/* Cancel button for queued messages - at message level so it works for text and attachment-only messages */}
-          {isQueued && onRemove && (
-            <button
-              onClick={onRemove}
-              className={cn(
-                'absolute -top-1 -right-1 p-1.5 rounded-md',
-                'bg-background/90 hover:bg-destructive/10',
-                'border border-border hover:border-destructive/50',
-                'shadow-sm',
-                'opacity-0 group-hover:opacity-100',
-                'transition-all',
-                'z-10',
-                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
-              )}
-              title="Cancel queued message"
-              type="button"
-              aria-label="Cancel queued message"
-            >
-              <X className="h-3.5 w-3.5 text-muted-foreground hover:text-destructive" />
-            </button>
-          )}
+          {/* Action buttons group - positioned at top-right */}
+          <div
+            className={cn(
+              'absolute -top-1 -right-1 flex items-center gap-1',
+              'opacity-0 group-hover:opacity-100',
+              'transition-all',
+              'z-10'
+            )}
+          >
+            {/* Copy button */}
+            {userText && (
+              <button
+                onClick={async () => {
+                  try {
+                    await navigator.clipboard.writeText(userText);
+                  } catch {
+                    // Silently fail
+                  }
+                }}
+                onMouseDown={(e) => e.preventDefault()}
+                className={cn(
+                  'p-1.5 rounded-md',
+                  'bg-background/90 hover:bg-background',
+                  'border border-border',
+                  'shadow-sm',
+                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+                )}
+                title="Copy to clipboard"
+                type="button"
+                aria-label="Copy message to clipboard"
+              >
+                <Copy className="h-3.5 w-3.5 text-muted-foreground hover:text-foreground" />
+              </button>
+            )}
+            {/* Cancel button for queued messages */}
+            {isQueued && onRemove && (
+              <button
+                onClick={onRemove}
+                className={cn(
+                  'p-1.5 rounded-md',
+                  'bg-background/90 hover:bg-destructive/10',
+                  'border border-border hover:border-destructive/50',
+                  'shadow-sm',
+                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+                )}
+                title="Cancel queued message"
+                type="button"
+                aria-label="Cancel queued message"
+              >
+                <X className="h-3.5 w-3.5 text-muted-foreground hover:text-destructive" />
+              </button>
+            )}
+          </div>
           {/* Attachments */}
           {message.attachments && message.attachments.length > 0 && (
             <AttachmentPreview attachments={message.attachments} readOnly />
           )}
           {/* Text */}
           {message.text && (
-            <div className="group relative inline-block max-w-full">
+            <div className="relative inline-block max-w-full">
               <div className="rounded bg-background border border-border px-3 py-2 break-words text-sm text-left whitespace-pre-wrap">
                 {userText}
               </div>
-              {userText && <CopyMessageButton textContent={userText} />}
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- Fixed overlapping copy and cancel buttons on queued user messages
- Grouped both buttons into a single flex container positioned at the top-right corner
- Buttons now appear side-by-side on hover instead of overlapping

## Test plan
- [ ] Send a message while the agent is running (so it gets queued)
- [ ] Hover over the queued message
- [ ] Verify the copy and cancel buttons appear side-by-side without overlapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that rearranges message action controls; main risk is minor hover/positioning regressions or clipboard behavior differences for user messages.
> 
> **Overview**
> Prevents overlapping controls on queued user messages by grouping the *copy* and *cancel* buttons into a single top-right hover container.
> 
> User message copying is now handled inline via a new `Copy` icon button (using `navigator.clipboard`) instead of rendering `CopyMessageButton` in the text bubble, while queued-message cancel remains available alongside it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89cc54d115bb4de9d472f3319ab343b39729142e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->