### PR TITLE
Fix code review issues: config caching, division by zero, and opacity inheritance

### DIFF
--- a/src/backend/services/config.service.ts
+++ b/src/backend/services/config.service.ts
@@ -142,6 +142,9 @@ interface SystemConfig {
   // Debug settings
   debug: DebugConfig;
 
+  // Event compression settings
+  compression: CompressionConfig;
+
   // Conversation rename settings
   branchRenameMessageThreshold: number;
 
@@ -364,6 +367,11 @@ function loadSystemConfig(): SystemConfig {
       chatWebSocket: process.env.DEBUG_CHAT_WS === 'true',
     },
 
+    // Event compression settings
+    compression: {
+      enabled: process.env.EVENT_COMPRESSION_ENABLED !== 'false',
+    },
+
     // Conversation rename settings
     branchRenameMessageThreshold: Number.parseInt(
       process.env.BRANCH_RENAME_MESSAGE_THRESHOLD || '2',
@@ -574,9 +582,7 @@ class ConfigService {
    * Get event compression configuration for replay optimization
    */
   getCompressionConfig(): CompressionConfig {
-    return {
-      enabled: process.env.EVENT_COMPRESSION_ENABLED !== 'false',
-    };
+    return { ...this.config.compression };
   }
 
   /**

--- a/src/backend/services/event-compression.service.ts
+++ b/src/backend/services/event-compression.service.ts
@@ -208,7 +208,7 @@ class EventCompressionService {
       return; // No compression occurred
     }
 
-    const ratio = stats.originalCount / stats.compressedCount;
+    const ratio = stats.compressedCount > 0 ? stats.originalCount / stats.compressedCount : 0;
     logger.info('Event compression applied', {
       sessionId,
       originalCount: stats.originalCount,

--- a/src/components/agent-activity/agent-activity.tsx
+++ b/src/components/agent-activity/agent-activity.tsx
@@ -50,13 +50,9 @@ export const MessageItem = memo(function MessageItem({
     const userText = stripThinkingSuffix(message.text);
     return (
       <MessageWrapper>
-        <div
-          className={cn(
-            'group relative inline-block max-w-full space-y-2',
-            isQueued && 'opacity-50'
-          )}
-        >
-          {/* Action buttons group - positioned at top-right */}
+        {/* Wrapper for positioning action buttons outside opacity container */}
+        <div className="group relative inline-block max-w-full">
+          {/* Action buttons group - positioned at top-right, outside opacity container */}
           <div
             className={cn(
               'absolute -top-1 -right-1 flex items-center gap-1',
@@ -109,18 +105,21 @@ export const MessageItem = memo(function MessageItem({
               </button>
             )}
           </div>
-          {/* Attachments */}
-          {message.attachments && message.attachments.length > 0 && (
-            <AttachmentPreview attachments={message.attachments} readOnly />
-          )}
-          {/* Text */}
-          {message.text && (
-            <div className="relative inline-block max-w-full">
-              <div className="rounded bg-background border border-border px-3 py-2 break-words text-sm text-left whitespace-pre-wrap">
-                {userText}
+          {/* Message content - opacity applied here to fade queued messages without affecting buttons */}
+          <div className={cn('space-y-2', isQueued && 'opacity-50')}>
+            {/* Attachments */}
+            {message.attachments && message.attachments.length > 0 && (
+              <AttachmentPreview attachments={message.attachments} readOnly />
+            )}
+            {/* Text */}
+            {message.text && (
+              <div className="relative inline-block max-w-full">
+                <div className="rounded bg-background border border-border px-3 py-2 break-words text-sm text-left whitespace-pre-wrap">
+                  {userText}
+                </div>
               </div>
-            </div>
-          )}
+            )}
+          </div>
         </div>
       </MessageWrapper>
     );


### PR DESCRIPTION
## Summary

- Fix `getCompressionConfig()` to use cached config instead of reading directly from `process.env` on every call
- Add defensive guard against division by zero in `logCompressionStats()`
- Fix cancel button opacity inheritance on queued messages

## Changes

### Config caching inconsistency
The `getCompressionConfig()` method was reading directly from `process.env.EVENT_COMPRESSION_ENABLED` on every call, bypassing the caching mechanism used by all other config methods. Now uses the cached `this.config.compression` like other methods.

### Division by zero guard
Added a guard in `logCompressionStats()` to handle the edge case where `stats.compressedCount` is 0:
```typescript
const ratio = stats.compressedCount > 0 ? stats.originalCount / stats.compressedCount : 0;
```

### Cancel button opacity inheritance
The cancel button on queued messages was inheriting reduced opacity from its parent container (CSS opacity stacks multiplicatively). Restructured the component so action buttons are positioned outside the opacity-50 container while maintaining proper hover behavior.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test src/backend/services/event-compression.service.test.ts` passes (20 tests)
- [x] `pnpm check:fix` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, targeted fixes to config access, defensive logging math, and a UI layout tweak with no changes to core data flows.
> 
> **Overview**
> Fixes event compression config handling by adding `compression` to the cached `SystemConfig` and updating `getCompressionConfig()` to return the cached value instead of rereading `process.env`.
> 
> Hardens `EventCompressionService.logCompressionStats()` against divide-by-zero when `compressedCount` is `0`, and restructures the queued user message UI so the cancel/copy buttons don’t inherit the queued message opacity.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96926fd6ccbb7c90f31b4ce3f3bb1bc768a04f03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->