### PR TITLE
Add missing workspace attention glow animation

### DIFF
--- a/src/client/globals.css
+++ b/src/client/globals.css
@@ -261,6 +261,30 @@
   }
 }
 
+/* Workspace attention glow animation */
+@keyframes waiting-pulse-animation {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 color-mix(in oklab, var(--destructive) 50%, transparent);
+    border-color: color-mix(in oklab, var(--destructive) 30%, var(--border));
+  }
+  50% {
+    box-shadow: 0 0 12px 2px color-mix(in oklab, var(--destructive) 40%, transparent);
+    border-color: color-mix(in oklab, var(--destructive) 60%, var(--border));
+  }
+}
+
+.waiting-pulse {
+  animation: waiting-pulse-animation 2s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .waiting-pulse {
+    animation: none;
+    border-color: color-mix(in oklab, var(--destructive) 50%, var(--border));
+  }
+}
+
 /* Enable text selection in toast notifications */
 [data-sonner-toast] {
   user-select: text !important;


### PR DESCRIPTION
## Summary
Fixes the missing visual feedback for workspace attention notifications. The notification sound was playing correctly, but the workspace cards in the sidebar weren't glowing as intended.

## Changes
- Added the missing `waiting-pulse` CSS animation and keyframes to `globals.css`
- Implements a soft red pulsing glow effect that lasts for 30 seconds
- Respects `prefers-reduced-motion` accessibility settings

## Details
The workspace attention system was already wired up:
- Backend sends `workspace_notification_request` events
- Frontend `WorkspaceNotificationManager` plays sound and dispatches attention events
- `useWorkspaceAttention` hook tracks which workspaces need attention
- Sidebar applies the `waiting-pulse` class to workspace items

However, the CSS animation for `.waiting-pulse` was never defined, so the visual glow effect didn't appear.

## Test plan
- [ ] Run the app and trigger a workspace completion notification
- [ ] Verify workspace card in sidebar shows a soft red pulsing glow
- [ ] Verify glow automatically stops after 30 seconds
- [ ] Test with reduced motion preference enabled (should show static border)

🤖 Generated with [Claude Code](https://claude.com/claude-code)