### PR TITLE
Fix kanban column scrolling when items overflow

### DIFF
--- a/src/frontend/components/kanban/kanban-board.tsx
+++ b/src/frontend/components/kanban/kanban-board.tsx
@@ -150,7 +150,9 @@ function IssuesColumn({ column, issues, projectId }: IssuesColumnProps) {
           </div>
         ) : (
           issues.map((issue) => (
-            <IssueCard key={issue.number} issue={issue} projectId={projectId} />
+            <div key={issue.number} className="shrink-0">
+              <IssueCard issue={issue} projectId={projectId} />
+            </div>
           ))
         )}
       </div>

--- a/src/frontend/components/kanban/kanban-column.tsx
+++ b/src/frontend/components/kanban/kanban-column.tsx
@@ -55,13 +55,14 @@ export function KanbanColumn({
           </div>
         ) : (
           workspaces.map((workspace) => (
-            <KanbanCard
-              key={workspace.id}
-              workspace={workspace}
-              projectSlug={projectSlug}
-              onToggleRatcheting={onToggleRatcheting}
-              isTogglePending={togglingWorkspaceId === workspace.id}
-            />
+            <div key={workspace.id} className="shrink-0">
+              <KanbanCard
+                workspace={workspace}
+                projectSlug={projectSlug}
+                onToggleRatcheting={onToggleRatcheting}
+                isTogglePending={togglingWorkspaceId === workspace.id}
+              />
+            </div>
           ))
         )}
       </div>


### PR DESCRIPTION
## Summary
Fixes an issue where kanban columns would squish cards instead of scrolling when they contained many items.

## Changes
- Wrapped `KanbanCard` components in kanban columns with `shrink-0` wrapper divs to prevent flexbox shrinking
- Wrapped `IssueCard` components in the GitHub Issues column with `shrink-0` wrapper divs
- This allows columns to properly scroll when content exceeds available height

## Root Cause
When a kanban column had many items, flex child elements were being allowed to shrink by default to fit the container, causing cards to be compressed. By adding `shrink-0` wrappers, we prevent this behavior and enable proper overflow scrolling.

## Test Plan
- [x] TypeScript type checking passes
- [x] All 1349 tests pass
- [x] Biome linting passes
- [x] Pre-commit hooks pass (typecheck, dependency checks, knip)

## Visual Impact
- Kanban columns with many items will now show a scrollbar instead of compressing cards
- Card sizes remain consistent regardless of number of items in column

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, UI-only layout change affecting card rendering in kanban columns; risk is limited to potential minor spacing/scroll regressions.
> 
> **Overview**
> Fixes kanban column overflow behavior by preventing cards from being flex-shrunk when many items are present.
> 
> In `kanban-column.tsx` and the `IssuesColumn` in `kanban-board.tsx`, each `KanbanCard`/`IssueCard` is wrapped in a `div` with `className="shrink-0"`, ensuring consistent card sizing and allowing the column’s `overflow-y-auto` area to scroll rather than squish content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6d0cd9f9466449ecc65c3669d9ef7c6b8f98d97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->