### PR TITLE
Fix crash when argumentHint is non-string in slash command cache

### DIFF
--- a/src/backend/services/slash-command-cache.service.ts
+++ b/src/backend/services/slash-command-cache.service.ts
@@ -23,11 +23,14 @@ function isCommandInfo(value: unknown): value is CommandInfo {
 }
 
 function normalizeCommands(commands: CommandInfo[]): CommandInfo[] {
-  return commands.map((command) => ({
-    name: command.name,
-    description: command.description ?? '',
-    argumentHint: command.argumentHint?.trim() ? command.argumentHint : undefined,
-  }));
+  return commands.map((command) => {
+    const hint = typeof command.argumentHint === 'string' ? command.argumentHint.trim() : undefined;
+    return {
+      name: command.name,
+      description: command.description ?? '',
+      argumentHint: hint || undefined,
+    };
+  });
 }
 
 function toCommandInfoArray(value: unknown): CommandInfo[] | null {


### PR DESCRIPTION
## Summary
- Fix `TypeError: command.argumentHint?.trim is not a function` crash in `slash-command-cache.service.ts`
- The CLI initialize response can return `argumentHint` as a non-string value (e.g. array), which passes optional chaining (`?.`) but crashes on `.trim()` since only strings have that method
- Added explicit `typeof command.argumentHint === 'string'` check before calling `.trim()`

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (1349 tests)
- [x] Pre-commit hooks pass (biome, depcruise, knip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized defensive change to input normalization; behavior only changes for malformed/non-string `argumentHint` values.
> 
> **Overview**
> Prevents a runtime crash in the slash command cache normalization when `argumentHint` is present but not a string.
> 
> `normalizeCommands` now explicitly checks `typeof command.argumentHint === 'string'` before calling `.trim()`, and only persists a non-empty trimmed hint; non-string values are treated as absent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0bd560f339476ae56bba33c3811c2c68dda99734. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->