### PR TITLE
Add draggable height resize to live activity feed

### DIFF
--- a/src/components/chat/agent-live-dock.tsx
+++ b/src/components/chat/agent-live-dock.tsx
@@ -109,6 +109,7 @@ export const AgentLiveDock = memo(function AgentLiveDock({
 
   useEffect(() => {
     skipNextPersistRef.current = true;
+    setIsDragging(false);
     const storedOpen = readToolWindowOpen(workspaceId);
     setToolWindowOpen(storedOpen ?? true);
     const storedHeight = readHeight(workspaceId);


### PR DESCRIPTION
## Summary
Users can now drag the bottom edge of the live activity feed to adjust its height dynamically. The height preference is persisted per workspace in localStorage.

## Changes
- Add resize handle at the bottom of the feed with hover/active states
- Implement mouse drag handlers to adjust height in real-time
- Add min (100px) and max (600px) height constraints
- Store height preference in localStorage per workspace
- Replace fixed Tailwind height classes with dynamic inline style

## Test plan
- [x] Run `pnpm typecheck` - passed
- [x] Run `pnpm check:fix` - passed
- [x] Run `pnpm test` - all tests passed
- [ ] Manual testing: verify dragging the bottom edge of the live activity feed resizes it
- [ ] Manual testing: verify height is preserved when switching workspaces
- [ ] Manual testing: verify height constraints (min 100px, max 600px) work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only behavior change with bounded state and `localStorage` persistence; main risk is minor UX regressions from drag handling or height clamping.
> 
> **Overview**
> Adds a draggable resize handle to the `AgentLiveDock` live activity feed, replacing the fixed Tailwind height with a dynamic inline height that updates during mouse drag.
> 
> Persists the chosen height per `workspaceId` in `localStorage` (with min/max clamping) and wires document-level `mousemove`/`mouseup` listeners to manage drag state and save the final height on release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5069e94fb9cebdab8080405e3a8b64bdd16bce0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->