### PR TITLE
Address leftover review comments and dedupe pathExists

### DIFF
--- a/src/backend/lib/file-helpers.test.ts
+++ b/src/backend/lib/file-helpers.test.ts
@@ -1,17 +1,35 @@
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { getLanguageFromPath, isBinaryContent, isPathSafe } from './file-helpers';
+import { getLanguageFromPath, isBinaryContent, isPathSafe, pathExists } from './file-helpers';
 
 // Mock fs/promises
 vi.mock('node:fs/promises', () => ({
   realpath: vi.fn(),
+  stat: vi.fn(),
 }));
 
-import { realpath } from 'node:fs/promises';
+import { realpath, stat } from 'node:fs/promises';
 
 const mockedRealpath = vi.mocked(realpath);
+const mockedStat = vi.mocked(stat);
 
 describe('file-helpers', () => {
+  describe('pathExists', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('returns true when stat succeeds', async () => {
+      mockedStat.mockResolvedValue({} as Awaited<ReturnType<typeof stat>>);
+      await expect(pathExists('/tmp/example')).resolves.toBe(true);
+    });
+
+    it('returns false when stat throws', async () => {
+      mockedStat.mockRejectedValue(new Error('ENOENT'));
+      await expect(pathExists('/tmp/missing')).resolves.toBe(false);
+    });
+  });
+
   describe('isPathSafe', () => {
     const worktreePath = '/home/user/project';
 

--- a/src/backend/lib/file-helpers.ts
+++ b/src/backend/lib/file-helpers.ts
@@ -1,4 +1,4 @@
-import { realpath } from 'node:fs/promises';
+import { realpath, stat } from 'node:fs/promises';
 import path from 'node:path';
 
 /**
@@ -8,6 +8,15 @@ export interface FileEntry {
   name: string;
   type: 'file' | 'directory';
   path: string;
+}
+
+export async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await stat(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/src/backend/services/git-ops.service.ts
+++ b/src/backend/services/git-ops.service.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { TRPCError } from '@trpc/server';
 import { GitClientFactory } from '../clients/git.client';
+import { pathExists } from '../lib/file-helpers';
 import { getWorkspaceGitStats } from '../lib/git-helpers';
 import { gitCommand } from '../lib/shell';
 
@@ -10,13 +11,6 @@ export type WorkspaceGitStats = Awaited<ReturnType<typeof getWorkspaceGitStats>>
 interface ProjectPaths {
   repoPath: string;
   worktreeBasePath: string;
-}
-
-function pathExists(targetPath: string): Promise<boolean> {
-  return fs
-    .stat(targetPath)
-    .then(() => true)
-    .catch(() => false);
 }
 
 class GitOpsService {

--- a/src/backend/services/worktree-lifecycle.service.ts
+++ b/src/backend/services/worktree-lifecycle.service.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { SessionStatus } from '@prisma-gen/client';
 import { TRPCError } from '@trpc/server';
+import { pathExists } from '../lib/file-helpers';
 import { claudeSessionAccessor } from '../resource_accessors/claude-session.accessor';
 import { workspaceAccessor } from '../resource_accessors/workspace.accessor';
 import { FactoryConfigService } from './factory-config.service';
@@ -174,13 +175,6 @@ function getProjectOrThrow(workspace: WorkspaceWithProject) {
     throw new Error('Workspace project paths are missing');
   }
   return project;
-}
-
-function pathExists(targetPath: string): Promise<boolean> {
-  return fs
-    .stat(targetPath)
-    .then(() => true)
-    .catch(() => false);
 }
 
 async function startProvisioningOrLog(workspaceId: string): Promise<boolean> {


### PR DESCRIPTION
## What this PR does

Addresses remaining actionable code-review feedback and verifies prior comments:

- ✅ `ChatLoading` duplication comment is already resolved in current code:
  - `src/client/routes/projects/workspaces/detail.tsx` already uses `<Loading message="Loading chat..." />`
  - no `workspace-detail-loading.tsx`/`ChatLoading` file exists anymore
- ✅ `main-view-tab-bar` icon-switch comment is no longer an issue:
  - `getTabIcon` currently returns icons for both `file` and `diff`
  - no unreachable `file` case in current implementation
- ✅ Fixed duplicated `pathExists` implementations by extracting shared helper:
  - added `pathExists` to `src/backend/lib/file-helpers.ts`
  - updated `src/backend/services/git-ops.service.ts`
  - updated `src/backend/services/worktree-lifecycle.service.ts`
  - added tests for `pathExists` in `src/backend/lib/file-helpers.test.ts`

## Validation

- `pnpm test -- src/backend/lib/file-helpers.test.ts`
- `pnpm typecheck`
- `pnpm exec biome check src/backend/lib/file-helpers.ts src/backend/lib/file-helpers.test.ts src/backend/services/git-ops.service.ts src/backend/services/worktree-lifecycle.service.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor that centralizes an `fs.stat` existence check and adds tests; behavior should remain the same aside from relying on the shared helper.
> 
> **Overview**
> Deduplicates `pathExists` by extracting a shared implementation into `src/backend/lib/file-helpers.ts` and updating `git-ops.service.ts` and `worktree-lifecycle.service.ts` to import and use it.
> 
> Adds unit tests for `pathExists` in `file-helpers.test.ts`, extending the `node:fs/promises` mock to cover `stat`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45973d5209bd886ac1f86ebd4231424064de5061. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>45973d5</u></sup><!-- /BUGBOT_STATUS -->