### PR TITLE
Test: Break CI with type error

### DIFF
--- a/src/client/main.tsx
+++ b/src/client/main.tsx
@@ -8,6 +8,9 @@ if (!rootElement) {
   throw new Error('Root element not found');
 }
 
+// Deliberate type error to break CI
+const brokenType: string = 12345;
+
 createRoot(rootElement).render(
   <StrictMode>
     <Router />


### PR DESCRIPTION
## Summary
This PR deliberately introduces a TypeScript type error to test CI failure handling.

## Changes
- Added `const brokenType: string = 12345;` in `src/client/main.tsx` which assigns a number to a string type

## Expected Result
The typecheck step in CI should fail with: `Type 'number' is not assignable to type 'string'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)