### PR TITLE
Add persistent visual indicator for WAITING workspaces

### DIFF
--- a/src/frontend/components/app-sidebar.tsx
+++ b/src/frontend/components/app-sidebar.tsx
@@ -74,7 +74,7 @@ function getProjectSlugFromPath(pathname: string): string | null {
 
 /**
  * Get status dot color class for a workspace.
- * Priority: working > merged > CI failure > CI pending > CI success > uncommitted > default
+ * Priority: working > merged > CI failure > CI pending > CI success > uncommitted > waiting > default
  */
 function getStatusDotClass(workspace: WorkspaceListItem): string {
   if (workspace.isWorking) {
@@ -94,6 +94,9 @@ function getStatusDotClass(workspace: WorkspaceListItem): string {
   }
   if (workspace.gitStats?.hasUncommitted) {
     return 'bg-orange-500';
+  }
+  if (workspace.cachedKanbanColumn === 'WAITING') {
+    return 'bg-amber-500 animate-pulse';
   }
   return 'bg-gray-400';
 }
@@ -120,6 +123,9 @@ function getStatusTooltip(workspace: WorkspaceListItem): string {
   }
   if (workspace.gitStats?.hasUncommitted) {
     return 'Uncommitted changes';
+  }
+  if (workspace.cachedKanbanColumn === 'WAITING') {
+    return 'Waiting for input';
   }
   return 'Ready';
 }


### PR DESCRIPTION
## Summary
- Added pulsing amber status dot for workspaces in the WAITING state
- Provides persistent visual indication that remains visible until user interacts with the workspace
- Complements existing notification system (sound and temporary 30-second red glow)

## Problem
When users have multiple workspaces and hear the notification sound ("owl hoot"), there was no way to identify which workspace needs attention after the 30-second temporary attention glow expires. This made it difficult to find the waiting workspace among 10+ active workspaces.

## Solution
Added a check for `cachedKanbanColumn === 'WAITING'` in the status dot logic:
- **Visual indicator**: Pulsing amber dot (similar to CI pending state)
- **Tooltip**: "Waiting for input"
- **Priority**: Positioned after uncommitted changes but before default state
- **Persistence**: Remains visible as long as workspace is in WAITING column

## Test plan
- [x] Code passes type checks (`pnpm typecheck`)
- [x] Code passes linting (`pnpm check:fix`)
- [ ] Manual testing: Create a workspace, complete a session, verify amber pulsing dot appears
- [ ] Manual testing: Verify tooltip shows "Waiting for input"
- [ ] Manual testing: Verify indicator persists after 30-second attention glow expires
- [ ] Manual testing: Verify indicator respects priority (doesn't override CI or merge states)

Fixes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)