### PR TITLE
Fix unhandled rejection in startDefaultClaudeSession

### DIFF
--- a/src/backend/services/worktree-lifecycle.service.ts
+++ b/src/backend/services/worktree-lifecycle.service.ts
@@ -596,7 +596,12 @@ class WorktreeLifecycleService {
         runScriptCleanupCommand: factoryConfig?.scripts.cleanup ?? null,
       });
 
-      void startDefaultClaudeSession(workspaceId);
+      void startDefaultClaudeSession(workspaceId).catch((error) => {
+        logger.error('Failed to start default Claude session', {
+          workspaceId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
 
       const ranFactorySetup = await runFactorySetupScriptIfConfigured(
         workspaceId,


### PR DESCRIPTION
## Summary
Fixes an unhandled promise rejection that was appearing in server logs when starting Claude sessions during workspace initialization.

## What Changed
- Added `.catch()` handler to the fire-and-forget `startDefaultClaudeSession` call in `worktree-lifecycle.service.ts`
- Errors during session startup are now properly logged with context instead of appearing as unhandled rejections

## Test Plan
- ✅ `pnpm typecheck` passes
- ✅ `pnpm check:fix` passes
- ✅ Dependency checks pass

## Before
```
{"level":"error","timestamp":"2026-02-05T19:14:56.171Z","message":"Unhandled rejection at promise","context":{"reason":{},"promise":{},"service":"factoryfactory","component":"server"}}
```

## After
Errors will now be logged with proper context:
```
{"level":"error","message":"Failed to start default Claude session","context":{"workspaceId":"...","error":"..."}}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to error handling/logging during workspace initialization; no behavioral changes besides preventing unhandled promise rejections.
> 
> **Overview**
> Prevents an unhandled promise rejection during workspace initialization by attaching a `.catch()` to the fire-and-forget `startDefaultClaudeSession` call.
> 
> If session startup fails, the error is now logged as `Failed to start default Claude session` with `workspaceId` and a normalized error message for easier debugging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f0803f78edeb3fdeeb478d2a554b9a390645bea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->