### PR TITLE
Auto-start agent with GitHub issue prompt when starting from Kanban

### DIFF
--- a/src/backend/services/worktree-lifecycle-init.test.ts
+++ b/src/backend/services/worktree-lifecycle-init.test.ts
@@ -148,7 +148,9 @@ describe('worktreeLifecycleService initialization', () => {
       status: SessionStatus.IDLE,
       limit: 1,
     });
-    expect(mocks.startClaudeSession).toHaveBeenCalledWith('session-1', { initialPrompt: '' });
+    expect(mocks.startClaudeSession).toHaveBeenCalledWith('session-1', {
+      initialPrompt: '',
+    });
 
     if (!resolveScript) {
       throw new Error('Expected startup script resolver to be defined');
@@ -194,7 +196,9 @@ describe('worktreeLifecycleService initialization', () => {
       useExistingBranch: false,
     });
 
-    expect(mocks.startClaudeSession).toHaveBeenCalledWith('session-1', { initialPrompt: '' });
+    expect(mocks.startClaudeSession).toHaveBeenCalledWith('session-1', {
+      initialPrompt: '',
+    });
     expect(mocks.stopWorkspaceSessions).toHaveBeenCalledWith('workspace-1');
     expect(mocks.markFailed).toHaveBeenCalled();
   });
@@ -215,7 +219,9 @@ describe('worktreeLifecycleService initialization', () => {
       useExistingBranch: false,
     });
 
-    expect(mocks.startClaudeSession).toHaveBeenCalledWith('session-1', { initialPrompt: '' });
+    expect(mocks.startClaudeSession).toHaveBeenCalledWith('session-1', {
+      initialPrompt: '',
+    });
     expect(mocks.stopWorkspaceSessions).toHaveBeenCalledWith('workspace-1');
   });
 });


### PR DESCRIPTION
## Summary

When clicking "Start" on a GitHub issue in the Kanban board, the agent now:
- Fetches the issue content from GitHub and displays it as a user message in the chat
- Automatically starts working on the task with full pipeline instructions (plan, implement, review, create PR)

## Changes

- **github-cli.service.ts**: Add `getIssue()` method to fetch a single GitHub issue by number
- **message-state.service.ts**: Add `injectCommittedUserMessage()` to inject synthetic user messages into the chat history
- **worktree-lifecycle.service.ts**: 
  - Add `buildInitialPromptFromGitHubIssue()` to build a comprehensive prompt from the linked issue
  - Update `startDefaultClaudeSession()` to inject the prompt into the UI and send it to Claude via `sendMessage`

## Test plan

- [x] Type check passes
- [x] Tests pass
- [x] Manual testing: Click "Start" on a GitHub issue in Kanban → prompt appears in chat and agent starts working

🤖 Generated with [Claude Code](https://claude.com/claude-code)