### PR TITLE
Create default workspace session

### DIFF
--- a/src/backend/trpc/workspace.trpc.ts
+++ b/src/backend/trpc/workspace.trpc.ts
@@ -1,5 +1,7 @@
 import { KanbanColumn, WorkspaceStatus } from '@prisma-gen/client';
 import { z } from 'zod';
+import { DEFAULT_FIRST_SESSION } from '../prompts/workflows';
+import { claudeSessionAccessor } from '../resource_accessors/claude-session.accessor';
 import { workspaceAccessor } from '../resource_accessors/workspace.accessor';
 import { workspaceQueryService } from '../services/workspace-query.service';
 import { worktreeLifecycleService } from '../services/worktree-lifecycle.service';
@@ -77,8 +79,27 @@ export const workspaceRouter = router({
     )
     .mutation(async ({ ctx, input }) => {
       const logger = getLogger(ctx);
+      const { configService } = ctx.appContext.services;
       // Create the workspace record
       const workspace = await workspaceAccessor.create(input);
+
+      // Create a default Claude session so the workspace always has a chat tab.
+      // This prevents users from getting stuck in file view before starting a session.
+      const maxSessions = configService.getMaxSessionsPerWorkspace();
+      if (maxSessions > 0) {
+        try {
+          await claudeSessionAccessor.create({
+            workspaceId: workspace.id,
+            workflow: DEFAULT_FIRST_SESSION,
+            name: 'Chat 1',
+          });
+        } catch (error) {
+          logger.warn('Failed to create default session for workspace', {
+            workspaceId: workspace.id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
 
       // Initialize the worktree in the background so the frontend can navigate
       // immediately. The workspace detail page polls for initialization status


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the workspace creation flow to add an extra DB write for a default Claude session; while failures are caught and only logged, misconfig/DB issues could affect initial user experience or add latency.
> 
> **Overview**
> When creating a workspace, the backend now *optionally* creates a default Claude session (`Chat 1`) using `DEFAULT_FIRST_SESSION`, gated by `configService.getMaxSessionsPerWorkspace()`.
> 
> Session creation failures are swallowed (workspace still creates) but logged via `logger.warn`, so users aren’t blocked from entering the workspace while still getting visibility into session setup issues.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3411ba327dc1c5c0fb955ff411e3dbb0f8f4909. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->