### PR TITLE
Persist tab scroll state

### DIFF
--- a/src/components/workspace/file-viewer.tsx
+++ b/src/components/workspace/file-viewer.tsx
@@ -1,12 +1,16 @@
+import type { inferRouterOutputs } from '@trpc/server';
 import { AlertCircle, AlertTriangle, Eye, FileCode, Loader2 } from 'lucide-react';
 import { useTheme } from 'next-themes';
-import { useState } from 'react';
+import type { RefObject, UIEvent } from 'react';
+import { useRef, useState } from 'react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneDark, oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { Button } from '@/components/ui/button';
 import { MarkdownRenderer } from '@/components/ui/markdown';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import type { AppRouter } from '@/frontend/lib/trpc';
 import { trpc } from '@/frontend/lib/trpc';
+import { usePersistentScroll } from './use-persistent-scroll';
 
 // =============================================================================
 // Types
@@ -15,7 +19,11 @@ import { trpc } from '@/frontend/lib/trpc';
 interface FileViewerProps {
   workspaceId: string;
   filePath: string;
+  tabId: string;
 }
+
+type RouterOutputs = inferRouterOutputs<AppRouter>;
+type FileData = RouterOutputs['workspace']['readFile'];
 
 // =============================================================================
 // Helper Functions
@@ -35,19 +43,12 @@ function formatFileSize(bytes: number): string {
 // Main Component
 // =============================================================================
 
-export function FileViewer({ workspaceId, filePath }: FileViewerProps) {
+export function FileViewer({ workspaceId, filePath, tabId }: FileViewerProps) {
   const { resolvedTheme } = useTheme();
   const { data, isLoading, error } = trpc.workspace.readFile.useQuery({
     workspaceId,
     path: filePath,
   });
-
-  const syntaxTheme = resolvedTheme === 'dark' ? oneDark : oneLight;
-  const [showPreview, setShowPreview] = useState(false);
-
-  // Check if file is markdown
-  const isMarkdown =
-    filePath.endsWith('.md') || filePath.endsWith('.markdown') || data?.language === 'markdown';
 
   if (isLoading) {
     return (
@@ -76,92 +77,207 @@ export function FileViewer({ workspaceId, filePath }: FileViewerProps) {
     );
   }
 
-  return (
-    <div className="h-full flex flex-col">
-      {/* Header */}
-      <div className="flex items-center justify-between gap-2 px-4 py-2 border-b bg-muted/30">
-        <div className="flex items-center gap-2 min-w-0">
-          <FileCode className="h-4 w-4 text-muted-foreground flex-shrink-0" />
-          <span className="text-sm font-mono text-foreground truncate">{filePath}</span>
-        </div>
-        <div className="flex items-center gap-2 text-xs text-muted-foreground flex-shrink-0">
-          {isMarkdown && !data.isBinary && (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => setShowPreview(!showPreview)}
-              className="h-7 gap-1.5"
-            >
-              {showPreview ? <FileCode className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
-              {showPreview ? 'Code' : 'Preview'}
-            </Button>
-          )}
-          <span>{formatFileSize(data.size)}</span>
-          <span className="uppercase">{data.language}</span>
-        </div>
-      </div>
+  const syntaxTheme = resolvedTheme === 'dark' ? oneDark : oneLight;
 
-      {/* Warnings */}
-      {data.truncated && (
+  return (
+    <FileViewerLoaded filePath={filePath} tabId={tabId} data={data} syntaxTheme={syntaxTheme} />
+  );
+}
+
+interface FileViewerLoadedProps {
+  filePath: string;
+  tabId: string;
+  data: FileData;
+  syntaxTheme: typeof oneDark;
+}
+
+function FileViewerHeader({
+  filePath,
+  isMarkdown,
+  showPreview,
+  onTogglePreview,
+  fileSizeLabel,
+  language,
+}: {
+  filePath: string;
+  isMarkdown: boolean;
+  showPreview: boolean;
+  onTogglePreview: () => void;
+  fileSizeLabel: string;
+  language: string;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-2 px-4 py-2 border-b bg-muted/30">
+      <div className="flex items-center gap-2 min-w-0">
+        <FileCode className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+        <span className="text-sm font-mono text-foreground truncate">{filePath}</span>
+      </div>
+      <div className="flex items-center gap-2 text-xs text-muted-foreground flex-shrink-0">
+        {isMarkdown && (
+          <Button variant="ghost" size="sm" onClick={onTogglePreview} className="h-7 gap-1.5">
+            {showPreview ? <FileCode className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
+            {showPreview ? 'Code' : 'Preview'}
+          </Button>
+        )}
+        <span>{fileSizeLabel}</span>
+        <span className="uppercase">{language}</span>
+      </div>
+    </div>
+  );
+}
+
+interface FileViewerWarningsProps {
+  truncated: boolean;
+  isBinary: boolean;
+  fileSizeLabel: string;
+}
+
+function FileViewerWarnings({ truncated, fileSizeLabel, isBinary }: FileViewerWarningsProps) {
+  return (
+    <>
+      {truncated && (
         <div className="flex items-center gap-2 px-4 py-2 bg-warning/10 border-b border-warning/20">
           <AlertTriangle className="h-4 w-4 text-warning" />
           <span className="text-sm text-warning">
-            File truncated to 1MB. Actual size: {formatFileSize(data.size)}
+            File truncated to 1MB. Actual size: {fileSizeLabel}
           </span>
         </div>
       )}
 
-      {data.isBinary && (
+      {isBinary && (
         <div className="flex items-center gap-2 px-4 py-2 bg-muted/50 border-b">
           <AlertTriangle className="h-4 w-4 text-muted-foreground" />
           <span className="text-sm text-muted-foreground">Binary file cannot be displayed</span>
         </div>
       )}
+    </>
+  );
+}
 
-      {/* Content */}
-      <ScrollArea className="flex-1">
-        {data.isBinary ? (
-          <div className="flex items-center justify-center h-full p-8">
-            <p className="text-muted-foreground">{data.content}</p>
-          </div>
-        ) : isMarkdown && showPreview ? (
-          <div className="p-4">
-            <MarkdownRenderer content={data.content} />
-          </div>
-        ) : (
-          <SyntaxHighlighter
-            language={data.language}
-            style={syntaxTheme}
-            showLineNumbers
-            wrapLines
-            customStyle={{
-              margin: 0,
-              padding: '1rem',
-              background: 'transparent',
-              fontSize: '0.75rem',
-              lineHeight: '1.5',
-            }}
-            codeTagProps={{
-              style: {
-                background: 'transparent',
-              },
-            }}
-            lineNumberStyle={{
-              minWidth: '3em',
-              paddingRight: '1em',
-              color: 'var(--muted-foreground)',
-              background: 'transparent',
-            }}
-            lineProps={{
-              style: {
-                background: 'transparent',
-              },
-            }}
-          >
-            {data.content}
-          </SyntaxHighlighter>
-        )}
+function FileViewerContent({
+  data,
+  isMarkdown,
+  showPreview,
+  syntaxTheme,
+  onScroll,
+  viewportRef,
+}: {
+  data: FileData;
+  isMarkdown: boolean;
+  showPreview: boolean;
+  syntaxTheme: typeof oneDark;
+  onScroll: (event: UIEvent<HTMLDivElement>) => void;
+  viewportRef: RefObject<HTMLDivElement | null>;
+}) {
+  if (data.isBinary) {
+    return (
+      <ScrollArea className="flex-1" onScroll={onScroll} viewportRef={viewportRef}>
+        <div className="flex items-center justify-center h-full p-8">
+          <p className="text-muted-foreground">{data.content}</p>
+        </div>
       </ScrollArea>
+    );
+  }
+
+  if (isMarkdown && showPreview) {
+    return (
+      <ScrollArea className="flex-1" onScroll={onScroll} viewportRef={viewportRef}>
+        <div className="p-4">
+          <MarkdownRenderer content={data.content} />
+        </div>
+      </ScrollArea>
+    );
+  }
+
+  return (
+    <ScrollArea className="flex-1" onScroll={onScroll} viewportRef={viewportRef}>
+      <SyntaxHighlighter
+        language={data.language}
+        style={syntaxTheme}
+        showLineNumbers
+        wrapLines
+        customStyle={{
+          margin: 0,
+          padding: '1rem',
+          background: 'transparent',
+          fontSize: '0.75rem',
+          lineHeight: '1.5',
+        }}
+        codeTagProps={{
+          style: {
+            background: 'transparent',
+          },
+        }}
+        lineNumberStyle={{
+          minWidth: '3em',
+          paddingRight: '1em',
+          color: 'var(--muted-foreground)',
+          background: 'transparent',
+        }}
+        lineProps={{
+          style: {
+            background: 'transparent',
+          },
+        }}
+      >
+        {data.content}
+      </SyntaxHighlighter>
+    </ScrollArea>
+  );
+}
+
+function FileViewerLoaded({ filePath, tabId, data, syntaxTheme }: FileViewerLoadedProps) {
+  const [showPreview, setShowPreview] = useState(false);
+  const codeViewportRef = useRef<HTMLDivElement>(null);
+  const markdownViewportRef = useRef<HTMLDivElement>(null);
+
+  const isMarkdown =
+    filePath.endsWith('.md') || filePath.endsWith('.markdown') || data.language === 'markdown';
+
+  const { handleScroll: handleCodeScroll } = usePersistentScroll({
+    tabId,
+    mode: 'code',
+    viewportRef: codeViewportRef,
+    enabled: !showPreview,
+    restoreDeps: [showPreview, filePath, data.content.length, data.size, data.isBinary],
+  });
+
+  const { handleScroll: handleMarkdownScroll } = usePersistentScroll({
+    tabId,
+    mode: 'markdown',
+    viewportRef: markdownViewportRef,
+    enabled: showPreview && isMarkdown,
+    restoreDeps: [showPreview, filePath, data.content.length, data.size, data.isBinary],
+  });
+
+  const fileSizeLabel = formatFileSize(data.size);
+  const onTogglePreview = () => setShowPreview((prev) => !prev);
+
+  return (
+    <div className="h-full flex flex-col">
+      <FileViewerHeader
+        filePath={filePath}
+        isMarkdown={isMarkdown && !data.isBinary}
+        showPreview={showPreview}
+        onTogglePreview={onTogglePreview}
+        fileSizeLabel={fileSizeLabel}
+        language={data.language}
+      />
+
+      <FileViewerWarnings
+        truncated={data.truncated}
+        isBinary={data.isBinary}
+        fileSizeLabel={fileSizeLabel}
+      />
+
+      <FileViewerContent
+        data={data}
+        isMarkdown={isMarkdown}
+        showPreview={showPreview}
+        syntaxTheme={syntaxTheme}
+        onScroll={showPreview ? handleMarkdownScroll : handleCodeScroll}
+        viewportRef={showPreview ? markdownViewportRef : codeViewportRef}
+      />
     </div>
   );
 }

--- a/src/components/workspace/index.ts
+++ b/src/components/workspace/index.ts
@@ -14,6 +14,7 @@ export * from './terminal-instance';
 export * from './terminal-panel';
 export * from './terminal-tab-bar';
 export * from './todo-panel-container';
+export * from './use-persistent-scroll';
 export * from './use-terminal-websocket';
 export * from './workflow-selector';
 export * from './workspace-content-view';

--- a/src/components/workspace/main-view-content.tsx
+++ b/src/components/workspace/main-view-content.tsx
@@ -23,14 +23,19 @@ export function MainViewContent({ workspaceId, children, className }: MainViewCo
   const showChat = !activeTab || activeTab.type === 'chat';
   const filePath = activeTab?.type === 'file' ? activeTab.path : undefined;
   const diffPath = activeTab?.type === 'diff' ? activeTab.path : undefined;
+  const activeTabKey = activeTab?.id;
 
   return (
     <div className={cn('h-full', className)}>
       {/* Always render chat children but hide when not active.
           This prevents unmounting/remounting which causes state loss. */}
       <div className={cn('h-full', !showChat && 'hidden')}>{children}</div>
-      {filePath && <FileViewer workspaceId={workspaceId} filePath={filePath} />}
-      {diffPath && <DiffViewer workspaceId={workspaceId} filePath={diffPath} />}
+      {filePath && activeTabKey && (
+        <FileViewer workspaceId={workspaceId} filePath={filePath} tabId={activeTabKey} />
+      )}
+      {diffPath && activeTabKey && (
+        <DiffViewer workspaceId={workspaceId} filePath={diffPath} tabId={activeTabKey} />
+      )}
     </div>
   );
 }

--- a/src/components/workspace/scroll-state.test.ts
+++ b/src/components/workspace/scroll-state.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getScrollStateFromRecord,
+  loadScrollStateRecord,
+  makeScrollStateKey,
+  makeScrollStorageKey,
+  removeScrollStatesForTab,
+  saveScrollStateRecord,
+  upsertScrollState,
+} from './scroll-state';
+
+function createStorage() {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    dump: () => store,
+  };
+}
+
+describe('scroll-state', () => {
+  it('round-trips scroll state records with versioned payload', () => {
+    const storage = createStorage();
+    const workspaceId = 'workspace-1';
+    const record = upsertScrollState({}, 'file-a', 'code', {
+      top: 120,
+      left: 10,
+      stickToBottom: true,
+    });
+
+    saveScrollStateRecord(storage, workspaceId, record);
+    const loaded = loadScrollStateRecord(storage, workspaceId);
+
+    expect(loaded).toEqual(record);
+    expect(storage.dump().get(makeScrollStorageKey(workspaceId))).toContain('"v":1');
+  });
+
+  it('filters invalid scroll state entries', () => {
+    const storage = createStorage();
+    const workspaceId = 'workspace-2';
+    storage.setItem(
+      makeScrollStorageKey(workspaceId),
+      JSON.stringify({
+        v: 1,
+        states: {
+          good: { top: 10, left: 20, stickToBottom: true },
+          bad: { top: -5, left: 'oops' },
+          alsoBad: { top: 5, left: 5, stickToBottom: 'nope' },
+        },
+      })
+    );
+
+    const loaded = loadScrollStateRecord(storage, workspaceId);
+
+    expect(loaded).toEqual({ good: { top: 10, left: 20, stickToBottom: true } });
+  });
+
+  it('removes all scroll states for a tab', () => {
+    const record = {
+      [makeScrollStateKey('tab-1', 'code')]: { top: 1, left: 2 },
+      [makeScrollStateKey('tab-1', 'markdown')]: { top: 3, left: 4 },
+      [makeScrollStateKey('tab-2', 'code')]: { top: 5, left: 6 },
+    };
+
+    const next = removeScrollStatesForTab(record, 'tab-1');
+
+    expect(next).toEqual({
+      [makeScrollStateKey('tab-2', 'code')]: { top: 5, left: 6 },
+    });
+  });
+
+  it('returns null when no scroll state exists for a tab', () => {
+    const record = upsertScrollState({}, 'tab-1', 'code', { top: 1, left: 2 });
+
+    expect(getScrollStateFromRecord(record, 'tab-2', 'code')).toBeNull();
+  });
+});

--- a/src/components/workspace/scroll-state.ts
+++ b/src/components/workspace/scroll-state.ts
@@ -1,0 +1,132 @@
+export type ScrollMode = 'code' | 'markdown' | 'chat';
+
+export interface ScrollState {
+  top: number;
+  left: number;
+  stickToBottom?: boolean;
+}
+
+export interface StorageLike {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+}
+
+interface ScrollStoragePayload {
+  v: 1;
+  states: Record<string, ScrollState>;
+}
+
+const STORAGE_VERSION = 1;
+const STORAGE_KEY_SCROLL_PREFIX = 'workspace-panel-scroll-';
+
+export function makeScrollStorageKey(workspaceId: string): string {
+  return `${STORAGE_KEY_SCROLL_PREFIX}${workspaceId}`;
+}
+
+export function makeScrollStateKey(tabId: string, mode: ScrollMode): string {
+  return `${tabId}:${mode}`;
+}
+
+function isValidScrollState(state: unknown): state is ScrollState {
+  if (typeof state !== 'object' || state === null) {
+    return false;
+  }
+  const candidate = state as Record<string, unknown>;
+  if ('stickToBottom' in candidate && typeof candidate.stickToBottom !== 'boolean') {
+    return false;
+  }
+  return (
+    typeof candidate.top === 'number' &&
+    Number.isFinite(candidate.top) &&
+    typeof candidate.left === 'number' &&
+    Number.isFinite(candidate.left) &&
+    candidate.top >= 0 &&
+    candidate.left >= 0
+  );
+}
+
+function sanitizeScrollState(state: ScrollState): ScrollState {
+  return {
+    top: Math.max(0, Number.isFinite(state.top) ? state.top : 0),
+    left: Math.max(0, Number.isFinite(state.left) ? state.left : 0),
+    stickToBottom: state.stickToBottom === true ? true : undefined,
+  };
+}
+
+export function loadScrollStateRecord(
+  storage: StorageLike,
+  workspaceId: string
+): Record<string, ScrollState> {
+  try {
+    const raw = storage.getItem(makeScrollStorageKey(workspaceId));
+    if (!raw) {
+      return {};
+    }
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      (parsed as ScrollStoragePayload).v !== STORAGE_VERSION ||
+      typeof (parsed as ScrollStoragePayload).states !== 'object' ||
+      (parsed as ScrollStoragePayload).states === null
+    ) {
+      return {};
+    }
+    const states = (parsed as ScrollStoragePayload).states;
+    const cleaned: Record<string, ScrollState> = {};
+    for (const [key, value] of Object.entries(states)) {
+      if (isValidScrollState(value)) {
+        cleaned[key] = sanitizeScrollState(value);
+      }
+    }
+    return cleaned;
+  } catch {
+    return {};
+  }
+}
+
+export function saveScrollStateRecord(
+  storage: StorageLike,
+  workspaceId: string,
+  record: Record<string, ScrollState>
+): void {
+  const payload: ScrollStoragePayload = {
+    v: STORAGE_VERSION,
+    states: record,
+  };
+  storage.setItem(makeScrollStorageKey(workspaceId), JSON.stringify(payload));
+}
+
+export function getScrollStateFromRecord(
+  record: Record<string, ScrollState>,
+  tabId: string,
+  mode: ScrollMode
+): ScrollState | null {
+  return record[makeScrollStateKey(tabId, mode)] ?? null;
+}
+
+export function upsertScrollState(
+  record: Record<string, ScrollState>,
+  tabId: string,
+  mode: ScrollMode,
+  state: ScrollState
+): Record<string, ScrollState> {
+  return {
+    ...record,
+    [makeScrollStateKey(tabId, mode)]: sanitizeScrollState(state),
+  };
+}
+
+export function removeScrollStatesForTab(
+  record: Record<string, ScrollState>,
+  tabId: string
+): Record<string, ScrollState> {
+  const prefix = `${tabId}:`;
+  const next: Record<string, ScrollState> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (!key.startsWith(prefix)) {
+      next[key] = value;
+    }
+  }
+  return next;
+}

--- a/src/components/workspace/use-persistent-scroll.ts
+++ b/src/components/workspace/use-persistent-scroll.ts
@@ -1,0 +1,121 @@
+import type { RefObject, UIEvent } from 'react';
+import { useCallback, useEffect } from 'react';
+
+import type { ScrollMode } from './scroll-state';
+import { useWorkspacePanel } from './workspace-panel-context';
+
+interface UsePersistentScrollOptions {
+  tabId: string | null;
+  mode: ScrollMode;
+  viewportRef: RefObject<HTMLDivElement | null>;
+  enabled?: boolean;
+  restoreDeps?: unknown[];
+  autoStickToBottom?: boolean;
+  stickToBottomThreshold?: number;
+  onRestore?: () => void;
+}
+
+export function usePersistentScroll({
+  tabId,
+  mode,
+  viewportRef,
+  enabled = true,
+  restoreDeps = [],
+  autoStickToBottom = false,
+  stickToBottomThreshold = 150,
+  onRestore,
+}: UsePersistentScrollOptions) {
+  const { getScrollState, setScrollState } = useWorkspacePanel();
+
+  const buildScrollState = useCallback(
+    (viewport: HTMLDivElement) => {
+      if (!autoStickToBottom) {
+        return { top: viewport.scrollTop, left: viewport.scrollLeft };
+      }
+
+      const distanceFromBottom = viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight;
+      const stickToBottom = distanceFromBottom < stickToBottomThreshold;
+
+      return { top: viewport.scrollTop, left: viewport.scrollLeft, stickToBottom };
+    },
+    [autoStickToBottom, stickToBottomThreshold]
+  );
+
+  const persistCurrent = useCallback(
+    (overrideTabId?: string) => {
+      const resolvedTabId = overrideTabId ?? tabId;
+      const shouldPersist = overrideTabId ? true : enabled;
+      if (!(shouldPersist && resolvedTabId)) {
+        return;
+      }
+      const viewport = viewportRef.current;
+      if (!viewport) {
+        return;
+      }
+      setScrollState(resolvedTabId, mode, buildScrollState(viewport));
+    },
+    [buildScrollState, enabled, mode, setScrollState, tabId, viewportRef]
+  );
+
+  const handleScroll = useCallback(
+    (event: UIEvent<HTMLDivElement>) => {
+      if (!(enabled && tabId)) {
+        return;
+      }
+      const viewport = event.currentTarget;
+      setScrollState(tabId, mode, buildScrollState(viewport));
+    },
+    [buildScrollState, enabled, mode, setScrollState, tabId]
+  );
+
+  useEffect(() => {
+    if (!(enabled && tabId)) {
+      return;
+    }
+    const viewport = viewportRef.current;
+    if (!viewport) {
+      return;
+    }
+    const saved = getScrollState(tabId, mode);
+    const handle = requestAnimationFrame(() => {
+      const currentViewport = viewportRef.current;
+      if (!currentViewport) {
+        return;
+      }
+      if (autoStickToBottom && (!saved || saved.stickToBottom)) {
+        currentViewport.scrollTop = currentViewport.scrollHeight;
+        if (!saved) {
+          setScrollState(tabId, mode, {
+            top: currentViewport.scrollTop,
+            left: currentViewport.scrollLeft,
+            stickToBottom: true,
+          });
+        }
+        onRestore?.();
+        return;
+      }
+      if (!saved) {
+        onRestore?.();
+        return;
+      }
+      const maxTop = Math.max(0, currentViewport.scrollHeight - currentViewport.clientHeight);
+      const maxLeft = Math.max(0, currentViewport.scrollWidth - currentViewport.clientWidth);
+      currentViewport.scrollTop = Math.min(Math.max(0, saved.top), maxTop);
+      currentViewport.scrollLeft = Math.min(Math.max(0, saved.left), maxLeft);
+      onRestore?.();
+    });
+    return () => cancelAnimationFrame(handle);
+  }, [
+    autoStickToBottom,
+    enabled,
+    getScrollState,
+    mode,
+    onRestore,
+    setScrollState,
+    tabId,
+    viewportRef,
+    ...restoreDeps,
+  ]);
+
+  return { handleScroll, persistCurrent };
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core workspace panel state and adds localStorage persistence, which can introduce subtle UI regressions (wrong restore timing, stale state, or storage edge cases) but is otherwise contained to client-side behavior.
> 
> **Overview**
> **Adds persistent scroll restoration per workspace tab (chat/file/diff).** A new `scroll-state` localStorage payload (versioned, validated/sanitized) is introduced and wired into `WorkspacePanelProvider` via `getScrollState`/`setScrollState` plus `clearScrollState` on tab/session close.
> 
> `FileViewer` and `DiffViewer` now receive a `tabId` and use a new `usePersistentScroll` hook to save/restore scroll for code vs markdown preview modes. Chat scrolling in `WorkspaceDetailContainer` is updated to persist per chat session and to maintain *stick-to-bottom* behavior while still restoring prior position when switching sessions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3482f0e98fc93cb1339998d6834fc11f757bb778. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->