### PR TITLE
Make workspace attention glow event-driven

### DIFF
--- a/src/components/workspace/WorkspaceNotificationManager.tsx
+++ b/src/components/workspace/WorkspaceNotificationManager.tsx
@@ -17,13 +17,20 @@ export function WorkspaceNotificationManager() {
 
   const handleWorkspaceNotification = useCallback(
     (request: NotificationRequest) => {
-      const { workspaceName, sessionCount } = request;
+      const { workspaceId, workspaceName, sessionCount } = request;
 
       // Only play sound if settings have loaded and user has it enabled
       // Default to true once settings are available, but don't play while loading
       // to avoid playing sound when user may have disabled it
       const playSoundOnComplete = isSuccess ? (settings?.playSoundOnComplete ?? true) : false;
       sendWorkspaceNotification(workspaceName, sessionCount, playSoundOnComplete);
+
+      // Dispatch attention event for red glow animation
+      window.dispatchEvent(
+        new CustomEvent('workspace-attention-required', {
+          detail: { workspaceId },
+        })
+      );
     },
     [settings?.playSoundOnComplete, isSuccess]
   );

--- a/src/frontend/hooks/use-workspace-attention.ts
+++ b/src/frontend/hooks/use-workspace-attention.ts
@@ -1,0 +1,76 @@
+import { useCallback, useEffect, useState } from 'react';
+
+/**
+ * Duration to show the red glow attention indicator (30 seconds)
+ */
+const ATTENTION_DURATION_MS = 30_000;
+
+/**
+ * Tracks which workspaces need user attention (for red glow animation).
+ * This is event-driven and synchronized with the notification sound.
+ */
+export function useWorkspaceAttention() {
+  const [attentionWorkspaces, setAttentionWorkspaces] = useState<Map<string, number>>(new Map());
+
+  useEffect(() => {
+    const handleAttentionRequest = (event: CustomEvent<{ workspaceId: string }>) => {
+      const { workspaceId } = event.detail;
+      const timestamp = Date.now();
+
+      setAttentionWorkspaces((prev) => {
+        const next = new Map(prev);
+        next.set(workspaceId, timestamp);
+        return next;
+      });
+    };
+
+    window.addEventListener(
+      'workspace-attention-required',
+      handleAttentionRequest as EventListener
+    );
+
+    return () => {
+      window.removeEventListener(
+        'workspace-attention-required',
+        handleAttentionRequest as EventListener
+      );
+    };
+  }, []);
+
+  // Clean up expired attention markers every second
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const now = Date.now();
+      setAttentionWorkspaces((prev) => {
+        const next = new Map(prev);
+        let changed = false;
+
+        for (const [workspaceId, timestamp] of next.entries()) {
+          if (now - timestamp > ATTENTION_DURATION_MS) {
+            next.delete(workspaceId);
+            changed = true;
+          }
+        }
+
+        return changed ? next : prev;
+      });
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  const needsAttention = useCallback(
+    (workspaceId: string): boolean => {
+      const timestamp = attentionWorkspaces.get(workspaceId);
+      if (!timestamp) {
+        return false;
+      }
+
+      const elapsed = Date.now() - timestamp;
+      return elapsed < ATTENTION_DURATION_MS;
+    },
+    [attentionWorkspaces]
+  );
+
+  return { needsAttention };
+}


### PR DESCRIPTION
## Summary
Makes the red glow animation on workspace cards event-driven instead of state-based, ensuring it's always synchronized with the notification sound.

## Problem
Previously, the red glow relied on cached database state (`cachedKanbanColumn` and `stateComputedAt`), which could become stale and out of sync with the notification sound. This caused the glow to sometimes not appear when a workspace needed attention, creating an inconsistent user experience.

## Solution
- Created `useWorkspaceAttention` hook to track workspace attention events in client-side memory
- Modified `WorkspaceNotificationManager` to dispatch `workspace-attention-required` event alongside the notification sound
- Updated app sidebar to use event-driven glow tracking instead of state-based checks
- Auto-cleanup of attention markers after 30 seconds

## Benefits
- **Always synchronized**: Glow and sound are triggered by the same `workspace_idle` backend event
- **More reliable**: No dependency on database state updates or `stateComputedAt` timing
- **Simpler**: Reduces coupling between UI feedback and database state
- **Consistent UX**: Users always see the glow when they hear the notification sound

## Test Plan
- [x] Run `pnpm typecheck` - passes
- [x] Run `pnpm check:fix` - passes
- [x] Verify imports are correct and unused utilities removed
- [ ] Manual test: Start a workspace session, let it complete, verify glow appears with sound
- [ ] Manual test: Verify glow disappears after 30 seconds
- [ ] Manual test: Verify glow doesn't appear when ratchet animation is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)