### PR TITLE
Remove icon from Dev Logs tab

### DIFF
--- a/src/components/workspace/right-panel.tsx
+++ b/src/components/workspace/right-panel.tsx
@@ -1,15 +1,6 @@
 'use client';
 
-import {
-  FileQuestion,
-  Files,
-  GitCompare,
-  ListTodo,
-  Plus,
-  ScrollText,
-  Terminal,
-  X,
-} from 'lucide-react';
+import { FileQuestion, Files, GitCompare, ListTodo, Plus, Terminal, X } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import type { ChatMessage } from '@/components/chat';
@@ -230,15 +221,12 @@ export function RightPanel({ workspaceId, className, messages = [] }: RightPanel
             <PanelTab
               label="Dev Logs"
               icon={
-                <span className="flex items-center gap-1.5">
-                  <ScrollText className="h-3.5 w-3.5" />
-                  <span
-                    className={cn(
-                      'w-1.5 h-1.5 rounded-full',
-                      devLogs.connected ? 'bg-green-500' : 'bg-red-500'
-                    )}
-                  />
-                </span>
+                <span
+                  className={cn(
+                    'w-1.5 h-1.5 rounded-full',
+                    devLogs.connected ? 'bg-green-500' : 'bg-red-500'
+                  )}
+                />
               }
               isActive={activeBottomTab === 'dev-logs'}
               onClick={() => handleBottomTabChange('dev-logs')}


### PR DESCRIPTION
## Summary
- Removed the ScrollText icon from the Dev Logs tab in the right panel
- The connection status dot (green/red) is now the only indicator, making the tab cleaner
- The dot was already always visible; this change just removes the icon that was clashing with it

## Test plan
- [ ] Open a workspace and check the Dev Logs tab in the bottom panel
- [ ] Verify only the status dot shows (no scroll icon)
- [ ] Verify the dot is green when connected, red when disconnected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that alters the Dev Logs tab indicator markup; no data flow or logic changes beyond removing an icon import/render.
> 
> **Overview**
> Simplifies the bottom-panel **Dev Logs** tab by removing the `ScrollText` icon and showing only the green/red connection status dot.
> 
> Also cleans up the `lucide-react` imports accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04ad4c9fd0170f2e24916c8a41fae3a6d9303918. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->