### PR TITLE
Release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to Factory Factory will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 2026-02-06
+
+### Added
+
+- Add draggable height resize to live activity feed (#757)
+- Show starting state for issue workspace auto-start (#758)
+
+### Changed
+
+- Stabilize live activity dock with internal tool scrolling (#754)
+- Clear ratchetActiveSessionId on session exit (#760)
+
+### Fixed
+
+- Fix chat replay flicker by showing loading state during reconnect (#756)
+- Fix agent messages lost when Claude process is replaced (#752)
+- Fix kanban column scrolling when items overflow (#753)
+- Fix crash when argumentHint is non-string in slash command cache (#743)
+
 ## [0.2.2] - 2026-02-06
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "factory-factory",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Workspace-based coding environment for running multiple Claude Code sessions in parallel",
   "private": false,
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Bump version from 0.2.2 to 0.2.3
- Update CHANGELOG.md with all changes since v0.2.2

### Changelog

#### Added
- Add draggable height resize to live activity feed (#757)
- Show starting state for issue workspace auto-start (#758)

#### Changed
- Stabilize live activity dock with internal tool scrolling (#754)
- Clear ratchetActiveSessionId on session exit (#760)

#### Fixed
- Fix chat replay flicker by showing loading state during reconnect (#756)
- Fix agent messages lost when Claude process is replaced (#752)
- Fix kanban column scrolling when items overflow (#753)
- Fix crash when argumentHint is non-string in slash command cache (#743)

## Test plan

- [ ] Verify `pnpm build` succeeds
- [ ] Verify `pnpm test` passes
- [ ] Verify `pnpm typecheck` passes
- [ ] Confirm version in package.json is 0.2.3
- [ ] Confirm CHANGELOG.md entry is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata-only update (version + changelog) with no runtime code changes.
> 
> **Overview**
> Prepares the `v0.2.3` release by bumping the npm package version from `0.2.2` to `0.2.3`.
> 
> Updates `CHANGELOG.md` with a new `0.2.3` entry summarizing recent additions, behavior changes, and bug fixes (no functional code changes included in this PR).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db64c969e30dac7bbcb7cb3021c3ef935c025d3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->