### PR TITLE
Fix diff vs main to prefer origin/main over local main

### DIFF
--- a/src/backend/lib/git-helpers.ts
+++ b/src/backend/lib/git-helpers.ts
@@ -93,14 +93,14 @@ export function parseNumstatOutput(output: string): { additions: number; deletio
 
 /**
  * Get the merge base between HEAD and the default branch.
- * Tries local branch first, falls back to origin/.
+ * Tries origin/ first (which stays current with fetches), falls back to local branch.
  * Returns null if no merge base can be found.
  */
 export async function getMergeBase(
   worktreePath: string,
   defaultBranch: string
 ): Promise<string | null> {
-  const candidates = [defaultBranch, `origin/${defaultBranch}`];
+  const candidates = [`origin/${defaultBranch}`, defaultBranch];
 
   for (const base of candidates) {
     const result = await gitCommand(['merge-base', 'HEAD', base], worktreePath);


### PR DESCRIPTION
## Summary
- Fixes the "diff vs main" feature to compare against `origin/main` instead of local `main`
- The local `main` branch gets stale as the remote advances, causing misleading diffs that show changes already merged upstream
- Now prefers `origin/main` (which stays current with `git fetch`) with fallback to local `main`

## Test plan
- [ ] Open a workspace on a branch that has commits merged to main
- [ ] Verify the "diff vs main" panel shows only the actual unmerged changes
- [ ] Verify it still works when origin/main is not available (falls back to local)

🤖 Generated with [Claude Code](https://claude.com/claude-code)