### PR TITLE
Add Shift+Tab keyboard shortcut to toggle plan mode

### DIFF
--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -372,8 +372,8 @@ export const ChatInput = memo(function ChatInput({
   // Handle key press for Enter to send and Shift+Tab for plan mode toggle
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLTextAreaElement>) => {
-      // Shift+Tab toggles plan mode
-      if (event.key === 'Tab' && event.shiftKey) {
+      // Shift+Tab toggles plan mode (only when not running, matching the button's disabled state)
+      if (event.key === 'Tab' && event.shiftKey && !running) {
         event.preventDefault();
         onSettingsChange?.({ planModeEnabled: !settings?.planModeEnabled });
         return;
@@ -391,7 +391,7 @@ export const ChatInput = memo(function ChatInput({
         }
       }
     },
-    [onSend, disabled, onChange, setAttachments, attachments, settings, onSettingsChange]
+    [onSend, disabled, running, onChange, setAttachments, attachments, settings, onSettingsChange]
   );
 
   // Handle send button click


### PR DESCRIPTION
## Summary
- Adds Shift+Tab keyboard shortcut to toggle planning mode when the chat input textarea is focused
- Provides a quick way to enable/disable plan mode without clicking the toggle button
- Does not interfere with normal Tab behavior (Tab without Shift still moves focus)

## Test plan
- [ ] Run `pnpm dev` and open a workspace chat
- [ ] Focus on the chat input textarea
- [ ] Press Shift+Tab and verify the plan mode toggle button changes state
- [ ] Press Shift+Tab again to toggle it back off
- [ ] Verify normal Tab behavior still moves focus between elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: adds a new keyboard shortcut in `ChatInput` and updates hook dependencies; no backend, auth, or data-handling logic is touched.
> 
> **Overview**
> Adds a **Shift+Tab** keyboard shortcut in `ChatInput` to toggle `planModeEnabled` via `onSettingsChange`, while preserving existing Enter-to-send behavior.
> 
> The shortcut is suppressed when the agent is `running` (matching the toggle button’s disabled state) and the `handleKeyDown` hook dependencies are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14bbb4065746be064d8ccdf565e8ff981c0e1bca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->