### PR TITLE
Extract chat transport handling

### DIFF
--- a/src/components/chat/use-chat-state.ts
+++ b/src/components/chat/use-chat-state.ts
@@ -27,31 +27,12 @@
  */
 
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
-import type {
-  ChatSettings,
-  ClaudeMessage,
-  ClaudeStreamEvent,
-  InputJsonDelta,
-  MessageAttachment,
-  QueuedMessage,
-  WebSocketMessage,
-} from '@/lib/claude-types';
-import {
-  DEFAULT_CHAT_SETTINGS,
-  DEFAULT_THINKING_BUDGET,
-  isStreamEventMessage,
-  isWebSocketMessage,
-  isWsClaudeMessage,
-} from '@/lib/claude-types';
+import type { ChatSettings, MessageAttachment, QueuedMessage } from '@/lib/claude-types';
+import { DEFAULT_CHAT_SETTINGS, DEFAULT_THINKING_BUDGET } from '@/lib/claude-types';
 import { createDebugLogger } from '@/lib/debug';
 import { clearDraft, loadAllSessionData, persistDraft, persistSettings } from './chat-persistence';
-import {
-  type ChatAction,
-  type ChatState,
-  chatReducer,
-  createActionFromWebSocketMessage,
-  createInitialChatState,
-} from './chat-reducer';
+import { type ChatState, chatReducer, createInitialChatState } from './chat-reducer';
+import { useChatTransport } from './use-chat-transport';
 
 // =============================================================================
 // Debug Logging
