### PR TITLE
Consolidate Claude protocol types (#546)

### DIFF
--- a/src/backend/services/chat-message-handlers.service.ts
+++ b/src/backend/services/chat-message-handlers.service.ts
@@ -9,7 +9,7 @@
  */
 
 import type { WebSocket } from 'ws';
-import { DEFAULT_THINKING_BUDGET, MessageState } from '@/shared/claude-protocol';
+import { DEFAULT_THINKING_BUDGET, MessageState } from '@/shared/claude';
 import type { ChatMessageInput } from '@/shared/websocket';
 import type { ClaudeClient } from '../claude/index';
 import type { ClaudeContentItem } from '../claude/types';

--- a/src/backend/services/chat-message-handlers/handlers/remove-queued-message.handler.ts
+++ b/src/backend/services/chat-message-handlers/handlers/remove-queued-message.handler.ts
@@ -1,4 +1,4 @@
-import { MessageState } from '@/shared/claude-protocol';
+import { MessageState } from '@/shared/claude';
 import type { RemoveQueuedMessageInput } from '@/shared/websocket';
 import { createLogger } from '../../logger.service';
 import { messageQueueService } from '../../message-queue.service';

--- a/src/backend/services/message-queue.service.ts
+++ b/src/backend/services/message-queue.service.ts
@@ -6,13 +6,13 @@
  * Claude when the session becomes idle.
  */
 
-import type { QueuedMessage } from '@/shared/claude-protocol';
+import type { QueuedMessage } from '@/shared/claude';
 import { createLogger } from './logger.service';
 
 const logger = createLogger('message-queue-service');
 
 // Re-export for backwards compatibility
-export type { QueuedMessage } from '@/shared/claude-protocol';
+export type { QueuedMessage } from '@/shared/claude';
 
 // Max queue size to prevent runaway queueing
 const MAX_QUEUE_SIZE = 100;

--- a/src/backend/services/message-state-machine.test.ts
+++ b/src/backend/services/message-state-machine.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import type { HistoryMessage, QueuedMessage } from '@/shared/claude-protocol';
-import { MessageState } from '@/shared/claude-protocol';
+import type { HistoryMessage, QueuedMessage } from '@/shared/claude';
+import { MessageState } from '@/shared/claude';
 import { isValidTransition, MessageStateMachine } from './message-state-machine';
 
 function createTestQueuedMessage(id: string, text = 'Test message'): QueuedMessage {

--- a/src/backend/services/message-state-machine.ts
+++ b/src/backend/services/message-state-machine.ts
@@ -8,7 +8,7 @@ import {
   type QueuedMessage,
   type UserMessageState,
   type UserMessageWithState,
-} from '@/shared/claude-protocol';
+} from '@/shared/claude';
 
 /**
  * Valid state transitions for user messages.

--- a/src/backend/services/message-state.service.test.ts
+++ b/src/backend/services/message-state.service.test.ts
@@ -4,8 +4,8 @@
  * Tests the message state machine that manages unified message state for chat sessions.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { HistoryMessage, QueuedMessage } from '@/shared/claude-protocol';
-import { isClaudeMessage, isUserMessage, MessageState } from '@/shared/claude-protocol';
+import type { HistoryMessage, QueuedMessage } from '@/shared/claude';
+import { isClaudeMessage, isUserMessage, MessageState } from '@/shared/claude';
 import { messageStateService } from './message-state.service';
 
 // Mock the chatConnectionService to prevent actual WebSocket broadcasts

--- a/src/backend/services/message-state.service.ts
+++ b/src/backend/services/message-state.service.ts
@@ -24,7 +24,7 @@ import {
   type QueuedMessage,
   type SessionStatus,
   type UserMessageWithState,
-} from '@/shared/claude-protocol';
+} from '@/shared/claude';
 import { chatConnectionService } from './chat-connection.service';
 import { createLogger } from './logger.service';
 import { MessageEventStore } from './message-event-store';

--- a/src/backend/services/slash-command-cache.service.ts
+++ b/src/backend/services/slash-command-cache.service.ts
@@ -1,5 +1,5 @@
 import type { Prisma } from '@prisma-gen/client';
-import type { CommandInfo } from '@/shared/claude-protocol';
+import type { CommandInfo } from '@/shared/claude';
 import { userSettingsAccessor } from '../resource_accessors/user-settings.accessor';
 import { createLogger } from './logger.service';
 

--- a/src/lib/claude-types.ts
+++ b/src/lib/claude-types.ts
@@ -1,11 +1,11 @@
 /**
  * Frontend helper utilities and UI-specific types for the Claude chat protocol.
  *
- * Core protocol types/constants are defined in src/shared/claude-protocol.ts
+ * Core protocol types/constants are defined in src/shared/claude/protocol.ts
  * and re-exported here for convenience.
  */
 
-export * from '@/shared/claude-protocol';
+export * from '@/shared/claude';
 
 import type {
   ChatMessage,
@@ -21,7 +21,7 @@ import type {
   ToolResultContentValue,
   ToolUseContent,
   WebSocketMessage,
-} from '@/shared/claude-protocol';
+} from '@/shared/claude';
 
 // =============================================================================
 // UI Chat Message Group Types

--- a/src/shared/claude/index.ts
+++ b/src/shared/claude/index.ts
@@ -1,0 +1,1 @@
+export * from './protocol';

--- a/src/shared/claude/protocol.ts
+++ b/src/shared/claude/protocol.ts
@@ -5,9 +5,9 @@
  * shared constants, and message state machine types.
  */
 
-import type { PendingInteractiveRequest } from './pending-request-types';
+import type { PendingInteractiveRequest } from '../pending-request-types';
 
-export type { PendingInteractiveRequest } from './pending-request-types';
+export type { PendingInteractiveRequest } from '../pending-request-types';
 
 // =============================================================================
 // Slash Command Types


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Mostly a type/module consolidation, but it touches widely imported shared protocol definitions; any subtle shape drift or export mismatch could surface as runtime/compile errors across backend, frontend, and tests.
> 
> **Overview**
> Moves the shared Claude chat/streaming protocol to a new `src/shared/claude` module and updates backend/frontend imports to use `@/shared/claude` instead of the previous path.
> 
> Refactors `src/backend/claude/types.ts` to *re-export* shared protocol types (and derive event subtypes from `ClaudeStreamEvent`) rather than duplicating content/tool/streaming definitions, reducing client/server type drift.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 737c8e07a500eac0d1eb0c9c151b5be8086f655e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Fixes #546