### PR TITLE
Fix tool preview height clipping in live activity box

### DIFF
--- a/src/components/chat/agent-live-dock.tsx
+++ b/src/components/chat/agent-live-dock.tsx
@@ -184,9 +184,10 @@ export const AgentLiveDock = memo(function AgentLiveDock({
   }
 
   // Calculate max height for tool details based on available space
-  // Container has: py-3 (24px padding) + Header (~32px) + mt-3 (12px top margin)
-  // When thinking is present, also account for: thinking section (~60px) + space-y-3 gap (12px)
-  const baseOverhead = 68; // py-3 (24px) + header (~32px) + mt-3 (12px)
+  // Container overhead: py-3 (24px) + Header (~32px) + mt-3 (12px) + tool trigger button (~28px)
+  // When thinking is present: thinking section (~60px) + space-y-3 gap (12px)
+  // The maxHeight is applied to CollapsibleContent which includes labels/padding internally
+  const baseOverhead = 84; // py-3 (24px) + header (~24px) + mt-3 (12px) + trigger (~24px)
   const thinkingReserve = hasThinking ? 72 : 0; // thinking height (~60px) + space-y-3 gap (12px)
   const toolDetailsMaxHeight = Math.max(60, height - baseOverhead - thinkingReserve);
 


### PR DESCRIPTION
## Summary
- Fix tool preview content being clipped in the resizable live activity box
- Increase `baseOverhead` from 68px to 84px to account for the tool trigger button height in the height calculation
- The `maxHeight` applied to `CollapsibleContent` now accurately reflects available space

## Test plan
- [ ] Open a workspace with a running agent
- [ ] Resize the live activity box and verify tool preview content is not clipped
- [ ] Verify with thinking section present and absent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change to height calculation for a scrollable/collapsible panel; low risk aside from minor layout regressions across screen sizes.
> 
> **Overview**
> Fixes tool preview content being clipped inside the resizable *Live activity* dock by adjusting the available-height calculation for tool details.
> 
> `AgentLiveDock` now reserves additional vertical space (updates `baseOverhead` from `68` to `84`) to account for the tool trigger/collapsible UI, so the `toolDetailsMaxHeight` passed to `ToolSequenceGroup` better matches the actual remaining space (with/without the thinking section).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24454ca5a7b1c6bd3ee14407ec6ac7bfbba74af3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->