### PR TITLE
Fix New Workspace button size in Kanban view

### DIFF
--- a/src/client/routes/projects/workspaces/list.tsx
+++ b/src/client/routes/projects/workspaces/list.tsx
@@ -74,7 +74,7 @@ export default function WorkspacesListPage() {
               </ToggleGroupItem>
             </ToggleGroup>
             <KanbanControls />
-            <Button asChild>
+            <Button size="sm" asChild>
               <Link to={`/projects/${slug}/workspaces/new`}>
                 <Plus className="h-4 w-4 mr-2" />
                 New Workspace


### PR DESCRIPTION
## Summary
- Added `size="sm"` to the "New Workspace" button in the Kanban view so it matches the height of the adjacent Refresh and Columns buttons.

## Screenshots
<img width="429" height="162" alt="image" src="https://github.com/user-attachments/assets/364b1596-5f24-4ed3-a646-499553cef1ca" />
