### PR TITLE
Use pnpm exec for lint-staged in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
-npx lint-staged
+pnpm exec lint-staged
 pnpm run typecheck
 pnpm exec prisma migrate diff --from-schema prisma/schema.prisma --to-migrations prisma/migrations --exit-code
 pnpm run deps:check


### PR DESCRIPTION
## What changed
- updated `.husky/pre-commit` to run `lint-staged` via `pnpm exec` instead of `npx`

## Why
- avoids npm/npx deprecated-config warnings during `git commit`

## Validation
- ran `pnpm exec lint-staged` successfully

## Notes
- local pre-commit `typecheck` currently fails due existing unrelated `WORKING` enum/type errors in kanban files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small developer-workflow change limited to the pre-commit hook, with no runtime or production behavior impact.
> 
> **Overview**
> Updates `.husky/pre-commit` to invoke `lint-staged` with `pnpm exec` rather than `npx`, avoiding `npx`/npm deprecation warnings while keeping the rest of the pre-commit checks unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52bcb550b6bbe33b4928f3a6d60ad3fbde38b6d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>52bcb55</u></sup><!-- /BUGBOT_STATUS -->