### PR TITLE
Fix node-pty spawn-helper permissions for npx installs

### DIFF
--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -35,29 +35,60 @@ if (existsSync(schemaPath)) {
 }
 
 // Fix node-pty spawn-helper permissions (Unix only)
+// This handles both local node_modules and npx cache installations
 if (process.platform !== 'win32') {
+	/**
+	 * Fix spawn-helper permissions in a given prebuilds directory
+	 */
+	function fixSpawnHelperPermissions(prebuildsDir) {
+		if (!existsSync(prebuildsDir)) {
+			return false;
+		}
+
+		let fixed = false;
+		for (const platform of readdirSync(prebuildsDir)) {
+			const spawnHelper = join(prebuildsDir, platform, 'spawn-helper');
+			if (existsSync(spawnHelper)) {
+				try {
+					chmodSync(spawnHelper, 0o755);
+					fixed = true;
+				} catch {
+					// Ignore permission errors
+				}
+			}
+		}
+		return fixed;
+	}
+
+	// 1. Fix in local node_modules (standard install)
 	try {
-		const prebuildsDir = join(
+		const localPrebuilds = join(
 			projectRoot,
 			'node_modules',
 			'node-pty',
 			'prebuilds',
 		);
+		fixSpawnHelperPermissions(localPrebuilds);
+	} catch {
+		// Ignore if node-pty doesn't exist locally
+	}
 
-		if (existsSync(prebuildsDir)) {
-			// Find all spawn-helper files in prebuild directories
-			for (const platform of readdirSync(prebuildsDir)) {
-				const spawnHelper = join(prebuildsDir, platform, 'spawn-helper');
-				if (existsSync(spawnHelper)) {
-					try {
-						chmodSync(spawnHelper, 0o755);
-					} catch {
-						// Ignore permission errors
-					}
-				}
+	// 2. Fix in the directory where this script is running from (npx case)
+	// When run via npx, the module is in a different location
+	try {
+		// Walk up from __dirname to find node_modules/node-pty
+		let searchDir = __dirname;
+		for (let i = 0; i < 10; i++) {
+			const candidate = join(searchDir, 'node_modules', 'node-pty', 'prebuilds');
+			if (existsSync(candidate)) {
+				fixSpawnHelperPermissions(candidate);
+				break;
 			}
+			const parent = dirname(searchDir);
+			if (parent === searchDir) break;
+			searchDir = parent;
 		}
 	} catch {
-		// Ignore if node-pty doesn't exist
+		// Ignore errors
 	}
 }


### PR DESCRIPTION
## Summary
- Fix "posix_spawnp failed" error when creating terminals via npx
- Extend postinstall script to find and fix spawn-helper permissions in npx cache

## Problem
When running Factory Factory via `npx factory-factory`, the terminal creation fails with:
```
Error: posix_spawnp failed.
    at new UnixTerminal (node-pty/lib/unixTerminal.js:92:24)
```

The root cause is that the `spawn-helper` binary in node-pty's prebuilds directory lacks executable permissions (`-rw-r--r--` instead of `-rwxr-xr-x`) after npm/npx extraction.

## Solution
The postinstall script already fixed this for local `node_modules`, but when running via npx, the module is installed in `~/.npm/_npx/<hash>/node_modules/` instead of the project directory.

This PR adds a second search path that walks up from the script's location to find and fix the spawn-helper in the npx cache.

## Test plan
- [x] Verified fix resolves the terminal spawn error
- [x] Tested postinstall script runs without errors
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to the Unix-only `postinstall` script and only attempt to `chmod` an existing `node-pty` helper binary without failing installation.
> 
> **Overview**
> Fixes terminal spawning failures when running via `npx` by extending the `scripts/postinstall.mjs` permission fix to also search for `node_modules/node-pty/prebuilds` relative to the script location (npx cache), not just the project’s local `node_modules`.
> 
> Refactors the chmod logic into a small helper (`fixSpawnHelperPermissions`) and keeps all errors non-fatal (missing paths/permission issues are ignored).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc11f6707b56623c787d5ba7cd55623b4fb1aaac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->