### PR TITLE
Fix dev server child processes not killed on shutdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "superjson": "^2.2.6",
     "tailwind-merge": "^3.4.0",
     "tailwindcss-animate": "^1.0.7",
+    "tree-kill": "^1.2.2",
     "tw-animate-css": "^1.4.0",
     "vaul": "^1.1.2",
     "ws": "^8.19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,6 +248,9 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@4.1.18)
+      tree-kill:
+        specifier: ^1.2.2
+        version: 1.2.2
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0

--- a/src/backend/services/run-script.service.ts
+++ b/src/backend/services/run-script.service.ts
@@ -1,4 +1,5 @@
 import { type ChildProcess, spawn } from 'node:child_process';
+import treeKill from 'tree-kill';
 import { workspaceAccessor } from '../resource_accessors/workspace.accessor';
 import { FactoryConfigService } from './factory-config.service';
 import { createLogger } from './logger.service';
@@ -422,27 +423,41 @@ export class RunScriptService {
         }
       }
 
-      // Kill the process
-      if (childProcess) {
+      // Kill the process tree
+      if (childProcess?.pid) {
+        const processPid = childProcess.pid;
         logger.info('Stopping run script via stored process', {
           workspaceId,
-          pid: childProcess.pid,
+          pid: processPid,
         });
-        childProcess.kill('SIGTERM');
-        RunScriptService.runningProcesses.delete(workspaceId);
+        await new Promise<void>((resolve) => {
+          treeKill(processPid, 'SIGTERM', (err) => {
+            if (err) {
+              logger.warn('Failed to tree-kill run script process', {
+                workspaceId,
+                pid: processPid,
+                error: err.message,
+              });
+            }
+            RunScriptService.runningProcesses.delete(workspaceId);
+            resolve();
+          });
+        });
       } else if (pid) {
         // Fallback: kill by PID if we don't have the process reference
         logger.info('Stopping run script via PID', { workspaceId, pid });
-        try {
-          process.kill(pid, 'SIGTERM');
-        } catch (error) {
-          // Process might already be dead
-          logger.warn('Failed to kill process, might already be stopped', {
-            workspaceId,
-            pid,
-            error,
+        await new Promise<void>((resolve) => {
+          treeKill(pid, 'SIGTERM', (err) => {
+            if (err) {
+              logger.warn('Failed to tree-kill process, might already be stopped', {
+                workspaceId,
+                pid,
+                error: err.message,
+              });
+            }
+            resolve();
           });
-        }
+        });
       }
 
       // Transition to IDLE state via state machine (completes stopping)
@@ -546,14 +561,21 @@ export class RunScriptService {
   }
 
   /**
-   * Synchronous cleanup for 'exit' event - kills processes without running cleanup scripts
+   * Synchronous cleanup for 'exit' event - kills processes without running cleanup scripts.
+   *
+   * Uses childProcess.kill() instead of tree-kill because this runs from the synchronous
+   * 'exit' event handler. For proper cleanup with full tree kill, graceful shutdown via
+   * SIGINT/SIGTERM handlers should be used instead (see cleanup() which calls stopRunScript).
+   *
    * @internal
    */
   static cleanupSync() {
     logger.info('Process exiting, killing any remaining run scripts');
     for (const [workspaceId, childProcess] of RunScriptService.runningProcesses.entries()) {
       try {
-        childProcess.kill('SIGKILL');
+        if (!childProcess.killed) {
+          childProcess.kill('SIGKILL');
+        }
         logger.info('Force killed run script on exit', {
           workspaceId,
           pid: childProcess.pid,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -11,9 +11,22 @@ import chalk from 'chalk';
 import { Command } from 'commander';
 import { config } from 'dotenv';
 import open from 'open';
+import treeKill from 'tree-kill';
 import { runMigrations as runDbMigrations } from '@/backend/migrate';
 
 const execPromise = promisify(exec);
+
+function treeKillAsync(pid: number, signal: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    treeKill(pid, signal, (err) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -71,16 +84,26 @@ async function waitForService(
     console.log(chalk.green(`  ✓ ${serviceName} ready on port ${port}`));
   } catch {
     console.error(chalk.red(`\n  ✗ ${serviceName} failed to start on port ${port}`));
-    killAllProcesses(processes);
+    await killAllProcesses(processes);
     process.exit(1);
   }
 }
 
-// Kill all tracked processes
-function killAllProcesses(processes: { name: string; proc: ChildProcess }[]): void {
-  for (const { proc } of processes) {
-    proc.kill('SIGTERM');
-  }
+// Kill all tracked processes and their child process trees
+async function killAllProcesses(processes: { name: string; proc: ChildProcess }[]): Promise<void> {
+  await Promise.allSettled(
+    processes
+      .filter(({ proc }) => proc.pid)
+      .map(async ({ name, proc }) => {
+        try {
+          await treeKillAsync(proc.pid as number, 'SIGTERM');
+        } catch (err) {
+          console.error(
+            chalk.yellow(`  Failed to kill ${name} (${proc.pid}): ${(err as Error).message}`)
+          );
+        }
+      })
+  );
 }
 
 // Create an exit promise for a process that resolves during shutdown, rejects on unexpected exit
@@ -314,21 +337,51 @@ function createShutdownHandler(
     shutdownState.shuttingDown = true;
 
     console.log(chalk.yellow(`\n  🛑 ${signal} received, shutting down...`));
-    for (const { proc } of processes) {
-      proc.kill('SIGTERM');
-    }
 
-    setTimeout(() => {
-      const alive = processes.filter(({ proc }) => !proc.killed && proc.exitCode === null);
+    // Send SIGTERM to all process trees
+    const termPromises = processes
+      .filter(({ proc }) => proc.pid)
+      .map(async ({ name, proc }) => {
+        try {
+          await treeKillAsync(proc.pid as number, 'SIGTERM');
+        } catch (err) {
+          console.error(
+            chalk.yellow(`  Failed to kill ${name} (${proc.pid}): ${(err as Error).message}`)
+          );
+        }
+      });
+
+    // Wait for graceful shutdown, then force kill remaining
+    setTimeout(async () => {
+      await Promise.allSettled(termPromises);
+
+      const alive = processes.filter(({ proc }) => proc.exitCode === null);
+      let killFailed = false;
+
       if (alive.length > 0) {
         console.log(
           chalk.red(`  Force killing remaining processes: ${alive.map((p) => p.name).join(', ')}`)
         );
-        for (const { proc } of alive) {
-          proc.kill('SIGKILL');
-        }
+        const killResults = await Promise.allSettled(
+          alive
+            .filter(({ proc }) => proc.pid)
+            .map(async ({ name, proc }) => {
+              try {
+                await treeKillAsync(proc.pid as number, 'SIGKILL');
+              } catch (err) {
+                console.error(
+                  chalk.yellow(
+                    `  Failed to force kill ${name} (${proc.pid}): ${(err as Error).message}`
+                  )
+                );
+                throw err;
+              }
+            })
+        );
+        killFailed = killResults.some((r) => r.status === 'rejected');
       }
-      process.exit(1);
+
+      process.exit(killFailed ? 1 : 0);
     }, 5000);
   };
 }
@@ -504,9 +557,9 @@ async function startDevelopmentMode(
   await Promise.race([
     createExitPromise(backend, 'Backend', shutdownState),
     createExitPromise(frontend, 'Frontend', shutdownState),
-  ]).catch((error) => {
+  ]).catch(async (error) => {
     console.error(chalk.red(`\n  ✗ ${error.message}`));
-    killAllProcesses(processes);
+    await killAllProcesses(processes);
     process.exit(1);
   });
 }
@@ -558,9 +611,9 @@ async function startProductionMode(
   const onReady = createOnReady(backendPort);
   await onReady();
 
-  await createExitPromise(backend, 'Server', shutdownState).catch((error) => {
+  await createExitPromise(backend, 'Server', shutdownState).catch(async (error) => {
     console.error(chalk.red(`\n  ✗ ${error.message}`));
-    killAllProcesses(processes);
+    await killAllProcesses(processes);
     process.exit(1);
   });
 }


### PR DESCRIPTION
## Summary
- Use `tree-kill` to kill entire process trees when shutting down the dev server (Ctrl+C or SIGTERM)
- Previously, only the direct `npx` child processes received signals, leaving grandchild processes (`tsx`, `vite`, `esbuild` workers) orphaned and still running
- Updates `createShutdownHandler` (SIGTERM + SIGKILL fallback) and `killAllProcesses` to use `treeKill`

## Test plan
- [ ] Run `pnpm dev`, then Ctrl+C — verify no orphaned node/vite processes remain (`ps aux | grep -E 'tsx|vite'`)
- [ ] Run `pnpm dev`, then `kill <pid>` — verify same cleanup behavior
- [ ] `pnpm typecheck` passes
- [ ] `pnpm check:fix` passes (no new lint errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
