### PR TITLE
Format statuses in status dropdown

### DIFF
--- a/src/client/routes/projects/workspaces/components/workspaces-table-view.tsx
+++ b/src/client/routes/projects/workspaces/components/workspaces-table-view.tsx
@@ -22,6 +22,7 @@ import { WorkspaceStatusBadge } from '@/components/workspace/workspace-status-ba
 import { CIFailureWarning } from '@/frontend/components/ci-failure-warning';
 import { Loading } from '@/frontend/components/loading';
 import { PageHeader } from '@/frontend/components/page-header';
+import { formatStatusLabel } from '@/lib/formatters';
 import { NewWorkspaceButton } from './new-workspace-button';
 import { ResumeBranchButton } from './resume-branch-button';
 import type { ViewMode } from './types';
@@ -69,7 +70,7 @@ export function WorkspacesTableView({
             <SelectItem value="all">All Statuses</SelectItem>
             {workspaceStatuses.map((status) => (
               <SelectItem key={status} value={status}>
-                {status}
+                {formatStatusLabel(status)}
               </SelectItem>
             ))}
           </SelectContent>

--- a/src/lib/formatters.test.ts
+++ b/src/lib/formatters.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { formatBytes, formatCpu, formatIdleTime, formatStatusLabel } from './formatters';
+
+describe('formatBytes', () => {
+  it('formats null/undefined as -', () => {
+    expect(formatBytes(null)).toBe('-');
+    expect(formatBytes(undefined)).toBe('-');
+  });
+
+  it('formats bytes correctly', () => {
+    expect(formatBytes(500)).toBe('500 B');
+    expect(formatBytes(1500)).toBe('1.5 KB');
+    expect(formatBytes(1_500_000)).toBe('1.4 MB');
+    expect(formatBytes(1_500_000_000)).toBe('1.40 GB');
+  });
+});
+
+describe('formatCpu', () => {
+  it('formats null/undefined as -', () => {
+    expect(formatCpu(null)).toBe('-');
+    expect(formatCpu(undefined)).toBe('-');
+  });
+
+  it('formats CPU percentage correctly', () => {
+    expect(formatCpu(25.5)).toBe('25.5%');
+    expect(formatCpu(100)).toBe('100.0%');
+  });
+});
+
+describe('formatIdleTime', () => {
+  it('formats null/undefined as -', () => {
+    expect(formatIdleTime(null)).toBe('-');
+    expect(formatIdleTime(undefined)).toBe('-');
+  });
+
+  it('formats idle time correctly', () => {
+    expect(formatIdleTime(500)).toBe('500ms');
+    expect(formatIdleTime(5000)).toBe('5s');
+    expect(formatIdleTime(120_000)).toBe('2.0m');
+  });
+});
+
+describe('formatStatusLabel', () => {
+  it('formats ALL_CAPS status to capitalized', () => {
+    expect(formatStatusLabel('NEW')).toBe('New');
+    expect(formatStatusLabel('PROVISIONING')).toBe('Provisioning');
+    expect(formatStatusLabel('READY')).toBe('Ready');
+    expect(formatStatusLabel('FAILED')).toBe('Failed');
+    expect(formatStatusLabel('ARCHIVED')).toBe('Archived');
+  });
+
+  it('handles mixed case input', () => {
+    expect(formatStatusLabel('MiXeD')).toBe('Mixed');
+  });
+
+  it('handles lowercase input', () => {
+    expect(formatStatusLabel('lowercase')).toBe('Lowercase');
+  });
+});

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -126,3 +126,11 @@ export function formatDateTimeShort(dateStr: string): string {
     return dateStr;
   }
 }
+
+/**
+ * Format status label from ALL_CAPS to Capitalized format.
+ * Used for displaying status labels in dropdowns and UI elements.
+ */
+export function formatStatusLabel(status: string): string {
+  return status.charAt(0).toUpperCase() + status.slice(1).toLowerCase();
+}


### PR DESCRIPTION
## Summary
- Added `formatStatusLabel()` utility function to format status labels from ALL_CAPS to capitalized format
- Updated workspaces table view to display status labels as "New", "Ready", "Provisioning", "Failed", "Archived" instead of all caps
- Added comprehensive tests for the new formatter function

## Test plan
- [x] All existing tests pass (`pnpm test`)
- [x] TypeScript type checking passes (`pnpm typecheck`)
- [x] Linter and formatter pass (`pnpm check:fix`)
- [x] Added unit tests for `formatStatusLabel()` function
- [x] Manually verified status dropdown displays properly formatted labels

Fixes #764

🤖 Generated with [Claude Code](https://claude.com/claude-code)
