### PR TITLE
Add model usage and cost tracking to chat UI

### DIFF
--- a/src/client/routes/projects/workspaces/detail.tsx
+++ b/src/client/routes/projects/workspaces/detail.tsx
@@ -35,7 +35,7 @@ import {
 } from '@/components/workspace';
 import { Loading } from '@/frontend/components/loading';
 import { trpc } from '@/frontend/lib/trpc';
-import type { CommandInfo } from '@/lib/claude-types';
+import type { CommandInfo, TokenStats } from '@/lib/claude-types';
 import { groupAdjacentToolCalls } from '@/lib/claude-types';
 import { cn } from '@/lib/utils';
 
@@ -103,6 +103,7 @@ interface ChatContentProps {
   pendingMessages: ReturnType<typeof useChatWebSocket>['pendingMessages'];
   isCompacting: ReturnType<typeof useChatWebSocket>['isCompacting'];
   slashCommands: CommandInfo[];
+  tokenStats: TokenStats;
 }
 
 /**
@@ -136,6 +137,7 @@ const ChatContent = memo(function ChatContent({
   pendingMessages,
   isCompacting,
   slashCommands,
+  tokenStats,
 }: ChatContentProps) {
   // Group adjacent tool calls for display (memoized)
   const groupedMessages = useMemo(() => groupAdjacentToolCalls(messages), [messages]);
@@ -229,6 +231,7 @@ const ChatContent = memo(function ChatContent({
           onHeightChange={handleHeightChange}
           pendingMessageCount={pendingMessages.size}
           slashCommands={slashCommands}
+          tokenStats={tokenStats}
         />
       </div>
     </div>
@@ -319,6 +322,7 @@ function WorkspaceChatContent() {
     pendingMessages,
     isCompacting,
     slashCommands,
+    tokenStats,
     sendMessage,
     stopChat,
     approvePermission,
@@ -590,6 +594,7 @@ function WorkspaceChatContent() {
                 pendingMessages={pendingMessages}
                 isCompacting={isCompacting}
                 slashCommands={slashCommands}
+                tokenStats={tokenStats}
               />
             </WorkspaceContentView>
           </div>

--- a/src/components/chat/chat-input/chat-input.tsx
+++ b/src/components/chat/chat-input/chat-input.tsx
@@ -13,8 +13,9 @@ import {
   InputGroupTextarea,
 } from '@/components/ui/input-group';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import type { ChatSettings, CommandInfo, MessageAttachment } from '@/lib/claude-types';
+import type { ChatSettings, CommandInfo, MessageAttachment, TokenStats } from '@/lib/claude-types';
 import { cn } from '@/lib/utils';
+import { ContextWindowIndicator } from '../usage-stats';
 
 import { ModelSelector } from './components/model-selector';
 import { QuickActionsDropdown } from './components/quick-actions-dropdown';
@@ -53,6 +54,8 @@ export interface ChatInputProps {
   onAttachmentsChange?: (attachments: MessageAttachment[]) => void;
   // Slash commands for autocomplete
   slashCommands?: CommandInfo[];
+  // Token usage stats for context window indicator
+  tokenStats?: TokenStats;
 }
 
 // =============================================================================
@@ -84,6 +87,7 @@ export const ChatInput = memo(function ChatInput({
   attachments: controlledAttachments,
   onAttachmentsChange,
   slashCommands = [],
+  tokenStats,
 }: ChatInputProps) {
   // State for file attachments (uncontrolled mode only)
   const [internalAttachments, setInternalAttachments] = useState<MessageAttachment[]>([]);
@@ -245,6 +249,13 @@ export const ChatInput = memo(function ChatInput({
               className="hidden"
               aria-label="File upload input"
             />
+            {/* Context window indicator */}
+            {tokenStats && (
+              <>
+                <div className="h-4 w-px bg-border" />
+                <ContextWindowIndicator tokenStats={tokenStats} />
+              </>
+            )}
           </div>
 
           {/* Right side: Sending indicator + Stop button (when running) + Send button */}

