### PR TITLE
Override brace-expansion to 5.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,6 +161,7 @@
       "sharp"
     ],
     "overrides": {
+      "@isaacs/brace-expansion": ">=5.0.1",
       "braces": ">=3.0.3",
       "micromatch": ">=4.0.8",
       "tar": ">=7.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@isaacs/brace-expansion': '>=5.0.1'
   braces: '>=3.0.3'
   micromatch: '>=4.0.8'
   tar: '>=7.5.0'
@@ -1013,8 +1014,8 @@ packages:
     resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
     engines: {node: 20 || >=22}
 
-  '@isaacs/brace-expansion@5.0.0':
-    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
+  '@isaacs/brace-expansion@5.0.1':
+    resolution: {integrity: sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==}
     engines: {node: 20 || >=22}
 
   '@isaacs/cliui@8.0.2':
@@ -7724,7 +7725,7 @@ snapshots:
 
   '@isaacs/balanced-match@4.0.1': {}
 
-  '@isaacs/brace-expansion@5.0.0':
+  '@isaacs/brace-expansion@5.0.1':
     dependencies:
       '@isaacs/balanced-match': 4.0.1
 
@@ -12758,7 +12759,7 @@ snapshots:
 
   minimatch@10.1.1:
     dependencies:
-      '@isaacs/brace-expansion': 5.0.0
+      '@isaacs/brace-expansion': 5.0.1
 
   minimatch@3.1.2:
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk dependency maintenance change; it only adjusts pnpm overrides and updates the lockfile, with no application logic changes.
> 
> **Overview**
> **Forces a patched `brace-expansion` version via pnpm overrides.** Adds an override for `@isaacs/brace-expansion` to require `>=5.0.1` in `package.json` and `pnpm-lock.yaml`.
> 
> Updates the lockfile to resolve `@isaacs/brace-expansion` from `5.0.0` to `5.0.1` (including `minimatch`’s dependency entry) to ensure installs pick up the newer version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 405fc4159e6805bfb956da699234623c569fdc52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->