### PR TITLE
Refactor chat message handlers attachment validation complexity

### DIFF
--- a/src/backend/services/chat-message-handlers.service.ts
+++ b/src/backend/services/chat-message-handlers.service.ts
@@ -14,7 +14,12 @@ import type { ChatMessageInput } from '@/shared/websocket';
 import type { ClaudeClient } from '../claude/index';
 import type { ClaudeContentItem } from '../claude/types';
 import { chatConnectionService } from './chat-connection.service';
-import { resolveAttachmentContentType } from './chat-message-handlers/attachment-utils';
+import {
+  buildCombinedText,
+  buildContentArray,
+  partitionAttachments,
+  validateAttachment,
+} from './chat-message-handlers/attachment-utils';
 import { DEBUG_CHAT_WS } from './chat-message-handlers/constants';
 import { createChatMessageHandlerRegistry } from './chat-message-handlers/registry';
 import type { ClientCreator } from './chat-message-handlers/types';
@@ -275,108 +280,45 @@ class ChatMessageHandlerService {
   }
 
   /**
-   * Validate an attachment before processing.
-   * @throws Error if attachment is invalid
-   */
-  private validateAttachment(attachment: {
-    id: string;
-    name: string;
-    type: string;
-    data: string;
-    contentType?: 'image' | 'text';
-  }): void {
-    if (!attachment.data) {
-      logger.error('[Chat WS] Attachment missing data', { attachmentId: attachment.id });
-      throw new Error(`Attachment "${attachment.name}" is missing data`);
-    }
-
-    const resolvedType = resolveAttachmentContentType(attachment);
-    if (resolvedType === 'image') {
-      // Validate base64 for image attachments (basic check - alphanumeric, +, /, =)
-      if (!/^[A-Za-z0-9+/=]+$/.test(attachment.data)) {
-        logger.error('[Chat WS] Invalid base64 data in attachment', {
-          attachmentId: attachment.id,
-          name: attachment.name,
-        });
-        throw new Error(`Attachment "${attachment.name}" has invalid image data`);
-      }
-    }
-  }
-
-  /**
-   * Sanitize attachment name to prevent log injection or display issues.
-   * Removes control characters and limits length.
-   */
-  private sanitizeAttachmentName(name: string): string {
-    // Remove control characters (ASCII 0-31 and 127) and limit length
-    // biome-ignore lint/suspicious/noControlCharactersInRegex: intentionally matching control chars to remove them
-    return name.replace(/[\x00-\x1F\x7F]/g, '').slice(0, 255);
-  }
-
-  /**
    * Build message content for sending to Claude.
    * Note: Thinking is now controlled via setMaxThinkingTokens, not message suffix.
    *
    * Text attachments are combined into the main text content with a prefix.
    * Image attachments are sent as separate image content blocks.
    */
