### PR TITLE
Fix ratchet to only dispatch when CI is in terminal state

### DIFF
--- a/src/backend/services/ratchet.service.ts
+++ b/src/backend/services/ratchet.service.ts
@@ -541,6 +541,18 @@ class RatchetService {
       };
     }
 
+    // Only dispatch when CI is in a terminal state (SUCCESS or FAILURE)
+    const isTerminalCIStatus =
+      context.prStateInfo.ciStatus === CIStatus.SUCCESS ||
+      context.prStateInfo.ciStatus === CIStatus.FAILURE;
+
+    if (!isTerminalCIStatus) {
+      return {
+        type: 'RETURN_ACTION',
+        action: { type: 'WAITING', reason: 'Waiting for CI to complete (not in terminal state)' },
+      };
+    }
+
     if (context.isCleanPrWithNoNewReviewActivity) {
       return {
         type: 'RETURN_ACTION',


### PR DESCRIPTION
## Summary

Previously, ratchet would dispatch when CI was still running (PENDING or UNKNOWN status), causing premature action before CI results were available. This fix ensures ratchet only acts when CI has completed.

## Changes

- Add explicit terminal state check in `decideRatchetAction` method
- Only dispatch when CI status is `SUCCESS` or `FAILURE` 
- Return waiting action with clear message for non-terminal states
- Add tests for PENDING and UNKNOWN CI statuses
- Update existing test to include ciStatus in context

## Benefits

- **Explicit Intent**: Code clearly states only terminal statuses trigger dispatch
- **Future-Proof**: New CI statuses automatically treated as non-terminal unless explicitly added
- **Self-Documenting**: Comment and variable name make intent obvious
- **Maintainable**: Easy to understand which statuses are terminal

## Test Plan

- [x] All existing ratchet tests pass (16/16)
- [x] Added 2 new tests for non-terminal CI states
- [x] Full test suite passes (1557/1557)
- [x] TypeScript type checking passes
- [x] Lint checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to ratchet dispatch gating logic plus additional unit coverage; main risk is delaying dispatch in edge cases where CI status is misreported as non-terminal.
> 
> **Overview**
> Prevents ratchet from dispatching fixer sessions until CI has reached a terminal result.
> 
> `decideRatchetAction` now treats any CI status other than `SUCCESS`/`FAILURE` as non-actionable and returns a `WAITING` action with an explicit reason. Tests were updated to include `ciStatus` in the actionable-context case and new cases were added to assert waiting behavior for `PENDING` and `UNKNOWN` CI statuses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7acf537ce08010dacb8d8e9f2f89d5c64c89d636. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->