@@ -164,146 +145,6 @@ function generateMessageId(): string {
   return `msg-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
 }
 
-/**
- * Get stream event data from a Claude message.
- * Returns the event if the message is a stream_event type, null otherwise.
- */
-function getStreamEvent(claudeMsg: ClaudeMessage): ClaudeStreamEvent | null {
-  if (!isStreamEventMessage(claudeMsg)) {
-    return null;
-  }
-  return claudeMsg.event;
-}
-
-/**
- * Handle tool_use block start - initialize accumulator.
- */
-function handleToolUseStart(
-  event: ClaudeStreamEvent,
-  toolInputAccumulatorRef: React.MutableRefObject<Map<string, string>>
-): void {
-  if (event.type !== 'content_block_start') {
-    return;
-  }
-  const block = event.content_block;
-  if (block.type === 'tool_use' && block.id) {
-    const toolUseId = block.id;
-    toolInputAccumulatorRef.current.set(toolUseId, '');
-    debug.log('Tool use started:', toolUseId, block.name);
-  }
-}
-
-/**
- * Handle tool input JSON delta - accumulate and try to parse.
- * Returns a TOOL_INPUT_UPDATE action if valid JSON was accumulated, null otherwise.
- */
-function handleToolInputDelta(
-  event: ClaudeStreamEvent,
-  toolInputAccumulatorRef: React.MutableRefObject<Map<string, string>>
-): ChatAction | null {
-  if (event.type !== 'content_block_delta') {
-    return null;
-  }
-
-  // Cast delta to check for input_json_delta
-  const delta = event.delta as InputJsonDelta | typeof event.delta;
-  if (delta.type !== 'input_json_delta' || !('partial_json' in delta)) {
-    return null;
-  }
-
-  const accumulatorEntries = Array.from(toolInputAccumulatorRef.current.entries());
-  if (accumulatorEntries.length === 0) {
-    return null;
-  }
-
-  // Get the last (most recent) tool_use_id
-  const [toolUseId, currentJson] = accumulatorEntries[accumulatorEntries.length - 1];
-  const newJson = currentJson + delta.partial_json;
-  toolInputAccumulatorRef.current.set(toolUseId, newJson);
-
-  // Try to parse the accumulated JSON and create update action
-  try {
-    const parsedInput = JSON.parse(newJson) as Record<string, unknown>;
-    debug.log('Tool input updated:', toolUseId, Object.keys(parsedInput));
-    return { type: 'TOOL_INPUT_UPDATE', payload: { toolUseId, input: parsedInput } };
-  } catch {
-    // JSON not complete yet, that's expected during streaming
-    return null;
-  }
-}
-
-/**
- * Handle tool input accumulation from stream events.
- * Returns a TOOL_INPUT_UPDATE action if input was accumulated, null otherwise.
- */
-function handleToolInputStreaming(
-  claudeMsg: ClaudeMessage,
-  toolInputAccumulatorRef: React.MutableRefObject<Map<string, string>>
-): ChatAction | null {
-  const event = getStreamEvent(claudeMsg);
-  if (!event) {
-    return null;
-  }
-
-  // Initialize accumulator for tool_use start events
-  handleToolUseStart(event, toolInputAccumulatorRef);
-
-  // Handle input JSON deltas
-  return handleToolInputDelta(event, toolInputAccumulatorRef);
-}
-
-/**
- * Handle thinking delta stream events (extended thinking mode).
- * Returns a THINKING_DELTA action for thinking deltas, THINKING_CLEAR for message_start, null otherwise.
- */
-function handleThinkingStreaming(claudeMsg: ClaudeMessage): ChatAction | null {
-  const event = getStreamEvent(claudeMsg);
-  if (!event) {
-    return null;
-  }
-
-  // Clear thinking on new message start
-  if (event.type === 'message_start') {
-    return { type: 'THINKING_CLEAR' };
-  }
-
-  // Accumulate thinking delta
-  if (event.type === 'content_block_delta') {
-    const delta = event.delta;
-    if (delta.type === 'thinking_delta') {
-      return { type: 'THINKING_DELTA', payload: { thinking: delta.thinking } };
-    }
-  }
-
-  return null;
-}
-
-/**
- * Handle Claude message with tool input streaming.
- * Expects a validated claude_message WebSocket message.
- */
-function handleClaudeMessageWithStreaming(
-  wsMessage: WebSocketMessage & { type: 'claude_message'; data: ClaudeMessage },
-  toolInputAccumulatorRef: React.MutableRefObject<Map<string, string>>,
-  dispatch: React.Dispatch<ChatAction>
-): void {
-  const claudeMsg = wsMessage.data;
-
-  // Handle tool input streaming before the main action
-  const toolInputAction = handleToolInputStreaming(claudeMsg, toolInputAccumulatorRef);
-  if (toolInputAction) {
-    dispatch(toolInputAction);
-    // Don't return - still need to dispatch the main action for content_block_start
-  }
-
-  // Handle thinking streaming (extended thinking mode)
-  const thinkingAction = handleThinkingStreaming(claudeMsg);
-  if (thinkingAction) {
-    dispatch(thinkingAction);
-    // Don't return - THINKING_CLEAR also needs the main action to process
-  }
-}
-
 // =============================================================================
 // Hook Implementation
 // =============================================================================
@@ -411,71 +252,12 @@ export function useChatState(options: UseChatStateOptions): UseChatStateReturn {
     }
   }, [state.lastRejectedMessage]);
 
-  // =============================================================================
-  // WebSocket Message Handler
-  // =============================================================================
-
-  /**
-   * Clears the rewind timeout if the response matches the current rewind request.
-   * Validates userMessageId to prevent stale responses from clearing the timeout.
-   */
-  const clearRewindTimeoutIfMatching = useCallback((wsMessage: WebSocketMessage) => {
-    if (wsMessage.type !== 'rewind_files_preview' && wsMessage.type !== 'rewind_files_error') {
-      return;
-    }
-    const currentUserMessageId = stateRef.current.rewindPreview?.userMessageId;
-    const responseUserMessageId = wsMessage.userMessageId;
-    // Only clear timeout if this response is for the current rewind request
-    if (
-      rewindTimeoutRef.current &&
-      (!responseUserMessageId || responseUserMessageId === currentUserMessageId)
-    ) {
-      clearTimeout(rewindTimeoutRef.current);
-      rewindTimeoutRef.current = null;
-    }
-  }, []);
-
-  const handleMessage = useCallback(
-    (data: unknown) => {
-      // Validate incoming data is a WebSocket message
-      if (!isWebSocketMessage(data)) {
-        debug.log('Received invalid WebSocket message:', data);
-        return;
-      }
-      const wsMessage = data;
-
-      // Handle workspace notification requests
-      if (wsMessage.type === 'workspace_notification_request') {
-        // Dispatch custom event for WorkspaceNotificationManager
-        window.dispatchEvent(
-          new CustomEvent('workspace-notification-request', {
-            detail: {
-              workspaceId: wsMessage.workspaceId,
-              workspaceName: wsMessage.workspaceName,
-              sessionCount: wsMessage.sessionCount,
-              finishedAt: wsMessage.finishedAt,
-            },
-          })
-        );
-        return;
-      }
-
-      // Clear rewind timeout when we receive rewind response for the current request
-      clearRewindTimeoutIfMatching(wsMessage);
-
-      // Handle Claude messages specially for tool input streaming
-      if (isWsClaudeMessage(wsMessage)) {
-        handleClaudeMessageWithStreaming(wsMessage, toolInputAccumulatorRef, dispatch);
-      }
-
-      // Convert WebSocket message to action and dispatch
-      const action = createActionFromWebSocketMessage(wsMessage);
-      if (action) {
-        dispatch(action);
-      }
-    },
-    [clearRewindTimeoutIfMatching]
-  );
+  const { handleMessage } = useChatTransport({
+    dispatch,
+    stateRef,
+    toolInputAccumulatorRef,
+    rewindTimeoutRef,
+  });
 
   // =============================================================================
   // Action Callbacks

--- a/src/components/chat/use-chat-transport.test.ts
+++ b/src/components/chat/use-chat-transport.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import type { ClaudeMessage } from '@/lib/claude-types';
+import { handleThinkingStreaming, handleToolInputStreaming } from './use-chat-transport';
+
+describe('handleToolInputStreaming', () => {
+  it('accumulates input_json_delta and returns TOOL_INPUT_UPDATE when JSON is complete', () => {
+    const toolInputAccumulatorRef = { current: new Map<string, string>() };
+
+    const startMsg: ClaudeMessage = {
+      type: 'stream_event',
+      event: {
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'tool_use', id: 'tool-1', name: 'search', input: {} },
+      },
+    };
+
+    expect(handleToolInputStreaming(startMsg, toolInputAccumulatorRef)).toBeNull();
+    expect(toolInputAccumulatorRef.current.get('tool-1')).toBe('');
+
+    const partialMsg: ClaudeMessage = {
+      type: 'stream_event',
+      event: {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'input_json_delta', partial_json: '{"query":"hi"' },
+      },
+    };
+
+    expect(handleToolInputStreaming(partialMsg, toolInputAccumulatorRef)).toBeNull();
+    expect(toolInputAccumulatorRef.current.get('tool-1')).toBe('{"query":"hi"');
+
+    const finalMsg: ClaudeMessage = {
+      type: 'stream_event',
+      event: {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'input_json_delta', partial_json: '}' },
+      },
+    };
+
+    expect(handleToolInputStreaming(finalMsg, toolInputAccumulatorRef)).toEqual({
+      type: 'TOOL_INPUT_UPDATE',
+      payload: { toolUseId: 'tool-1', input: { query: 'hi' } },
+    });
+  });
+
+  it('returns null when message is not a stream_event', () => {
+    const toolInputAccumulatorRef = { current: new Map<string, string>() };
+    const nonStream: ClaudeMessage = {
+      type: 'assistant',
+      message: { role: 'assistant', content: 'ok' },
+    };
+
+    expect(handleToolInputStreaming(nonStream, toolInputAccumulatorRef)).toBeNull();
+    expect(toolInputAccumulatorRef.current.size).toBe(0);
+  });
+});
+
+describe('handleThinkingStreaming', () => {
+  it('clears thinking on message_start', () => {
+    const msg: ClaudeMessage = {
+      type: 'stream_event',
+      event: {
+        type: 'message_start',
+        message: { role: 'assistant', content: '' },
+      },
+    };
+
+    expect(handleThinkingStreaming(msg)).toEqual({ type: 'THINKING_CLEAR' });
+  });
+
+  it('returns THINKING_DELTA for thinking_delta events', () => {
+    const msg: ClaudeMessage = {
+      type: 'stream_event',
+      event: {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'thinking_delta', thinking: 'step-by-step' },
+      },
+    };
+
+    expect(handleThinkingStreaming(msg)).toEqual({
+      type: 'THINKING_DELTA',
+      payload: { thinking: 'step-by-step' },
+    });
+  });
+});

--- a/src/components/chat/use-chat-transport.ts
+++ b/src/components/chat/use-chat-transport.ts
@@ -1,0 +1,254 @@
+'use client';
+
+import { useCallback } from 'react';
+import type {
+  ClaudeMessage,
+  ClaudeStreamEvent,
+  InputJsonDelta,
+  WebSocketMessage,
+} from '@/lib/claude-types';
+import { isStreamEventMessage, isWebSocketMessage, isWsClaudeMessage } from '@/lib/claude-types';
+import { createDebugLogger } from '@/lib/debug';
+import type { ChatAction, ChatState } from './chat-reducer';
+import { createActionFromWebSocketMessage } from './chat-reducer';
+
+// =============================================================================
+// Debug Logging
+// =============================================================================
+
+const DEBUG_CHAT_TRANSPORT = false;
+const debug = createDebugLogger(DEBUG_CHAT_TRANSPORT);
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface UseChatTransportOptions {
+  dispatch: React.Dispatch<ChatAction>;
+  stateRef: React.MutableRefObject<ChatState>;
+  toolInputAccumulatorRef: React.MutableRefObject<Map<string, string>>;
+  rewindTimeoutRef: React.MutableRefObject<ReturnType<typeof setTimeout> | null>;
+}
+
+export interface UseChatTransportReturn {
+  handleMessage: (data: unknown) => void;
+}
+
+// =============================================================================
+// Streaming Helpers
+// =============================================================================
+
+/**
+ * Get stream event data from a Claude message.
+ * Returns the event if the message is a stream_event type, null otherwise.
+ */
+function getStreamEvent(claudeMsg: ClaudeMessage): ClaudeStreamEvent | null {
+  if (!isStreamEventMessage(claudeMsg)) {
+    return null;
+  }
+  return claudeMsg.event;
+}
+
+/**
+ * Handle tool_use block start - initialize accumulator.
+ */
+function handleToolUseStart(
+  event: ClaudeStreamEvent,
+  toolInputAccumulatorRef: React.MutableRefObject<Map<string, string>>
+): void {
+  if (event.type !== 'content_block_start') {
+    return;
+  }
+  const block = event.content_block;
+  if (block.type === 'tool_use' && block.id) {
+    const toolUseId = block.id;
+    toolInputAccumulatorRef.current.set(toolUseId, '');
+    debug.log('Tool use started:', toolUseId, block.name);
+  }
+}
+
+/**
+ * Handle tool input JSON delta - accumulate and try to parse.
+ * Returns a TOOL_INPUT_UPDATE action if valid JSON was accumulated, null otherwise.
+ */
+function handleToolInputDelta(
+  event: ClaudeStreamEvent,
+  toolInputAccumulatorRef: React.MutableRefObject<Map<string, string>>
+): ChatAction | null {
+  if (event.type !== 'content_block_delta') {
+    return null;
+  }
+
+  // Cast delta to check for input_json_delta
+  const delta = event.delta as InputJsonDelta | typeof event.delta;
+  if (delta.type !== 'input_json_delta' || !('partial_json' in delta)) {
+    return null;
+  }
+
+  const accumulatorEntries = Array.from(toolInputAccumulatorRef.current.entries());
+  if (accumulatorEntries.length === 0) {
+    return null;
+  }
+
+  // Get the last (most recent) tool_use_id
+  const [toolUseId, currentJson] = accumulatorEntries[accumulatorEntries.length - 1];
+  const newJson = currentJson + delta.partial_json;
+  toolInputAccumulatorRef.current.set(toolUseId, newJson);
+
+  // Try to parse the accumulated JSON and create update action
+  try {
+    const parsedInput = JSON.parse(newJson) as Record<string, unknown>;
+    debug.log('Tool input updated:', toolUseId, Object.keys(parsedInput));
+    return { type: 'TOOL_INPUT_UPDATE', payload: { toolUseId, input: parsedInput } };
+  } catch {
+    // JSON not complete yet, that's expected during streaming
+    return null;
+  }
+}
+
+/**
+ * Handle tool input accumulation from stream events.
+ * Returns a TOOL_INPUT_UPDATE action if input was accumulated, null otherwise.
+ */
+export function handleToolInputStreaming(
+  claudeMsg: ClaudeMessage,
+  toolInputAccumulatorRef: React.MutableRefObject<Map<string, string>>
+): ChatAction | null {
+  const event = getStreamEvent(claudeMsg);
+  if (!event) {
+    return null;
+  }
+
+  // Initialize accumulator for tool_use start events
+  handleToolUseStart(event, toolInputAccumulatorRef);
+
+  // Handle input JSON deltas
+  return handleToolInputDelta(event, toolInputAccumulatorRef);
+}
+
+/**
+ * Handle thinking delta stream events (extended thinking mode).
+ * Returns a THINKING_DELTA action for thinking deltas, THINKING_CLEAR for message_start, null otherwise.
+ */
+export function handleThinkingStreaming(claudeMsg: ClaudeMessage): ChatAction | null {
+  const event = getStreamEvent(claudeMsg);
+  if (!event) {
+    return null;
+  }
+
+  // Clear thinking on new message start
+  if (event.type === 'message_start') {
+    return { type: 'THINKING_CLEAR' };
+  }
+
+  // Accumulate thinking delta
+  if (event.type === 'content_block_delta') {
+    const delta = event.delta;
+    if (delta.type === 'thinking_delta') {
+      return { type: 'THINKING_DELTA', payload: { thinking: delta.thinking } };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Handle Claude message with tool input streaming.
+ * Expects a validated claude_message WebSocket message.
+ */
+function handleClaudeMessageWithStreaming(
+  wsMessage: WebSocketMessage & { type: 'claude_message'; data: ClaudeMessage },
+  toolInputAccumulatorRef: React.MutableRefObject<Map<string, string>>,
+  dispatch: React.Dispatch<ChatAction>
+): void {
+  const claudeMsg = wsMessage.data;
+
+  // Handle tool input streaming before the main action
+  const toolInputAction = handleToolInputStreaming(claudeMsg, toolInputAccumulatorRef);
+  if (toolInputAction) {
+    dispatch(toolInputAction);
+    // Don't return - still need to dispatch the main action for content_block_start
+  }
+
+  // Handle thinking streaming (extended thinking mode)
+  const thinkingAction = handleThinkingStreaming(claudeMsg);
+  if (thinkingAction) {
+    dispatch(thinkingAction);
+    // Don't return - THINKING_CLEAR also needs the main action to process
+  }
+}
+
+// =============================================================================
+// Hook Implementation
+// =============================================================================
+
+export function useChatTransport(options: UseChatTransportOptions): UseChatTransportReturn {
+  const { dispatch, stateRef, toolInputAccumulatorRef, rewindTimeoutRef } = options;
+
+  /**
+   * Clears the rewind timeout if the response matches the current rewind request.
+   * Validates userMessageId to prevent stale responses from clearing the timeout.
+   */
+  const clearRewindTimeoutIfMatching = useCallback(
+    (wsMessage: WebSocketMessage) => {
+      if (wsMessage.type !== 'rewind_files_preview' && wsMessage.type !== 'rewind_files_error') {
+        return;
+      }
+      const currentUserMessageId = stateRef.current.rewindPreview?.userMessageId;
+      const responseUserMessageId = wsMessage.userMessageId;
+      // Only clear timeout if this response is for the current rewind request
+      if (
+        rewindTimeoutRef.current &&
+        (!responseUserMessageId || responseUserMessageId === currentUserMessageId)
+      ) {
+        clearTimeout(rewindTimeoutRef.current);
+        rewindTimeoutRef.current = null;
+      }
+    },
+    [rewindTimeoutRef, stateRef]
+  );
+
+  const handleMessage = useCallback(
+    (data: unknown) => {
+      // Validate incoming data is a WebSocket message
+      if (!isWebSocketMessage(data)) {
+        debug.log('Received invalid WebSocket message:', data);
+        return;
+      }
+      const wsMessage = data;
+
+      // Handle workspace notification requests
+      if (wsMessage.type === 'workspace_notification_request') {
+        // Dispatch custom event for WorkspaceNotificationManager
+        window.dispatchEvent(
+          new CustomEvent('workspace-notification-request', {
+            detail: {
+              workspaceId: wsMessage.workspaceId,
+              workspaceName: wsMessage.workspaceName,
+              sessionCount: wsMessage.sessionCount,
+              finishedAt: wsMessage.finishedAt,
+            },
+          })
+        );
+        return;
+      }
+
+      // Clear rewind timeout when we receive rewind response for the current request
+      clearRewindTimeoutIfMatching(wsMessage);
+
+      // Handle Claude messages specially for tool input streaming
+      if (isWsClaudeMessage(wsMessage)) {
+        handleClaudeMessageWithStreaming(wsMessage, toolInputAccumulatorRef, dispatch);
+      }
+
+      // Convert WebSocket message to action and dispatch
+      const action = createActionFromWebSocketMessage(wsMessage);
+      if (action) {
+        dispatch(action);
+      }
+    },
+    [clearRewindTimeoutIfMatching, dispatch, toolInputAccumulatorRef]
+  );
+
+  return { handleMessage };
+}


### PR DESCRIPTION
## Summary
- extract WebSocket/streaming handling into a dedicated chat transport hook
- keep use-chat-state focused on state/persistence and wire in the transport handler
- add streaming helper tests for tool input accumulation and thinking deltas

## Testing
- pnpm test -- --run src/components/chat/use-chat-transport.test.ts

Fixes #518

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors core WebSocket message handling and streaming-related dispatching, so regressions could affect chat updates, rewind timeouts, or tool/thinking streaming behavior. Functional intent appears unchanged and is partially covered by new unit tests.
> 
> **Overview**
> Extracts WebSocket message validation/dispatch logic out of `use-chat-state` into a new `useChatTransport` hook, keeping state/persistence concerns separate while preserving behaviors like workspace-notification events and rewind timeout clearing.
> 
> Moves Claude streaming helpers for tool input JSON accumulation and extended thinking deltas into `use-chat-transport.ts` and adds focused Vitest coverage for `handleToolInputStreaming` and `handleThinkingStreaming`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e2d9e4fa9a8504e702b627e45c1133cc069cde9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->