### PR TITLE
Fix ratchet idle check for non-ratchet sessions

### DIFF
--- a/src/backend/services/ratchet.service.ts
+++ b/src/backend/services/ratchet.service.ts
@@ -664,9 +664,7 @@ class RatchetService {
       if (session.workflow === RATCHET_WORKFLOW) {
         return false;
       }
-      return (
-        session.status === SessionStatus.RUNNING || sessionService.isSessionRunning(session.id)
-      );
+      return sessionService.isSessionWorking(session.id);
     });
   }
 


### PR DESCRIPTION
## Summary
- Fix ratchet idle gating to ignore non-ratchet sessions that are alive but idle.
- Previously, ratcheting could be blocked by any non-ratchet session with DB status `RUNNING` or an alive process.
- Now, ratchet blocks only when a non-ratchet session is actually working (`sessionService.isSessionWorking`).

## Why
Ratcheting should only be blocked by active user/agent work in the workspace. An idle-but-alive session should not prevent ratchet from dispatching.

## Changes
- `src/backend/services/ratchet.service.ts`
  - `hasNonRatchetActiveSession(...)` now checks `sessionService.isSessionWorking(session.id)` for non-ratchet sessions.
- `src/backend/services/ratchet.service.test.ts`
  - Added `isSessionWorking` mock wiring.
  - Updated busy-session test to explicitly mock a working session.
  - Added test coverage for running-but-idle non-ratchet session still allowing ratchet dispatch.

## Validation
- `pnpm test src/backend/services/ratchet.service.test.ts`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the condition that suppresses ratchet dispatch, which could increase/alter dispatch frequency if `isSessionWorking` misclassifies sessions. Scope is small and covered by targeted unit tests.
> 
> **Overview**
> Updates ratchet idle gating so **non-ratchet sessions only block dispatch when they’re actually doing work**, switching `hasNonRatchetActiveSession` from DB/runtime "running" checks to `sessionService.isSessionWorking(session.id)`.
> 
> Extends `ratchet.service.test.ts` to mock `isSessionWorking`, explicitly cover the "busy" case, and add a new test ensuring ratchet still dispatches when a non-ratchet session is alive but idle.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eece36943b1c2e0577a49bde2019beaaf1e01555. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->