### PR TITLE
Lighten secondary text in dark mode

### DIFF
--- a/src/client/globals.css
+++ b/src/client/globals.css
@@ -158,7 +158,7 @@
   --secondary: oklch(0.22 0 0);
   --secondary-foreground: oklch(0.98 0 0);
   --muted: oklch(0.22 0 0);
-  --muted-foreground: oklch(0.5 0 0);
+  --muted-foreground: oklch(0.65 0 0);
   --accent: oklch(0.22 0 0);
   --accent-foreground: oklch(0.98 0 0);
   /* Factory Yellow: #FFE500 */


### PR DESCRIPTION
## Summary
- Fixes #767
- Increased `--muted-foreground` lightness from 50% to 65% in dark mode for better readability

## Changes
- Updated `src/client/globals.css` to lighten the `--muted-foreground` color in dark mode from `oklch(0.5 0 0)` to `oklch(0.65 0 0)`

## Impact
This change improves readability for all secondary text in dark mode throughout the application, including:
- Kanban column empty states ("Agent is working", etc.)
- Helper text in forms and dialogs
- Secondary information in tables
- Timestamps and metadata displays

The text remains clearly distinguishable as secondary (foreground is at 98% lightness) while being much more readable.

## Test plan
- [ ] Start the app in dark mode
- [ ] View kanban board with empty columns to see "Agent is working" text
- [ ] Navigate through various screens to verify secondary text is more readable
- [ ] Confirm the visual hierarchy is still clear (primary vs secondary text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)