### PR TITLE
Fix #801: Simplify agent status to unified field

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,7 @@ enum WorkspaceStatus {
 
 enum SessionStatus {
   IDLE
+  STARTING  // Process initiated but not yet fully running
   RUNNING
   PAUSED
   COMPLETED

--- a/src/backend/services/session.service.ts
+++ b/src/backend/services/session.service.ts
@@ -64,6 +64,11 @@ class SessionService {
       throw new Error('Session is already running');
     }
 
+    // Set STARTING status before creating client
+    await this.repository.updateSession(sessionId, {
+      status: SessionStatus.STARTING,
+    });
+
     // Use getOrCreateClient for race-protected creation
     // If concurrent starts happen, one will succeed and others will wait then fail the check above
     const client = await this.getOrCreateClient(sessionId, {

--- a/src/shared/schemas/export-data.schema.ts
+++ b/src/shared/schemas/export-data.schema.ts
@@ -33,7 +33,7 @@ const RatchetState = z.enum([
   'READY',
   'MERGED',
 ]);
-const SessionStatus = z.enum(['IDLE', 'RUNNING', 'PAUSED', 'COMPLETED', 'FAILED']);
+const SessionStatus = z.enum(['IDLE', 'STARTING', 'RUNNING', 'PAUSED', 'COMPLETED', 'FAILED']);
 
 const exportedProjectSchema = z.object({
   id: z.string(),


### PR DESCRIPTION
## Summary
- Added unified `agentStatus` field to workspace status combining agent activity and CI state
- Implemented `STARTING` session status to track process initialization state
- Simplified status computation to avoid confusion from multiple status indicators

## Changes
- **Schema**: Added `STARTING` state to `SessionStatus` enum for clear process initialization tracking
- **Backend**:
  - Set session status to `STARTING` before client creation in session service
  - Track `isStarting` flag in workspace query service
  - Extract `computeWorkspaceStatuses` helper to reduce complexity
- **Shared**:
  - Add unified `agentStatus` field to `WorkspaceSidebarStatus` with states: IDLE, STARTING, WORKING, CI_RUNNING, CI_PASSING, CI_FAILING, MERGED
  - Add helper functions `getWorkspaceAgentStatusLabel` and `getWorkspaceAgentStatusTooltip`
  - Update export schema to include `STARTING` status
- **Tests**: Added comprehensive test coverage for new status logic including STARTING state and unified status computation

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Verified that agent status shows correct state when:
  - Agent is idle
  - Agent process is starting (brief state)
  - Agent is working
  - PR has CI running/passing/failing
  - PR is merged

Closes #801

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persisted session/workspace status fields and derivation logic used for UI state, so regressions could misreport activity/CI state or leave sessions stuck in `STARTING` if errors occur.
> 
> **Overview**
> Adds a new `SessionStatus.STARTING` state and updates session startup to persist `STARTING` before client creation, then transition to `RUNNING` once the Claude process is ready.
> 
> Simplifies workspace status reporting by computing per-workspace `isStarting` and returning a unified `sidebarStatus.agentStatus` (IDLE/STARTING/WORKING/CI_* /MERGED) derived from work activity, PR presence, CI, and ratchet state; export/import validation is updated to accept the new session status, and sidebar status tests are expanded to cover the new priority/derivation rules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 049875ec010fc26c9f18539d163c3ee9b4bf7953. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->