-  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: attachment validation and branching logic is inherently complex
   private buildMessageContent(msg: QueuedMessage): string | ClaudeContentItem[] {
-    // If there are attachments, process them
-    if (msg.attachments && msg.attachments.length > 0) {
-      // Validate all attachments before processing
-      for (const attachment of msg.attachments) {
-        this.validateAttachment(attachment);
-      }
-
-      const resolvedAttachments = msg.attachments.map((attachment) => ({
-        attachment,
-        contentType: resolveAttachmentContentType(attachment),
-      }));
-      const textAttachments = resolvedAttachments
-        .filter((entry) => entry.contentType === 'text')
-        .map((entry) => entry.attachment);
-      const imageAttachments = resolvedAttachments
-        .filter((entry) => entry.contentType === 'image')
-        .map((entry) => entry.attachment);
-
-      // Build the combined text content (user message + text attachments)
-      let combinedText = msg.text || '';
-
-      // Append text attachments with a prefix for context
-      for (const attachment of textAttachments) {
-        const prefix = combinedText ? '\n\n' : '';
-        const safeName = this.sanitizeAttachmentName(attachment.name);
-        combinedText += `${prefix}[Pasted content: ${safeName}]\n${attachment.data}`;
-      }
-
-      // If we only have text (no images), return as string
-      if (imageAttachments.length === 0) {
-        return combinedText;
-      }
-
-      // If we have images, build content array
-      const content: ClaudeContentItem[] = [];
-
-      if (combinedText) {
-        content.push({ type: 'text', text: combinedText });
-      }
-
-      for (const attachment of imageAttachments) {
-        content.push({
-          type: 'image',
-          source: {
-            type: 'base64',
-            media_type: attachment.type,
-            data: attachment.data,
-          },
-        } as unknown as ClaudeContentItem);
-      }
-
-      return content;
+    // If there are no attachments, return the text as-is
+    if (!msg.attachments || msg.attachments.length === 0) {
+      return msg.text;
     }
 
-    return msg.text;
+    // Validate all attachments before processing
+    for (const attachment of msg.attachments) {
+      try {
+        validateAttachment(attachment);
+      } catch (error) {
+        logger.error('[Chat WS] Attachment validation failed', {
+          attachmentId: attachment.id,
+          name: attachment.name,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        throw error;
+      }
+    }
+
+    // Partition attachments by type
+    const { textAttachments, imageAttachments } = partitionAttachments(msg.attachments);
+
+    // Build combined text from message text and text attachments
+    const combinedText = buildCombinedText(msg.text, textAttachments);
+
+    // If we only have text (no images), return as string
+    if (imageAttachments.length === 0) {
+      return combinedText;
+    }
+
+    // If we have images, build and return content array
+    return buildContentArray(combinedText, imageAttachments);
   }
 
   // ============================================================================

--- a/src/backend/services/chat-message-handlers/attachment-utils.ts
+++ b/src/backend/services/chat-message-handlers/attachment-utils.ts
@@ -1,4 +1,5 @@
 import type { MessageAttachment } from '@/shared/claude';
+import type { ClaudeContentItem } from '../../claude/types';
 
 const PASTED_TEXT_NAME = /^Pasted text\b/i;
 const BASE64_REGEX = /^[A-Za-z0-9+/=]+$/;
@@ -35,4 +36,105 @@ export function resolveAttachmentContentType(attachment: AttachmentLike): 'text'
   }
 
   return 'image';
+}
+
+/**
+ * Sanitize attachment name to prevent log injection or display issues.
+ * Removes control characters and limits length.
+ */
+export function sanitizeAttachmentName(name: string): string {
+  // Remove control characters (ASCII 0-31 and 127) and limit length
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: intentionally matching control chars to remove them
+  return name.replace(/[\x00-\x1F\x7F]/g, '').slice(0, 255);
+}
+
+/**
+ * Validate an attachment before processing.
+ * @throws Error if attachment is invalid
+ */
+export function validateAttachment(attachment: {
+  id: string;
+  name: string;
+  type: string;
+  data: string;
+  contentType?: 'image' | 'text';
+}): void {
+  if (!attachment.data) {
+    throw new Error(`Attachment "${attachment.name}" is missing data`);
+  }
+
+  const resolvedType = resolveAttachmentContentType(attachment);
+  if (resolvedType === 'image') {
+    // Validate base64 for image attachments (basic check - alphanumeric, +, /, =)
+    if (!BASE64_REGEX.test(attachment.data)) {
+      throw new Error(`Attachment "${attachment.name}" has invalid image data`);
+    }
+  }
+}
+
+/**
+ * Partition attachments into text and image groups.
+ */
+export function partitionAttachments(attachments: MessageAttachment[]): {
+  textAttachments: MessageAttachment[];
+  imageAttachments: MessageAttachment[];
+} {
+  const textAttachments: MessageAttachment[] = [];
+  const imageAttachments: MessageAttachment[] = [];
+
+  for (const attachment of attachments) {
+    const contentType = resolveAttachmentContentType(attachment);
+    if (contentType === 'text') {
+      textAttachments.push(attachment);
+    } else {
+      imageAttachments.push(attachment);
+    }
+  }
+
+  return { textAttachments, imageAttachments };
+}
+
+/**
+ * Build combined text from message text and text attachments.
+ */
+export function buildCombinedText(
+  messageText: string,
+  textAttachments: MessageAttachment[]
+): string {
+  let combinedText = messageText || '';
+
+  for (const attachment of textAttachments) {
+    const prefix = combinedText ? '\n\n' : '';
+    const safeName = sanitizeAttachmentName(attachment.name);
+    combinedText += `${prefix}[Pasted content: ${safeName}]\n${attachment.data}`;
+  }
+
+  return combinedText;
+}
+
+/**
+ * Build a content array from text and image attachments.
+ */
+export function buildContentArray(
+  combinedText: string,
+  imageAttachments: MessageAttachment[]
+): ClaudeContentItem[] {
+  const content: ClaudeContentItem[] = [];
+
+  if (combinedText) {
+    content.push({ type: 'text', text: combinedText });
+  }
+
+  for (const attachment of imageAttachments) {
+    content.push({
+      type: 'image',
+      source: {
+        type: 'base64',
+        media_type: attachment.type,
+        data: attachment.data,
+      },
+    } as unknown as ClaudeContentItem);
+  }
+
+  return content;
 }


### PR DESCRIPTION
## Summary
Refactors attachment validation logic in `chat-message-handlers.service.ts` to reduce cognitive complexity and remove the Biome ignore directive.

## Changes
- Extracted `validateAttachment` and `sanitizeAttachmentName` to `attachment-utils.ts`
- Added new pure helper functions:
  - `partitionAttachments`: Splits attachments into text and image groups
  - `buildCombinedText`: Combines message text with text attachments
  - `buildContentArray`: Builds Claude content array from text and images
- Simplified `buildMessageContent` to use the new helpers
- Removed `biome-ignore` for cognitive complexity

## Test Coverage
- All existing tests pass (1287 tests)
- Validation behavior and error messages are preserved
- Typecheck and linting pass

## Related Issue
Closes #581
