### PR TITLE
Add rendered plan view with inline expansion

### DIFF
--- a/src/components/chat/permission-prompt.tsx
+++ b/src/components/chat/permission-prompt.tsx
@@ -2,8 +2,10 @@ import { FileText, ShieldCheck, ShieldX, Terminal } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
+import { MarkdownRenderer } from '@/components/ui/markdown';
 import type { PermissionRequest } from '@/lib/claude-types';
 import { cn } from '@/lib/utils';
+import { type PlanViewMode, usePlanViewMode } from './plan-view-preference';
 
 // =============================================================================
 // Types
@@ -59,6 +61,38 @@ function formatToolInput(input: Record<string, unknown>): string {
 }
 
 // =============================================================================
+// Plan View Toggle
+// =============================================================================
+
+interface PlanViewToggleProps {
+  value: PlanViewMode;
+  onChange: (mode: PlanViewMode) => void;
+}
+
+function PlanViewToggle({ value, onChange }: PlanViewToggleProps) {
+  return (
+    <div className="flex items-center rounded-md border bg-background p-0.5">
+      {(['rendered', 'raw'] as const).map((mode) => (
+        <button
+          key={mode}
+          type="button"
+          aria-pressed={value === mode}
+          onClick={() => onChange(mode)}
+          className={cn(
+            'text-[11px] px-2 py-1 rounded-sm transition-colors',
+            value === mode
+              ? 'bg-muted text-foreground'
+              : 'text-muted-foreground hover:text-foreground'
+          )}
+        >
+          {mode === 'rendered' ? 'Rendered' : 'Raw'}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+// =============================================================================
 // Plan Approval Component
 // =============================================================================
 
@@ -69,6 +103,7 @@ function formatToolInput(input: Record<string, unknown>): string {
 function PlanApprovalPrompt({ permission, onApprove }: PermissionPromptProps) {
   const approveButtonRef = useRef<HTMLButtonElement>(null);
   const [expanded, setExpanded] = useState(true);
+  const [viewMode, setViewMode] = usePlanViewMode();
   const permissionRequestId = permission?.requestId;
 
   useEffect(() => {
@@ -104,26 +139,30 @@ function PlanApprovalPrompt({ permission, onApprove }: PermissionPromptProps) {
             <FileText className="h-5 w-5 shrink-0 text-blue-500" aria-hidden="true" />
             <span className="text-sm font-medium">Review Plan</span>
           </div>
-          <button
-            type="button"
-            onClick={() => setExpanded(!expanded)}
-            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-          >
-            {expanded ? 'Collapse' : 'Expand'}
-          </button>
+          <div className="flex items-center gap-2">
+            {planContent && <PlanViewToggle value={viewMode} onChange={setViewMode} />}
+            <button
+              type="button"
+              onClick={() => setExpanded(!expanded)}
+              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              {expanded ? 'Collapse' : 'Expand'}
+            </button>
+          </div>
         </div>
 
         {/* Plan Content */}
         {expanded && planContent && (
           <div className="bg-background rounded-md border overflow-hidden">
-            <pre
-              className={cn(
-                'text-xs p-3 overflow-auto whitespace-pre-wrap font-mono',
-                'max-h-64' // Limit height with scroll
+            <div className="max-h-[70vh] overflow-auto">
+              {viewMode === 'rendered' ? (
+                <div className="p-3">
+                  <MarkdownRenderer content={planContent} />
+                </div>
+              ) : (
+                <pre className="text-xs p-3 whitespace-pre-wrap font-mono">{planContent}</pre>
               )}
-            >
-              {planContent}
-            </pre>
+            </div>
           </div>
         )}
 

--- a/src/components/chat/plan-view-preference.test.ts
+++ b/src/components/chat/plan-view-preference.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { loadPlanViewMode, persistPlanViewMode } from './plan-view-preference';
+
+const mockStorage = new Map<string, string>();
+
+const mockLocalStorage = {
+  getItem: vi.fn((key: string) => mockStorage.get(key) ?? null),
+  setItem: vi.fn((key: string, value: string) => mockStorage.set(key, value)),
+  removeItem: vi.fn((key: string) => mockStorage.delete(key)),
+  clear: vi.fn(() => mockStorage.clear()),
+  get length() {
+    return mockStorage.size;
+  },
+  key: vi.fn((index: number) => {
+    const keys = Array.from(mockStorage.keys());
+    return keys[index] ?? null;
+  }),
+};
+
+beforeEach(() => {
+  mockStorage.clear();
+  vi.stubGlobal('localStorage', mockLocalStorage);
+  vi.stubGlobal('window', { localStorage: mockLocalStorage });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  mockStorage.clear();
+  vi.clearAllMocks();
+});
+
+describe('loadPlanViewMode', () => {
+  it('should return rendered when no stored preference exists', () => {
+    const result = loadPlanViewMode();
+    expect(result).toBe('rendered');
+  });
+
+  it('should return stored preference when valid', () => {
+    mockStorage.set('ff:plan-view-mode', 'raw');
+    const result = loadPlanViewMode();
+    expect(result).toBe('raw');
+  });
+
+  it('should fall back to rendered for invalid stored values', () => {
+    mockStorage.set('ff:plan-view-mode', 'invalid');
+    const result = loadPlanViewMode();
+    expect(result).toBe('rendered');
+  });
+
+  it('should return rendered on storage errors', () => {
+    mockLocalStorage.getItem.mockImplementationOnce(() => {
+      throw new Error('Storage error');
+    });
+    const result = loadPlanViewMode();
+    expect(result).toBe('rendered');
+  });
+});
+
+describe('persistPlanViewMode', () => {
+  it('should store the preference', () => {
+    persistPlanViewMode('raw');
+    expect(mockStorage.get('ff:plan-view-mode')).toBe('raw');
+  });
+
+  it('should silently handle storage errors', () => {
+    mockLocalStorage.setItem.mockImplementationOnce(() => {
+      throw new Error('Storage full');
+    });
+    expect(() => persistPlanViewMode('rendered')).not.toThrow();
+  });
+});

--- a/src/components/chat/plan-view-preference.ts
+++ b/src/components/chat/plan-view-preference.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+
+export type PlanViewMode = 'rendered' | 'raw';
+
+const PLAN_VIEW_STORAGE_KEY = 'ff:plan-view-mode';
+const DEFAULT_PLAN_VIEW_MODE: PlanViewMode = 'rendered';
+
+function isPlanViewMode(value: unknown): value is PlanViewMode {
+  return value === 'rendered' || value === 'raw';
+}
+
+export function loadPlanViewMode(): PlanViewMode {
+  if (typeof window === 'undefined') {
+    return DEFAULT_PLAN_VIEW_MODE;
+  }
+  try {
+    const stored = window.localStorage.getItem(PLAN_VIEW_STORAGE_KEY);
+    if (stored && isPlanViewMode(stored)) {
+      return stored;
+    }
+  } catch {
+    return DEFAULT_PLAN_VIEW_MODE;
+  }
+  return DEFAULT_PLAN_VIEW_MODE;
+}
+
+export function persistPlanViewMode(mode: PlanViewMode): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    window.localStorage.setItem(PLAN_VIEW_STORAGE_KEY, mode);
+  } catch {
+    // Silently ignore storage errors
+  }
+}
+
+export function usePlanViewMode(): [PlanViewMode, (mode: PlanViewMode) => void] {
+  const [mode, setMode] = useState<PlanViewMode>(() => loadPlanViewMode());
+
+  useEffect(() => {
+    persistPlanViewMode(mode);
+  }, [mode]);
+
+  return [mode, setMode];
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI change limited to the plan approval prompt; main risk is minor rendering/layout issues or unexpected markdown interpretation of plan text, mitigated by using the existing `MarkdownRenderer` and a default-safe localStorage preference.
> 
> **Overview**
> Adds a **Rendered/Raw** toggle to the `ExitPlanMode` plan approval prompt so plans can be viewed as markdown (`MarkdownRenderer`) or plain preformatted text, with a taller scroll container for long plans.
> 
> Introduces `plan-view-preference` utilities + `usePlanViewMode` hook that **persists the selected view mode in `localStorage`** (defaulting to `rendered` and safely handling SSR/storage errors), along with Vitest coverage for loading/persisting behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c5616a2a84f7cdd39e6125b481151ba6d8aa261. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->