### PR TITLE
Remove adaptLegacyCreateInput compatibility path

### DIFF
--- a/src/backend/services/workspace-creation.service.test.ts
+++ b/src/backend/services/workspace-creation.service.test.ts
@@ -8,7 +8,6 @@ import type { configService } from './config.service';
 import * as gitOpsServiceModule from './git-ops.service';
 import type { createLogger } from './logger.service';
 import {
-  adaptLegacyCreateInput,
   WorkspaceCreationService,
   type WorkspaceCreationSource,
 } from './workspace-creation.service';
@@ -412,120 +411,6 @@ describe('WorkspaceCreationService', () => {
           })
         );
       });
-    });
-  });
-
-  describe('adaptLegacyCreateInput', () => {
-    it('should adapt manual creation input', () => {
-      const input = {
-        projectId: 'proj-1',
-        name: 'My Workspace',
-        description: 'Test description',
-        branchName: 'feature/test',
-      };
-
-      const result = adaptLegacyCreateInput(input);
-
-      expect(result).toEqual({
-        type: 'MANUAL',
-        projectId: 'proj-1',
-        name: 'My Workspace',
-        description: 'Test description',
-        branchName: 'feature/test',
-        ratchetEnabled: undefined,
-        githubIssueNumber: undefined,
-        githubIssueUrl: undefined,
-      });
-    });
-
-    it('should preserve partial GitHub issue data in manual fallback', () => {
-      const input = {
-        projectId: 'proj-1',
-        name: 'Test',
-        githubIssueNumber: 42,
-        // missing githubIssueUrl
-      };
-
-      const result = adaptLegacyCreateInput(input);
-
-      expect(result.type).toBe('MANUAL');
-      expect(result).toEqual(
-        expect.objectContaining({
-          githubIssueNumber: 42,
-          githubIssueUrl: undefined,
-        })
-      );
-    });
-
-    it('should adapt resume branch input', () => {
-      const input = {
-        projectId: 'proj-1',
-        name: 'Resumed Workspace',
-        branchName: 'existing-branch',
-        useExistingBranch: true,
-      };
-
-      const result = adaptLegacyCreateInput(input);
-
-      expect(result).toEqual({
-        type: 'RESUME_BRANCH',
-        projectId: 'proj-1',
-        branchName: 'existing-branch',
-        name: 'Resumed Workspace',
-        description: undefined,
-        ratchetEnabled: undefined,
-      });
-    });
-
-    it('should adapt GitHub issue input', () => {
-      const input = {
-        projectId: 'proj-1',
-        name: 'Issue Workspace',
-        githubIssueNumber: 42,
-        githubIssueUrl: 'https://github.com/org/repo/issues/42',
-        ratchetEnabled: false,
-      };
-
-      const result = adaptLegacyCreateInput(input);
-
-      expect(result).toEqual({
-        type: 'GITHUB_ISSUE',
-        projectId: 'proj-1',
-        issueNumber: 42,
-        issueUrl: 'https://github.com/org/repo/issues/42',
-        name: 'Issue Workspace',
-        description: undefined,
-        ratchetEnabled: false,
-      });
-    });
-
-    it('should prioritize resume branch over GitHub issue', () => {
-      const input = {
-        projectId: 'proj-1',
-        name: 'Test',
-        branchName: 'branch',
-        useExistingBranch: true,
-        githubIssueNumber: 42,
-        githubIssueUrl: 'https://github.com/org/repo/issues/42',
-      };
-
-      const result = adaptLegacyCreateInput(input);
-
-      expect(result.type).toBe('RESUME_BRANCH');
-    });
-
-    it('should treat GitHub issue with useExistingBranch=false as GitHub issue', () => {
-      const input = {
-        projectId: 'proj-1',
-        name: 'Test',
-        useExistingBranch: false,
-        githubIssueNumber: 42,
-        githubIssueUrl: 'https://github.com/org/repo/issues/42',
-      };
-
-      const result = adaptLegacyCreateInput(input);
-
-      expect(result.type).toBe('GITHUB_ISSUE');
     });
   });
 });

--- a/src/backend/services/workspace-creation.service.ts
+++ b/src/backend/services/workspace-creation.service.ts
@@ -25,10 +25,6 @@ export type WorkspaceCreationSource =
       description?: string;
       branchName?: string;
       ratchetEnabled?: boolean;
-      /** Preserved from legacy input for backward compatibility */
-      githubIssueNumber?: number;
-      /** Preserved from legacy input for backward compatibility */
-      githubIssueUrl?: string;
     }
   | {
       type: 'RESUME_BRANCH';
@@ -47,64 +43,6 @@ export type WorkspaceCreationSource =
       description?: string;
       ratchetEnabled?: boolean;
     };
