### PR TITLE
Fix agent messages lost when Claude process is replaced

### DIFF
--- a/src/backend/services/chat-event-forwarder.service.ts
+++ b/src/backend/services/chat-event-forwarder.service.ts
@@ -188,6 +188,9 @@ class ChatEventForwarderService {
     if (existingClient) {
       logger.info('[Chat WS] Replacing event forwarding with new client', { dbSessionId });
       this.removeForwardingListeners(dbSessionId, existingClient);
+      // Clear stale interactive requests from the old client so the UI
+      // doesn't try to respond to a request the new client knows nothing about
+      this.pendingInteractiveRequests.delete(dbSessionId);
     }
 
     this.clientEventSetup.set(dbSessionId, client);


### PR DESCRIPTION
## Summary

- Fix agent messages being silently lost when a second Claude process replaces an existing one for the same session
- Change `clientEventSetup` from `Set<string>` to `Map<string, ClaudeClient>` to track which specific client instance has event forwarding, not just the session ID
- When a new client is detected for an already-setup session, tear down old listeners and re-attach to the new client

## Root Cause

`chatEventForwarderService.setupClientEvents()` used a `Set<string>` to guard against duplicate setup. When a second `ClaudeClient` was created for the same DB session (e.g., user switches models, race condition in process creation), the guard saw the session ID was "already set up" and skipped attaching event listeners. The new client's `stream`, `result`, `message` events were never forwarded to WebSocket connections — all messages were silently dropped.

Observed in production: a workspace had two live Claude processes (sonnet + opus) for the same session, created 6 seconds apart. The second client had no event forwarding, causing a completely empty chat.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` — all 1349 tests pass
- [x] `pnpm check:fix` — no lint issues
- [ ] Manual: open a workspace, send messages with different model settings, verify messages appear in real-time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core event-listener lifecycle for chat streaming; incorrect teardown/reattach logic could cause duplicate events or missing forwards, though the change is localized to forwarding setup/cleanup.
> 
> **Overview**
> Fixes cases where chat events were dropped when a session’s `ClaudeClient` instance is replaced.
> 
> `ChatEventForwarderService` now tracks forwarding setup per session *and* client instance (switching `clientEventSetup` from `Set` to `Map`), and when a new client appears for an existing session it removes only this service’s previously-registered listeners, clears stale pending interactive requests, and re-attaches forwarding listeners to the new client. Exit handling is updated to stop using `removeAllListeners()` and instead performs precise teardown to avoid disrupting other client listeners.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0257bbda6a321355bee2973759aa7004cc24ec7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->