### PR TITLE
Test: Intentional CI breakage

### DIFF
--- a/src/lib/paste-utils.test.ts
+++ b/src/lib/paste-utils.test.ts
@@ -34,6 +34,8 @@ describe('getClipboardImages', () => {
 
   it('returns empty results when clipboard data is missing', async () => {
     const result = await getClipboardImages(createClipboardEvent());
+    // Intentional type error to break CI
+    const _breakCI: string = 12_345;
     expect(result).toEqual({ attachments: [], errors: [] });
   });
 


### PR DESCRIPTION
## Summary
This PR intentionally introduces a TypeScript type error to test CI failure detection.

## Changes
- Added a type error in `src/lib/paste-utils.test.ts:38` where a number is assigned to a string type

## Expected Outcome
The CI typecheck step should fail with:
```
error TS2322: Type 'number' is not assignable to type 'string'.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)