### PR TITLE
Release v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to Factory Factory will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.5] - 2026-02-07
+
+### Added
+
+- Centralize sidebar status and add CI chip (#799)
+- Enable concurrent multi-workspace archiving (#787)
+- Enhance GitHub issue prompt with orchestrated workflow (#783)
+
+### Changed
+
+- Unify session runtime status model and transport (#807)
+- Unify CI status icons across workspace views (#806)
+- Simplify ratchet to a single idle-gated dispatch loop (#798)
+- Batch session hydration to eliminate tab-switch replay flicker (#797)
+- Move live activity drag handle from bottom to top (#796)
+- Improve archiving workspace overlay with multi-ring animation (#791)
+- Enable noImplicitOverride TypeScript compiler option (#795)
+- Increase Vite chunk size warning limit to 5MB
+- Update homepage URL to https://factoryfactory.ai
+
+### Fixed
+
+- Fix sidebar width localStorage persistence (#808)
+- Fix #800: Unify the Markdown loading logic (#804)
+- Fix #727: Introduce guarded run-script runtime state machine (#792)
+- Fix #750: Add lint guardrails for unsafe JSON.parse casts and unknown resolver casts (#794)
+- Fix #747: Validate persisted JSON stores with Zod schemas (#793)
+- Fix #748: Use shared schema for frontend backup import parsing (#789)
+- Fix #746: Schema-validate GitHub CLI JSON responses (#788)
+- Fix task list clipping and blank state during TodoWrite (#784, #786)
+- Fix queued message ordering to use dispatch time instead of queue time (#782)
+
+### Refactored
+
+- Validate Claude stream JSON and session JSONL inputs at parse boundaries (#745, #790)
+- Refactor chat handler registry to eliminate message payload casts (#785)
+
 ## [0.2.4] - 2026-02-06
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "factory-factory",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Workspace-based coding environment for running multiple Claude Code sessions in parallel",
   "private": false,
   "license": "MIT",
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/purplefish-ai/factory-factory/issues"
   },
-  "homepage": "https://github.com/purplefish-ai/factory-factory#readme",
+  "homepage": "https://factoryfactory.ai",
   "keywords": [
     "claude",
     "claude-code",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
   },
   build: {
     outDir: 'dist/client',
-    chunkSizeWarningLimit: 3000,
+    chunkSizeWarningLimit: 5000,
   },
   server: {
     proxy: {


### PR DESCRIPTION
## Summary

- Bump version to 0.2.5
- Increase Vite chunk size warning limit from 3MB to 5MB
- Update homepage URL to https://factoryfactory.ai

## Test plan

- [x] All files committed successfully
- [x] Pre-commit hooks passed (biome, typecheck, deps:check, knip)
- [x] CHANGELOG.md updated with release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release bookkeeping and build-warning threshold changes only; no runtime logic changes included in this PR.
> 
> **Overview**
> Cuts the `0.2.5` release by bumping the npm package version and adding the `0.2.5` release notes to `CHANGELOG.md`.
> 
> Also updates package metadata to point `homepage` at `https://factoryfactory.ai` and raises Vite’s `chunkSizeWarningLimit` from `3000` to `5000` (5MB).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0deadb57f0c7f96f4256626ea976dff21d0b5c6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->