### PR TITLE
Fix Express 5 sendFile requiring root option for SPA fallback

### DIFF
--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -171,12 +171,12 @@ export function createServer(requestedPort?: number): ServerInstance {
       ) {
         return next();
       }
-      const indexPath = join(frontendStaticPath, 'index.html');
       // Set no-cache headers for index.html so browsers always check for updates
       res.set('Cache-Control', 'no-cache, no-store, must-revalidate');
       res.set('Pragma', 'no-cache');
       res.set('Expires', '0');
-      res.sendFile(indexPath, (err) => {
+      // Express 5 requires the root option for sendFile to work correctly
+      res.sendFile('index.html', { root: frontendStaticPath }, (err) => {
         if (err) {
           // File not found or read error - log at debug level since this can happen
           // during page refresh timing issues and is usually transient


### PR DESCRIPTION
## Summary
- Fix 503 errors when serving index.html in production npm package
- Express 5 requires the `root` option for `res.sendFile()` to work correctly

## Problem
When running `npx factory-factory@latest serve`, users got "Service temporarily unavailable" (503) errors. The page wouldn't load at all.

Express 5 changed the behavior of `res.sendFile()`. When passing an absolute path directly, the underlying `send` package returns a "Not Found" error even when the file exists. This is a security-related change in Express 5.

## Solution
Use the `root` option which is the correct way to serve files in Express 5:

```typescript
// Before (broken in Express 5)
res.sendFile(join(frontendStaticPath, 'index.html'))

// After (Express 5 compatible)  
res.sendFile('index.html', { root: frontendStaticPath })
```

## Test plan
- [x] All 1021 tests pass
- [x] Build succeeds
- [ ] Test with `npm pack` and install locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to the SPA fallback file-serving call to align with Express 5 behavior; impact is limited to production static serving of `index.html`.
> 
> **Overview**
> Fixes the SPA fallback in `src/backend/server.ts` to be Express 5 compatible by switching `res.sendFile()` from an absolute path to `res.sendFile('index.html', { root: frontendStaticPath })`, while keeping the existing no-cache headers and 503-on-error handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3e84ef6df0f080bd1b13d1a57607ad2ffdf3281. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->