### PR TITLE
Unify New Workspace button behavior across UI

### DIFF
--- a/src/client/routes/projects/workspaces/list.tsx
+++ b/src/client/routes/projects/workspaces/list.tsx
@@ -66,6 +66,10 @@ function useCreateWorkspace(projectId: string | undefined, slug: string) {
 
       utils.workspace.list.invalidate({ projectId });
       utils.workspace.getProjectSummaryState.invalidate({ projectId });
+      // Note: We intentionally don't reset isCreating here. On success, navigate()
+      // unmounts this component, making state updates unnecessary. Resetting in a
+      // finally block could trigger React warnings about updating unmounted components.
+      // This matches the sidebar implementation in app-sidebar.tsx.
       navigate(`/projects/${slug}/workspaces/${workspace.id}`);
     } catch (error) {
       setIsCreating(false);


### PR DESCRIPTION
## Summary
- Make the "New Workspace" button on the kanban/list page behave the same as the sidebar + button
- Both buttons now immediately create a workspace with an auto-generated name and navigate to it
- Previously, the kanban button navigated to a separate form page while the sidebar button created immediately

## Changes
- Added `useCreateWorkspace` hook to encapsulate workspace creation logic
- Added `NewWorkspaceButton` component for consistent button rendering
- Updated all three button locations (kanban header, list header, empty state) to use the new component

## Test plan
- [ ] Click the + button in the sidebar - should create workspace and navigate to it
- [ ] Click "New Workspace" in the kanban view header - should behave the same
- [ ] Click "New Workspace" in the list view header - should behave the same
- [ ] Click "Create your first workspace" in the empty state - should behave the same
- [ ] Verify loading spinner appears while workspace is being created

🤖 Generated with [Claude Code](https://claude.com/claude-code)