### PR TITLE
Show only most recent tool call in Live Activity Feed

### DIFF
--- a/src/components/chat/agent-live-dock.tsx
+++ b/src/components/chat/agent-live-dock.tsx
@@ -89,8 +89,18 @@ export const AgentLiveDock = memo(function AgentLiveDock({
     saveToolWindowOpen(workspaceId, toolWindowOpen);
   }, [workspaceId, toolWindowOpen]);
 
+  // Get only the most recent tool call from the sequence
+  const mostRecentToolCall =
+    latestToolSequence?.pairedCalls[latestToolSequence.pairedCalls.length - 1];
+  const mostRecentToolSequence = mostRecentToolCall
+    ? {
+        ...latestToolSequence,
+        pairedCalls: [mostRecentToolCall],
+      }
+    : null;
+
   const hasThinking = latestThinking !== null && (running || stopping || Boolean(permissionMode));
-  const hasContent = hasThinking || Boolean(latestToolSequence);
+  const hasContent = hasThinking || Boolean(mostRecentToolSequence);
   const { label, tone } = getPhaseLabel({ running, starting, stopping, permissionMode });
 
   if (!(hasContent || running || starting || stopping || permissionMode)) {
@@ -107,10 +117,10 @@ export const AgentLiveDock = memo(function AgentLiveDock({
           </Badge>
         </div>
 
-        {latestToolSequence && (
+        {mostRecentToolSequence && (
           <div>
             <ToolSequenceGroup
-              sequence={latestToolSequence}
+              sequence={mostRecentToolSequence}
               summaryOrder="latest-first"
               open={toolWindowOpen}
               onOpenChange={setToolWindowOpen}


### PR DESCRIPTION
## Summary
- Reduced noise in the Live Activity Feed by showing only the most recently initiated tool call instead of all parallel tool calls

## What Changed
- Modified `AgentLiveDock` component to extract only the most recent tool call from the `latestToolSequence`
- The feed now displays a single tool call at a time, making it easier to track current progress

## Test Plan
- [x] TypeScript type checking passes (`pnpm typecheck`)
- [x] Linter and formatter checks pass (`pnpm check:fix`)
- [x] Dependency checks pass
- Manual testing: Verify that the Live Activity Feed shows only one tool call at a time when multiple tools are running in parallel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change that filters displayed tool calls; risk is limited to potentially hiding earlier in-flight calls or edge cases with empty `pairedCalls`.
> 
> **Overview**
> Updates `AgentLiveDock` so the Live Activity feed renders **only the most recent** tool call from `latestToolSequence` by slicing `pairedCalls` down to the last entry before passing it to `ToolSequenceGroup`.
> 
> This reduces UI noise when multiple tool calls are present, and adjusts the “has content” check to key off the trimmed sequence.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b934e15e5b10d2d43eff9c8a812869de3073418b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->