### PR TITLE
Fix pasted text attachments not responding to interactive requests

### DIFF
--- a/src/shared/websocket/chat-message.schema.ts
+++ b/src/shared/websocket/chat-message.schema.ts
@@ -15,6 +15,7 @@ export const AttachmentSchema = z.object({
   type: z.string(),
   size: z.number(),
   data: z.string(),
+  contentType: z.enum(['image', 'text']).optional(),
 });
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Fix pasted large text (10+ lines or 1000+ chars) not responding to interactive requests (like AskUserQuestion)
- When user pastes large text, it becomes a text attachment instead of inline text
- The queue-message handler only checked inline text for interactive responses, causing attachments-only messages to be queued instead of handled as responses
- This left the agent stuck waiting for a response that was never processed

## Changes

- Added `extractTextFromAttachments` helper function to extract text content from text attachments
- Modified queue-message handler to use attachment text content when inline text is empty
- Added `contentType` field to the websocket attachment schema for text vs image discrimination
- Added tests for attachments-only message handling with and without pending interactive requests

## Test plan

- [x] Added unit tests for the new behavior
- [x] Ran full test suite (1207 tests pass)
- [x] Ran typecheck
- [x] Ran lint/format

Fixes #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)