### PR TITLE
Fix thinking streaming display

### DIFF
--- a/src/components/chat/virtualized-message-list.tsx
+++ b/src/components/chat/virtualized-message-list.tsx
@@ -1,8 +1,10 @@
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { Loader2 } from 'lucide-react';
-import { memo, useCallback, useEffect, useRef } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { GroupedMessageItemRenderer, LoadingIndicator } from '@/components/agent-activity';
+import { ThinkingCompletionProvider } from '@/components/agent-activity/message-renderers';
 import type { GroupedMessageItem } from '@/lib/claude-types';
+import { isStreamEventMessage, isToolSequence } from '@/lib/claude-types';
 import { CompactingIndicator } from './compacting-indicator';
 import { LatestThinking } from './latest-thinking';
 
@@ -116,6 +118,23 @@ export const VirtualizedMessageList = memo(function VirtualizedMessageList({
   const isNearBottomRef = useRef(isNearBottom);
   isNearBottomRef.current = isNearBottom;
 
+  const lastThinkingMessageId = useMemo(() => {
+    for (let i = messages.length - 1; i >= 0; i -= 1) {
+      const item = messages[i];
+      if (isToolSequence(item)) {
+        continue;
+      }
+      if (!(item.message && isStreamEventMessage(item.message))) {
+        continue;
+      }
+      const event = item.message.event;
+      if (event?.type === 'content_block_start' && event.content_block.type === 'thinking') {
+        return item.id;
+      }
+    }
+    return null;
+  }, [messages]);
+
   // Initialize virtualizer with dynamic measurement
   // Reduce overscan during active running to improve performance
   const virtualizer = useVirtualizer({
@@ -189,72 +208,76 @@ export const VirtualizedMessageList = memo(function VirtualizedMessageList({
   }
 
   return (
-    <div className="p-4 min-w-0">
-      {/* Virtualized message container */}
-      <div
-        style={{
-          height: `${totalSize}px`,
-          width: '100%',
-          position: 'relative',
-        }}
-      >
-        {virtualItems.map((virtualRow) => {
-          const item = messages[virtualRow.index];
-          const isQueued = queuedMessageIds?.has(item.id) ?? false;
-          // Get UUID for user messages to enable rewind functionality
-          // Use message ID (stable identifier) instead of array index to avoid issues
-          // when messages are grouped or filtered
-          const userMessageUuid =
-            'source' in item && item.source === 'user' ? getUuidForMessageId?.(item.id) : undefined;
-          return (
-            <div
-              key={virtualRow.key}
-              style={{
-                position: 'absolute',
-                top: 0,
-                left: 0,
-                width: '100%',
-                transform: `translateY(${virtualRow.start}px)`,
-              }}
-            >
-              <VirtualRow
-                item={item}
-                index={virtualRow.index}
-                measureElement={virtualizer.measureElement}
-                isQueued={isQueued}
-                onRemove={
-                  isQueued && onRemoveQueuedMessage
-                    ? () => onRemoveQueuedMessage(item.id)
-                    : undefined
-                }
-                userMessageUuid={userMessageUuid}
-                onRewindToMessage={onRewindToMessage}
-              />
-            </div>
-          );
-        })}
-      </div>
-
-      {/* Latest thinking from extended thinking mode */}
-      {latestThinking && running && (
-        <LatestThinking thinking={latestThinking} running={running} className="mb-4" />
-      )}
-
-      {/* Context compaction indicator */}
-      <CompactingIndicator isCompacting={isCompacting} className="mb-4" />
-
-      {/* Loading indicators after messages */}
-      {running && <LoadingIndicator className="py-4" />}
-
-      {startingSession && !running && (
-        <div className="flex items-center gap-2 text-muted-foreground py-4">
-          <Loader2 className="h-4 w-4 animate-spin" />
-          <span className="text-sm">Starting agent...</span>
+    <ThinkingCompletionProvider lastThinkingMessageId={lastThinkingMessageId} running={running}>
+      <div className="p-4 min-w-0">
+        {/* Virtualized message container */}
+        <div
+          style={{
+            height: `${totalSize}px`,
+            width: '100%',
+            position: 'relative',
+          }}
+        >
+          {virtualItems.map((virtualRow) => {
+            const item = messages[virtualRow.index];
+            const isQueued = queuedMessageIds?.has(item.id) ?? false;
+            // Get UUID for user messages to enable rewind functionality
+            // Use message ID (stable identifier) instead of array index to avoid issues
+            // when messages are grouped or filtered
+            const userMessageUuid =
+              'source' in item && item.source === 'user'
+                ? getUuidForMessageId?.(item.id)
+                : undefined;
+            return (
+              <div
+                key={virtualRow.key}
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  width: '100%',
+                  transform: `translateY(${virtualRow.start}px)`,
+                }}
+              >
+                <VirtualRow
+                  item={item}
+                  index={virtualRow.index}
+                  measureElement={virtualizer.measureElement}
+                  isQueued={isQueued}
+                  onRemove={
+                    isQueued && onRemoveQueuedMessage
+                      ? () => onRemoveQueuedMessage(item.id)
+                      : undefined
+                  }
+                  userMessageUuid={userMessageUuid}
+                  onRewindToMessage={onRewindToMessage}
+                />
+              </div>
+            );
+          })}
         </div>
-      )}
 
-      {/* Scroll anchor */}
-      <div ref={messagesEndRef} className="h-px" />
-    </div>
+        {/* Latest thinking from extended thinking mode */}
+        {latestThinking && running && (
+          <LatestThinking thinking={latestThinking} running={running} className="mb-4" />
+        )}
+
+        {/* Context compaction indicator */}
+        <CompactingIndicator isCompacting={isCompacting} className="mb-4" />
+
+        {/* Loading indicators after messages */}
+        {running && <LoadingIndicator className="py-4" />}
+
+        {startingSession && !running && (
+          <div className="flex items-center gap-2 text-muted-foreground py-4">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            <span className="text-sm">Starting agent...</span>
+          </div>
+        )}
+
+        {/* Scroll anchor */}
+        <div ref={messagesEndRef} className="h-px" />
+      </div>
+    </ThinkingCompletionProvider>
   );
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches chat reducer state updates and message list rendering during streaming, which can impact ordering/immutability and UI behavior under rapid updates. Scope is limited to thinking-related stream events and their display context.
> 
> **Overview**
> Fixes *extended thinking* streaming so `thinking_delta` events append into the most recent matching `content_block_start` (by block `index`) instead of being dropped from state.
> 
> Updates the chat message list to compute the last thinking message ID and wraps rendering in `ThinkingCompletionProvider`, enabling the UI to treat only the latest thinking block as *in progress* while streaming.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb5da5e191ae2537157a10bc07347ada2986a3c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->