### PR TITLE
Show factory-factory.json preview on new workspace page

### DIFF
--- a/src/client/routes/admin.tsx
+++ b/src/client/routes/admin.tsx
@@ -1,7 +1,8 @@
-import { CheckCircle2, Download, FileJson, RefreshCw } from 'lucide-react';
+import { Download, FileJson, RefreshCw } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { DataImportButton } from '@/components/data-import/data-import-button';
+import { FactoryConfigScripts } from '@/components/factory-config-scripts';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -81,53 +82,7 @@ function FactoryConfigSection({ projectId }: { projectId: string }) {
       </CardHeader>
       {factoryConfig && (
         <CardContent className="space-y-4">
-          <div className="rounded-md border bg-muted/50 p-4 space-y-3">
-            <div className="flex items-start gap-3">
-              <CheckCircle2 className="w-5 h-5 text-green-600 mt-0.5" />
-              <div className="space-y-1 flex-1">
-                <p className="font-medium text-sm">Configuration Found</p>
-                <p className="text-xs text-muted-foreground">
-                  factory-factory.json is configured in this repository
-                </p>
-              </div>
-            </div>
-
-            <div className="space-y-2 pl-8">
-              {factoryConfig.scripts.setup && (
-                <div className="space-y-1">
-                  <p className="text-xs font-medium text-muted-foreground">Setup Script</p>
-                  <code className="block bg-background px-3 py-2 rounded text-xs font-mono">
-                    {factoryConfig.scripts.setup}
-                  </code>
-                  <p className="text-xs text-muted-foreground">
-                    Runs automatically when a new workspace is created
-                  </p>
-                </div>
-              )}
-
-              {factoryConfig.scripts.run && (
-                <div className="space-y-1">
-                  <p className="text-xs font-medium text-muted-foreground">Run Script</p>
-                  <code className="block bg-background px-3 py-2 rounded text-xs font-mono">
-                    {factoryConfig.scripts.run}
-                  </code>
-                  <p className="text-xs text-muted-foreground">
-                    Available via the play button in each workspace
-                  </p>
-                </div>
-              )}
-
-              {factoryConfig.scripts.cleanup && (
-                <div className="space-y-1">
-                  <p className="text-xs font-medium text-muted-foreground">Cleanup Script</p>
-                  <code className="block bg-background px-3 py-2 rounded text-xs font-mono">
-                    {factoryConfig.scripts.cleanup}
-                  </code>
-                  <p className="text-xs text-muted-foreground">Runs when stopping the dev server</p>
-                </div>
-              )}
-            </div>
-          </div>
+          <FactoryConfigScripts factoryConfig={factoryConfig} variant="card" />
 
           <div className="text-xs text-muted-foreground space-y-1">
             <p>

--- a/src/client/routes/projects/workspaces/new.tsx
+++ b/src/client/routes/projects/workspaces/new.tsx
@@ -1,7 +1,8 @@
 import type { Workspace } from '@prisma-gen/browser';
-import { ArrowLeft, CheckCircle2, FileJson } from 'lucide-react';
+import { ArrowLeft } from 'lucide-react';
 import { useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router';
+import { FactoryConfigScripts } from '@/components/factory-config-scripts';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -76,54 +77,7 @@ export default function NewWorkspacePage() {
         </div>
       </div>
 
-      {factoryConfig &&
-        (factoryConfig.scripts.setup ||
-          factoryConfig.scripts.run ||
-          factoryConfig.scripts.cleanup) && (
-          <Alert className="bg-green-50 dark:bg-green-950 border-green-200 dark:border-green-800">
-            <FileJson className="h-4 w-4 text-green-600 dark:text-green-400" />
-            <AlertDescription>
-              <div className="space-y-2">
-                <div className="flex items-center gap-2">
-                  <CheckCircle2 className="h-4 w-4 text-green-600 dark:text-green-400" />
-                  <span className="font-medium text-green-900 dark:text-green-100">
-                    factory-factory.json detected
-                  </span>
-                </div>
-                <p className="text-sm text-green-800 dark:text-green-200">
-                  This project has a factory-factory.json configuration file. New workspaces will
-                  automatically:
-                </p>
-                <ul className="text-sm text-green-800 dark:text-green-200 space-y-1 ml-4">
-                  {factoryConfig.scripts.setup && (
-                    <li className="list-disc">
-                      Run setup script:{' '}
-                      <code className="bg-green-100 dark:bg-green-900 px-1 rounded text-xs">
-                        {factoryConfig.scripts.setup}
-                      </code>
-                    </li>
-                  )}
-                  {factoryConfig.scripts.run && (
-                    <li className="list-disc">
-                      Have a dev server available via the play button:{' '}
-                      <code className="bg-green-100 dark:bg-green-900 px-1 rounded text-xs">
-                        {factoryConfig.scripts.run}
-                      </code>
-                    </li>
-                  )}
-                  {factoryConfig.scripts.cleanup && (
-                    <li className="list-disc">
-                      Run cleanup on stop:{' '}
-                      <code className="bg-green-100 dark:bg-green-900 px-1 rounded text-xs">
-                        {factoryConfig.scripts.cleanup}
-                      </code>
-                    </li>
-                  )}
-                </ul>
-              </div>
-            </AlertDescription>
-          </Alert>
-        )}
+      {factoryConfig && <FactoryConfigScripts factoryConfig={factoryConfig} variant="alert" />}
 
       <Card>
         <CardContent className="pt-6">

--- a/src/components/factory-config-scripts.tsx
+++ b/src/components/factory-config-scripts.tsx
@@ -1,0 +1,119 @@
+import { CheckCircle2, FileJson } from 'lucide-react';
+import type { FactoryConfig } from '@/backend/services/factory-config.service';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+
+interface FactoryConfigScriptsProps {
+  factoryConfig: FactoryConfig;
+  variant?: 'alert' | 'card';
+}
+
+export function FactoryConfigScripts({
+  factoryConfig,
+  variant = 'alert',
+}: FactoryConfigScriptsProps) {
+  const hasScripts =
+    factoryConfig.scripts.setup || factoryConfig.scripts.run || factoryConfig.scripts.cleanup;
+
+  if (!hasScripts) {
+    return null;
+  }
+
+  if (variant === 'alert') {
+    return (
+      <Alert className="bg-green-50 dark:bg-green-950 border-green-200 dark:border-green-800">
+        <FileJson className="h-4 w-4 text-green-600 dark:text-green-400" />
+        <AlertDescription>
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <CheckCircle2 className="h-4 w-4 text-green-600 dark:text-green-400" />
+              <span className="font-medium text-green-900 dark:text-green-100">
+                factory-factory.json detected
+              </span>
+            </div>
+            <p className="text-sm text-green-800 dark:text-green-200">
+              This project has a factory-factory.json configuration file. New workspaces will
+              automatically:
+            </p>
+            <ul className="text-sm text-green-800 dark:text-green-200 space-y-1 ml-4">
+              {factoryConfig.scripts.setup && (
+                <li className="list-disc">
+                  Run setup script:{' '}
+                  <code className="bg-green-100 dark:bg-green-900 px-1 rounded text-xs">
+                    {factoryConfig.scripts.setup}
+                  </code>
+                </li>
+              )}
+              {factoryConfig.scripts.run && (
+                <li className="list-disc">
+                  Have a dev server available via the play button:{' '}
+                  <code className="bg-green-100 dark:bg-green-900 px-1 rounded text-xs">
+                    {factoryConfig.scripts.run}
+                  </code>
+                </li>
+              )}
+              {factoryConfig.scripts.cleanup && (
+                <li className="list-disc">
+                  Run cleanup on stop:{' '}
+                  <code className="bg-green-100 dark:bg-green-900 px-1 rounded text-xs">
+                    {factoryConfig.scripts.cleanup}
+                  </code>
+                </li>
+              )}
+            </ul>
+          </div>
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  // Card variant for admin page
+  return (
+    <div className="rounded-md border bg-muted/50 p-4 space-y-3">
+      <div className="flex items-start gap-3">
+        <CheckCircle2 className="w-5 h-5 text-green-600 mt-0.5" />
+        <div className="space-y-1 flex-1">
+          <p className="font-medium text-sm">Configuration Found</p>
+          <p className="text-xs text-muted-foreground">
+            factory-factory.json is configured in this repository
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-2 pl-8">
+        {factoryConfig.scripts.setup && (
+          <div className="space-y-1">
+            <p className="text-xs font-medium text-muted-foreground">Setup Script</p>
+            <code className="block bg-background px-3 py-2 rounded text-xs font-mono">
+              {factoryConfig.scripts.setup}
+            </code>
+            <p className="text-xs text-muted-foreground">
+              Runs automatically when a new workspace is created
+            </p>
+          </div>
+        )}
+
+        {factoryConfig.scripts.run && (
+          <div className="space-y-1">
+            <p className="text-xs font-medium text-muted-foreground">Run Script</p>
+            <code className="block bg-background px-3 py-2 rounded text-xs font-mono">
+              {factoryConfig.scripts.run}
+            </code>
+            <p className="text-xs text-muted-foreground">
+              Available via the play button in each workspace
+            </p>
+          </div>
+        )}
+
+        {factoryConfig.scripts.cleanup && (
+          <div className="space-y-1">
+            <p className="text-xs font-medium text-muted-foreground">Cleanup Script</p>
+            <code className="block bg-background px-3 py-2 rounded text-xs font-mono">
+              {factoryConfig.scripts.cleanup}
+            </code>
+            <p className="text-xs text-muted-foreground">Runs when stopping the dev server</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Displays factory-factory.json configuration details on the new workspace page when the configuration file is detected. This helps users understand that the project has automated workspace setup configured without needing to manually configure build scripts.

Closes #679

## What Changed

### User Experience
When creating a new workspace, if the project has a factory-factory.json configuration file, users will see a green alert banner showing:
- ✅ Confirmation that factory-factory.json was detected
- 📋 Preview of which scripts will run automatically:
  - Setup script (runs on workspace creation)
  - Run script (available via play button)
  - Cleanup script (runs on stop)

### Implementation
- Query `getFactoryConfig` tRPC endpoint when loading the new workspace page
- Display configuration details in a visually clear alert component
- Live detection - configuration is read from the file system, not persisted to the database
- Conditional rendering - only shows when factory-factory.json exists

## Benefits
- **Transparency**: Users immediately know their workspace will have automated setup
- **No surprises**: Clear preview of what scripts will run
- **Better UX**: Users don't need to wonder if they should configure build scripts manually
- **Live updates**: Configuration changes are reflected immediately (no database cache to refresh)

## Test Plan
- [x] Type checking passes (`pnpm typecheck`)
- [x] All tests pass (`pnpm test`)
- [x] Linting passes (`pnpm check:fix`)
- [x] Alert only shows when factory-factory.json exists
- [x] All configured scripts are displayed correctly
- [x] Styling works in both light and dark modes

## Screenshots
The new alert banner appears above the workspace creation form, showing users exactly what automation is configured for the project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes that add a read-only preview of existing `factory-factory.json` scripts; minimal risk beyond an extra query on page load.
> 
> **Overview**
> Adds a `factory-factory.json` script preview to the **New Workspace** flow by fetching `trpc.workspace.getFactoryConfig` and conditionally rendering a green alert describing which setup/run/cleanup scripts will execute.
> 
> Refactors the admin dashboard’s factory-config display into a reusable `FactoryConfigScripts` component (with `alert` and `card` variants) to avoid duplicating the script-rendering UI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce285bf1aaaf7500e0499f4295f18738f1cb2dc9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->