### PR TITLE
Fix paste attachments without contentType

### DIFF
--- a/src/backend/services/chat-message-handlers/attachment-utils.test.ts
+++ b/src/backend/services/chat-message-handlers/attachment-utils.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import type { MessageAttachment } from '@/shared/claude';
+import { resolveAttachmentContentType } from './attachment-utils';
+
+function createAttachment(overrides: Partial<MessageAttachment> = {}): MessageAttachment {
+  return {
+    id: 'att-1',
+    name: 'attachment',
+    type: 'text/plain',
+    size: 10,
+    data: 'hello world',
+    ...overrides,
+  };
+}
+
+describe('resolveAttachmentContentType', () => {
+  it('prefers explicit contentType', () => {
+    expect(resolveAttachmentContentType(createAttachment({ contentType: 'text' }))).toBe('text');
+    expect(resolveAttachmentContentType(createAttachment({ contentType: 'image' }))).toBe('image');
+  });
+
+  it('uses MIME type when present', () => {
+    expect(
+      resolveAttachmentContentType(createAttachment({ type: 'text/plain', data: 'SGVsbG8=' }))
+    ).toBe('text');
+    expect(
+      resolveAttachmentContentType(createAttachment({ type: 'image/png', data: 'iVBORw0KGgo=' }))
+    ).toBe('image');
+  });
+
+  it('treats pasted text names as text', () => {
+    expect(
+      resolveAttachmentContentType(
+        createAttachment({
+          type: '',
+          name: 'Pasted text (3 lines)',
+          data: 'SGVsbG8=',
+        })
+      )
+    ).toBe('text');
+  });
+
+  it('treats non-base64 payloads as text', () => {
+    expect(
+      resolveAttachmentContentType(
+        createAttachment({ type: '', name: 'notes', data: 'hello\nworld' })
+      )
+    ).toBe('text');
+  });
+
+  it('defaults to image for base64-like data when type is unknown', () => {
+    expect(
+      resolveAttachmentContentType(createAttachment({ type: '', name: 'blob', data: 'SGVsbG8=' }))
+    ).toBe('image');
+  });
+});

--- a/src/backend/services/chat-message-handlers/attachment-utils.ts
+++ b/src/backend/services/chat-message-handlers/attachment-utils.ts
@@ -1,0 +1,38 @@
+import type { MessageAttachment } from '@/shared/claude';
+
+const PASTED_TEXT_NAME = /^Pasted text\b/i;
+const BASE64_REGEX = /^[A-Za-z0-9+/=]+$/;
+
+function looksLikeBase64(data: string): boolean {
+  return BASE64_REGEX.test(data);
+}
+
+function isNameLikelyText(name: string): boolean {
+  return PASTED_TEXT_NAME.test(name);
+}
+
+type AttachmentLike = Pick<MessageAttachment, 'name' | 'type' | 'data' | 'contentType'>;
+
+export function resolveAttachmentContentType(attachment: AttachmentLike): 'text' | 'image' {
+  if (attachment.contentType === 'text' || attachment.contentType === 'image') {
+    return attachment.contentType;
+  }
+
+  if (attachment.type?.startsWith('text/')) {
+    return 'text';
+  }
+
+  if (attachment.type?.startsWith('image/')) {
+    return 'image';
+  }
+
+  if (isNameLikelyText(attachment.name)) {
+    return 'text';
+  }
+
+  if (!looksLikeBase64(attachment.data)) {
+    return 'text';
+  }
+
+  return 'image';
+}

--- a/src/backend/services/chat-message-handlers/handlers/queue-message.handler.ts
+++ b/src/backend/services/chat-message-handlers/handlers/queue-message.handler.ts
@@ -1,6 +1,7 @@
 import type { QueueMessageInput } from '@/shared/websocket';
 import { messageQueueService } from '../../message-queue.service';
 import { messageStateService } from '../../message-state.service';
+import { resolveAttachmentContentType } from '../attachment-utils';
 import { tryHandleAsInteractiveResponse } from '../interactive-response';
 import type { ChatMessageHandler, HandlerRegistryDependencies } from '../types';
 import { buildQueuedMessage, notifyMessageAccepted } from '../utils';
@@ -20,7 +21,7 @@ function extractTextFromAttachments(
   // Collect text from all text attachments
   const textParts: string[] = [];
   for (const attachment of attachments) {
-    if (attachment.contentType === 'text' && attachment.data) {
+    if (resolveAttachmentContentType(attachment) === 'text' && attachment.data) {
       textParts.push(attachment.data);
     }
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to attachment classification/validation that primarily affects how pasted/attachment-only messages are interpreted; main risk is misclassifying ambiguous attachments as text vs image.
> 
> **Overview**
> Fixes handling of attachments that arrive without `contentType` by introducing `resolveAttachmentContentType` and using it across message building, validation, and interactive-response extraction.
> 
> Adds unit tests for the resolver and a handler test to ensure `text/plain` pasted attachments without `contentType` are treated as text (so they can satisfy pending `AskUserQuestion` requests instead of being queued or mis-validated).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef6171a3775681ca59efcb4062e7a461bdef93b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->