### PR TITLE
Fix streaming tool input undefined error

### DIFF
--- a/src/components/agent-activity/tool-renderers.tsx
+++ b/src/components/agent-activity/tool-renderers.tsx
@@ -563,7 +563,7 @@ const ToolInputRenderer = memo(function ToolInputRenderer({ name, input }: ToolI
           <FilePathDisplay path={input.file_path as string} />
           <div className="rounded bg-muted px-1.5 py-1">
             <pre className="text-xs overflow-x-auto max-h-32 overflow-y-auto">
-              {truncateContent(input.content as string, 500)}
+              {truncateContent((input.content as string) ?? '', 500)}
             </pre>
           </div>
         </div>
@@ -577,13 +577,13 @@ const ToolInputRenderer = memo(function ToolInputRenderer({ name, input }: ToolI
             <div className="rounded bg-destructive/10 px-1.5 py-1 min-w-0">
               <div className="text-[10px] font-medium text-destructive mb-0.5">Remove</div>
               <pre className="text-xs overflow-x-auto max-h-16 overflow-y-auto">
-                {truncateContent(input.old_string as string, 200)}
+                {truncateContent((input.old_string as string) ?? '', 200)}
               </pre>
             </div>
             <div className="rounded bg-success/10 px-1.5 py-1 min-w-0">
               <div className="text-[10px] font-medium text-success mb-0.5">Add</div>
               <pre className="text-xs overflow-x-auto max-h-16 overflow-y-auto">
-                {truncateContent(input.new_string as string, 200)}
+                {truncateContent((input.new_string as string) ?? '', 200)}
               </pre>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Fix "Cannot read properties of undefined (reading 'length')" error that occurs intermittently when viewing streaming tool calls
- Add nullish coalescing fallbacks for tool input properties that may be undefined during streaming

## Test plan
- [ ] Start a chat session and trigger Write or Edit tool calls
- [ ] Observe the tool call rendering during streaming - no console errors should appear
- [ ] Verify the tool inputs display correctly once streaming completes

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds nullish fallbacks to avoid runtime errors when tool inputs are temporarily undefined during streaming.
> 
> **Overview**
> Prevents intermittent tool-call rendering crashes by defaulting `Write`/`Edit` input strings (`content`, `old_string`, `new_string`) to empty strings before passing them to `truncateContent`, avoiding undefined `.length` access during streaming.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 672a2121a19511232030ced5b68a7dbbe4d8cc3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->