### PR TITLE
Fix tool call ordering in chat log header vs expanded view

### DIFF
--- a/src/components/agent-activity/tool-renderers/tool-info-renderer.tsx
+++ b/src/components/agent-activity/tool-renderers/tool-info-renderer.tsx
@@ -170,7 +170,10 @@ export const ToolSequenceGroup = memo(function ToolSequenceGroup({
   const setIsOpen = onOpenChange ?? setInternalOpen;
 
   const { pairedCalls } = sequence;
+  // For the header summary, use the specified order
   const summaryCalls = summaryOrder === 'latest-first' ? [...pairedCalls].reverse() : pairedCalls;
+  // For the expanded view, always show oldest-first (chronological order)
+  const expandedCalls = pairedCalls;
 
   if (pairedCalls.length === 0) {
     return null;
@@ -293,7 +296,7 @@ export const ToolSequenceGroup = memo(function ToolSequenceGroup({
         </CollapsibleTrigger>
         <CollapsibleContent>
           <div className="border-t space-y-1 p-1.5 overflow-x-auto">
-            {summaryCalls.map((call) => (
+            {expandedCalls.map((call) => (
               <div key={call.id} className="pl-2">
                 <PairedToolCallRenderer call={call} defaultOpen={false} />
               </div>


### PR DESCRIPTION
## Summary

Fixed the tool call ordering inconsistency in the chat log. Previously, both the collapsed header and expanded view showed tools in the same order. Now:

- **Header summary**: Shows tools from newest to oldest (most recent first)
- **Expanded view**: Shows tools from oldest to newest (chronological order)

This provides a better UX where users can quickly see the most recent tool activity in the header, but when they expand it, they see the full chronological flow of how the tools were executed.

## Changes

Modified `ToolSequenceGroup` component in `src/components/agent-activity/tool-renderers/tool-info-renderer.tsx`:
- Added separate `expandedCalls` array that always uses original chronological order
- Header summary continues to use `summaryCalls` which respects the `summaryOrder` prop (set to `'latest-first'`)
- Expanded view now uses `expandedCalls` to show oldest-first ordering

## Test Plan

- [x] TypeScript type checking passes (`pnpm typecheck`)
- [x] Linting and formatting passes (`pnpm check:fix`)
- [x] Pre-commit hooks pass

Manual testing:
- Open a workspace chat with multiple tool calls
- Verify header shows tools from newest to oldest
- Expand the tool sequence
- Verify expanded view shows tools from oldest to newest

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only ordering change confined to rendering logic; low risk aside from potential minor regressions in perceived tool sequence order.
> 
> **Overview**
> Fixes tool-call ordering in `ToolSequenceGroup` so the *collapsed header* respects `summaryOrder` (e.g., newest-first) while the *expanded view* always renders tool calls oldest-first for chronological readability.
> 
> This is done by splitting the data used for rendering into `summaryCalls` (possibly reversed) for the header/tool-name/status summary and `expandedCalls` (original `pairedCalls`) for the expanded list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6efc46e65bfc95a38d04a334ed85406d9e34bf0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->