### PR TITLE
Add data export/import for database backup and restore

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -2,6 +2,9 @@
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "entry": [
     "src/client/main.tsx",
+    "src/cli/index.ts",
+    "src/backend/index.ts",
+    "src/backend/server.ts",
     "src/backend/migrate.ts",
     "electron/main/index.ts",
     "electron/preload/index.ts"

--- a/src/backend/services/data-backup.service.ts
+++ b/src/backend/services/data-backup.service.ts
@@ -1,0 +1,550 @@
+/**
+ * Data Backup Service
+ *
+ * Handles export and import of database data for backup/restore purposes.
+ * Used when database migrations require a reset.
+ */
+
+import {
+  CIStatus,
+  KanbanColumn,
+  PRState,
+  type Prisma,
+  SessionStatus,
+  WorkspaceStatus,
+} from '@prisma-gen/client';
+import { z } from 'zod';
+import { prisma } from '../db';
+import { createLogger } from './logger.service';
+
+type TransactionClient = Prisma.TransactionClient;
+
+const logger = createLogger('data-backup');
+
+// ============================================================================
+// Schemas
+// ============================================================================
+
+const exportedProjectSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  slug: z.string(),
+  repoPath: z.string(),
+  worktreeBasePath: z.string(),
+  defaultBranch: z.string(),
+  githubOwner: z.string().nullable(),
+  githubRepo: z.string().nullable(),
+  isArchived: z.boolean(),
+  startupScriptCommand: z.string().nullable(),
+  startupScriptPath: z.string().nullable(),
+  startupScriptTimeout: z.number(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+const exportedWorkspaceSchema = z.object({
+  id: z.string(),
+  projectId: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
+  status: z.nativeEnum(WorkspaceStatus),
+  worktreePath: z.string().nullable(),
+  branchName: z.string().nullable(),
+  initErrorMessage: z.string().nullable(),
+  initOutput: z.string().nullable(),
+  initStartedAt: z.string().nullable(),
+  initCompletedAt: z.string().nullable(),
+  initRetryCount: z.number(),
+  runScriptCommand: z.string().nullable(),
+  runScriptCleanupCommand: z.string().nullable(),
+  runScriptPid: z.number().nullable(),
+  runScriptPort: z.number().nullable(),
+  runScriptStartedAt: z.string().nullable(),
+  runScriptStatus: z.nativeEnum(SessionStatus),
+  prUrl: z.string().nullable(),
+  githubIssueNumber: z.number().nullable(),
+  githubIssueUrl: z.string().nullable(),
+  prNumber: z.number().nullable(),
+  prState: z.nativeEnum(PRState),
+  prReviewState: z.string().nullable(),
+  prCiStatus: z.nativeEnum(CIStatus),
+  prUpdatedAt: z.string().nullable(),
+  prCiFailedAt: z.string().nullable(),
+  prCiLastNotifiedAt: z.string().nullable(),
+  hasHadSessions: z.boolean(),
+  cachedKanbanColumn: z.nativeEnum(KanbanColumn),
+  stateComputedAt: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+const exportedClaudeSessionSchema = z.object({
+  id: z.string(),
+  workspaceId: z.string(),
+  name: z.string().nullable(),
+  workflow: z.string(),
+  model: z.string(),
+  status: z.nativeEnum(SessionStatus),
+  claudeSessionId: z.string().nullable(),
+  claudeProcessPid: z.number().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+const exportedTerminalSessionSchema = z.object({
+  id: z.string(),
+  workspaceId: z.string(),
+  name: z.string().nullable(),
+  status: z.nativeEnum(SessionStatus),
+  pid: z.number().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+const exportedUserSettingsSchema = z.object({
+  preferredIde: z.string(),
+  customIdeCommand: z.string().nullable(),
+  playSoundOnComplete: z.boolean(),
+  notificationSoundPath: z.string().nullable(),
+  autoFixCiIssues: z.boolean(),
+});
+
+export const exportDataSchema = z.object({
+  meta: z.object({
+    exportedAt: z.string(),
+    version: z.string(),
+    schemaVersion: z.literal(1),
+  }),
+  data: z.object({
+    projects: z.array(exportedProjectSchema),
+    workspaces: z.array(exportedWorkspaceSchema),
+    claudeSessions: z.array(exportedClaudeSessionSchema),
+    terminalSessions: z.array(exportedTerminalSessionSchema),
+    userSettings: exportedUserSettingsSchema.nullable(),
+  }),
+});
+
+export type ExportData = z.infer<typeof exportDataSchema>;
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface ImportCounter {
+  imported: number;
+  skipped: number;
+}
+
+export interface ImportResults {
+  projects: ImportCounter;
+  workspaces: ImportCounter;
+  claudeSessions: ImportCounter;
+  terminalSessions: ImportCounter;
+  userSettings: { imported: boolean; skipped: boolean };
+}
+
+type ExportedProject = z.infer<typeof exportedProjectSchema>;
+type ExportedWorkspace = z.infer<typeof exportedWorkspaceSchema>;
+type ExportedClaudeSession = z.infer<typeof exportedClaudeSessionSchema>;
+type ExportedTerminalSession = z.infer<typeof exportedTerminalSessionSchema>;
+type ExportedUserSettings = z.infer<typeof exportedUserSettingsSchema>;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const toISOString = (date: Date | null): string | null => (date ? date.toISOString() : null);
+const parseDate = (str: string | null): Date | null => (str ? new Date(str) : null);
+
+// ============================================================================
+// Import Functions
+// ============================================================================
+
+async function importProjects(
+  projects: ExportedProject[],
+  tx: TransactionClient
+): Promise<ImportCounter> {
+  const counter: ImportCounter = { imported: 0, skipped: 0 };
+
+  for (const p of projects) {
+    const existing = await tx.project.findUnique({ where: { id: p.id } });
+    if (existing) {
+      counter.skipped++;
+      continue;
+    }
+
+    const slugConflict = await tx.project.findUnique({ where: { slug: p.slug } });
+    if (slugConflict) {
+      logger.warn('Skipping project due to slug conflict', { id: p.id, slug: p.slug });
+      counter.skipped++;
+      continue;
+    }
+
+    await tx.project.create({
+      data: {
+        id: p.id,
+        name: p.name,
+        slug: p.slug,
+        repoPath: p.repoPath,
+        worktreeBasePath: p.worktreeBasePath,
+        defaultBranch: p.defaultBranch,
+        githubOwner: p.githubOwner,
+        githubRepo: p.githubRepo,
+        isArchived: p.isArchived,
+        startupScriptCommand: p.startupScriptCommand,
+        startupScriptPath: p.startupScriptPath,
+        startupScriptTimeout: p.startupScriptTimeout,
+        createdAt: new Date(p.createdAt),
+        updatedAt: new Date(p.updatedAt),
+      },
+    });
+    counter.imported++;
+  }
+
+  return counter;
+}
+
+async function importWorkspaces(
+  workspaces: ExportedWorkspace[],
+  tx: TransactionClient
+): Promise<ImportCounter> {
+  const counter: ImportCounter = { imported: 0, skipped: 0 };
+
+  for (const w of workspaces) {
+    const existing = await tx.workspace.findUnique({ where: { id: w.id } });
+    if (existing) {
+      counter.skipped++;
+      continue;
+    }
+
+    const project = await tx.project.findUnique({ where: { id: w.projectId } });
+    if (!project) {
+      logger.warn('Skipping workspace due to missing project', {
+        workspaceId: w.id,
+        projectId: w.projectId,
+      });
+      counter.skipped++;
+      continue;
+    }
+
+    await tx.workspace.create({
+      data: {
+        id: w.id,
+        projectId: w.projectId,
+        name: w.name,
+        description: w.description,
+        status: w.status,
+        worktreePath: w.worktreePath,
+        branchName: w.branchName,
+        initErrorMessage: w.initErrorMessage,
+        initOutput: w.initOutput,
+        initStartedAt: parseDate(w.initStartedAt),
+        initCompletedAt: parseDate(w.initCompletedAt),
+        initRetryCount: w.initRetryCount,
+        runScriptCommand: w.runScriptCommand,
+        runScriptCleanupCommand: w.runScriptCleanupCommand,
+        runScriptPid: w.runScriptPid,
+        runScriptPort: w.runScriptPort,
+        runScriptStartedAt: parseDate(w.runScriptStartedAt),
+        runScriptStatus: w.runScriptStatus,
+        prUrl: w.prUrl,
+        githubIssueNumber: w.githubIssueNumber,
+        githubIssueUrl: w.githubIssueUrl,
+        prNumber: w.prNumber,
+        prState: w.prState,
+        prReviewState: w.prReviewState,
+        prCiStatus: w.prCiStatus,
+        prUpdatedAt: parseDate(w.prUpdatedAt),
+        prCiFailedAt: parseDate(w.prCiFailedAt),
+        prCiLastNotifiedAt: parseDate(w.prCiLastNotifiedAt),
+        hasHadSessions: w.hasHadSessions,
+        cachedKanbanColumn: w.cachedKanbanColumn,
+        stateComputedAt: parseDate(w.stateComputedAt),
+        createdAt: new Date(w.createdAt),
+        updatedAt: new Date(w.updatedAt),
+      },
+    });
+    counter.imported++;
+  }
+
+  return counter;
+}
+
+async function importClaudeSessions(
+  sessions: ExportedClaudeSession[],
+  tx: TransactionClient
+): Promise<ImportCounter> {
+  const counter: ImportCounter = { imported: 0, skipped: 0 };
+
+  for (const s of sessions) {
+    const existing = await tx.claudeSession.findUnique({ where: { id: s.id } });
+    if (existing) {
+      counter.skipped++;
+      continue;
+    }
+
+    const workspace = await tx.workspace.findUnique({ where: { id: s.workspaceId } });
+    if (!workspace) {
+      logger.warn('Skipping claude session due to missing workspace', {
+        sessionId: s.id,
+        workspaceId: s.workspaceId,
+      });
+      counter.skipped++;
+      continue;
+    }
+
+    await tx.claudeSession.create({
+      data: {
+        id: s.id,
+        workspaceId: s.workspaceId,
+        name: s.name,
+        workflow: s.workflow,
+        model: s.model,
+        status: s.status,
+        claudeSessionId: s.claudeSessionId,
+        claudeProcessPid: s.claudeProcessPid,
+        createdAt: new Date(s.createdAt),
+        updatedAt: new Date(s.updatedAt),
+      },
+    });
+    counter.imported++;
+  }
+
+  return counter;
+}
+
+async function importTerminalSessions(
+  sessions: ExportedTerminalSession[],
+  tx: TransactionClient
+): Promise<ImportCounter> {
+  const counter: ImportCounter = { imported: 0, skipped: 0 };
+
+  for (const s of sessions) {
+    const existing = await tx.terminalSession.findUnique({ where: { id: s.id } });
+    if (existing) {
+      counter.skipped++;
+      continue;
+    }
+
+    const workspace = await tx.workspace.findUnique({ where: { id: s.workspaceId } });
+    if (!workspace) {
+      logger.warn('Skipping terminal session due to missing workspace', {
+        sessionId: s.id,
+        workspaceId: s.workspaceId,
+      });
+      counter.skipped++;
+      continue;
+    }
+
+    await tx.terminalSession.create({
+      data: {
+        id: s.id,
+        workspaceId: s.workspaceId,
+        name: s.name,
+        status: s.status,
+        pid: s.pid,
+        createdAt: new Date(s.createdAt),
+        updatedAt: new Date(s.updatedAt),
+      },
+    });
+    counter.imported++;
+  }
+
+  return counter;
+}
+
+async function importUserSettings(
+  settings: ExportedUserSettings | null,
+  tx: TransactionClient
+): Promise<{ imported: boolean; skipped: boolean }> {
+  if (!settings) {
+    return { imported: false, skipped: false };
+  }
+
+  const existing = await tx.userSettings.findFirst({ where: { userId: 'default' } });
+  if (existing) {
+    return { imported: false, skipped: true };
+  }
+
+  await tx.userSettings.create({
+    data: {
+      userId: 'default',
+      preferredIde: settings.preferredIde,
+      customIdeCommand: settings.customIdeCommand,
+      playSoundOnComplete: settings.playSoundOnComplete,
+      notificationSoundPath: settings.notificationSoundPath,
+      autoFixCiIssues: settings.autoFixCiIssues,
+    },
+  });
+
+  return { imported: true, skipped: false };
+}
+
+// ============================================================================
+// Service Class
+// ============================================================================
+
+class DataBackupService {
+  /**
+   * Export all data for backup/migration.
+   * Exports projects, workspaces, sessions, and user preferences.
+   * Excludes cached data (workspaceOrder, cachedSlashCommands) which will rebuild.
+   */
+  async exportData(appVersion: string): Promise<ExportData> {
+    logger.info('Exporting database data');
+
+    // Fetch all data
+    const [projects, workspaces, claudeSessions, terminalSessions, userSettings] =
+      await Promise.all([
+        prisma.project.findMany({ orderBy: { createdAt: 'asc' } }),
+        prisma.workspace.findMany({ orderBy: { createdAt: 'asc' } }),
+        prisma.claudeSession.findMany({ orderBy: { createdAt: 'asc' } }),
+        prisma.terminalSession.findMany({ orderBy: { createdAt: 'asc' } }),
+        prisma.userSettings.findFirst({ where: { userId: 'default' } }),
+      ]);
+
+    const exportData: ExportData = {
+      meta: {
+        exportedAt: new Date().toISOString(),
+        version: appVersion,
+        schemaVersion: 1,
+      },
+      data: {
+        projects: projects.map((p) => ({
+          id: p.id,
+          name: p.name,
+          slug: p.slug,
+          repoPath: p.repoPath,
+          worktreeBasePath: p.worktreeBasePath,
+          defaultBranch: p.defaultBranch,
+          githubOwner: p.githubOwner,
+          githubRepo: p.githubRepo,
+          isArchived: p.isArchived,
+          startupScriptCommand: p.startupScriptCommand,
+          startupScriptPath: p.startupScriptPath,
+          startupScriptTimeout: p.startupScriptTimeout,
+          createdAt: p.createdAt.toISOString(),
+          updatedAt: p.updatedAt.toISOString(),
+        })),
+        workspaces: workspaces.map((w) => ({
+          id: w.id,
+          projectId: w.projectId,
+          name: w.name,
+          description: w.description,
+          status: w.status,
+          worktreePath: w.worktreePath,
+          branchName: w.branchName,
+          initErrorMessage: w.initErrorMessage,
+          initOutput: w.initOutput,
+          initStartedAt: toISOString(w.initStartedAt),
+          initCompletedAt: toISOString(w.initCompletedAt),
+          initRetryCount: w.initRetryCount,
+          runScriptCommand: w.runScriptCommand,
+          runScriptCleanupCommand: w.runScriptCleanupCommand,
+          runScriptPid: w.runScriptPid,
+          runScriptPort: w.runScriptPort,
+          runScriptStartedAt: toISOString(w.runScriptStartedAt),
+          runScriptStatus: w.runScriptStatus,
+          prUrl: w.prUrl,
+          githubIssueNumber: w.githubIssueNumber,
+          githubIssueUrl: w.githubIssueUrl,
+          prNumber: w.prNumber,
+          prState: w.prState,
+          prReviewState: w.prReviewState,
+          prCiStatus: w.prCiStatus,
+          prUpdatedAt: toISOString(w.prUpdatedAt),
+          prCiFailedAt: toISOString(w.prCiFailedAt),
+          prCiLastNotifiedAt: toISOString(w.prCiLastNotifiedAt),
+          hasHadSessions: w.hasHadSessions,
+          cachedKanbanColumn: w.cachedKanbanColumn,
+          stateComputedAt: toISOString(w.stateComputedAt),
+          createdAt: w.createdAt.toISOString(),
+          updatedAt: w.updatedAt.toISOString(),
+        })),
+        claudeSessions: claudeSessions.map((s) => ({
+          id: s.id,
+          workspaceId: s.workspaceId,
+          name: s.name,
+          workflow: s.workflow,
+          model: s.model,
+          status: s.status,
+          claudeSessionId: s.claudeSessionId,
+          claudeProcessPid: s.claudeProcessPid,
+          createdAt: s.createdAt.toISOString(),
+          updatedAt: s.updatedAt.toISOString(),
+        })),
+        terminalSessions: terminalSessions.map((s) => ({
+          id: s.id,
+          workspaceId: s.workspaceId,
+          name: s.name,
+          status: s.status,
+          pid: s.pid,
+          createdAt: s.createdAt.toISOString(),
+          updatedAt: s.updatedAt.toISOString(),
+        })),
+        userSettings: userSettings
+          ? {
+              preferredIde: userSettings.preferredIde,
+              customIdeCommand: userSettings.customIdeCommand,
+              playSoundOnComplete: userSettings.playSoundOnComplete,
+              notificationSoundPath: userSettings.notificationSoundPath,
+              autoFixCiIssues: userSettings.autoFixCiIssues,
+            }
+          : null,
+      },
+    };
+
+    logger.info('Export completed', {
+      projectCount: projects.length,
+      workspaceCount: workspaces.length,
+      claudeSessionCount: claudeSessions.length,
+      terminalSessionCount: terminalSessions.length,
+    });
+
+    return exportData;
+  }
+
+  /**
+   * Import data from a backup file.
+   * Skips records that already exist (by ID).
+   * Returns counts of imported/skipped records.
+   * All imports are wrapped in a transaction for atomicity.
+   */
+  async importData(input: ExportData): Promise<ImportResults> {
+    logger.info('Starting data import', {
+      schemaVersion: input.meta.schemaVersion,
+      exportedAt: input.meta.exportedAt,
+      projectCount: input.data.projects.length,
+      workspaceCount: input.data.workspaces.length,
+    });
+
+    // Import in dependency order within a transaction for atomicity
+    const results = await prisma.$transaction(async (tx) => {
+      const projects = await importProjects(input.data.projects, tx);
+      const workspaces = await importWorkspaces(input.data.workspaces, tx);
+      const claudeSessions = await importClaudeSessions(input.data.claudeSessions, tx);
+      const terminalSessions = await importTerminalSessions(input.data.terminalSessions, tx);
+      const userSettings = await importUserSettings(input.data.userSettings, tx);
+
+      return {
+        projects,
+        workspaces,
+        claudeSessions,
+        terminalSessions,
+        userSettings,
+      };
+    });
+
+    logger.info('Import completed', {
+      projects: results.projects,
+      workspaces: results.workspaces,
+      claudeSessions: results.claudeSessions,
+      terminalSessions: results.terminalSessions,
+    });
+
+    return results;
+  }
+}
+
+// Export singleton instance
+export const dataBackupService = new DataBackupService();

--- a/src/backend/services/index.ts
+++ b/src/backend/services/index.ts
@@ -20,6 +20,14 @@ export { ciMonitorService } from './ci-monitor.service';
 export { type CLIHealthStatus, cliHealthService } from './cli-health.service';
 // Configuration service
 export { configService, type SessionProfile } from './config.service';
+// Data backup service
+export {
+  dataBackupService,
+  type ExportData,
+  exportDataSchema,
+  type ImportCounter,
+  type ImportResults,
+} from './data-backup.service';
 // GitHub CLI service
 export { type GitHubCLIHealthStatus, githubCLIService } from './github-cli.service';
 // Kanban state service

--- a/src/backend/trpc/admin.trpc.ts
+++ b/src/backend/trpc/admin.trpc.ts
@@ -12,6 +12,7 @@ import {
   terminalSessionAccessor,
   workspaceAccessor,
 } from '../resource_accessors/index';
+import { dataBackupService, exportDataSchema } from '../services';
 import { type Context, publicProcedure, router } from './trpc';
 
 const loggerName = 'admin-trpc';
@@ -315,6 +316,29 @@ export const adminRouter = router({
       checked: result.checked,
       stateChanges: result.stateChanges,
       actionsTriggered: result.actionsTriggered,
+    };
+  }),
+
+  /**
+   * Export all data for backup/migration.
+   * Exports projects, workspaces, sessions, and user preferences.
+   * Excludes cached data (workspaceOrder, cachedSlashCommands) which will rebuild.
+   */
+  exportData: publicProcedure.query(({ ctx }) => {
+    const { configService } = ctx.appContext.services;
+    return dataBackupService.exportData(configService.getAppVersion());
+  }),
+
+  /**
+   * Import data from a backup file.
+   * Skips records that already exist (by ID).
+   * Returns counts of imported/skipped records.
+   */
+  importData: publicProcedure.input(exportDataSchema).mutation(async ({ input }) => {
+    const results = await dataBackupService.importData(input);
+    return {
+      success: true,
+      results,
     };
   }),
 });

--- a/src/client/routes/admin.tsx
+++ b/src/client/routes/admin.tsx
@@ -2,18 +2,21 @@ import type { inferRouterOutputs } from '@trpc/server';
 import {
   Bot,
   CheckCircle2,
+  Download,
   FileJson,
   MessageSquare,
   RefreshCw,
   Terminal,
+  Upload,
   Wrench,
 } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router';
 import { toast } from 'sonner';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
@@ -1176,6 +1179,211 @@ function RatchetSettingsSection() {
   );
 }
 
+// ============================================================================
+// Data Backup Section
+// ============================================================================
+
+interface ImportConfirmState {
+  open: boolean;
+  data: unknown;
+  summary: string;
+}
+
+function DataBackupSection() {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [isExporting, setIsExporting] = useState(false);
+  const [confirmState, setConfirmState] = useState<ImportConfirmState>({
+    open: false,
+    data: null,
+    summary: '',
+  });
+  const utils = trpc.useUtils();
+
+  const importData = trpc.admin.importData.useMutation({
+    onSuccess: (result) => {
+      const { results } = result;
+      const summary = [
+        `Projects: ${results.projects.imported} imported, ${results.projects.skipped} skipped`,
+        `Workspaces: ${results.workspaces.imported} imported, ${results.workspaces.skipped} skipped`,
+        `Claude Sessions: ${results.claudeSessions.imported} imported, ${results.claudeSessions.skipped} skipped`,
+        `Terminal Sessions: ${results.terminalSessions.imported} imported, ${results.terminalSessions.skipped} skipped`,
+        `User Settings: ${results.userSettings.imported ? 'imported' : results.userSettings.skipped ? 'skipped (exists)' : 'none'}`,
+      ].join('\n');
+
+      toast.success('Import completed', { description: summary, duration: 10_000 });
+      setConfirmState({ open: false, data: null, summary: '' });
+
+      // Invalidate all queries to refresh data
+      utils.invalidate();
+    },
+    onError: (error) => {
+      toast.error(`Import failed: ${error.message}`);
+      setConfirmState({ open: false, data: null, summary: '' });
+    },
+  });
+
+  const handleExport = async () => {
+    setIsExporting(true);
+    try {
+      const data = await utils.admin.exportData.fetch();
+      const json = JSON.stringify(data, null, 2);
+      const blob = new Blob([json], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `factory-factory-backup-${new Date().toISOString().split('T')[0]}.json`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      toast.success('Export completed');
+    } catch (error) {
+      toast.error(`Export failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  const buildImportSummary = (data: {
+    data: {
+      projects: unknown[];
+      workspaces: unknown[];
+      claudeSessions: unknown[];
+      terminalSessions: unknown[];
+      userSettings: unknown;
+    };
+    meta: { exportedAt: string; version: string };
+  }): string => {
+    return [
+      `Exported: ${new Date(data.meta.exportedAt).toLocaleString()}`,
+      `Version: ${data.meta.version}`,
+      '',
+      `Projects: ${data.data.projects.length}`,
+      `Workspaces: ${data.data.workspaces.length}`,
+      `Claude Sessions: ${data.data.claudeSessions.length}`,
+      `Terminal Sessions: ${data.data.terminalSessions.length}`,
+      `User Settings: ${data.data.userSettings ? 'Yes' : 'No'}`,
+    ].join('\n');
+  };
+
+  const getErrorMessage = (error: unknown): string => {
+    if (error instanceof Error) {
+      return error.message;
+    }
+    return 'Unknown error';
+  };
+
+  const validateAndParseFile = async (file: File): Promise<unknown> => {
+    const text = await file.text();
+    const data = JSON.parse(text);
+
+    // Basic validation
+    if (!(data.meta?.exportedAt && data.meta?.version && data.data)) {
+      throw new Error('Invalid backup file format');
+    }
+
+    return data;
+  };
+
+  const handleFileSelect = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    try {
+      const data = (await validateAndParseFile(file)) as {
+        data: {
+          projects: unknown[];
+          workspaces: unknown[];
+          claudeSessions: unknown[];
+          terminalSessions: unknown[];
+          userSettings: unknown;
+        };
+        meta: { exportedAt: string; version: string };
+      };
+
+      // Show confirmation dialog with summary
+      setConfirmState({
+        open: true,
+        data,
+        summary: buildImportSummary(data),
+      });
+    } catch (error) {
+      toast.error(`Failed to read file: ${getErrorMessage(error)}`);
+    }
+
+    // Reset file input
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  const handleConfirmImport = () => {
+    if (confirmState.data) {
+      // biome-ignore lint/suspicious/noExplicitAny: Dynamic import data
+      importData.mutate(confirmState.data as any);
+    }
+  };
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <FileJson className="w-5 h-5" />
+            Data Backup
+          </CardTitle>
+          <CardDescription>
+            Export and import database data for backup or migration purposes
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex gap-4">
+            <Button onClick={handleExport} disabled={isExporting} variant="outline">
+              <Download className="w-4 h-4 mr-2" />
+              {isExporting ? 'Exporting...' : 'Export Data'}
+            </Button>
+            <Button
+              onClick={() => fileInputRef.current?.click()}
+              disabled={importData.isPending}
+              variant="outline"
+            >
+              <Upload className="w-4 h-4 mr-2" />
+              {importData.isPending ? 'Importing...' : 'Import Data'}
+            </Button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".json"
+              onChange={handleFileSelect}
+              className="hidden"
+            />
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Export includes projects, workspaces, session metadata, and user preferences. Caches
+            will be rebuilt automatically after import.
+          </p>
+        </CardContent>
+      </Card>
+
+      <ConfirmDialog
+        open={confirmState.open}
+        onOpenChange={(open) => {
+          if (!open) {
+            setConfirmState({ open: false, data: null, summary: '' });
+          }
+        }}
+        title="Confirm Import"
+        description={`Review the data to be imported. Existing records will be skipped.\n\n${confirmState.summary}`}
+        confirmText="Import"
+        onConfirm={handleConfirmImport}
+        isPending={importData.isPending}
+      />
+    </>
+  );
+}
+
 export default function AdminDashboardPage() {
   const {
     data: stats,
@@ -1249,6 +1457,9 @@ export default function AdminDashboardPage() {
 
         {/* Legacy PR Review Settings (deprecated - use Ratchet instead) */}
         <PrReviewSettingsSection />
+
+        {/* Data Backup */}
+        <DataBackupSection />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Adds data export/import functionality to the admin panel for database backup and restore scenarios. This is useful when:
- Running `prisma db reset` during schema migrations
- Moving data between environments
- Creating backups before major changes

## Changes

- **New service**: `src/backend/services/data-backup.service.ts` with all export/import logic
- **tRPC endpoints**: `exportData` query and `importData` mutation in admin router
- **Admin UI**: New "Data Backup" section with Export/Import buttons
- **knip.json**: Added missing entry points (cli, backend server)

## What gets exported

- Projects (with repo URLs, settings)
- Workspaces (names, paths, branches)
- Claude sessions (metadata - chat history resumes via Claude's session IDs)
- Terminal sessions
- User preferences (excluding caches which auto-rebuild)

## What gets excluded

- Decision logs (can be regenerated)
- Workspace order caches (auto-rebuild)
- Slash command caches (auto-rebuild)

## Import behavior

- Skips records that already exist (by ID)
- Uses Prisma transaction for atomicity
- Shows summary of what will be imported before confirmation

## Test plan

- [ ] Export data from admin panel, verify JSON structure
- [ ] Import data after DB reset, verify records created
- [ ] Verify duplicate imports are skipped gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)