### PR TITLE
Move live activity drag handle from bottom to top

### DIFF
--- a/src/components/chat/agent-live-dock.tsx
+++ b/src/components/chat/agent-live-dock.tsx
@@ -140,7 +140,7 @@ export const AgentLiveDock = memo(function AgentLiveDock({
     }
 
     const handleMouseMove = (e: MouseEvent) => {
-      const deltaY = e.clientY - startYRef.current;
+      const deltaY = startYRef.current - e.clientY;
       const newHeight = Math.max(MIN_HEIGHT, Math.min(MAX_HEIGHT, startHeightRef.current + deltaY));
       setHeight(newHeight);
     };
@@ -148,7 +148,7 @@ export const AgentLiveDock = memo(function AgentLiveDock({
     const handleMouseUp = (e: MouseEvent) => {
       setIsDragging(false);
       // Calculate the final height directly to avoid stale closure
-      const deltaY = e.clientY - startYRef.current;
+      const deltaY = startYRef.current - e.clientY;
       const finalHeight = Math.max(
         MIN_HEIGHT,
         Math.min(MAX_HEIGHT, startHeightRef.current + deltaY)
@@ -219,7 +219,7 @@ export const AgentLiveDock = memo(function AgentLiveDock({
       <button
         type="button"
         className={cn(
-          'absolute bottom-0 left-0 right-0 h-1.5 cursor-ns-resize hover:bg-primary/20 transition-colors border-0 p-0',
+          'absolute top-0 left-0 right-0 h-1.5 cursor-ns-resize hover:bg-primary/20 transition-colors border-0 p-0',
           isDragging && 'bg-primary/30'
         )}
         onMouseDown={handleMouseDown}


### PR DESCRIPTION
## Summary
- Moved the drag handle from the bottom to the top of the live activity panel
- Reversed the drag direction logic so dragging up expands the panel and dragging down shrinks it

The previous bottom placement was unintuitive. With the handle at the top, the interaction is more natural for a bottom-docked component.

## Test plan
- [ ] Open a workspace with live agent activity
- [ ] Verify the drag handle appears at the top of the activity panel
- [ ] Drag up and verify the panel expands
- [ ] Drag down and verify the panel shrinks
- [ ] Verify the height persists across workspace switches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated UI interaction change to resize logic and handle positioning with no security or data-handling impact.
> 
> **Overview**
> Updates `AgentLiveDock` resizing to match a top-mounted drag handle on the live activity panel.
> 
> The resize handle is repositioned from `bottom-0` to `top-0`, and the drag delta calculation is inverted so dragging up increases the panel height (and dragging down decreases it) while keeping the same min/max clamping and persisted height behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7975b59d21044922879c5b87d7a7717be36e1355. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->