### PR TITLE
Fix Claude keepalive activity timeout

### DIFF
--- a/src/backend/claude/process.test.ts
+++ b/src/backend/claude/process.test.ts
@@ -1,0 +1,38 @@
+import { EventEmitter } from 'node:events';
+import { describe, expect, it, vi } from 'vitest';
+import { ClaudeProcess } from './process';
+
+type TestClaudeProcess = EventEmitter & {
+  protocol: EventEmitter;
+  monitor: { recordActivity: () => void };
+  status: string;
+  claudeSessionId: string | null;
+  process: { pid: number };
+  stderrBuffer: string[];
+  isIntentionallyStopping: boolean;
+  setupEventForwarding: () => void;
+};
+
+describe('ClaudeProcess', () => {
+  it('records activity on keep_alive events', () => {
+    const protocol = new EventEmitter();
+    const recordActivity = vi.fn();
+
+    const claudeProcess = new EventEmitter() as unknown as TestClaudeProcess;
+    Object.setPrototypeOf(claudeProcess, ClaudeProcess.prototype);
+
+    claudeProcess.protocol = protocol;
+    claudeProcess.monitor = { recordActivity };
+    claudeProcess.status = 'ready';
+    claudeProcess.claudeSessionId = null;
+    claudeProcess.process = { pid: 12_345 };
+    claudeProcess.stderrBuffer = [];
+    claudeProcess.isIntentionallyStopping = false;
+
+    claudeProcess.setupEventForwarding();
+
+    protocol.emit('keep_alive', { type: 'keep_alive' });
+
+    expect(recordActivity).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/backend/claude/process.ts
+++ b/src/backend/claude/process.ts
@@ -538,6 +538,11 @@ export class ClaudeProcess extends EventEmitter {
       this.setStatus('running');
     });
 
+    // Keep-alive indicates the CLI is still alive, so treat it as activity.
+    this.protocol.on('keep_alive', () => {
+      this.updateActivity();
+    });
+
     // Forward all messages
     this.protocol.on('message', (msg: ClaudeJson) => {
       this.emit('message', msg);

--- a/src/backend/services/config.service.ts
+++ b/src/backend/services/config.service.ts
@@ -277,7 +277,7 @@ function buildCorsConfig(): CorsConfig {
  * Build Claude process configuration from environment with validation
  */
 function buildClaudeProcessConfig(): ClaudeProcessConfig {
-  const DEFAULT_HUNG_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes (matches original in process.ts)
+  const DEFAULT_HUNG_TIMEOUT_MS = 60 * 60 * 1000; // 60 minutes
   const envValue = process.env.CLAUDE_HUNG_TIMEOUT_MS;
 
   if (!envValue) {
@@ -286,7 +286,7 @@ function buildClaudeProcessConfig(): ClaudeProcessConfig {
 
   const parsed = Number.parseInt(envValue, 10);
   if (Number.isNaN(parsed) || parsed <= 0) {
-    logger.warn(`Invalid CLAUDE_HUNG_TIMEOUT_MS value: ${envValue}, using default (30 minutes)`);
+    logger.warn(`Invalid CLAUDE_HUNG_TIMEOUT_MS value: ${envValue}, using default (60 minutes)`);
     return { hungTimeoutMs: DEFAULT_HUNG_TIMEOUT_MS };
   }
 


### PR DESCRIPTION
## Summary
- fix Claude process activity tracking by treating protocol `keep_alive` events as activity
- increase default `CLAUDE_HUNG_TIMEOUT_MS` fallback from 30 minutes to 60 minutes
- add regression test for keep-alive activity updates

## Problem
Healthy Claude processes could be killed after the activity timeout because keep-alive events were not updating `lastActivityAt`.

## Changes
- `src/backend/claude/process.ts`
  - subscribe to `keep_alive` and call `updateActivity()`
- `src/backend/services/config.service.ts`
  - update default hung timeout to `60 * 60 * 1000`
  - update invalid-env warning text accordingly
- `src/backend/claude/process.test.ts`
  - add unit test asserting keep_alive triggers activity recording

## Validation
- `pnpm exec biome check src/backend/claude/process.test.ts src/backend/claude/process.ts src/backend/services/config.service.ts`
- `pnpm vitest run src/backend/claude/process.test.ts`

## Notes
- Repository-wide `pnpm typecheck` is currently failing on unrelated existing issues in this branch baseline.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to Claude process activity tracking plus a safer default timeout; minimal surface area beyond hung-process detection behavior.
> 
> **Overview**
> Fixes Claude hung-process detection by treating protocol `keep_alive` events as activity (calling `updateActivity()`), preventing healthy CLI sessions from being killed for idleness.
> 
> Increases the default `CLAUDE_HUNG_TIMEOUT_MS` fallback from 30 to 60 minutes (and updates the invalid-env warning text), and adds a Vitest regression test asserting `keep_alive` triggers activity recording.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a40a2a37be662d0d1a0d564ebf8ce77e2e1a189d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->