### PR TITLE
Fix quick action not executing when clicked

### DIFF
--- a/src/client/routes/projects/workspaces/detail.tsx
+++ b/src/client/routes/projects/workspaces/detail.tsx
@@ -327,6 +327,8 @@ function WorkspaceChatContent() {
   // Derive boolean flags from sessionStatus for local use
   const running = sessionStatus.phase === 'running';
   const loadingSession = sessionStatus.phase === 'loading';
+  // Session is ready when session_loaded has been received (ready or running phase)
+  const isSessionReady = sessionStatus.phase === 'ready' || sessionStatus.phase === 'running';
 
   // Session management
   const {
@@ -350,6 +352,7 @@ function WorkspaceChatContent() {
     selectedDbSessionId,
     setSelectedDbSessionId,
     selectedModel: chatSettings.selectedModel,
+    isSessionReady,
   });
 
   // Ref for scroll handling (virtualized list manages its own content)


### PR DESCRIPTION
## Summary
- Fix quick actions (e.g., "Fetch & Rebase") not executing when clicked
- The issue was a timing race condition where the message was sent before the WebSocket session was ready
- Added `isSessionReady` check and `hasSeenLoadingRef` tracking to ensure the session goes through loading → ready before sending the prompt
- Fixed null model validation error by converting `selectedModel` from `null` to `undefined`

## Root Cause
When a quick action was clicked:
1. A new session was created via `createSession.mutate()`
2. The `selectedDbSessionId` was set immediately on success
3. An effect tried to send the pending prompt, but the WebSocket wasn't connected/ready yet
4. Additionally, when switching between workspaces, `isSessionReady` could be stale from the previous session

## Fix
1. Added `isSessionReady` prop to `useSessionManagement` to track when the session is ready
2. Added `hasSeenLoadingRef` to detect that the session has gone through the `loading` phase (avoiding stale state from previous sessions)
3. The effect now waits for: session selected + session went through loading + session is ready
4. Fixed `model: selectedModel` → `model: selectedModel || undefined` to satisfy zod validation

## Test plan
- [ ] Click "Fetch & Rebase" quick action on a workspace with no existing sessions
- [ ] Verify the action executes and a chat session is created with the prompt
- [ ] Switch to a different workspace and click a quick action
- [ ] Verify the action works correctly in the new workspace
- [ ] Verify normal chat functionality still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)