-
-/**
- * Compatibility adapter for old workspace create input format.
- * Supports migration from existing tRPC procedure input shape.
- */
-export interface LegacyCreateWorkspaceInput {
-  projectId: string;
-  name: string;
-  description?: string;
-  branchName?: string;
-  useExistingBranch?: boolean;
-  githubIssueNumber?: number;
-  githubIssueUrl?: string;
-  ratchetEnabled?: boolean;
-}
-
-/**
- * Converts legacy input format to source-discriminated format.
- */
-export function adaptLegacyCreateInput(input: LegacyCreateWorkspaceInput): WorkspaceCreationSource {
-  // Resume branch takes precedence
-  if (input.useExistingBranch && input.branchName) {
-    return {
-      type: 'RESUME_BRANCH',
-      projectId: input.projectId,
-      branchName: input.branchName,
-      name: input.name,
-      description: input.description,
-      ratchetEnabled: input.ratchetEnabled,
-    };
-  }
-
-  // GitHub issue creation
-  if (input.githubIssueNumber !== undefined && input.githubIssueUrl) {
-    return {
-      type: 'GITHUB_ISSUE',
-      projectId: input.projectId,
-      issueNumber: input.githubIssueNumber,
-      issueUrl: input.githubIssueUrl,
-      name: input.name,
-      description: input.description,
-      ratchetEnabled: input.ratchetEnabled,
-    };
-  }
-
-  // Default to manual creation, preserving any partial GitHub issue data
-  // to maintain backward compatibility with old code that passed all fields through.
-  return {
-    type: 'MANUAL',
-    projectId: input.projectId,
-    name: input.name,
-    description: input.description,
-    branchName: input.branchName,
-    ratchetEnabled: input.ratchetEnabled,
-    githubIssueNumber: input.githubIssueNumber,
-    githubIssueUrl: input.githubIssueUrl,
-  };
-}
 
 /**
  * Result of workspace creation operation.
@@ -203,8 +141,6 @@ export class WorkspaceCreationService {
             name: source.name,
             description: source.description,
             branchName: source.branchName,
-            githubIssueNumber: source.githubIssueNumber,
-            githubIssueUrl: source.githubIssueUrl,
           },
         };
       }

--- a/src/client/routes/projects/workspaces/list.tsx
+++ b/src/client/routes/projects/workspaces/list.tsx
@@ -85,10 +85,10 @@ export default function WorkspacesListPage() {
 
     try {
       const workspace = await resumeWorkspace.mutateAsync({
+        type: 'RESUME_BRANCH',
         projectId: project.id,
-        name: workspaceName,
         branchName: branch.name,
-        useExistingBranch: true,
+        name: workspaceName,
       });
 
       rememberResumeWorkspace(workspace.id);

--- a/src/client/routes/projects/workspaces/new.tsx
+++ b/src/client/routes/projects/workspaces/new.tsx
@@ -52,6 +52,7 @@ export default function NewWorkspacePage() {
     }
 
     createWorkspace.mutate({
+      type: 'MANUAL',
       projectId: project.id,
       name,
       description: description || undefined,

--- a/src/frontend/components/kanban/issue-card.tsx
+++ b/src/frontend/components/kanban/issue-card.tsx
@@ -45,10 +45,11 @@ export function IssueCard({ issue, projectId }: IssueCardProps) {
     e.stopPropagation();
 
     createWorkspaceMutation.mutate({
+      type: 'GITHUB_ISSUE',
       projectId,
+      issueNumber: issue.number,
+      issueUrl: issue.url,
       name: issue.title,
-      githubIssueNumber: issue.number,
-      githubIssueUrl: issue.url,
       ratchetEnabled,
     });
   };

--- a/src/frontend/hooks/use-create-workspace.ts
+++ b/src/frontend/hooks/use-create-workspace.ts
@@ -38,6 +38,7 @@ export function useCreateWorkspace(
 
     try {
       const workspace = await createWorkspace.mutateAsync({
+        type: 'MANUAL',
         projectId,
         name,
       });


### PR DESCRIPTION
## Summary
This PR removes the `adaptLegacyCreateInput` compatibility adapter and migrates all workspace creation flows to use the canonical `WorkspaceCreationSource` discriminated union directly.

## Changes
- **Removed**: `adaptLegacyCreateInput` function and `LegacyCreateWorkspaceInput` interface from `workspace-creation.service.ts`
- **Updated**: tRPC `workspace.create` endpoint to accept `WorkspaceCreationSource` directly via Zod discriminated union schema
- **Migrated**: All client-side callers to use source-discriminated format:
  - `useCreateWorkspace` hook: `type: 'MANUAL'`
  - `issue-card.tsx`: `type: 'GITHUB_ISSUE'` with `issueNumber`/`issueUrl`
  - `new.tsx`: `type: 'MANUAL'`
  - `list.tsx`: `type: 'RESUME_BRANCH'`
- **Cleaned up**: Removed backward compatibility fields (`githubIssueNumber`/`githubIssueUrl`) from `MANUAL` source type
- **Tests**: Removed all tests for `adaptLegacyCreateInput`

## Testing
- ✅ All 1333 tests pass
- ✅ TypeScript type checking passes
- ✅ Linting and formatting checks pass
- ✅ Behavior remains unchanged for existing workspace create flows

## Related
Closes #713

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the request contract for `workspace.create`, so any out-of-date clients or integrations using the legacy input fields may break. Implementation is mostly plumbing/type-shape refactoring with limited runtime logic change.
> 
> **Overview**
> Removes the `adaptLegacyCreateInput`/`LegacyCreateWorkspaceInput` compatibility path and drops the extra GitHub-issue fields from the `MANUAL` `WorkspaceCreationSource` shape.
> 
> Updates `workspace.create` (tRPC) to validate a `type`-discriminated Zod union and passes the source directly into `WorkspaceCreationService`, while migrating all frontend callers (manual create, resume branch, and GitHub issue card) to send the new `type`-tagged payload and renamed issue fields (`issueNumber`/`issueUrl`). Tests covering the removed adapter are deleted.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f33267daaf77179cbb21265a630c7ee9f332e7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->