### PR TITLE
Fix #771: Identify pending plan approval and user questions in Kanban and sidebar

### DIFF
--- a/src/backend/services/chat-event-forwarder.service.ts
+++ b/src/backend/services/chat-event-forwarder.service.ts
@@ -737,6 +737,14 @@ class ChatEventForwarderService {
   }
 
   /**
+   * Get all pending interactive requests indexed by session ID.
+   * Used by workspace query service to determine which workspaces have pending requests.
+   */
+  getAllPendingRequests(): Map<string, PendingInteractiveRequest> {
+    return new Map(this.pendingInteractiveRequests);
+  }
+
+  /**
    * Notify interceptors about tool results.
    */
   private notifyToolResultInterceptors(

--- a/src/frontend/components/kanban/kanban-card.tsx
+++ b/src/frontend/components/kanban/kanban-card.tsx
@@ -1,5 +1,5 @@
 import type { KanbanColumn, Workspace, WorkspaceStatus } from '@prisma-gen/browser';
-import { Archive, GitBranch, GitPullRequest } from 'lucide-react';
+import { Archive, FileCheck, GitBranch, GitPullRequest, MessageCircleQuestion } from 'lucide-react';
 import { Link } from 'react-router';
 import { CiStatusChip } from '@/components/shared/ci-status-chip';
 import { Badge } from '@/components/ui/badge';
@@ -14,6 +14,7 @@ export interface WorkspaceWithKanban extends Workspace {
   ratchetButtonAnimated?: boolean;
   flowPhase?: string | null;
   isArchived?: boolean;
+  pendingRequestType?: 'plan_approval' | 'user_question' | null;
 }
 
 interface KanbanCardProps {
@@ -55,13 +56,88 @@ function CardStatusIndicator({
   return <WorkspaceStatusBadge status={status} errorMessage={errorMessage} />;
 }
 
+function PendingRequestBadge({ type }: { type: 'plan_approval' | 'user_question' }) {
+  if (type === 'plan_approval') {
+    return (
+      <Badge
+        variant="outline"
+        className="text-[10px] gap-1 bg-amber-500/10 text-amber-700 dark:text-amber-400 border-amber-500/30"
+      >
+        <FileCheck className="h-2.5 w-2.5" />
+        Plan Approval Needed
+      </Badge>
+    );
+  }
+  return (
+    <Badge
+      variant="outline"
+      className="text-[10px] gap-1 bg-blue-500/10 text-blue-700 dark:text-blue-400 border-blue-500/30"
+    >
+      <MessageCircleQuestion className="h-2.5 w-2.5" />
+      Question Waiting
+    </Badge>
+  );
+}
+
+function CardMetadataRow({
+  workspace,
+  ratchetEnabled,
+  isTogglePending,
+  isArchived,
+  onToggleRatcheting,
+  showPR,
+}: {
+  workspace: WorkspaceWithKanban;
+  ratchetEnabled: boolean;
+  isTogglePending: boolean;
+  isArchived: boolean;
+  onToggleRatcheting?: (workspaceId: string, enabled: boolean) => void;
+  showPR: boolean;
+}) {
+  return (
+    <div className="flex items-center gap-2 text-[11px] text-muted-foreground min-w-0">
+      <RatchetToggleButton
+        enabled={ratchetEnabled}
+        state={workspace.ratchetState}
+        animated={workspace.ratchetButtonAnimated ?? false}
+        className="h-5 w-5 shrink-0"
+        disabled={isTogglePending || isArchived || !onToggleRatcheting}
+        stopPropagation
+        onToggle={(enabled) => {
+          onToggleRatcheting?.(workspace.id, enabled);
+        }}
+      />
+      {workspace.branchName && (
+        <>
+          <GitBranch className="h-3 w-3 shrink-0" />
+          <span className="font-mono truncate">{workspace.branchName}</span>
+        </>
+      )}
+      {showPR && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            window.open(workspace.prUrl as string, '_blank', 'noopener,noreferrer');
+          }}
+          className="ml-auto inline-flex items-center gap-1 text-muted-foreground hover:text-foreground"
+        >
+          <GitPullRequest className="h-3 w-3" />
+          <span>#{workspace.prNumber}</span>
+        </button>
+      )}
+    </div>
+  );
+}
+
 export function KanbanCard({
   workspace,
   projectSlug,
   onToggleRatcheting,
   isTogglePending = false,
 }: KanbanCardProps) {
-  const showPR = workspace.prState !== 'NONE' && workspace.prNumber && workspace.prUrl;
+  const showPR = Boolean(workspace.prState !== 'NONE' && workspace.prNumber && workspace.prUrl);
   const isArchived = workspace.isArchived || workspace.status === 'ARCHIVED';
   const ratchetEnabled = workspace.ratchetEnabled ?? true;
 
@@ -96,43 +172,24 @@ export function KanbanCard({
           </div>
         </CardHeader>
         <CardContent className="space-y-2">
-          <div className="flex items-center gap-2 text-[11px] text-muted-foreground min-w-0">
-            <RatchetToggleButton
-              enabled={ratchetEnabled}
-              state={workspace.ratchetState}
-              animated={workspace.ratchetButtonAnimated ?? false}
-              className="h-5 w-5 shrink-0"
-              disabled={isTogglePending || isArchived || !onToggleRatcheting}
-              stopPropagation
-              onToggle={(enabled) => {
-                onToggleRatcheting?.(workspace.id, enabled);
-              }}
-            />
-            {workspace.branchName && (
-              <>
-                <GitBranch className="h-3 w-3 shrink-0" />
-                <span className="font-mono truncate">{workspace.branchName}</span>
-              </>
-            )}
-            {showPR && (
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  window.open(workspace.prUrl as string, '_blank', 'noopener,noreferrer');
-                }}
-                className="ml-auto inline-flex items-center gap-1 text-muted-foreground hover:text-foreground"
-              >
-                <GitPullRequest className="h-3 w-3" />
-                <span>#{workspace.prNumber}</span>
-              </button>
-            )}
-          </div>
+          <CardMetadataRow
+            workspace={workspace}
+            ratchetEnabled={ratchetEnabled}
+            isTogglePending={isTogglePending}
+            isArchived={isArchived}
+            onToggleRatcheting={onToggleRatcheting}
+            showPR={showPR}
+          />
 
           {sidebarStatus.ciState !== 'NONE' && (
             <div className="flex items-center gap-2 text-xs text-muted-foreground">
               <CiStatusChip ciState={sidebarStatus.ciState} prState={workspace.prState} size="sm" />
+            </div>
+          )}
+
+          {workspace.pendingRequestType && (
+            <div className="flex items-center gap-2">
+              <PendingRequestBadge type={workspace.pendingRequestType} />
             </div>
           )}
 

--- a/src/frontend/components/use-workspace-list-state.ts
+++ b/src/frontend/components/use-workspace-list-state.ts
@@ -33,6 +33,7 @@ export interface ServerWorkspace {
   cachedKanbanColumn?: string | null;
   stateComputedAt?: string | null;
   sidebarStatus?: WorkspaceSidebarStatus;
+  pendingRequestType?: 'plan_approval' | 'user_question' | null;
 }
 
 export interface WorkspaceListItem extends ServerWorkspace {

--- a/src/frontend/components/workspace-sidebar-items.tsx
+++ b/src/frontend/components/workspace-sidebar-items.tsx
@@ -1,5 +1,12 @@
 import type { useSortable } from '@dnd-kit/sortable';
-import { Archive, CheckCircle2, GitPullRequest, GripVertical } from 'lucide-react';
+import {
+  Archive,
+  CheckCircle2,
+  FileCheck,
+  GitPullRequest,
+  GripVertical,
+  MessageCircleQuestion,
+} from 'lucide-react';
 import { Link } from 'react-router';
 import { CiStatusChip } from '@/components/shared/ci-status-chip';
 import { SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
@@ -212,6 +219,28 @@ export function ActiveWorkspaceItem({
                   <TooltipContent side="right">Archive</TooltipContent>
                 </Tooltip>
               </div>
+
+              {/* Pending request indicator */}
+              {workspace.pendingRequestType && (
+                <div className="flex items-center gap-1 text-[10px] leading-tight mt-0.5">
+                  {workspace.pendingRequestType === 'plan_approval' && (
+                    <>
+                      <FileCheck className="h-2.5 w-2.5 text-amber-600 dark:text-amber-400" />
+                      <span className="text-amber-700 dark:text-amber-400 font-medium">
+                        Plan Approval Needed
+                      </span>
+                    </>
+                  )}
+                  {workspace.pendingRequestType === 'user_question' && (
+                    <>
+                      <MessageCircleQuestion className="h-2.5 w-2.5 text-blue-600 dark:text-blue-400" />
+                      <span className="text-blue-700 dark:text-blue-400 font-medium">
+                        Question Waiting
+                      </span>
+                    </>
+                  )}
+                </div>
+              )}
 
               {/* Row 2: branch name */}
               {workspace.branchName && (


### PR DESCRIPTION
## Summary
- Adds visual indicators in the Kanban board and sidebar to show when agents are waiting for plan approval or have user questions
- Helps users quickly identify workspaces that need attention without opening each one
- Uses color-coded badges: amber for plan approval, blue for user questions

## Changes
- **Backend**: Track pending requests from active sessions (ExitPlanMode and AskUserQuestion) and expose via workspace query endpoints
- **Kanban Board**: Display badges showing "Plan Approval Needed" or "Question Waiting" in workspace cards
- **Sidebar**: Add inline indicators with icons and labels for pending requests
- **Refactoring**: Reduced complexity in KanbanCard component by extracting helper components

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Verify badges appear when agent has pending plan approval or user question

Closes #771

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new cross-service state derived from in-memory session data into workspace list responses, which could cause stale/incorrect UI indicators if pending-request lifecycle handling is incomplete; otherwise changes are additive UI and query fields.
> 
> **Overview**
> Workspaces returned by `getProjectSummaryState` and `listWithKanbanState` now include a `pendingRequestType` field that indicates whether any active session is waiting on `ExitPlanMode` (*plan approval*) or `AskUserQuestion` (*user question*), derived from chat forwarder pending interactive requests.
> 
> The frontend consumes this new field to show color-coded “Plan Approval Needed” / “Question Waiting” indicators in both Kanban cards and the workspace sidebar, with a small `KanbanCard` refactor to extract metadata/badge subcomponents.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe642abf961c73eb834f55e6cafe26323e3850cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->