### PR TITLE
Fix workspace header controls layout consistency

### DIFF
--- a/src/client/routes/projects/workspaces/list.tsx
+++ b/src/client/routes/projects/workspaces/list.tsx
@@ -60,6 +60,7 @@ export default function WorkspacesListPage() {
       <KanbanProvider projectId={project.id} projectSlug={slug}>
         <div className="flex flex-col h-screen p-6 gap-4">
           <PageHeader title="Workspaces">
+            <KanbanControls />
             <ToggleGroup
               type="single"
               value={viewMode}
@@ -73,7 +74,6 @@ export default function WorkspacesListPage() {
                 <List className="h-4 w-4" />
               </ToggleGroupItem>
             </ToggleGroup>
-            <KanbanControls />
             <Button size="sm" asChild>
               <Link to={`/projects/${slug}/workspaces/new`}>
                 <Plus className="h-4 w-4 mr-2" />
@@ -93,19 +93,6 @@ export default function WorkspacesListPage() {
   return (
     <div className="space-y-4 p-6">
       <PageHeader title="Workspaces">
-        <ToggleGroup
-          type="single"
-          value={viewMode}
-          onValueChange={(value) => value && setViewMode(value as ViewMode)}
-          size="sm"
-        >
-          <ToggleGroupItem value="board" aria-label="Board view">
-            <Kanban className="h-4 w-4" />
-          </ToggleGroupItem>
-          <ToggleGroupItem value="list" aria-label="List view">
-            <List className="h-4 w-4" />
-          </ToggleGroupItem>
-        </ToggleGroup>
         <Select value={statusFilter} onValueChange={setStatusFilter}>
           <SelectTrigger className="w-[150px]">
             <SelectValue placeholder="All Statuses" />
@@ -119,7 +106,20 @@ export default function WorkspacesListPage() {
             ))}
           </SelectContent>
         </Select>
-        <Button asChild>
+        <ToggleGroup
+          type="single"
+          value={viewMode}
+          onValueChange={(value) => value && setViewMode(value as ViewMode)}
+          size="sm"
+        >
+          <ToggleGroupItem value="board" aria-label="Board view">
+            <Kanban className="h-4 w-4" />
+          </ToggleGroupItem>
+          <ToggleGroupItem value="list" aria-label="List view">
+            <List className="h-4 w-4" />
+          </ToggleGroupItem>
+        </ToggleGroup>
+        <Button size="sm" asChild>
           <Link to={`/projects/${slug}/workspaces/new`}>
             <Plus className="h-4 w-4 mr-2" />
             New Workspace


### PR DESCRIPTION
## Summary
- Make New Workspace button size consistent (`size="sm"`) in both Kanban and list views
- Move view toggles next to the New Workspace button so they don't jump when switching between views

## Test plan
- [ ] Navigate to a project's workspaces page
- [ ] Verify the New Workspace button is the same size in both Kanban and list views
- [ ] Toggle between Kanban and list views and verify the toggle buttons and New Workspace button don't shift position

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: reorders header controls and standardizes button sizing with no impact to data fetching or business logic.
> 
> **Overview**
> Improves `Workspaces` page header layout consistency between board and list views by placing the view-mode `ToggleGroup` next to the primary actions and standardizing the **New Workspace** button to `size="sm"` in both layouts.
> 
> This reduces control “jumping” when switching between board and list views without changing workspace data behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0e3eb3bf7453065fa4c93c9907912f09362c79f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->