### PR TITLE
Decompose Claude client/process concerns

### DIFF
--- a/src/backend/claude/monitoring.ts
+++ b/src/backend/claude/monitoring.ts
@@ -1,0 +1,207 @@
+/**
+ * Resource monitoring for Claude CLI processes.
+ *
+ * Tracks CPU/memory usage and detects hung processes.
+ */
+
+import { EventEmitter } from 'node:events';
+import pidusage from 'pidusage';
+import { configService } from '../services/config.service';
+import { createLogger } from '../services/logger.service';
+import type { ResourceUsage } from './types/process-types';
+
+const logger = createLogger('claude-process-monitor');
+
+/**
+ * Options for resource monitoring.
+ */
+export interface ResourceMonitoringOptions {
+  /** Enable resource monitoring (default: true) */
+  enabled?: boolean;
+  /** Maximum memory in bytes before killing process (default: 2GB) */
+  maxMemoryBytes?: number;
+  /** Maximum CPU percentage to warn about (default: 90%) */
+  maxCpuPercent?: number;
+  /** Time in ms without activity before considering process hung (default: 30 minutes) */
+  activityTimeoutMs?: number;
+  /** Time in ms before timeout to emit a warning (default: 80% of activityTimeoutMs) */
+  hungWarningThresholdMs?: number;
+  /** Interval in ms between resource checks (default: 5 seconds) */
+  monitoringIntervalMs?: number;
+}
+
+export interface MonitorTarget {
+  getPid(): number | undefined;
+  isRunning(): boolean;
+  kill(): void;
+}
+
+export interface MonitorEvents {
+  resource_exceeded: (data: { type: 'memory' | 'cpu'; value: number }) => void;
+  hung_warning: (data: { lastActivity: number; idleTimeMs: number; timeoutMs: number }) => void;
+  hung_process: (data: { lastActivity: number }) => void;
+  resource_usage: (usage: ResourceUsage) => void;
+}
+
+export class ClaudeProcessMonitor extends EventEmitter {
+  private target: MonitorTarget;
+  private options: Required<ResourceMonitoringOptions>;
+  private monitoringInterval: NodeJS.Timeout | null = null;
+  private lastActivityAt: number = Date.now();
+  private lastResourceUsage: ResourceUsage | null = null;
+  private hungWarningEmitted = false;
+
+  constructor(target: MonitorTarget, options?: ResourceMonitoringOptions) {
+    super();
+    this.target = target;
+    this.options = {
+      ...ClaudeProcessMonitor.buildDefaultMonitoring(),
+      ...options,
+    };
+  }
+
+  static buildDefaultMonitoring(): Required<ResourceMonitoringOptions> {
+    const activityTimeoutMs = configService.getClaudeProcessConfig().hungTimeoutMs;
+    return {
+      enabled: true,
+      maxMemoryBytes: 2 * 1024 * 1024 * 1024, // 2GB
+      maxCpuPercent: 90,
+      activityTimeoutMs,
+      hungWarningThresholdMs: Math.floor(activityTimeoutMs * 0.8),
+      monitoringIntervalMs: 5000,
+    };
+  }
+
+  isEnabled(): boolean {
+    return this.options.enabled;
+  }
+
+  start(): void {
+    if (!this.options.enabled || this.monitoringInterval) {
+      return;
+    }
+
+    const { monitoringIntervalMs } = this.options;
+    this.monitoringInterval = setInterval(async () => {
+      await this.performResourceCheck();
+    }, monitoringIntervalMs);
+  }
+
+  stop(): void {
+    if (this.monitoringInterval) {
+      clearInterval(this.monitoringInterval);
+      this.monitoringInterval = null;
+    }
+  }
+
+  recordActivity(): void {
+    this.lastActivityAt = Date.now();
+    this.hungWarningEmitted = false;
+  }
+
+  getLastActivityAt(): number {
+    return this.lastActivityAt;
+  }
+
+  getIdleTimeMs(): number {
+    return Date.now() - this.lastActivityAt;
+  }
+
+  getResourceUsage(): ResourceUsage | null {
+    return this.lastResourceUsage;
+  }
+
+  private async performResourceCheck(): Promise<void> {
+    const pid = this.target.getPid();
+    if (!(pid && this.target.isRunning())) {
+      this.stop();
+      return;
+    }
+
+    try {
+      const usage = await pidusage(pid);
+      this.updateResourceUsage(usage, pid);
+      this.checkIdleTime(pid);
+    } catch (error) {
+      logger.debug('Failed to get resource usage, stopping monitoring', {
+        pid,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      this.stop();
+    }
+  }
+
+  private updateResourceUsage(usage: { cpu: number; memory: number }, pid: number): void {
+    const { maxMemoryBytes, maxCpuPercent } = this.options;
+
+    const resourceUsage: ResourceUsage = {
+      cpu: usage.cpu,
+      memory: usage.memory,
+      timestamp: new Date(),
+    };
+    this.lastResourceUsage = resourceUsage;
+    this.emit('resource_usage', resourceUsage);
+
+    if (usage.memory > maxMemoryBytes) {
+      logger.warn('Process exceeded memory threshold, killing', {
+        pid,
+        memoryBytes: usage.memory,
+        maxMemoryBytes,
+      });
+      this.emit('resource_exceeded', { type: 'memory', value: usage.memory });
+      this.target.kill();
+      return;
+    }
+
+    if (usage.cpu > maxCpuPercent) {
+      this.emit('resource_exceeded', { type: 'cpu', value: usage.cpu });
+    }
+  }
+
+  private checkIdleTime(pid: number): void {
+    const { activityTimeoutMs, hungWarningThresholdMs } = this.options;
+    const idleTime = Date.now() - this.lastActivityAt;
+
+    if (idleTime > hungWarningThresholdMs && !this.hungWarningEmitted) {
+      logger.warn('Process approaching hung timeout', {
+        pid,
+        idleTimeMs: idleTime,
+        warningThresholdMs: hungWarningThresholdMs,
+        timeoutMs: activityTimeoutMs,
+      });
+      this.hungWarningEmitted = true;
+      this.emit('hung_warning', {
+        lastActivity: this.lastActivityAt,
+        idleTimeMs: idleTime,
+        timeoutMs: activityTimeoutMs,
+      });
+    }
+
+    if (idleTime > activityTimeoutMs) {
+      logger.warn('Process exceeded activity timeout, killing', {
+        pid,
+        idleTimeMs: idleTime,
+        activityTimeoutMs,
+      });
+      this.emit('hung_process', { lastActivity: this.lastActivityAt });
+      this.target.kill();
+    }
+  }
+
+  // =========================================================================
+  // Event Emitter Overloads (for TypeScript)
+  // =========================================================================
+
+  override on<K extends keyof MonitorEvents>(event: K, handler: MonitorEvents[K]): this;
+  override on(event: string, handler: (...args: unknown[]) => void): this {
+    return super.on(event, handler);
+  }
+
+  override emit<K extends keyof MonitorEvents>(
+    event: K,
+    ...args: Parameters<MonitorEvents[K]>
+  ): boolean;
+  override emit(event: string, ...args: unknown[]): boolean {
+    return super.emit(event, ...args);
+  }
+}

--- a/src/backend/claude/permission-coordinator.test.ts
+++ b/src/backend/claude/permission-coordinator.test.ts
@@ -1,0 +1,119 @@
+import { EventEmitter } from 'node:events';
+import { describe, expect, it, vi } from 'vitest';
+import { ClaudePermissionCoordinator } from './permission-coordinator';
+import { AutoApproveHandler } from './permissions';
+import type { ControlResponseBody } from './protocol';
+import type { ProtocolIO } from './protocol-io';
+import type {
+  ClaudeContentItem,
+  ControlCancelRequest,
+  ControlRequest,
+  InitializeResponseData,
+  PermissionMode,
+  RewindFilesResponse,
+} from './types';
+
+class FakeProtocol extends EventEmitter implements ProtocolIO {
+  sendControlResponse = vi.fn(
+    async (_requestId: string, _response: ControlResponseBody) => undefined
+  );
+  sendInitialize = vi.fn(async () => ({}) as InitializeResponseData);
+  sendSetPermissionMode = vi.fn(async (_mode: PermissionMode) => undefined);
+  sendUserMessage = vi.fn(async (_content: string | ClaudeContentItem[]) => undefined);
+  sendSetModel = vi.fn(async (_model?: string) => undefined);
+  sendSetMaxThinkingTokens = vi.fn(async (_tokens: number | null) => undefined);
+  sendInterrupt = vi.fn(async () => undefined);
+  sendRewindFiles = vi.fn(async () => ({}) as RewindFilesResponse);
+
+  start(): void {
+    // no-op
+  }
+
+  stop(): void {
+    // no-op
+  }
+}
+
+const askUserQuestionInput = {
+  questions: [
+    {
+      question: 'Ready to proceed?',
+      header: 'Confirm',
+      options: [
+        { label: 'Yes', description: 'Continue' },
+        { label: 'No', description: 'Cancel' },
+      ],
+    },
+  ],
+};
+
+const buildAskUserQuestionRequest = (requestId: string, toolUseId: string): ControlRequest => ({
+  type: 'control_request',
+  request_id: requestId,
+  request: {
+    subtype: 'can_use_tool',
+    tool_name: 'AskUserQuestion',
+    tool_use_id: toolUseId,
+    input: askUserQuestionInput,
+  },
+});
+
+describe('ClaudePermissionCoordinator', () => {
+  it('emits interactive_request and sends answers via protocol', async () => {
+    const protocol = new FakeProtocol();
+    const coordinator = new ClaudePermissionCoordinator({
+      permissionHandler: new AutoApproveHandler(),
+    });
+
+    coordinator.bind(protocol);
+
+    const interactivePromise = new Promise<{ requestId: string }>((resolve) => {
+      coordinator.on('interactive_request', (request) => resolve(request));
+    });
+
+    protocol.emit('control_request', buildAskUserQuestionRequest('req-1', 'tool-1'));
+
+    const interactive = await interactivePromise;
+    coordinator.answerQuestion(interactive.requestId, { 'Ready to proceed?': 'Yes' });
+
+    await vi.waitFor(() => expect(protocol.sendControlResponse).toHaveBeenCalled());
+
+    const [requestId, response] = protocol.sendControlResponse.mock.calls[0];
+    expect(requestId).toBe('req-1');
+    expect(response).toEqual({
+      behavior: 'allow',
+      updatedInput: {
+        questions: askUserQuestionInput.questions,
+        answers: { 'Ready to proceed?': 'Yes' },
+      },
+    });
+  });
+
+  it('emits permission_cancelled without sending a deny response', async () => {
+    const protocol = new FakeProtocol();
+    const coordinator = new ClaudePermissionCoordinator({
+      permissionHandler: new AutoApproveHandler(),
+    });
+
+    coordinator.bind(protocol);
+
+    const cancelledPromise = new Promise<string>((resolve) => {
+      coordinator.on('permission_cancelled', (requestId) => resolve(requestId));
+    });
+
+    protocol.emit('control_request', buildAskUserQuestionRequest('req-2', 'tool-2'));
+
+    const cancel: ControlCancelRequest = {
+      type: 'control_cancel_request',
+      request_id: 'req-2',
+    };
+
+    protocol.emit('control_cancel', cancel);
+
+    const cancelledId = await cancelledPromise;
+    expect(cancelledId).toBe('tool-2');
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(protocol.sendControlResponse).not.toHaveBeenCalled();
+  });
+});

--- a/src/backend/claude/permission-coordinator.ts
+++ b/src/backend/claude/permission-coordinator.ts
@@ -1,0 +1,271 @@
+/**
+ * Permission coordination for Claude CLI control requests.
+ *
+ * Bridges protocol control requests with permission handlers and
+ * interactive approval flows.
+ */
+
+import { EventEmitter } from 'node:events';
+import { AskUserQuestionInputSchema, safeParseToolInput } from '../schemas/tool-inputs.schema';
+import { createLogger } from '../services/logger.service';
+import {
+  createAllowResponse,
+  DeferredHandler,
+  INTERACTIVE_TOOLS,
+  type PermissionHandler,
+} from './permissions';
+import type { ControlResponseBody } from './protocol';
+import type { ProtocolIO } from './protocol-io';
+import type {
+  CanUseToolRequest,
+  ControlCancelRequest,
+  ControlRequest,
+  HookCallbackRequest,
+} from './types';
+import { isCanUseToolRequest, isHookCallbackRequest } from './types';
+
+const logger = createLogger('claude-permissions');
+
+export interface PendingInteractiveRequest {
+  requestId: string;
+  toolName: string;
+  toolUseId: string;
+  input: Record<string, unknown>;
+}
+
+export interface PermissionCoordinatorOptions {
+  permissionHandler: PermissionHandler;
+  interactiveHandler?: DeferredHandler;
+  interactiveTimeoutMs?: number;
+}
+
+export interface PermissionCoordinatorEvents {
+  permission_request: (request: ControlRequest) => void;
+  interactive_request: (request: PendingInteractiveRequest) => void;
+  permission_cancelled: (requestId: string) => void;
+}
+
+export class ClaudePermissionCoordinator extends EventEmitter {
+  private permissionHandler: PermissionHandler;
+  private interactiveHandler: DeferredHandler;
+  private pendingInteractiveRequests: Map<string, CanUseToolRequest> = new Map();
+  private protocolToToolRequestId: Map<string, string> = new Map();
+  private cancelledProtocolRequests: Set<string> = new Set();
+  private protocol: ProtocolIO | null = null;
+  private boundHandlers: {
+    onControlRequest: (request: ControlRequest) => void;
+    onControlCancel: (request: ControlCancelRequest) => void;
+  } | null = null;
+
+  constructor(options: PermissionCoordinatorOptions) {
+    super();
+    this.permissionHandler = options.permissionHandler;
+    this.interactiveHandler =
+      options.interactiveHandler ??
+      new DeferredHandler({ timeout: options.interactiveTimeoutMs ?? 300_000 });
+
+    this.interactiveHandler.on('permission_request', (request, requestId) => {
+      this.pendingInteractiveRequests.set(requestId, request);
+
+      this.emit('interactive_request', {
+        requestId,
+        toolName: request.tool_name,
+        toolUseId: request.tool_use_id ?? requestId,
+        input: request.input,
+      });
+    });
+
+    this.interactiveHandler.on('request_timeout', (requestId) => {
+      this.pendingInteractiveRequests.delete(requestId);
+    });
+  }
+
+  bind(protocol: ProtocolIO): void {
+    if (this.protocol) {
+      this.unbind();
+    }
+
+    this.protocol = protocol;
+
+    const onControlRequest = (controlRequest: ControlRequest) => {
+      void this.handleControlRequestMessage(controlRequest);
+    };
+
+    const onControlCancel = (cancelRequest: ControlCancelRequest) => {
+      this.handleControlCancelMessage(cancelRequest);
+    };
+
+    this.boundHandlers = { onControlRequest, onControlCancel };
+
+    protocol.on('control_request', onControlRequest);
+    protocol.on('control_cancel', onControlCancel);
+  }
+
+  unbind(): void {
+    if (!(this.protocol && this.boundHandlers)) {
+      this.protocol = null;
+      this.boundHandlers = null;
+      return;
+    }
+
+    this.protocol.removeListener('control_request', this.boundHandlers.onControlRequest);
+    this.protocol.removeListener('control_cancel', this.boundHandlers.onControlCancel);
+    this.protocol = null;
+    this.boundHandlers = null;
+  }
+
+  stop(reason?: string): void {
+    this.pendingInteractiveRequests.clear();
+    this.interactiveHandler.cancelAll(reason ?? 'Permission coordinator stopped');
+  }
+
+  answerQuestion(requestId: string, answers: Record<string, string | string[]>): void {
+    const storedRequest = this.pendingInteractiveRequests.get(requestId);
+    if (!storedRequest) {
+      throw new Error(`No pending interactive request found with ID: ${requestId}`);
+    }
+
+    const parsed = safeParseToolInput(
+      AskUserQuestionInputSchema,
+      storedRequest.input,
+      'AskUserQuestion'
+    );
+    if (!parsed.success) {
+      throw new Error(`Invalid AskUserQuestion input for request ID: ${requestId}`);
+    }
+    const questions = parsed.data.questions;
+
+    this.pendingInteractiveRequests.delete(requestId);
+    this.interactiveHandler.approve(requestId, { questions, answers });
+  }
+
+  approveInteractiveRequest(requestId: string): void {
+    const storedRequest = this.pendingInteractiveRequests.get(requestId);
+    if (!storedRequest) {
+      throw new Error(`No pending interactive request found with ID: ${requestId}`);
+    }
+
+    this.pendingInteractiveRequests.delete(requestId);
+    this.interactiveHandler.approve(requestId, storedRequest.input);
+  }
+
+  denyInteractiveRequest(requestId: string, reason: string): void {
+    this.pendingInteractiveRequests.delete(requestId);
+    this.interactiveHandler.deny(requestId, reason);
+  }
+
+  private async handleControlRequestMessage(controlRequest: ControlRequest): Promise<void> {
+    this.emit('permission_request', controlRequest);
+
+    if (
+      isCanUseToolRequest(controlRequest.request) &&
+      INTERACTIVE_TOOLS.has(controlRequest.request.tool_name)
+    ) {
+      const toolUseId = controlRequest.request.tool_use_id;
+      if (toolUseId) {
+        this.protocolToToolRequestId.set(controlRequest.request_id, toolUseId);
+      }
+    }
+
+    try {
+      const response = await this.handleControlRequest(controlRequest.request);
+      this.protocolToToolRequestId.delete(controlRequest.request_id);
+      await this.protocol?.sendControlResponse(controlRequest.request_id, response);
+    } catch (error) {
+      this.protocolToToolRequestId.delete(controlRequest.request_id);
+
+      if (this.cancelledProtocolRequests.has(controlRequest.request_id)) {
+        this.cancelledProtocolRequests.delete(controlRequest.request_id);
+        logger.debug('Skipping deny response for cancelled request', {
+          requestId: controlRequest.request_id,
+        });
+        return;
+      }
+
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      await this.protocol?.sendControlResponse(controlRequest.request_id, {
+        behavior: 'deny',
+        message: `Permission handler error: ${errorMessage}`,
+      });
+    }
+  }
+
+  private handleControlCancelMessage(cancelRequest: ControlCancelRequest): void {
+    const toolUseId = this.protocolToToolRequestId.get(cancelRequest.request_id);
+    const requestIdToCancel = toolUseId ?? cancelRequest.request_id;
+
+    logger.debug('Control cancel received', {
+      protocolRequestId: cancelRequest.request_id,
+      toolUseId,
+      requestIdToCancel,
+    });
+
+    this.cancelledProtocolRequests.add(cancelRequest.request_id);
+    this.interactiveHandler.cancel(requestIdToCancel, 'Request cancelled by CLI');
+
+    const hadStoredRequest = this.pendingInteractiveRequests.has(requestIdToCancel);
+    this.pendingInteractiveRequests.delete(requestIdToCancel);
+    this.protocolToToolRequestId.delete(cancelRequest.request_id);
+
+    logger.debug('Request cancelled cleanup', {
+      requestIdToCancel,
+      hadStoredRequest,
+    });
+
+    this.emit('permission_cancelled', requestIdToCancel);
+  }
+
+  private async handleControlRequest(
+    request: ControlRequest['request']
+  ): Promise<ControlResponseBody> {
+    if (isCanUseToolRequest(request)) {
+      if (INTERACTIVE_TOOLS.has(request.tool_name)) {
+        return await this.interactiveHandler.onCanUseTool(request);
+      }
+      return await this.permissionHandler.onCanUseTool(request);
+    }
+
+    if (isHookCallbackRequest(request)) {
+      return await this.handleHookCallback(request);
+    }
+
+    return {
+      behavior: 'deny',
+      message: `Unknown request subtype: ${(request as { subtype?: string }).subtype ?? 'undefined'}`,
+    };
+  }
+
+  private async handleHookCallback(request: HookCallbackRequest): Promise<ControlResponseBody> {
+    const hookEventName = request.input.hook_event_name;
+
+    if (hookEventName === 'PreToolUse') {
+      return await this.permissionHandler.onPreToolUseHook(request);
+    }
+
+    if (hookEventName === 'Stop') {
+      return await this.permissionHandler.onStopHook(request);
+    }
+
+    return createAllowResponse();
+  }
+
+  // =========================================================================
+  // Event Emitter Overloads (for TypeScript)
+  // =========================================================================
+
+  override on<K extends keyof PermissionCoordinatorEvents>(
+    event: K,
+    handler: PermissionCoordinatorEvents[K]
+  ): this;
+  override on(event: string, handler: (...args: unknown[]) => void): this {
+    return super.on(event, handler);
+  }
+
+  override emit<K extends keyof PermissionCoordinatorEvents>(
+    event: K,
+    ...args: Parameters<PermissionCoordinatorEvents[K]>
+  ): boolean;
+  override emit(event: string, ...args: unknown[]): boolean {
+    return super.emit(event, ...args);
+  }
+}

--- a/src/backend/claude/protocol-io.ts
+++ b/src/backend/claude/protocol-io.ts
@@ -1,0 +1,134 @@
+/**
+ * Protocol IO adapter for Claude CLI.
+ *
+ * Provides a stable interface around ClaudeProtocol for dependency injection
+ * and easier testing.
+ */
+
+import { EventEmitter } from 'node:events';
+import type { Readable, Writable } from 'node:stream';
+import { ClaudeProtocol, type ClaudeProtocolOptions, type ControlResponseBody } from './protocol';
+import type {
+  ClaudeContentItem,
+  ClaudeJson,
+  ControlCancelRequest,
+  ControlRequest,
+  HooksConfig,
+  InitializeResponseData,
+  KeepAliveMessage,
+  PermissionMode,
+  RewindFilesResponse,
+  StreamEventMessage,
+} from './types';
+
+export interface ProtocolIOEvents {
+  message: (msg: ClaudeJson) => void;
+  control_request: (req: ControlRequest) => void;
+  control_cancel: (req: ControlCancelRequest) => void;
+  stream_event: (msg: StreamEventMessage) => void;
+  keep_alive: (msg: KeepAliveMessage) => void;
+  sending: () => void;
+  error: (error: Error) => void;
+  close: () => void;
+}
+
+export interface ProtocolIO {
+  start(): void;
+  stop(): void;
+  sendInitialize(hooks?: HooksConfig): Promise<InitializeResponseData>;
+  sendSetPermissionMode(mode: PermissionMode): Promise<void>;
+  sendUserMessage(content: string | ClaudeContentItem[]): Promise<void>;
+  sendControlResponse(requestId: string, response: ControlResponseBody): Promise<void>;
+  sendSetModel(model?: string): Promise<void>;
+  sendSetMaxThinkingTokens(tokens: number | null): Promise<void>;
+  sendInterrupt(): Promise<void>;
+  sendRewindFiles(userMessageId: string, dryRun?: boolean): Promise<RewindFilesResponse>;
+  on<K extends keyof ProtocolIOEvents>(event: K, handler: ProtocolIOEvents[K]): this;
+  removeListener<K extends keyof ProtocolIOEvents>(event: K, handler: ProtocolIOEvents[K]): this;
+}
+
+export class ClaudeProtocolIO extends EventEmitter implements ProtocolIO {
+  private protocol: ClaudeProtocol;
+
+  constructor(stdin: Writable, stdout: Readable, options?: ClaudeProtocolOptions) {
+    super();
+    this.protocol = new ClaudeProtocol(stdin, stdout, options);
+    this.forwardEvents();
+  }
+
+  start(): void {
+    this.protocol.start();
+  }
+
+  stop(): void {
+    this.protocol.stop();
+  }
+
+  sendInitialize(hooks?: HooksConfig): Promise<InitializeResponseData> {
+    return this.protocol.sendInitialize(hooks);
+  }
+
+  sendSetPermissionMode(mode: PermissionMode): Promise<void> {
+    return this.protocol.sendSetPermissionMode(mode);
+  }
+
+  sendUserMessage(content: string | ClaudeContentItem[]): Promise<void> {
+    return this.protocol.sendUserMessage(content);
+  }
+
+  sendControlResponse(requestId: string, response: ControlResponseBody): Promise<void> {
+    return this.protocol.sendControlResponse(requestId, response);
+  }
+
+  sendSetModel(model?: string): Promise<void> {
+    return this.protocol.sendSetModel(model);
+  }
+
+  sendSetMaxThinkingTokens(tokens: number | null): Promise<void> {
+    return this.protocol.sendSetMaxThinkingTokens(tokens);
+  }
+
+  sendInterrupt(): Promise<void> {
+    return this.protocol.sendInterrupt();
+  }
+
+  sendRewindFiles(userMessageId: string, dryRun?: boolean): Promise<RewindFilesResponse> {
+    return this.protocol.sendRewindFiles(userMessageId, dryRun);
+  }
+
+  private forwardEvents(): void {
+    this.protocol.on('message', (msg) => this.emit('message', msg));
+    this.protocol.on('control_request', (req) => this.emit('control_request', req));
+    this.protocol.on('control_cancel', (req) => this.emit('control_cancel', req));
+    this.protocol.on('stream_event', (msg) => this.emit('stream_event', msg));
+    this.protocol.on('keep_alive', (msg) => this.emit('keep_alive', msg));
+    this.protocol.on('sending', () => this.emit('sending'));
+    this.protocol.on('error', (error) => this.emit('error', error));
+    this.protocol.on('close', () => this.emit('close'));
+  }
+
+  // =========================================================================
+  // Event Emitter Overloads (for TypeScript)
+  // =========================================================================
+
+  override on<K extends keyof ProtocolIOEvents>(event: K, handler: ProtocolIOEvents[K]): this;
+  override on(event: string, handler: (...args: unknown[]) => void): this {
+    return super.on(event, handler);
+  }
+
+  override emit<K extends keyof ProtocolIOEvents>(
+    event: K,
+    ...args: Parameters<ProtocolIOEvents[K]>
+  ): boolean;
+  override emit(event: string, ...args: unknown[]): boolean {
+    return super.emit(event, ...args);
+  }
+
+  override removeListener<K extends keyof ProtocolIOEvents>(
+    event: K,
+    handler: ProtocolIOEvents[K]
+  ): this;
+  override removeListener(event: string, handler: (...args: unknown[]) => void): this {
+    return super.removeListener(event, handler);
+  }
+}


### PR DESCRIPTION
Fixes #547 
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Refactors Claude CLI lifecycle and permission/cancel handling by moving logic into new coordinator/monitor abstractions; regressions could impact interactive approvals, cancellation semantics, or monitoring-triggered process termination.
> 
> **Overview**
> **Decomposes Claude CLI integration into smaller units.** `ClaudeClient` no longer implements control-request/interactive-tool flow directly; it now delegates all permission/interactive approval, cancellation, and AskUserQuestion answer wiring to a new `ClaudePermissionCoordinator` (and re-exports it), while preserving the same outward events (`permission_request`, `interactive_request`, `permission_cancelled`).
> 
> **Extracts process monitoring and protocol wiring.** `ClaudeProcess` drops its inline CPU/memory + hung detection implementation in favor of a new `ClaudeProcessMonitor`, and swaps direct `ClaudeProtocol` usage for a new `ProtocolIO`/`ClaudeProtocolIO` adapter to make protocol interactions injectable/testable. A focused `ClaudePermissionCoordinator` test suite was added to validate interactive answers and cancel behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcfc5a74fa83ff9f9abd1338c48e225dbb6ab4be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->