### PR TITLE
Enable text selection in toast notifications

### DIFF
--- a/src/client/globals.css
+++ b/src/client/globals.css
@@ -260,3 +260,12 @@
     animation: none;
   }
 }
+
+/* Enable text selection in toast notifications */
+[data-sonner-toast] {
+  user-select: text !important;
+}
+
+[data-sonner-toast] * {
+  user-select: text !important;
+}


### PR DESCRIPTION
## Summary
- Fixes text selection being disabled in toast error messages
- Adds CSS overrides to enable text selection in all toast notifications

## Problem
The sonner toast library includes `user-select: none` by default, which prevents users from selecting and copying error messages from toast notifications. This makes it difficult to share error details or paste them elsewhere for debugging.

## Solution
Added CSS rules in `globals.css` to override the library's default behavior:
- Applied `user-select: text !important` to all toast containers
- Also applied to all child elements to ensure everything is selectable

## Testing
- Test by triggering any error toast in the UI
- Verify that error text can be selected and copied

🤖 Generated with [Claude Code](https://claude.com/claude-code)