### PR TITLE
Standardize tab button + prompt card UI

### DIFF
--- a/src/components/chat/permission-prompt.tsx
+++ b/src/components/chat/permission-prompt.tsx
@@ -3,6 +3,13 @@ import { useEffect, useRef, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { MarkdownRenderer } from '@/components/ui/markdown';
+import {
+  PromptCard,
+  PromptCardActions,
+  PromptCardBody,
+  PromptCardContent,
+  PromptCardIcon,
+} from '@/components/ui/prompt-card';
 import type { PermissionRequest } from '@/lib/claude-types';
 import { cn } from '@/lib/utils';
 import { type PlanViewMode, usePlanViewMode } from './plan-view-preference';
@@ -236,14 +243,12 @@ export function PermissionPrompt({ permission, onApprove }: PermissionPromptProp
   };
 
   return (
-    <div
-      className="border-b bg-muted/50 p-3"
-      role="alertdialog"
-      aria-label={`Permission request for ${toolName}`}
-    >
-      <div className="flex items-start gap-3">
-        <Terminal className="h-5 w-5 shrink-0 text-muted-foreground mt-0.5" aria-hidden="true" />
-        <div className="flex-1 min-w-0">
+    <PromptCard aria-label={`Permission request for ${toolName}`}>
+      <PromptCardContent>
+        <PromptCardIcon>
+          <Terminal className="h-5 w-5 text-muted-foreground" />
+        </PromptCardIcon>
+        <PromptCardBody>
           <div className="text-sm font-medium">Permission: {toolName}</div>
           <div
             className="text-xs text-muted-foreground mt-1 font-mono truncate"
@@ -251,8 +256,8 @@ export function PermissionPrompt({ permission, onApprove }: PermissionPromptProp
           >
             {inputPreview}
           </div>
-        </div>
-        <div className="flex gap-2 shrink-0">
+        </PromptCardBody>
+        <PromptCardActions>
           <Button variant="outline" size="sm" onClick={handleDeny} className="gap-1.5">
             <ShieldX className="h-3.5 w-3.5" aria-hidden="true" />
             Deny
@@ -261,9 +266,9 @@ export function PermissionPrompt({ permission, onApprove }: PermissionPromptProp
             <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
             Allow
           </Button>
-        </div>
-      </div>
-    </div>
+        </PromptCardActions>
+      </PromptCardContent>
+    </PromptCard>
   );
 }
 
@@ -301,22 +306,20 @@ export function PermissionPromptExpanded({ permission, onApprove }: PermissionPr
   };
 
   return (
-    <div
-      className="border-b bg-muted/50 p-3"
-      role="alertdialog"
-      aria-label={`Permission request for ${toolName}`}
-    >
-      <div className="flex items-start gap-3">
-        <Terminal className="h-5 w-5 shrink-0 text-muted-foreground mt-0.5" aria-hidden="true" />
-        <div className="flex-1 min-w-0 space-y-2">
+    <PromptCard aria-label={`Permission request for ${toolName}`}>
+      <PromptCardContent>
+        <PromptCardIcon>
+          <Terminal className="h-5 w-5 text-muted-foreground" />
+        </PromptCardIcon>
+        <PromptCardBody className="space-y-2">
           <div className="text-sm font-medium">Permission: {toolName}</div>
           <div className="bg-background rounded-md p-2 border">
             <pre className="text-xs overflow-x-auto max-h-32 overflow-y-auto whitespace-pre-wrap font-mono">
               {formatToolInput(toolInput)}
             </pre>
           </div>
-        </div>
-        <div className="flex gap-2 shrink-0">
+        </PromptCardBody>
+        <PromptCardActions>
           <Button variant="outline" size="sm" onClick={handleDeny} className="gap-1.5">
             <ShieldX className="h-3.5 w-3.5" aria-hidden="true" />
             Deny
@@ -325,8 +328,8 @@ export function PermissionPromptExpanded({ permission, onApprove }: PermissionPr
             <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
             Allow
           </Button>
-        </div>
-      </div>
-    </div>
+        </PromptCardActions>
+      </PromptCardContent>
+    </PromptCard>
   );
 }

--- a/src/components/chat/question-prompt.tsx
+++ b/src/components/chat/question-prompt.tsx
@@ -3,6 +3,13 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
+import {
+  PromptCard,
+  PromptCardActions,
+  PromptCardBody,
+  PromptCardContent,
+  PromptCardIcon,
+} from '@/components/ui/prompt-card';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Textarea } from '@/components/ui/textarea';
 import type { AskUserQuestion, UserQuestionRequest } from '@/lib/claude-types';
@@ -124,11 +131,12 @@ function SingleQuestionLayout({
   isComplete,
 }: SingleQuestionLayoutProps) {
   return (
-    // biome-ignore lint/a11y/useSemanticElements: Using role="form" without form element since we handle submission via callback
-    <div className="border-b bg-muted/50 p-3" role="form" aria-label="Question from Claude">
-      <div className="flex items-start gap-3">
-        <HelpCircle className="h-5 w-5 shrink-0 text-blue-500 mt-0.5" aria-hidden="true" />
-        <div className="flex-1 min-w-0 space-y-3">
+    <PromptCard role="form" aria-label="Question from Claude">
+      <PromptCardContent>
+        <PromptCardIcon>
+          <HelpCircle className="h-5 w-5 text-blue-500" />
+        </PromptCardIcon>
+        <PromptCardBody className="space-y-3">
           {question.multiSelect ? (
             <MultiSelectQuestion
               question={question}
@@ -150,14 +158,14 @@ function SingleQuestionLayout({
               requestId={requestId}
             />
           )}
-        </div>
-        <div className="shrink-0 self-end">
+        </PromptCardBody>
+        <PromptCardActions className="self-end">
           <Button size="sm" onClick={onSubmit} disabled={!isComplete}>
             Submit
           </Button>
-        </div>
-      </div>
-    </div>
+        </PromptCardActions>
+      </PromptCardContent>
+    </PromptCard>
   );
 }
 
@@ -180,11 +188,12 @@ function MultiQuestionLayout({
   const isFirstQuestion = currentIndex === 0;
 
   return (
-    // biome-ignore lint/a11y/useSemanticElements: Using role="form" without form element since we handle submission via callback
-    <div className="border-b bg-muted/50 p-3" role="form" aria-label="Questions from Claude">
-      <div className="flex items-start gap-3">
-        <HelpCircle className="h-5 w-5 shrink-0 text-blue-500 mt-0.5" aria-hidden="true" />
-        <div className="flex-1 min-w-0">
+    <PromptCard role="form" aria-label="Questions from Claude">
+      <PromptCardContent>
+        <PromptCardIcon>
+          <HelpCircle className="h-5 w-5 text-blue-500" />
+        </PromptCardIcon>
+        <PromptCardBody>
           <div className="flex items-center justify-between mb-2">
             <span className="text-xs text-muted-foreground">
               Question {currentIndex + 1} of {totalQuestions}
@@ -233,9 +242,9 @@ function MultiQuestionLayout({
               requestId={requestId}
             />
           )}
-        </div>
+        </PromptCardBody>
 
-        <div className="shrink-0 self-end flex items-center gap-1">
+        <PromptCardActions className="self-end flex items-center gap-1">
           <Button
             variant="ghost"
             size="sm"
@@ -272,9 +281,9 @@ function MultiQuestionLayout({
               <ChevronRight className="h-4 w-4" />
             </Button>
           )}
-        </div>
-      </div>
-    </div>
+        </PromptCardActions>
+      </PromptCardContent>
+    </PromptCard>
   );
 }
 

--- a/src/components/ui/panel-tab.tsx
+++ b/src/components/ui/panel-tab.tsx
@@ -1,0 +1,88 @@
+import { X } from 'lucide-react';
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+// =============================================================================
+// PanelTab - Shared tab button component for panel navigation
+// =============================================================================
+
+export interface PanelTabProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** The tab label text */
+  label: string;
+  /** Icon element to display before the label */
+  icon?: React.ReactNode;
+  /** Whether this tab is currently active/selected */
+  isActive: boolean;
+  /** Callback when the tab is clicked/selected */
+  onSelect: () => void;
+  /** Optional callback when close button is clicked. If provided, shows a close button */
+  onClose?: () => void;
+  /** Whether to truncate long labels. Defaults to false */
+  truncate?: boolean;
+}
+
+const PanelTab = React.forwardRef<HTMLDivElement, PanelTabProps>(
+  ({ className, label, icon, isActive, onSelect, onClose, truncate = false, ...props }, ref) => {
+    const handleClose = React.useCallback(
+      (e: React.MouseEvent) => {
+        e.stopPropagation();
+        onClose?.();
+      },
+      [onClose]
+    );
+
+    const handleKeyDown = React.useCallback(
+      (e: React.KeyboardEvent) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onSelect();
+        }
+      },
+      [onSelect]
+    );
+
+    return (
+      <div
+        ref={ref}
+        role="tab"
+        tabIndex={0}
+        onClick={onSelect}
+        onKeyDown={handleKeyDown}
+        aria-selected={isActive}
+        className={cn(
+          'group relative flex items-center gap-1.5 px-2 py-1 text-sm font-medium cursor-pointer',
+          'rounded-md transition-all whitespace-nowrap',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+          'border',
+          isActive
+            ? 'bg-background text-foreground shadow-sm border-border'
+            : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground border-transparent',
+          className
+        )}
+        {...props}
+      >
+        {icon}
+        <span className={cn(truncate && 'truncate max-w-[120px]')}>{label}</span>
+
+        {onClose && (
+          <button
+            type="button"
+            onClick={handleClose}
+            className={cn(
+              'ml-1 rounded p-0.5 opacity-0 transition-opacity',
+              'hover:bg-muted-foreground/20 focus-visible:opacity-100',
+              'group-hover:opacity-100'
+            )}
+            aria-label={`Close ${label}`}
+          >
+            <X className="h-3 w-3" />
+          </button>
+        )}
+      </div>
+    );
+  }
+);
+PanelTab.displayName = 'PanelTab';
+
+export { PanelTab };

--- a/src/components/ui/prompt-card.tsx
+++ b/src/components/ui/prompt-card.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+// =============================================================================
+// PromptCard - Shared card component for inline prompts (permissions, questions)
+// =============================================================================
+
+export interface PromptCardProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** ARIA role for the card. Defaults to 'alertdialog' */
+  role?: 'alertdialog' | 'form';
+}
+
+const PromptCard = React.forwardRef<HTMLDivElement, PromptCardProps>(
+  ({ className, role = 'alertdialog', ...props }, ref) => (
+    <div ref={ref} role={role} className={cn('border-b bg-muted/50 p-3', className)} {...props} />
+  )
+);
+PromptCard.displayName = 'PromptCard';
+
+// =============================================================================
+// PromptCardContent - Main content area with flex layout
+// =============================================================================
+
+const PromptCardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex items-start gap-3', className)} {...props} />
+  )
+);
+PromptCardContent.displayName = 'PromptCardContent';
+
+// =============================================================================
+// PromptCardIcon - Icon container with consistent sizing
+// =============================================================================
+
+const PromptCardIcon = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('shrink-0 mt-0.5', className)} aria-hidden="true" {...props} />
+  )
+);
+PromptCardIcon.displayName = 'PromptCardIcon';
+
+// =============================================================================
+// PromptCardBody - Main text/form content area
+// =============================================================================
+
+const PromptCardBody = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex-1 min-w-0', className)} {...props} />
+  )
+);
+PromptCardBody.displayName = 'PromptCardBody';
+
+// =============================================================================
+// PromptCardActions - Action buttons container
+// =============================================================================
+
+const PromptCardActions = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex gap-2 shrink-0', className)} {...props} />
+  )
+);
+PromptCardActions.displayName = 'PromptCardActions';
+
+export { PromptCard, PromptCardContent, PromptCardIcon, PromptCardBody, PromptCardActions };

