### PR TITLE
Place new workspaces at top

### DIFF
--- a/src/backend/services/workspace-query.service.ts
+++ b/src/backend/services/workspace-query.service.ts
@@ -97,6 +97,7 @@ class WorkspaceQueryService {
         return {
           id: w.id,
           name: w.name,
+          createdAt: w.createdAt,
           branchName: w.branchName,
           prUrl: w.prUrl,
           prNumber: w.prNumber,

--- a/src/frontend/components/app-sidebar.stories.tsx
+++ b/src/frontend/components/app-sidebar.stories.tsx
@@ -12,6 +12,7 @@ const mockWorkspaces: ServerWorkspace[] = [
   {
     id: 'ws-1',
     name: 'Refactor auth flows',
+    createdAt: new Date(now.getTime() - 2 * 60 * 60 * 1000).toISOString(),
     branchName: 'feature/refactor-auth-flow',
     prUrl: 'https://github.com/example/repo/pull/42',
     prNumber: 42,
@@ -24,6 +25,7 @@ const mockWorkspaces: ServerWorkspace[] = [
   {
     id: 'ws-2',
     name: 'Polish Kanban layout',
+    createdAt: new Date(now.getTime() - 6 * 60 * 60 * 1000).toISOString(),
     branchName: 'chore/kanban-layout-alignments',
     prUrl: 'https://github.com/example/repo/pull/57',
     prNumber: 57,
@@ -36,6 +38,7 @@ const mockWorkspaces: ServerWorkspace[] = [
   {
     id: 'ws-3',
     name: 'Debug CI flake',
+    createdAt: new Date(now.getTime() - 12 * 60 * 60 * 1000).toISOString(),
     branchName: 'fix/ci-flake-runs-forever',
     prUrl: 'https://github.com/example/repo/pull/63',
     prNumber: 63,
@@ -48,6 +51,7 @@ const mockWorkspaces: ServerWorkspace[] = [
   {
     id: 'ws-4',
     name: 'Research indexing approach',
+    createdAt: new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString(),
     branchName: 'research/semantic-indexing',
     prUrl: null,
     prNumber: null,
@@ -60,6 +64,7 @@ const mockWorkspaces: ServerWorkspace[] = [
   {
     id: 'ws-5',
     name: 'Archive onboarding cleanup',
+    createdAt: new Date(now.getTime() - 3 * 24 * 60 * 60 * 1000).toISOString(),
     branchName: 'cleanup/onboarding',
     prUrl: 'https://github.com/example/repo/pull/71',
     prNumber: 71,

--- a/src/frontend/components/use-workspace-list-state.test.ts
+++ b/src/frontend/components/use-workspace-list-state.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import type { ServerWorkspace } from './use-workspace-list-state';
+import { sortWorkspaces } from './use-workspace-list-state';
+
+function makeWorkspace(
+  overrides: Partial<ServerWorkspace> & { id: string; name: string; createdAt: string | Date }
+): ServerWorkspace {
+  const { id, name, createdAt, ...rest } = overrides;
+  return {
+    id,
+    name,
+    createdAt,
+    isWorking: false,
+    gitStats: null,
+    branchName: null,
+    prUrl: null,
+    prNumber: null,
+    prState: null,
+    prCiStatus: null,
+    ...rest,
+  };
+}
+
+describe('sortWorkspaces', () => {
+  it('sorts by createdAt desc when no custom order is provided', () => {
+    const workspaces = [
+      makeWorkspace({ id: 'a', name: 'Alpha', createdAt: '2024-01-01T00:00:00Z' }),
+      makeWorkspace({ id: 'b', name: 'Beta', createdAt: '2024-02-01T00:00:00Z' }),
+      makeWorkspace({ id: 'c', name: 'Charlie', createdAt: '2024-01-15T00:00:00Z' }),
+    ];
+
+    const sorted = sortWorkspaces(workspaces, undefined);
+
+    expect(sorted.map((w) => w.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('places workspaces missing from custom order at the top (newest first)', () => {
+    const workspaces = [
+      makeWorkspace({ id: 'a', name: 'Alpha', createdAt: '2024-01-01T00:00:00Z' }),
+      makeWorkspace({ id: 'b', name: 'Beta', createdAt: '2024-01-02T00:00:00Z' }),
+      makeWorkspace({ id: 'c', name: 'Gamma', createdAt: '2024-03-01T00:00:00Z' }),
+      makeWorkspace({ id: 'd', name: 'Delta', createdAt: '2024-02-15T00:00:00Z' }),
+    ];
+
+    const sorted = sortWorkspaces(workspaces, ['b', 'a']);
+
+    expect(sorted.map((w) => w.id)).toEqual(['c', 'd', 'b', 'a']);
+  });
+
+  it('keeps custom order stable regardless of createdAt', () => {
+    const workspaces = [
+      makeWorkspace({ id: 'a', name: 'Alpha', createdAt: '2024-03-01T00:00:00Z' }),
+      makeWorkspace({ id: 'b', name: 'Beta', createdAt: '2024-01-01T00:00:00Z' }),
+      makeWorkspace({ id: 'c', name: 'Gamma', createdAt: '2024-02-01T00:00:00Z' }),
+    ];
+
+    const sorted = sortWorkspaces(workspaces, ['b', 'a', 'c']);
+
+    expect(sorted.map((w) => w.id)).toEqual(['b', 'a', 'c']);
+  });
+});


### PR DESCRIPTION
## Summary
- include `createdAt` in workspace summary payloads for sorting
- sort workspaces by createdAt, keeping custom order stable while placing new items on top
- add unit tests for workspace list sorting

## Testing
- pnpm test -- --run src/frontend/components/use-workspace-list-state.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workspace ordering logic in the UI and adds `createdAt` to the backend summary payload, which can affect list stability/UX and may surface date parsing edge cases, but does not touch auth or persistence logic.
> 
> **Overview**
> **Workspace list ordering now prioritizes newly created workspaces.** The backend `getProjectSummaryState` payload now includes `createdAt`, and the frontend `ServerWorkspace` type is updated accordingly.
> 
> The workspace list sorting is reworked to default to `createdAt` descending (instead of name), while preserving any provided custom ID order and placing workspaces missing from that custom order at the top (newest first). Adds unit tests for `sortWorkspaces` and updates Storybook mock data to include `createdAt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a74007ce4e0ccb2f97423f10864a55449672cb4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->