--- a/src/components/chat/usage-stats/context-window-indicator.stories.tsx
+++ b/src/components/chat/usage-stats/context-window-indicator.stories.tsx
@@ -1,0 +1,99 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { createTokenStats } from '@/lib/claude-fixtures';
+import type { TokenStats } from '@/lib/claude-types';
+import { ContextWindowIndicator } from './context-window-indicator';
+
+const meta: Meta<typeof ContextWindowIndicator> = {
+  title: 'Chat/UsageStats/ContextWindowIndicator',
+  component: ContextWindowIndicator,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Helper to create token stats with specific usage percentage
+function createStatsWithUsage(usagePercent: number, contextWindow = 200_000): TokenStats {
+  const usedTokens = Math.round(contextWindow * (usagePercent / 100));
+  const inputTokens = Math.round(usedTokens * 0.7);
+  const outputTokens = usedTokens - inputTokens;
+
+  return createTokenStats({
+    inputTokens,
+    outputTokens,
+    contextWindow,
+    totalCostUsd: usedTokens * 0.000_01,
+    turnCount: Math.ceil(usagePercent / 10),
+  });
+}
+
+export const LowUsage: Story = {
+  args: {
+    tokenStats: createStatsWithUsage(30),
+  },
+};
+
+export const MediumUsage: Story = {
+  args: {
+    tokenStats: createStatsWithUsage(60),
+  },
+};
+
+export const WarningLevel: Story = {
+  args: {
+    tokenStats: createStatsWithUsage(85),
+  },
+};
+
+export const CriticalLevel: Story = {
+  args: {
+    tokenStats: createStatsWithUsage(97),
+  },
+};
+
+export const NoContextWindow: Story = {
+  name: 'No Context Window Info',
+  args: {
+    tokenStats: createTokenStats({
+      inputTokens: 5000,
+      outputTokens: 2000,
+      contextWindow: null,
+    }),
+  },
+};
+
+export const Empty: Story = {
+  name: 'Empty (No Data)',
+  args: {
+    tokenStats: createTokenStats({
+      inputTokens: 0,
+      outputTokens: 0,
+    }),
+  },
+};
+
+export const AllStates: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-4">
+        <span className="text-sm text-muted-foreground w-24">Low (30%)</span>
+        <ContextWindowIndicator tokenStats={createStatsWithUsage(30)} />
+      </div>
+      <div className="flex items-center gap-4">
+        <span className="text-sm text-muted-foreground w-24">Medium (60%)</span>
+        <ContextWindowIndicator tokenStats={createStatsWithUsage(60)} />
+      </div>
+      <div className="flex items-center gap-4">
+        <span className="text-sm text-muted-foreground w-24">Warning (85%)</span>
+        <ContextWindowIndicator tokenStats={createStatsWithUsage(85)} />
+      </div>
+      <div className="flex items-center gap-4">
+        <span className="text-sm text-muted-foreground w-24">Critical (97%)</span>
+        <ContextWindowIndicator tokenStats={createStatsWithUsage(97)} />
+      </div>
+    </div>
+  ),
+};

