### PR TITLE
Enable noImplicitOverride TypeScript compiler option

### DIFF
--- a/src/client/error-boundary.tsx
+++ b/src/client/error-boundary.tsx
@@ -20,7 +20,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     return { hasError: true, error };
   }
 
-  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+  override componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     // biome-ignore lint/suspicious/noConsole: Error logging is intentional for debugging
     console.error('ErrorBoundary caught an error:', error, errorInfo);
   }
@@ -29,7 +29,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     this.setState({ hasError: false, error: null });
   };
 
-  render() {
+  override render() {
     if (this.state.hasError) {
       if (this.props.fallback) {
         return this.props.fallback;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,7 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
     "skipLibCheck": true,
     "isolatedModules": true,
     "plugins": [


### PR DESCRIPTION
## Summary
- Enable `noImplicitOverride` TypeScript compiler option in tsconfig.json
- Add `override` keywords to ErrorBoundary component methods that override React.Component base class methods

## Changes
- **tsconfig.json**: Add `noImplicitOverride: true` to compiler options
- **src/client/error-boundary.tsx**: Add `override` keyword to `componentDidCatch` and `render` methods

## Benefits
- Improves code clarity by making overrides explicit
- Prevents accidental method overrides
- Aligns with TypeScript best practices for class inheritance

## Test plan
- ✅ `pnpm typecheck` passes with no errors
- ✅ `pnpm test` passes all tests
- ✅ `pnpm check:fix` passes linting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-safety configuration change with minimal code edits; primary risk is new compile errors surfacing in other overridden methods during CI/build.
> 
> **Overview**
> Enables the TypeScript compiler option `noImplicitOverride` to require explicit `override` annotations for class members that override base implementations.
> 
> Updates `ErrorBoundary` to add `override` on `componentDidCatch` and `render` to satisfy the new compiler rule (no runtime behavior changes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2be47bbef138856dbe890e7d6c19997a27f1ddda. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->