### PR TITLE
Fix task list clipping and blank state during TodoWrite

### DIFF
--- a/src/components/chat/todo-panel.tsx
+++ b/src/components/chat/todo-panel.tsx
@@ -48,7 +48,7 @@ export const TodoPanel = memo(function TodoPanel({ todoState }: TodoPanelProps) 
         </div>
 
         {/* Todo List */}
-        <div className="space-y-1.5 max-h-48 overflow-y-auto">
+        <div className="space-y-1.5 overflow-y-auto">
           {todos.map((todo, index) => (
             <TodoItem key={`${todo.content}-${index}`} todo={todo} />
           ))}

--- a/src/components/chat/use-todo-tracker.ts
+++ b/src/components/chat/use-todo-tracker.ts
@@ -68,7 +68,8 @@ function extractTodosFromStreamEvent(
     if (isTodoWriteInput(block.input)) {
       return calculateTodoState(block.input.todos, timestamp);
     }
-    return calculateTodoState([], timestamp);
+    // Don't return empty state for incomplete input - keep showing previous state
+    return null;
   }
 
   return null;
@@ -90,7 +91,8 @@ function extractTodosFromAssistantMessage(
       if (isTodoWriteInput(item.input)) {
         return calculateTodoState(item.input.todos, timestamp);
       }
-      return calculateTodoState([], timestamp);
+      // Don't return empty state for incomplete input - keep showing previous state
+      return null;
     }
   }
 


### PR DESCRIPTION
## Summary
Fixes #784 

This PR resolves two issues with the task list in the side panel:

1. **Task list clipping**: Removed the `max-h-48` constraint that limited the visible area to ~8 tasks. Now all tasks can be scrolled through.

2. **Blank state during TodoWrite**: Fixed the issue where the task list would temporarily go blank during a TodoWrite operation. The root cause was that when streaming tool uses with incomplete input, the code was returning an empty array instead of `null`, which caused the component to briefly show no tasks. Now it returns `null` for incomplete input, preserving the previous todo state during streaming.

## Changes
- `src/components/chat/todo-panel.tsx`: Removed `max-h-48` constraint from todo list container
- `src/components/chat/use-todo-tracker.ts`: Return `null` instead of empty array when TodoWrite input is incomplete

## Test plan
- ✅ TypeScript type checking passes
- ✅ Linting passes
- ✅ Pre-commit hooks pass
- Manual testing needed: Verify that task lists with >8 items are fully scrollable and don't go blank during TodoWrite operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UI/layout tweak plus a conservative state-handling change for incomplete streaming tool inputs; low chance of affecting other chat behavior.
> 
> **Overview**
> Fixes todo panel UX issues by removing the fixed height cap so longer task lists don’t get clipped and can scroll fully.
> 
> Updates `use-todo-tracker` to **stop emitting an empty todo state** when a `TodoWrite` tool use arrives with incomplete input (streaming), returning `null` instead so the UI keeps showing the last known tasks instead of briefly going blank.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce31d570a3e65127748b77e0b504ddc390972b6a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->