--- a/src/components/chat/usage-stats/context-window-indicator.tsx
+++ b/src/components/chat/usage-stats/context-window-indicator.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { Activity } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Progress } from '@/components/ui/progress';
+import type { TokenStats } from '@/lib/claude-types';
+import { CONTEXT_CRITICAL_THRESHOLD, CONTEXT_WARNING_THRESHOLD } from '@/lib/claude-types';
+import { cn } from '@/lib/utils';
+import { UsageStatsPopover } from './usage-stats-popover';
+
+interface ContextWindowIndicatorProps {
+  tokenStats: TokenStats;
+  className?: string;
+}
+
+/**
+ * Formats a number with K/M suffix for compact display.
+ */
+function formatTokenCount(count: number): string {
+  if (count >= 1_000_000) {
+    return `${(count / 1_000_000).toFixed(1)}M`;
+  }
+  if (count >= 1000) {
+    return `${(count / 1000).toFixed(0)}K`;
+  }
+  return count.toString();
+}
+
+/**
+ * Calculates context window usage percentage.
+ * Returns 0 if context window is not available.
+ */
+function calculateUsagePercentage(stats: TokenStats): number {
+  if (!stats.contextWindow || stats.contextWindow === 0) {
+    return 0;
+  }
+  const usedTokens = stats.inputTokens + stats.outputTokens;
+  return Math.min((usedTokens / stats.contextWindow) * 100, 100);
+}
+
+/**
+ * Gets the color class based on usage percentage.
+ */
+function getUsageColorClass(percentage: number): string {
+  if (percentage >= CONTEXT_CRITICAL_THRESHOLD * 100) {
+    return 'text-red-500';
+  }
+  if (percentage >= CONTEXT_WARNING_THRESHOLD * 100) {
+    return 'text-yellow-500';
+  }
+  return 'text-muted-foreground';
+}
+
+/**
+ * Gets the progress bar color class based on usage percentage.
+ */
+function getProgressColorClass(percentage: number): string {
+  if (percentage >= CONTEXT_CRITICAL_THRESHOLD * 100) {
+    return '[&>div]:bg-red-500';
+  }
+  if (percentage >= CONTEXT_WARNING_THRESHOLD * 100) {
+    return '[&>div]:bg-yellow-500';
+  }
+  return '[&>div]:bg-green-500';
+}
+
+/**
+ * Compact context window usage indicator for the chat input toolbar.
+ * Shows current usage as a percentage with color coding.
+ * Click to open detailed usage stats popover.
+ */
+export function ContextWindowIndicator({ tokenStats, className }: ContextWindowIndicatorProps) {
+  const usagePercentage = calculateUsagePercentage(tokenStats);
+  const usedTokens = tokenStats.inputTokens + tokenStats.outputTokens;
+  const hasData = usedTokens > 0;
+
+  // Don't show if no data yet
+  if (!hasData) {
+    return null;
+  }
+
+  const colorClass = getUsageColorClass(usagePercentage);
+  const progressColorClass = getProgressColorClass(usagePercentage);
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className={cn('h-6 gap-1.5 px-2 text-xs', colorClass, className)}
+          aria-label="View usage statistics"
+        >
+          <Activity className="h-3 w-3" />
+          <div className="flex items-center gap-1.5">
+            <span>{formatTokenCount(usedTokens)}</span>
+            {tokenStats.contextWindow && (
+              <>
+                <span className="text-muted-foreground">/</span>
+                <span className="text-muted-foreground">
+                  {formatTokenCount(tokenStats.contextWindow)}
+                </span>
+              </>
+            )}
+          </div>
+          {tokenStats.contextWindow && (
+            <Progress value={usagePercentage} className={cn('h-1 w-8', progressColorClass)} />
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-64 p-0" align="start">
+        <UsageStatsPopover tokenStats={tokenStats} />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/chat/usage-stats/index.ts
+++ b/src/components/chat/usage-stats/index.ts
@@ -1,0 +1,2 @@
+export { ContextWindowIndicator } from './context-window-indicator';
+export { UsageStatsPopover } from './usage-stats-popover';

--- a/src/components/chat/usage-stats/usage-stats-popover.stories.tsx
+++ b/src/components/chat/usage-stats/usage-stats-popover.stories.tsx
@@ -1,0 +1,162 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { createTokenStats } from '@/lib/claude-fixtures';
+import { UsageStatsPopover } from './usage-stats-popover';
+
+const meta: Meta<typeof UsageStatsPopover> = {
+  title: 'Chat/UsageStats/UsageStatsPopover',
+  component: UsageStatsPopover,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="w-64 border rounded-md shadow-lg bg-popover">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const MinimalStats: Story = {
+  name: 'New Session (Minimal)',
+  args: {
+    tokenStats: createTokenStats({
+      inputTokens: 500,
+      outputTokens: 200,
+      cacheReadInputTokens: 0,
+      cacheCreationInputTokens: 0,
+      totalCostUsd: 0.001,
+      totalDurationMs: 1500,
+      totalDurationApiMs: 1200,
+      turnCount: 1,
+      webSearchRequests: 0,
+      contextWindow: 200_000,
+    }),
+  },
+};
+
+export const ActiveSession: Story = {
+  name: 'Active Session (Full Stats)',
+  args: {
+    tokenStats: createTokenStats({
+      inputTokens: 45_000,
+      outputTokens: 12_000,
+      cacheReadInputTokens: 35_000,
+      cacheCreationInputTokens: 5000,
+      totalCostUsd: 0.0847,
+      totalDurationMs: 45_000,
+      totalDurationApiMs: 38_000,
+      turnCount: 8,
+      webSearchRequests: 0,
+      contextWindow: 200_000,
+    }),
+  },
+};
+
+export const WithWebSearches: Story = {
+  name: 'With Web Searches',
+  args: {
+    tokenStats: createTokenStats({
+      inputTokens: 30_000,
+      outputTokens: 8000,
+      cacheReadInputTokens: 20_000,
+      cacheCreationInputTokens: 3000,
+      totalCostUsd: 0.125,
+      totalDurationMs: 60_000,
+      totalDurationApiMs: 50_000,
+      turnCount: 5,
+      webSearchRequests: 3,
+      contextWindow: 200_000,
+    }),
+  },
+};
+
+export const HighCacheHitRate: Story = {
+  name: 'High Cache Hit Rate',
+  args: {
+    tokenStats: createTokenStats({
+      inputTokens: 25_000,
+      outputTokens: 5000,
+      cacheReadInputTokens: 50_000,
+      cacheCreationInputTokens: 2000,
+      totalCostUsd: 0.042,
+      totalDurationMs: 30_000,
+      totalDurationApiMs: 25_000,
+      turnCount: 10,
+      webSearchRequests: 0,
+      contextWindow: 200_000,
+    }),
+  },
+};
+
+export const WarningUsage: Story = {
+  name: 'Warning Level (85%)',
+  args: {
+    tokenStats: createTokenStats({
+      inputTokens: 120_000,
+      outputTokens: 50_000,
+      cacheReadInputTokens: 80_000,
+      cacheCreationInputTokens: 10_000,
+      totalCostUsd: 0.95,
+      totalDurationMs: 180_000,
+      totalDurationApiMs: 150_000,
+      turnCount: 25,
+      webSearchRequests: 2,
+      contextWindow: 200_000,
+    }),
+  },
+};
+
+export const CriticalUsage: Story = {
+  name: 'Critical Level (97%)',
+  args: {
+    tokenStats: createTokenStats({
+      inputTokens: 140_000,
+      outputTokens: 54_000,
+      cacheReadInputTokens: 90_000,
+      cacheCreationInputTokens: 15_000,
+      totalCostUsd: 1.23,
+      totalDurationMs: 240_000,
+      totalDurationApiMs: 200_000,
+      turnCount: 35,
+      webSearchRequests: 5,
+      contextWindow: 200_000,
+    }),
+  },
+};
+
+export const WithServiceTier: Story = {
+  name: 'With Service Tier',
+  args: {
+    tokenStats: createTokenStats({
+      inputTokens: 20_000,
+      outputTokens: 5000,
+      totalCostUsd: 0.05,
+      totalDurationMs: 20_000,
+      totalDurationApiMs: 15_000,
+      turnCount: 4,
+      contextWindow: 200_000,
+      serviceTier: 'scale',
+    }),
+  },
+};
+
+export const NoContextWindow: Story = {
+  name: 'No Context Window',
+  args: {
+    tokenStats: createTokenStats({
+      inputTokens: 10_000,
+      outputTokens: 3000,
+      totalCostUsd: 0.02,
+      totalDurationMs: 10_000,
+      totalDurationApiMs: 8000,
+      turnCount: 2,
+      contextWindow: null,
+    }),
+  },
+};

--- a/src/components/chat/usage-stats/usage-stats-popover.tsx
+++ b/src/components/chat/usage-stats/usage-stats-popover.tsx
@@ -1,0 +1,234 @@
+'use client';
+
+import { Clock, Coins, Database, Globe, Layers, Zap } from 'lucide-react';
+
+import { Progress } from '@/components/ui/progress';
+import type { TokenStats } from '@/lib/claude-types';
+import { CONTEXT_CRITICAL_THRESHOLD, CONTEXT_WARNING_THRESHOLD } from '@/lib/claude-types';
+import { cn } from '@/lib/utils';
+
+interface UsageStatsPopoverProps {
+  tokenStats: TokenStats;
+}
+
+/**
+ * Formats a number with K/M suffix for display.
+ */
+function formatTokenCount(count: number): string {
+  if (count >= 1_000_000) {
+    return `${(count / 1_000_000).toFixed(1)}M`;
+  }
+  if (count >= 1000) {
+    return `${(count / 1000).toFixed(1)}K`;
+  }
+  return count.toLocaleString();
+}
+
+/**
+ * Formats cost in USD with appropriate precision.
+ */
+function formatCost(cost: number): string {
+  if (cost === 0) {
+    return '$0.00';
+  }
+  if (cost < 0.01) {
+    return `$${cost.toFixed(4)}`;
+  }
+  return `$${cost.toFixed(2)}`;
+}
+
+/**
+ * Formats duration in milliseconds to a readable string.
+ */
+function formatDuration(ms: number): string {
+  if (ms < 1000) {
+    return `${ms}ms`;
+  }
+  const seconds = ms / 1000;
+  if (seconds < 60) {
+    return `${seconds.toFixed(1)}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = Math.round(seconds % 60);
+  return `${minutes}m ${remainingSeconds}s`;
+}
+
+/**
+ * Calculates cache hit rate as a percentage.
+ */
+function calculateCacheHitRate(stats: TokenStats): number {
+  const totalCacheTokens = stats.cacheReadInputTokens + stats.cacheCreationInputTokens;
+  if (totalCacheTokens === 0) {
+    return 0;
+  }
+  return (stats.cacheReadInputTokens / totalCacheTokens) * 100;
+}
+
+/**
+ * Gets the color class based on usage percentage.
+ */
+function getUsageColorClass(percentage: number): string {
+  if (percentage >= CONTEXT_CRITICAL_THRESHOLD * 100) {
+    return 'text-red-500';
+  }
+  if (percentage >= CONTEXT_WARNING_THRESHOLD * 100) {
+    return 'text-yellow-500';
+  }
+  return 'text-green-500';
+}
+
+/**
+ * Gets the progress bar color class based on usage percentage.
+ */
+function getProgressColorClass(percentage: number): string {
+  if (percentage >= CONTEXT_CRITICAL_THRESHOLD * 100) {
+    return '[&>div]:bg-red-500';
+  }
+  if (percentage >= CONTEXT_WARNING_THRESHOLD * 100) {
+    return '[&>div]:bg-yellow-500';
+  }
+  return '[&>div]:bg-green-500';
+}
+
+interface StatRowProps {
+  icon: React.ReactNode;
+  label: string;
+  value: string | number;
+  subValue?: string;
+  className?: string;
+}
+
+function StatRow({ icon, label, value, subValue, className }: StatRowProps) {
+  return (
+    <div className={cn('flex items-center justify-between py-1', className)}>
+      <div className="flex items-center gap-2 text-muted-foreground">
+        {icon}
+        <span className="text-xs">{label}</span>
+      </div>
+      <div className="text-right">
+        <span className="text-xs font-medium">{value}</span>
+        {subValue && <span className="ml-1 text-xs text-muted-foreground">{subValue}</span>}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Detailed usage statistics popover content.
+ * Shows token breakdown, cost, cache stats, and timing.
+ */
+export function UsageStatsPopover({ tokenStats }: UsageStatsPopoverProps) {
+  const usedTokens = tokenStats.inputTokens + tokenStats.outputTokens;
+  const usagePercentage = tokenStats.contextWindow
+    ? Math.min((usedTokens / tokenStats.contextWindow) * 100, 100)
+    : 0;
+  const cacheHitRate = calculateCacheHitRate(tokenStats);
+  const hasCacheData =
+    tokenStats.cacheReadInputTokens > 0 || tokenStats.cacheCreationInputTokens > 0;
+
+  return (
+    <div className="p-3">
+      <h4 className="mb-3 text-sm font-medium">Session Usage</h4>
+
+      {/* Context Window Progress */}
+      {tokenStats.contextWindow && (
+        <div className="mb-3">
+          <div className="mb-1 flex items-center justify-between">
+            <span className="text-xs text-muted-foreground">Context Window</span>
+            <span className={cn('text-xs font-medium', getUsageColorClass(usagePercentage))}>
+              {usagePercentage.toFixed(0)}%
+            </span>
+          </div>
+          <Progress
+            value={usagePercentage}
+            className={cn('h-1.5', getProgressColorClass(usagePercentage))}
+          />
+          <div className="mt-1 flex justify-between text-xs text-muted-foreground">
+            <span>{formatTokenCount(usedTokens)} used</span>
+            <span>{formatTokenCount(tokenStats.contextWindow)} max</span>
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-0.5">
+        {/* Token Breakdown */}
+        <StatRow
+          icon={<Layers className="h-3 w-3" />}
+          label="Input tokens"
+          value={formatTokenCount(tokenStats.inputTokens)}
+        />
+        <StatRow
+          icon={<Layers className="h-3 w-3" />}
+          label="Output tokens"
+          value={formatTokenCount(tokenStats.outputTokens)}
+        />
+
+        {/* Cache Stats */}
+        {hasCacheData && (
+          <>
+            <div className="my-1.5 border-t" />
+            <StatRow
+              icon={<Database className="h-3 w-3" />}
+              label="Cache read"
+              value={formatTokenCount(tokenStats.cacheReadInputTokens)}
+              subValue={cacheHitRate > 0 ? `(${cacheHitRate.toFixed(0)}% hit)` : undefined}
+            />
+            <StatRow
+              icon={<Database className="h-3 w-3" />}
+              label="Cache created"
+              value={formatTokenCount(tokenStats.cacheCreationInputTokens)}
+            />
+          </>
+        )}
+
+        {/* Cost and Performance */}
+        <div className="my-1.5 border-t" />
+        <StatRow
+          icon={<Coins className="h-3 w-3" />}
+          label="Cost"
+          value={formatCost(tokenStats.totalCostUsd)}
+        />
+
+        {tokenStats.turnCount > 0 && (
+          <StatRow icon={<Zap className="h-3 w-3" />} label="Turns" value={tokenStats.turnCount} />
+        )}
+
+        {tokenStats.totalDurationMs > 0 && (
+          <StatRow
+            icon={<Clock className="h-3 w-3" />}
+            label="Total time"
+            value={formatDuration(tokenStats.totalDurationMs)}
+          />
+        )}
+
+        {tokenStats.totalDurationApiMs > 0 && (
+          <StatRow
+            icon={<Clock className="h-3 w-3" />}
+            label="API time"
+            value={formatDuration(tokenStats.totalDurationApiMs)}
+          />
+        )}
+
+        {tokenStats.webSearchRequests > 0 && (
+          <StatRow
+            icon={<Globe className="h-3 w-3" />}
+            label="Web searches"
+            value={tokenStats.webSearchRequests}
+          />
+        )}
+
+        {/* Service Tier */}
+        {tokenStats.serviceTier && (
+          <>
+            <div className="my-1.5 border-t" />
+            <StatRow
+              icon={<Zap className="h-3 w-3" />}
+              label="Service tier"
+              value={tokenStats.serviceTier}
+            />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat/use-chat-websocket.ts
+++ b/src/components/chat/use-chat-websocket.ts
@@ -9,6 +9,7 @@ import type {
   MessageAttachment,
   QueuedMessage,
   SessionInfo,
+  TokenStats,
 } from '@/lib/claude-types';
 import { buildWebSocketUrl } from '@/lib/websocket-config';
 import type { PendingMessageContent, PendingRequest, SessionStatus } from './chat-reducer';
@@ -59,6 +60,8 @@ export interface UseChatWebSocketReturn {
   permissionMode: string | null;
   // Slash commands from CLI initialize response
   slashCommands: CommandInfo[];
+  // Accumulated token usage stats for the session
+  tokenStats: TokenStats;
   // Actions
   sendMessage: (text: string) => void;
   stopChat: () => void;
@@ -165,6 +168,7 @@ export function useChatWebSocket(options: UseChatWebSocketOptions): UseChatWebSo
     taskNotifications: chat.taskNotifications,
     permissionMode: chat.permissionMode,
     slashCommands: chat.slashCommands,
+    tokenStats: chat.tokenStats,
     // Actions from chat
     sendMessage: chat.sendMessage,
     stopChat: chat.stopChat,

--- a/src/lib/claude-fixtures.ts
+++ b/src/lib/claude-fixtures.ts
@@ -468,9 +468,16 @@ export function createTokenStats(overrides: Partial<TokenStats> = {}): TokenStat
   return {
     inputTokens: overrides.inputTokens ?? 1500,
     outputTokens: overrides.outputTokens ?? 850,
+    cacheReadInputTokens: overrides.cacheReadInputTokens ?? 800,
+    cacheCreationInputTokens: overrides.cacheCreationInputTokens ?? 200,
     totalCostUsd: overrides.totalCostUsd ?? 0.0125,
     totalDurationMs: overrides.totalDurationMs ?? 3500,
+    totalDurationApiMs: overrides.totalDurationApiMs ?? 2800,
     turnCount: overrides.turnCount ?? 3,
+    webSearchRequests: overrides.webSearchRequests ?? 0,
+    contextWindow: overrides.contextWindow ?? 200_000,
+    maxOutputTokens: overrides.maxOutputTokens ?? 16_384,
+    serviceTier: overrides.serviceTier ?? null,
   };
 }
 


### PR DESCRIPTION
## Summary

Exposes detailed model usage statistics from the Claude SDK to the frontend, addressing #451.

- **Context Window Indicator**: Shows running token usage vs context window with color-coded thresholds (green → yellow at 80% → red at 95%)
- **Detailed Stats Popover**: Click the indicator to see full breakdown including cache stats, cost, and timing
- **Session Tracking**: Stats accumulate across result messages and reset on session switch

## Changes

### Types (`src/lib/claude-types.ts`)
- Added `ModelUsage` interface matching SDK's model_usage structure
- Extended `TokenStats` with cache tokens, context window, API timing, service tier
- Added `duration_api_ms` and `model_usage` to `ClaudeMessage`
- Added threshold constants for warning (80%) and critical (95%) usage

### State Management
- Track `tokenStats` in chat reducer, accumulating from result messages
- Expose via `useChatWebSocket` hook

### UI Components (`src/components/chat/usage-stats/`)
- `ContextWindowIndicator`: Compact button showing usage with progress bar
- `UsageStatsPopover`: Detailed breakdown with token counts, cache hit rate, cost, timing

### Integration
- Indicator appears in chat input toolbar (left side, after file upload)
- Storybook stories for all component states
- Comprehensive tests for stats accumulation

## Test plan

- [ ] Start a chat session, send messages
- [ ] Verify context indicator appears after first response
- [ ] Verify indicator updates after each result message
- [ ] Click indicator to see detailed popover
- [ ] Verify warning colors at 80% and 95% thresholds
- [ ] Verify stats reset when switching sessions
- [ ] Run Storybook (`pnpm storybook`) to see component stories
- [ ] Run tests (`pnpm test`)

## Screenshots

The indicator displays in the chat input toolbar:
```
[Model ▼] [🧠] [📋] [📎]  [📊 45K / 200K ████░░]  [⬛] [➤]
```

Popover shows detailed stats:
```
Session Usage
━━━━━━━━━━━━━━━━━━━━━
Context Window         75%
████████████░░░░░░░░░
45K used              200K max

Input tokens          31.5K
Output tokens         13.5K
━━━━━━━━━━━━━━━━━━━━━
Cache read           25K (83% hit)
Cache created         5K
━━━━━━━━━━━━━━━━━━━━━
Cost                  $0.08
Turns                 8
Total time           45s
API time             38s
```

Closes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates core chat state/types to accumulate and reset token usage stats from `result` WebSocket messages and adds new UI around those stats. Moderate risk of regressions in chat reducer/state transitions and message parsing, but no auth/security impact.
> 
> **Overview**
> Adds end-to-end **session usage tracking** in the chat UI by extending `ClaudeMessage`/`TokenStats` to include cache tokens, API duration, web-search counts, context window/max output limits, and service tier (plus 80%/95% warning thresholds).
> 
> The chat reducer now stores `tokenStats`, updates them on each `result` message (accumulating tokens/durations and taking latest cost/turn/context info), and resets stats on `CLEAR_CHAT` and session switches; `useChatWebSocket` and the workspace chat route plumb `tokenStats` through to the UI.
> 
> Introduces a `usage-stats` UI: a compact `ContextWindowIndicator` in the chat input toolbar that opens a `UsageStatsPopover` with token/cache/cost/timing details, with Storybook stories and new reducer tests covering stats accumulation and resets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54bcd7caf3c4ef337acb845b307fcb7a58ed1c1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->