### PR TITLE
Refactor paste handling complexity

### DIFF
--- a/src/lib/paste-utils.test.ts
+++ b/src/lib/paste-utils.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getClipboardImages } from './paste-utils';
+
+vi.mock('./image-utils', async () => {
+  const actual = await vi.importActual<typeof import('./image-utils')>('./image-utils');
+  return {
+    ...actual,
+    fileToBase64: vi.fn().mockResolvedValue('base64-data'),
+    generateAttachmentId: () => 'att-test',
+    MAX_IMAGE_SIZE: 5,
+  };
+});
+
+import { fileToBase64, MAX_IMAGE_SIZE } from './image-utils';
+
+function createClipboardEvent(items?: DataTransferItem[]): ClipboardEvent {
+  return {
+    clipboardData: items ? ({ items } as unknown as DataTransfer) : undefined,
+  } as ClipboardEvent;
+}
+
+function createClipboardItem(options: { type: string; file?: File | null }): DataTransferItem {
+  return {
+    type: options.type,
+    getAsFile: () => options.file ?? null,
+  } as DataTransferItem;
+}
+
+describe('getClipboardImages', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns empty results when clipboard data is missing', async () => {
+    const result = await getClipboardImages(createClipboardEvent());
+    expect(result).toEqual({ attachments: [], errors: [] });
+  });
+
+  it('creates an image attachment for a supported clipboard image', async () => {
+    const file = {
+      name: 'clip.png',
+      size: 4,
+      type: 'image/png',
+    } as File;
+    const item = createClipboardItem({ type: 'image/png', file });
+    const result = await getClipboardImages(createClipboardEvent([item]));
+
+    expect(fileToBase64).toHaveBeenCalledWith(file);
+    expect(result.errors).toEqual([]);
+    expect(result.attachments).toHaveLength(1);
+    expect(result.attachments[0]).toMatchObject({
+      id: 'att-test',
+      name: 'clip.png',
+      type: 'image/png',
+      size: 4,
+      data: 'base64-data',
+      contentType: 'image',
+    });
+  });
+
+  it('collects an error when an image cannot be extracted', async () => {
+    const item = createClipboardItem({ type: 'image/png', file: null });
+    const result = await getClipboardImages(createClipboardEvent([item]));
+
+    expect(result.attachments).toEqual([]);
+    expect(result.errors).toEqual(['Could not extract image from clipboard (image/png)']);
+  });
+
+  it('collects an error when an image exceeds the size limit', async () => {
+    const file = {
+      name: 'big.png',
+      size: MAX_IMAGE_SIZE + 1,
+      type: 'image/png',
+    } as File;
+    const item = createClipboardItem({ type: 'image/png', file });
+    const result = await getClipboardImages(createClipboardEvent([item]));
+
+    expect(result.attachments).toEqual([]);
+    expect(result.errors).toEqual(['Image too large: 6 B (max 5 B)']);
+  });
+});


### PR DESCRIPTION
## Summary
- refactor paste/drop handling into helper functions to reduce cognitive complexity
- add unit tests for clipboard image extraction helpers

## Testing
- pnpm test -- src/lib/paste-utils.test.ts

Fixes #562

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core paste/drag-drop attachment creation and error reporting paths in the chat input, which could subtly change UX or edge-case handling. Added unit tests reduce but don’t eliminate regression risk across browsers.
> 
> **Overview**
> **Paste/drop handling was refactored to reduce complexity without changing intended behavior.** `usePasteDropHandler` now delegates image-paste, large-text detection, and file-drop processing to focused helpers (with clearer error aggregation and `void`ed async calls).
> 
> **Clipboard image extraction was decomposed and covered by tests.** `getClipboardImages` now filters image items and processes each via a helper (including size-limit and extraction failures), and a new `paste-utils.test.ts` validates success and common error cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53ac5fcddd309cf74224070ce1c5b21668825540. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->