### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to Factory Factory will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] - 2025-02-01
+
+### Fixed
+- User messages appearing at top instead of chronological position (#438)
+- Express 5 sendFile requiring root option for SPA fallback (#437)
+
+### Changed
+- Grouped copy and cancel buttons for queued messages (#436)
+
 ## [0.1.2] - 2025-02-01
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "factory-factory",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Workspace-based coding environment for running multiple Claude Code sessions in parallel",
   "private": false,
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump version to 0.1.3
- Update CHANGELOG.md with recent fixes

## Changes since v0.1.2

### Fixed
- User messages appearing at top instead of chronological position (#438)
- Express 5 sendFile requiring root option for SPA fallback (#437)

### Changed
- Grouped copy and cancel buttons for queued messages (#436)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: release bookkeeping only (version bump and changelog entry) with no runtime code changes.
> 
> **Overview**
> Prepares the `v0.1.3` release by bumping `package.json` from `0.1.2` to `0.1.3`.
> 
> Updates `CHANGELOG.md` with a new `0.1.3` section summarizing recent fixes and a small UI behavior change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 169781a39175645042f82ed43fa99ac1c97904be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->