### PR TITLE
Fix issue-workspace startup UI showing idle state

### DIFF
--- a/src/client/routes/projects/workspaces/workspace-detail-chat-content.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-chat-content.tsx
@@ -49,6 +49,7 @@ interface ChatContentProps {
   confirmRewind: ReturnType<typeof useChatWebSocket>['confirmRewind'];
   cancelRewind: ReturnType<typeof useChatWebSocket>['cancelRewind'];
   getUuidForMessageId: ReturnType<typeof useChatWebSocket>['getUuidForMessageId'];
+  autoStartPending?: boolean;
 }
 
 export const ChatContent = memo(function ChatContent({
@@ -87,6 +88,7 @@ export const ChatContent = memo(function ChatContent({
   confirmRewind,
   cancelRewind,
   getUuidForMessageId,
+  autoStartPending = false,
 }: ChatContentProps) {
   const groupedMessages = useMemo(() => groupAdjacentToolCalls(messages), [messages]);
   const latestToolSequence = useMemo(() => {
@@ -117,6 +119,7 @@ export const ChatContent = memo(function ChatContent({
   const running = sessionStatus.phase === 'running';
   const stopping = sessionStatus.phase === 'stopping';
   const startingSession = sessionStatus.phase === 'starting';
+  const displayStartingState = startingSession || autoStartPending;
   const loadingSession = sessionStatus.phase === 'loading';
 
   const permissionRequestId =
@@ -139,6 +142,9 @@ export const ChatContent = memo(function ChatContent({
     if (stopping) {
       return 'Stopping...';
     }
+    if (displayStartingState && !running) {
+      return 'Agent is starting...';
+    }
     if (
       pendingRequest.type === 'permission' &&
       pendingRequest.request.toolName === 'ExitPlanMode'
@@ -157,7 +163,7 @@ export const ChatContent = memo(function ChatContent({
         <VirtualizedMessageList
           messages={groupedMessages}
           running={running}
-          startingSession={startingSession}
+          startingSession={displayStartingState}
           loadingSession={loadingSession}
           scrollContainerRef={viewportRef}
           onScroll={onScroll}
@@ -189,7 +195,7 @@ export const ChatContent = memo(function ChatContent({
         <AgentLiveDock
           workspaceId={workspaceId}
           running={running}
-          starting={startingSession}
+          starting={displayStartingState}
           stopping={stopping}
           permissionMode={permissionMode}
           latestThinking={latestThinking ?? null}

--- a/src/client/routes/projects/workspaces/workspace-detail-container.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-container.tsx
@@ -92,6 +92,13 @@ export function WorkspaceDetailContainer() {
   const running = sessionStatus.phase === 'running';
   const loadingSession = sessionStatus.phase === 'loading';
   const isSessionReady = sessionStatus.phase === 'ready' || sessionStatus.phase === 'running';
+  const isIssueAutoStartPending =
+    workspace?.creationSource === 'GITHUB_ISSUE' &&
+    selectedDbSessionId !== null &&
+    (sessionStatus.phase === 'loading' || sessionStatus.phase === 'ready') &&
+    (processStatus.state === 'unknown' || processStatus.state === 'alive') &&
+    messages.some((message) => message.source === 'user') &&
+    !messages.some((message) => message.source === 'claude');
 
   const wasRunningRef = useRef(false);
   useEffect(() => {
@@ -265,6 +272,7 @@ export function WorkspaceDetailContainer() {
       confirmRewind={confirmRewind}
       cancelRewind={cancelRewind}
       getUuidForMessageId={getUuidForMessageId}
+      isIssueAutoStartPending={isIssueAutoStartPending}
       rightPanelVisible={rightPanelVisible}
       archiveDialogOpen={archiveDialogOpen}
       setArchiveDialogOpen={setArchiveDialogOpen}

--- a/src/client/routes/projects/workspaces/workspace-detail-view.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-view.tsx
@@ -71,6 +71,7 @@ export interface WorkspaceDetailViewProps {
   confirmRewind: ReturnType<typeof useChatWebSocket>['confirmRewind'];
   cancelRewind: ReturnType<typeof useChatWebSocket>['cancelRewind'];
   getUuidForMessageId: ReturnType<typeof useChatWebSocket>['getUuidForMessageId'];
+  isIssueAutoStartPending: boolean;
   rightPanelVisible: boolean;
   archiveDialogOpen: boolean;
   setArchiveDialogOpen: Dispatch<SetStateAction<boolean>>;
@@ -138,6 +139,7 @@ export function WorkspaceDetailView({
   confirmRewind,
   cancelRewind,
   getUuidForMessageId,
+  isIssueAutoStartPending,
   rightPanelVisible,
   archiveDialogOpen,
   setArchiveDialogOpen,
@@ -246,6 +248,7 @@ export function WorkspaceDetailView({
                 confirmRewind={confirmRewind}
                 cancelRewind={cancelRewind}
                 getUuidForMessageId={getUuidForMessageId}
+                autoStartPending={isIssueAutoStartPending}
               />
             </WorkspaceContentView>
           </div>


### PR DESCRIPTION
## Summary
Fixes confusing initial UX when opening a workspace created from a GitHub issue before the agent has fully started.

Previously, the issue prompt could appear while session status still looked idle (gray), which made it seem like the agent had crashed. After refresh, state usually corrected itself.

## What changed
- Added a derived `isIssueAutoStartPending` state in workspace detail container for issue-created workspaces.
- Plumbed this signal into workspace detail chat content.
- Treated this signal as a temporary starting state so UI shows startup feedback consistently:
  - Live activity dock shows `Starting`
  - Message list shows `Starting agent...`
  - Chat input placeholder shows `Agent is starting...`

## Why
Issue-created workspaces auto-inject/send the initial prompt while backend startup events can lag, creating a brief but confusing state gap. This change makes that gap explicit to users.

## Validation
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, client-only state derivation and prop plumbing that only affects startup display logic; low risk aside from potential misclassification of the pending state conditions.
> 
> **Overview**
> Fixes a UX gap for GitHub-issue-created workspaces by deriving an `isIssueAutoStartPending` state and plumbing it into chat UI components.
> 
> While this flag is true, `ChatContent` treats the session as temporarily *starting* (even if the websocket status is still `ready`/`loading`), updating `VirtualizedMessageList`, `AgentLiveDock`, and the chat input placeholder to show “Agent is starting…” instead of an idle-looking state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3905c55fe3a78462888dc12df380d02eae077c10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->