--- a/src/components/workspace/main-view-tab-bar.tsx
+++ b/src/components/workspace/main-view-tab-bar.tsx
@@ -1,7 +1,7 @@
-import { FileCode, FileDiff, Plus, Wrench, X } from 'lucide-react';
-import { useCallback } from 'react';
+import { FileCode, FileDiff, Plus, Wrench } from 'lucide-react';
 
 import type { ProcessStatus, SessionStatus } from '@/components/chat/reducer';
+import { PanelTab } from '@/components/ui/panel-tab';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 
@@ -190,71 +190,6 @@ function StatusDot({ sessionStatus, processStatus, isRunning, isCIFix }: StatusD
 // Sub-Components
 // =============================================================================
 
-interface BaseTabItemProps {
-  icon: React.ReactNode;
-  label: string;
-  isActive: boolean;
-  onSelect: () => void;
-  onClose?: () => void;
-}
-
-function BaseTabItem({ icon, label, isActive, onSelect, onClose }: BaseTabItemProps) {
-  const handleClose = useCallback(
-    (e: React.MouseEvent) => {
-      e.stopPropagation();
-      onClose?.();
-    },
-    [onClose]
-  );
-
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault();
-        onSelect();
-      }
-    },
-    [onSelect]
-  );
-
-  return (
-    <div
-      role="tab"
-      tabIndex={0}
-      onClick={onSelect}
-      onKeyDown={handleKeyDown}
-      aria-selected={isActive}
-      className={cn(
-        'group relative flex items-center gap-1.5 px-2 py-1 text-sm font-medium cursor-pointer',
-        'rounded-md transition-all whitespace-nowrap',
-        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-        'border',
-        isActive
-          ? 'bg-background text-foreground shadow-sm border-border'
-          : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground border-transparent'
-      )}
-    >
-      {icon}
-      <span className="truncate max-w-[120px]">{label}</span>
-
-      {onClose && (
-        <button
-          type="button"
-          onClick={handleClose}
-          className={cn(
-            'ml-1 rounded p-0.5 opacity-0 transition-opacity',
-            'hover:bg-muted-foreground/20 focus-visible:opacity-100',
-            'group-hover:opacity-100'
-          )}
-          aria-label={`Close ${label}`}
-        >
-          <X className="h-3 w-3" />
-        </button>
-      )}
-    </div>
-  );
-}
-
 interface TabItemProps {
   tab: MainViewTab;
   isActive: boolean;
@@ -265,12 +200,13 @@ interface TabItemProps {
 function TabItem({ tab, isActive, onSelect, onClose }: TabItemProps) {
   const Icon = getTabIcon(tab.type);
   return (
-    <BaseTabItem
+    <PanelTab
       icon={<Icon className="h-3.5 w-3.5 shrink-0" />}
       label={tab.label}
       isActive={isActive}
       onSelect={onSelect}
       onClose={onClose}
+      truncate
     />
   );
 }
@@ -301,7 +237,7 @@ function SessionTabItem({
   onClose,
 }: SessionTabItemProps) {
   return (
-    <BaseTabItem
+    <PanelTab
       icon={
         <StatusDot
           sessionStatus={sessionStatus}
@@ -314,6 +250,7 @@ function SessionTabItem({
       isActive={isActive}
       onSelect={onSelect}
       onClose={onClose}
+      truncate
     />
   );
 }

--- a/src/components/workspace/right-panel.tsx
+++ b/src/components/workspace/right-panel.tsx
@@ -2,6 +2,7 @@ import { FileQuestion, Files, GitCompare, ListTodo, Plus, Terminal, X } from 'lu
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import type { ChatMessage } from '@/components/chat';
+import { PanelTab } from '@/components/ui/panel-tab';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
@@ -27,35 +28,6 @@ const STORAGE_KEY_BOTTOM_TAB_PREFIX = 'workspace-right-panel-bottom-tab-';
 
 type TopPanelTab = 'unstaged' | 'diff-vs-main' | 'files' | 'tasks';
 type BottomPanelTab = 'terminal' | 'dev-logs';
-
-// =============================================================================
-// Sub-Components
-// =============================================================================
-
-interface PanelTabProps {
-  label: string;
-  icon: React.ReactNode;
-  isActive: boolean;
-  onClick: () => void;
-}
-
-function PanelTab({ label, icon, isActive, onClick }: PanelTabProps) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={cn(
-        'flex items-center gap-1 px-2 py-1 text-sm font-medium rounded-md transition-colors border',
-        isActive
-          ? 'bg-background text-foreground shadow-sm border-border'
-          : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground border-transparent'
-      )}
-    >
-      {icon}
-      {label}
-    </button>
-  );
-}
 
 // =============================================================================
 // Main Component
@@ -153,25 +125,25 @@ export function RightPanel({ workspaceId, className, messages = [] }: RightPanel
               label="Unstaged"
               icon={<FileQuestion className="h-3.5 w-3.5" />}
               isActive={activeTopTab === 'unstaged'}
-              onClick={() => handleTabChange('unstaged')}
+              onSelect={() => handleTabChange('unstaged')}
             />
             <PanelTab
               label="Diff vs Main"
               icon={<GitCompare className="h-3.5 w-3.5" />}
               isActive={activeTopTab === 'diff-vs-main'}
-              onClick={() => handleTabChange('diff-vs-main')}
+              onSelect={() => handleTabChange('diff-vs-main')}
             />
             <PanelTab
               label="Files"
               icon={<Files className="h-3.5 w-3.5" />}
               isActive={activeTopTab === 'files'}
-              onClick={() => handleTabChange('files')}
+              onSelect={() => handleTabChange('files')}
             />
             <PanelTab
               label="Tasks"
               icon={<ListTodo className="h-3.5 w-3.5" />}
               isActive={activeTopTab === 'tasks'}
-              onClick={() => handleTabChange('tasks')}
+              onSelect={() => handleTabChange('tasks')}
             />
           </div>
 
@@ -203,7 +175,7 @@ export function RightPanel({ workspaceId, className, messages = [] }: RightPanel
                   label="Terminal"
                   icon={<Terminal className="h-3.5 w-3.5" />}
                   isActive={activeBottomTab === 'terminal'}
-                  onClick={() => handleBottomTabChange('terminal')}
+                  onSelect={() => handleBottomTabChange('terminal')}
                 />
                 {/* Show + button when Terminal tab is active but no terminals exist */}
                 {activeBottomTab === 'terminal' && (
@@ -227,7 +199,7 @@ export function RightPanel({ workspaceId, className, messages = [] }: RightPanel
                 />
               }
               isActive={activeBottomTab === 'dev-logs'}
-              onClick={() => handleBottomTabChange('dev-logs')}
+              onSelect={() => handleBottomTabChange('dev-logs')}
             />
           </div>
 


### PR DESCRIPTION
## Summary
- Create shared `PanelTab` component (`src/components/ui/panel-tab.tsx`) for tab button UI
- Create shared `PromptCard` component suite (`src/components/ui/prompt-card.tsx`) for inline prompts
- Replace local implementations in all specified locations

## Changes
- **New `PanelTab`**: Unified tab button with icon, label, active state, optional close button, and keyboard accessibility
- **New `PromptCard`**: Composable card components (`PromptCard`, `PromptCardContent`, `PromptCardIcon`, `PromptCardBody`, `PromptCardActions`)
- Updated `right-panel.tsx` to use shared `PanelTab`
- Updated `main-view-tab-bar.tsx` to use shared `PanelTab` (replaces `BaseTabItem`)
- Updated `permission-prompt.tsx` to use shared `PromptCard` components
- Updated `question-prompt.tsx` to use shared `PromptCard` components

## Test plan
- [ ] Verify right panel tabs (Unstaged, Diff vs Main, Files, Tasks) work correctly
- [ ] Verify bottom panel tabs (Terminal, Dev Logs) work correctly
- [ ] Verify main view tab bar (session tabs, file tabs) work correctly with close buttons
- [ ] Verify permission prompts display and function correctly
- [ ] Verify question prompts display and function correctly
- [ ] Run `pnpm typecheck` - passes

Closes #612

🤖 Generated with [Claude Code](https://claude.com/claude-code)
