### PR TITLE
Lighten secondary text color in dark mode

### DIFF
--- a/src/client/globals.css
+++ b/src/client/globals.css
@@ -158,7 +158,7 @@
   --secondary: oklch(0.22 0 0);
   --secondary-foreground: oklch(0.98 0 0);
   --muted: oklch(0.22 0 0);
-  --muted-foreground: oklch(0.5 0 0);
+  --muted-foreground: oklch(0.6 0 0);
   --accent: oklch(0.22 0 0);
   --accent-foreground: oklch(0.98 0 0);
   /* Factory Yellow: #FFE500 */


### PR DESCRIPTION
## Summary
Fixes #767

Increases the muted-foreground color lightness in dark mode from 50% to 60% (oklch lightness value). This makes secondary text elements more readable in dark mode, including:
- Kanban column placeholders (e.g., "Agent is working")
- Description text throughout the UI
- Other muted/secondary content

## Changes
- Updated `--muted-foreground` CSS variable in dark mode from `oklch(0.5 0 0)` to `oklch(0.6 0 0)`

## Test plan
- [x] Run `pnpm typecheck` - passes
- [x] Run `pnpm check:fix` - passes  
- [ ] Visual verification: Open the app in dark mode and check that secondary text in kanban columns and other UI elements is lighter and more readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)