### PR TITLE
Add collapsible Live Activity dock

### DIFF
--- a/src/components/chat/agent-live-dock.tsx
+++ b/src/components/chat/agent-live-dock.tsx
@@ -1,5 +1,7 @@
+import { ChevronDown, ChevronRight } from 'lucide-react';
 import { memo, useEffect, useRef, useState } from 'react';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import type { ToolSequence } from '@/lib/claude-types';
 import { cn } from '@/lib/utils';
 import { ToolSequenceGroup } from '../agent-activity/tool-renderers';
@@ -41,6 +43,7 @@ function getPhaseLabel({
 }
 
 const TOOL_WINDOW_OPEN_KEY_PREFIX = 'agent-live-dock-tool-open-';
+const DOCK_EXPANDED_KEY_PREFIX = 'agent-live-dock-expanded-';
 
 function readToolWindowOpen(workspaceId: string): boolean | null {
   try {
@@ -62,6 +65,26 @@ function saveToolWindowOpen(workspaceId: string, open: boolean): void {
   }
 }
 
+function readDockExpanded(workspaceId: string): boolean | null {
+  try {
+    const stored = window.localStorage.getItem(`${DOCK_EXPANDED_KEY_PREFIX}${workspaceId}`);
+    if (stored === null) {
+      return null;
+    }
+    return stored === 'true';
+  } catch {
+    return null;
+  }
+}
+
+function saveDockExpanded(workspaceId: string, expanded: boolean): void {
+  try {
+    window.localStorage.setItem(`${DOCK_EXPANDED_KEY_PREFIX}${workspaceId}`, String(expanded));
+  } catch {
+    // Ignore localStorage failures.
+  }
+}
+
 export const AgentLiveDock = memo(function AgentLiveDock({
   workspaceId,
   running,
@@ -72,22 +95,38 @@ export const AgentLiveDock = memo(function AgentLiveDock({
   latestToolSequence,
   className,
 }: AgentLiveDockProps) {
-  const skipNextPersistRef = useRef(false);
+  const skipNextToolPersistRef = useRef(false);
+  const skipNextDockPersistRef = useRef(false);
   const [toolWindowOpen, setToolWindowOpen] = useState(true);
+  const [dockExpanded, setDockExpanded] = useState(true);
 
   useEffect(() => {
-    skipNextPersistRef.current = true;
+    skipNextToolPersistRef.current = true;
     const storedOpen = readToolWindowOpen(workspaceId);
     setToolWindowOpen(storedOpen ?? true);
   }, [workspaceId]);
 
   useEffect(() => {
-    if (skipNextPersistRef.current) {
-      skipNextPersistRef.current = false;
+    if (skipNextToolPersistRef.current) {
+      skipNextToolPersistRef.current = false;
       return;
     }
     saveToolWindowOpen(workspaceId, toolWindowOpen);
   }, [workspaceId, toolWindowOpen]);
+
+  useEffect(() => {
+    skipNextDockPersistRef.current = true;
+    const storedExpanded = readDockExpanded(workspaceId);
+    setDockExpanded(storedExpanded ?? true);
+  }, [workspaceId]);
+
+  useEffect(() => {
+    if (skipNextDockPersistRef.current) {
+      skipNextDockPersistRef.current = false;
+      return;
+    }
+    saveDockExpanded(workspaceId, dockExpanded);
+  }, [workspaceId, dockExpanded]);
 
   const hasThinking = latestThinking !== null && (running || stopping || Boolean(permissionMode));
   const hasContent = hasThinking || Boolean(latestToolSequence);
@@ -101,13 +140,25 @@ export const AgentLiveDock = memo(function AgentLiveDock({
     <div className={cn('bg-muted/20 border-b', className)}>
       <div className="px-4 py-3 space-y-3">
         <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-5 w-5 p-0 hover:bg-muted/50"
+            onClick={() => setDockExpanded(!dockExpanded)}
+          >
+            {dockExpanded ? (
+              <ChevronDown className="h-3.5 w-3.5" />
+            ) : (
+              <ChevronRight className="h-3.5 w-3.5" />
+            )}
+          </Button>
           <span className="text-xs font-medium text-muted-foreground">Live activity</span>
           <Badge variant={tone} className="text-[10px] px-1.5 py-0">
             {label}
           </Badge>
         </div>
 
-        {latestToolSequence && (
+        {dockExpanded && latestToolSequence && (
           <div>
             <ToolSequenceGroup
               sequence={latestToolSequence}
@@ -118,7 +169,7 @@ export const AgentLiveDock = memo(function AgentLiveDock({
           </div>
         )}
 
-        {hasThinking && (
+        {dockExpanded && hasThinking && (
           <div className="space-y-1">
             <div className="text-[10px] font-medium text-muted-foreground">Latest thinking</div>
             <LatestThinking thinking={latestThinking} running={running || starting} />


### PR DESCRIPTION
## Summary
Adds collapse/expand functionality to the Live Activity dock so users can minimize it while agents are running, preventing it from taking over the screen.

## Changes
- Added a chevron button to the AgentLiveDock header that toggles between expanded and collapsed states
- Persisted the collapsed/expanded state per workspace in localStorage
- When collapsed, only the status header is shown (e.g., "Live activity Running")
- When expanded, all tool sequences and thinking content are displayed as before
- Defaults to expanded on first load

## Test Plan
- Start an agent session and verify the Live Activity dock appears
- Click the chevron button to collapse the dock - only the header should remain
- Click again to expand - all content should reappear
- Navigate away and back - the state should persist
- Switch to a different workspace - each workspace should have its own collapsed state

🤖 Generated with [Claude Code](https://claude.com/claude-code)