### PR TITLE
Show branch name in sidebar instead of workspace name

### DIFF
--- a/src/frontend/components/app-sidebar.tsx
+++ b/src/frontend/components/app-sidebar.tsx
@@ -329,7 +329,9 @@ export function AppSidebar() {
 
                             {/* Name (truncates) */}
                             <span className="truncate font-medium text-sm flex-1 min-w-0 ml-1">
-                              {isArchivingItem ? 'Archiving...' : workspace.name}
+                              {isArchivingItem
+                                ? 'Archiving...'
+                                : workspace.branchName || workspace.name}
                             </span>
 
                             {/* Diff stats */}


### PR DESCRIPTION
## Summary
- Display the renamed branch name (`branchName`) in the left sidebar menu when available
- Fall back to the original workspace name if no branch name is set
- This makes the sidebar show more descriptive names like `adeeshaek/ci-monitoring-service` instead of the original generated name like `ridge`

## Test plan
- [ ] Rename a workspace branch using the "Rename branch" quick action
- [ ] Verify the sidebar shows the new branch name instead of the original workspace name
- [ ] Create a new workspace and verify the sidebar shows the original name (before any rename)

🤖 Generated with [Claude Code](https://claude.com/claude-code)