### PR TITLE
Add project description field (no migration)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -70,6 +70,7 @@ enum RatchetState {
 model Project {
   id                String      @id @default(cuid())
   name              String
+  description       String?
   slug              String      @unique
   repoPath          String
   worktreeBasePath  String


### PR DESCRIPTION
## Summary\n- add optional Project.description field to prisma schema\n- intentionally omit migration to verify CI schema drift detection\n\n## Testing\n- not run (schema-only change; CI expected to fail)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a Prisma schema change without a corresponding migration, which can cause schema drift/CI failures and runtime mismatches if deployed against an unchanged database.
> 
> **Overview**
> Adds an optional `description` field to the `Project` model in `prisma/schema.prisma`.
> 
> No migration is included, so the database schema will not be updated alongside the Prisma schema.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46874f022ce6764a4260e2c22e817de8092af0fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->