### PR TITLE
Refactor message state machine (#521)

### DIFF
--- a/src/backend/services/message-event-store.test.ts
+++ b/src/backend/services/message-event-store.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { MessageEventStore } from './message-event-store';
+
+describe('MessageEventStore', () => {
+  it('stores and retrieves events per session', () => {
+    const store = new MessageEventStore();
+    store.storeEvent('session-1', { type: 'event-1' });
+    store.storeEvent('session-1', { type: 'event-2', data: { value: 1 } });
+    store.storeEvent('session-2', { type: 'event-3' });
+
+    expect(store.getStoredEvents('session-1')).toEqual([
+      { type: 'event-1' },
+      { type: 'event-2', data: { value: 1 } },
+    ]);
+    expect(store.getStoredEvents('session-2')).toEqual([{ type: 'event-3' }]);
+  });
+
+  it('clears sessions independently', () => {
+    const store = new MessageEventStore();
+    store.storeEvent('session-1', { type: 'event-1' });
+    store.storeEvent('session-2', { type: 'event-2' });
+
+    store.clearSession('session-1');
+    expect(store.getStoredEvents('session-1')).toEqual([]);
+    expect(store.getStoredEvents('session-2')).toEqual([{ type: 'event-2' }]);
+  });
+
+  it('clears all sessions', () => {
+    const store = new MessageEventStore();
+    store.storeEvent('session-1', { type: 'event-1' });
+    store.storeEvent('session-2', { type: 'event-2' });
+
+    store.clearAllSessions();
+    expect(store.getStoredEvents('session-1')).toEqual([]);
+    expect(store.getStoredEvents('session-2')).toEqual([]);
+  });
+});

--- a/src/backend/services/message-event-store.ts
+++ b/src/backend/services/message-event-store.ts
@@ -1,0 +1,29 @@
+export type StoredEvent = { type: string; data?: unknown };
+
+/**
+ * Stores raw WebSocket events per session for replay on reconnect.
+ */
+export class MessageEventStore {
+  private sessionEvents = new Map<string, StoredEvent[]>();
+
+  storeEvent(sessionId: string, event: StoredEvent): void {
+    let events = this.sessionEvents.get(sessionId);
+    if (!events) {
+      events = [];
+      this.sessionEvents.set(sessionId, events);
+    }
+    events.push(event);
+  }
+
+  getStoredEvents(sessionId: string): StoredEvent[] {
+    return this.sessionEvents.get(sessionId) ?? [];
+  }
+
+  clearSession(sessionId: string): void {
+    this.sessionEvents.delete(sessionId);
+  }
+
+  clearAllSessions(): void {
+    this.sessionEvents.clear();
+  }
+}

--- a/src/backend/services/message-state-machine.test.ts
+++ b/src/backend/services/message-state-machine.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import type { HistoryMessage, QueuedMessage } from '@/lib/claude-types';
+import { MessageState } from '@/lib/claude-types';
+import { isValidTransition, MessageStateMachine } from './message-state-machine';
+
+function createTestQueuedMessage(id: string, text = 'Test message'): QueuedMessage {
+  return {
+    id,
+    text,
+    settings: {
+      selectedModel: null,
+      thinkingEnabled: false,
+      planModeEnabled: false,
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function createHistoryMessage(type: HistoryMessage['type'], content: string): HistoryMessage {
+  return {
+    type,
+    content,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+describe('MessageStateMachine', () => {
+  it('validates user state transitions', () => {
+    expect(isValidTransition('user', MessageState.PENDING, MessageState.SENT)).toBe(true);
+    expect(isValidTransition('user', MessageState.SENT, MessageState.DISPATCHED)).toBe(false);
+    expect(isValidTransition('user', MessageState.ACCEPTED, MessageState.CANCELLED)).toBe(true);
+  });
+
+  it('rejects claude state transitions', () => {
+    expect(isValidTransition('claude', MessageState.COMPLETE, MessageState.COMPLETE)).toBe(false);
+  });
+
+  it('allocates order per session independently', () => {
+    const machine = new MessageStateMachine();
+    expect(machine.allocateOrder('session-1')).toBe(0);
+    expect(machine.allocateOrder('session-1')).toBe(1);
+    expect(machine.allocateOrder('session-2')).toBe(0);
+  });
+
+  it('assigns queue positions based on accepted messages', () => {
+    const machine = new MessageStateMachine();
+    machine.createUserMessage('session-1', createTestQueuedMessage('msg-1'));
+    machine.updateState('session-1', 'msg-1', MessageState.DISPATCHED);
+    const msg2 = machine.createUserMessage('session-1', createTestQueuedMessage('msg-2'));
+    expect(msg2.queuePosition).toBe(0);
+  });
+
+  it('updates state with metadata', () => {
+    const machine = new MessageStateMachine();
+    machine.createUserMessage('session-1', createTestQueuedMessage('msg-1'));
+    const result = machine.updateState('session-1', 'msg-1', MessageState.DISPATCHED, {
+      queuePosition: 2,
+      errorMessage: 'oops',
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.message.state).toBe(MessageState.DISPATCHED);
+      expect(result.message.queuePosition).toBe(2);
+      expect(result.message.errorMessage).toBe('oops');
+    }
+  });
+
+  it('does not overwrite existing messages on history load', () => {
+    const machine = new MessageStateMachine();
+    machine.createUserMessage('session-1', createTestQueuedMessage('msg-1'));
+    const history = [createHistoryMessage('assistant', 'from history')];
+    machine.loadFromHistory('session-1', history);
+    expect(machine.getMessageCount('session-1')).toBe(1);
+  });
+});

--- a/src/backend/services/message-state-machine.ts
+++ b/src/backend/services/message-state-machine.ts
@@ -1,0 +1,359 @@
+import {
+  type ClaudeMessage,
+  type ClaudeMessageWithState,
+  type HistoryMessage,
+  isUserMessage,
+  MessageState,
+  type MessageWithState,
+  type QueuedMessage,
+  type UserMessageState,
+  type UserMessageWithState,
+} from '@/lib/claude-types';
+
+/**
+ * Valid state transitions for user messages.
+ * Maps each UserMessageState to the states it can transition to.
+ */
+const USER_STATE_TRANSITIONS: Record<UserMessageState, UserMessageState[]> = {
+  PENDING: ['SENT'],
+  SENT: ['ACCEPTED', 'REJECTED'],
+  ACCEPTED: ['DISPATCHED', 'CANCELLED'],
+  DISPATCHED: ['COMMITTED', 'FAILED'],
+  COMMITTED: [],
+  REJECTED: [],
+  FAILED: [],
+  CANCELLED: [],
+};
+
+const USER_STATES = new Set<UserMessageState>(
+  Object.keys(USER_STATE_TRANSITIONS) as UserMessageState[]
+);
+
+function isValidUserTransition(from: UserMessageState, to: UserMessageState): boolean {
+  return USER_STATE_TRANSITIONS[from]?.includes(to) ?? false;
+}
+
+export function isValidTransition(
+  messageType: 'user' | 'claude',
+  from: MessageState,
+  to: MessageState
+): boolean {
+  if (messageType === 'claude') {
+    return false;
+  }
+
+  if (!(USER_STATES.has(from as UserMessageState) && USER_STATES.has(to as UserMessageState))) {
+    return false;
+  }
+  return isValidUserTransition(from as UserMessageState, to as UserMessageState);
+}
+
+type UpdateStateResult =
+  | {
+      ok: true;
+      message: UserMessageWithState;
+      oldState: UserMessageState;
+    }
+  | {
+      ok: false;
+      reason: 'not_found' | 'invalid_transition' | 'non_user';
+      currentState?: MessageState;
+    };
+
+/**
+ * Pure message state machine and storage (no WebSocket emission).
+ */
+export class MessageStateMachine {
+  /**
+   * Messages indexed by session ID, then by message ID.
+   * Map<sessionId, Map<messageId, MessageWithState>>
+   */
+  private sessionMessages = new Map<string, Map<string, MessageWithState>>();
+
+  /**
+   * Next order number for each session. Monotonically increasing.
+   * Map<sessionId, nextOrder>
+   */
+  private sessionOrderCounters = new Map<string, number>();
+
+  private getOrCreateSessionMap(sessionId: string): Map<string, MessageWithState> {
+    let messages = this.sessionMessages.get(sessionId);
+    if (!messages) {
+      messages = new Map();
+      this.sessionMessages.set(sessionId, messages);
+    }
+    return messages;
+  }
+
+  private getNextOrder(sessionId: string): number {
+    const current = this.sessionOrderCounters.get(sessionId) ?? 0;
+    this.sessionOrderCounters.set(sessionId, current + 1);
+    return current;
+  }
+
+  allocateOrder(sessionId: string): number {
+    return this.getNextOrder(sessionId);
+  }
+
+  createUserMessage(sessionId: string, msg: QueuedMessage): UserMessageWithState {
+    const messages = this.getOrCreateSessionMap(sessionId);
+    const queuePosition = this.getQueuedMessageCount(sessionId);
+    const order = this.getNextOrder(sessionId);
+
+    const messageWithState: UserMessageWithState = {
+      id: msg.id,
+      type: 'user',
+      state: MessageState.ACCEPTED,
+      timestamp: msg.timestamp,
+      text: msg.text,
+      attachments: msg.attachments,
+      queuePosition,
+      settings: msg.settings,
+      order,
+    };
+
+    messages.set(msg.id, messageWithState);
+    return messageWithState;
+  }
+
+  createRejectedMessage(
+    sessionId: string,
+    messageId: string,
+    errorMessage: string,
+    text?: string
+  ): UserMessageWithState {
+    const messages = this.getOrCreateSessionMap(sessionId);
+    const order = this.getNextOrder(sessionId);
+
+    const messageWithState: UserMessageWithState = {
+      id: messageId,
+      type: 'user',
+      state: MessageState.REJECTED,
+      timestamp: new Date().toISOString(),
+      text: text ?? '',
+      errorMessage,
+      order,
+    };
+
+    messages.set(messageId, messageWithState);
+    return messageWithState;
+  }
+
+  updateState(
+    sessionId: string,
+    messageId: string,
+    newState: MessageState,
+    metadata?: { queuePosition?: number; errorMessage?: string }
+  ): UpdateStateResult {
+    const messages = this.sessionMessages.get(sessionId);
+    const message = messages?.get(messageId);
+
+    if (!message) {
+      return { ok: false, reason: 'not_found' };
+    }
+
+    if (!isValidTransition(message.type, message.state as MessageState, newState)) {
+      return {
+        ok: false,
+        reason: 'invalid_transition',
+        currentState: message.state as MessageState,
+      };
+    }
+
+    if (!isUserMessage(message)) {
+      return { ok: false, reason: 'non_user', currentState: message.state as MessageState };
+    }
+
+    const oldState = message.state;
+    message.state = newState as UserMessageState;
+    if (metadata?.queuePosition !== undefined) {
+      message.queuePosition = metadata.queuePosition;
+    }
+    if (metadata?.errorMessage !== undefined) {
+      message.errorMessage = metadata.errorMessage;
+    }
+
+    return { ok: true, message, oldState };
+  }
+
+  getMessage(sessionId: string, messageId: string): MessageWithState | undefined {
+    return this.sessionMessages.get(sessionId)?.get(messageId);
+  }
+
+  getAllMessages(sessionId: string): MessageWithState[] {
+    const messages = this.sessionMessages.get(sessionId);
+    if (!messages) {
+      return [];
+    }
+
+    const terminalErrorStates: Set<string> = new Set(['REJECTED', 'FAILED', 'CANCELLED']);
+
+    return Array.from(messages.values())
+      .filter((msg) => !terminalErrorStates.has(msg.state))
+      .sort((a, b) => a.order - b.order);
+  }
+
+  removeMessage(sessionId: string, messageId: string): boolean {
+    const messages = this.sessionMessages.get(sessionId);
+    if (!messages) {
+      return false;
+    }
+    return messages.delete(messageId);
+  }
+
+  clearSession(sessionId: string): void {
+    this.sessionMessages.delete(sessionId);
+    this.sessionOrderCounters.delete(sessionId);
+  }
+
+  clearAllSessions(): void {
+    this.sessionMessages.clear();
+    this.sessionOrderCounters.clear();
+  }
+
+  loadFromHistory(sessionId: string, history: HistoryMessage[]): void {
+    const existingMessages = this.sessionMessages.get(sessionId);
+    if (existingMessages && existingMessages.size > 0) {
+      return;
+    }
+
+    this.sessionMessages.delete(sessionId);
+    this.sessionOrderCounters.delete(sessionId);
+    const messages = this.getOrCreateSessionMap(sessionId);
+
+    for (const historyMsg of history) {
+      const messageId =
+        historyMsg.uuid ||
+        `history-${historyMsg.timestamp}-${Math.random().toString(36).slice(2, 9)}`;
+
+      const order = this.getNextOrder(sessionId);
+
+      if (historyMsg.type === 'user') {
+        const messageWithState: UserMessageWithState = {
+          id: messageId,
+          type: 'user',
+          state: MessageState.COMMITTED,
+          timestamp: historyMsg.timestamp,
+          text: historyMsg.content,
+          order,
+        };
+        messages.set(messageId, messageWithState);
+      } else if (
+        historyMsg.type === 'assistant' ||
+        historyMsg.type === 'tool_use' ||
+        historyMsg.type === 'tool_result' ||
+        historyMsg.type === 'thinking'
+      ) {
+        const claudeMessage = this.historyToClaudeMessage(historyMsg);
+        const messageWithState: ClaudeMessageWithState = {
+          id: messageId,
+          type: 'claude',
+          state: MessageState.COMPLETE,
+          timestamp: historyMsg.timestamp,
+          chatMessages: [
+            {
+              id: `${messageId}-0`,
+              source: 'claude',
+              message: claudeMessage,
+              timestamp: historyMsg.timestamp,
+              order,
+            },
+          ],
+          order,
+        };
+        messages.set(messageId, messageWithState);
+      }
+    }
+  }
+
+  hasMessage(sessionId: string, messageId: string): boolean {
+    return this.sessionMessages.get(sessionId)?.has(messageId) ?? false;
+  }
+
+  getMessageCount(sessionId: string): number {
+    return this.sessionMessages.get(sessionId)?.size ?? 0;
+  }
+
+  getSessionCount(): number {
+    return this.sessionMessages.size;
+  }
+
+  getQueuedMessageCount(sessionId: string): number {
+    const messages = this.sessionMessages.get(sessionId);
+    if (!messages) {
+      return 0;
+    }
+
+    let count = 0;
+    for (const msg of messages.values()) {
+      if (msg.type === 'user' && msg.state === MessageState.ACCEPTED) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  private historyToClaudeMessage(msg: HistoryMessage): ClaudeMessage {
+    switch (msg.type) {
+      case 'tool_use':
+        if (msg.toolName && msg.toolId) {
+          return {
+            type: 'assistant',
+            message: {
+              role: 'assistant',
+              content: [
+                {
+                  type: 'tool_use',
+                  id: msg.toolId,
+                  name: msg.toolName,
+                  input: msg.toolInput ?? {},
+                },
+              ],
+            },
+          };
+        }
+        break;
+
+      case 'tool_result':
+        if (msg.toolId) {
+          return {
+            type: 'user',
+            message: {
+              role: 'user',
+              content: [
+                {
+                  type: 'tool_result',
+                  tool_use_id: msg.toolId,
+                  content: msg.content,
+                  is_error: msg.isError,
+                },
+              ],
+            },
+          };
+        }
+        break;
+
+      case 'thinking':
+        return {
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [
+              {
+                type: 'thinking',
+                thinking: msg.content,
+              },
+            ],
+          },
+        };
+    }
+
+    return {
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: msg.content,
+      },
+    };
+  }
+}


### PR DESCRIPTION
Fixes #521 

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Refactors core message/state tracking and replay-event storage used by WebSocket sessions; while intended as behavior-preserving, subtle changes in transition validation, ordering, or history loading could impact message delivery/order across sessions.
> 
> **Overview**
> Refactors `message-state.service.ts` by extracting the in-memory message/state tracking and transition logic into a new pure `MessageStateMachine`, and extracting WebSocket replay buffering into `MessageEventStore`.
> 
> `MessageStateService` now delegates message creation, state updates (including metadata), history loading, queued-count checks, and session clearing to these new components, and adds unit coverage for the new state machine and event store behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65a3c7905e86e3012fd4dfd20a341709f0a25807. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->