### PR TITLE
Skip pre-commit hooks when archiving workspaces

### DIFF
--- a/src/backend/services/git-ops.service.ts
+++ b/src/backend/services/git-ops.service.ts
@@ -77,7 +77,10 @@ class GitOpsService {
     }
 
     const commitMessage = `Archive workspace ${workspaceName}`;
-    const commitResult = await gitCommand(['commit', '-m', commitMessage], worktreePath);
+    const commitResult = await gitCommand(
+      ['commit', '-m', commitMessage, '--no-verify'],
+      worktreePath
+    );
     if (commitResult.code !== 0) {
       throw new TRPCError({
         code: 'INTERNAL_SERVER_ERROR',


### PR DESCRIPTION
## Summary

- Skip pre-commit hooks when committing during workspace archiving to prevent lint/type-check errors from blocking the archive operation

## Changes

- **git-ops.service.ts**: Added `--no-verify` flag to the `git commit` command in `commitIfNeeded()` method when archiving workspaces

## Context

When archiving workspaces, the system may need to commit uncommitted changes. Previously, if these changes contained lint or type errors, the pre-commit hooks would fail and block the entire archiving process. Since archiving is a cleanup operation and the workspace is being removed anyway, it's appropriate to skip these validation hooks.

## Testing

- [x] Code compiles (`pnpm typecheck`)
- [x] Lint passes (`pnpm check:fix`)
- [ ] Manual testing: Archive a workspace with uncommitted changes that would fail lint/type checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to a maintenance-only `git commit` invocation; main risk is bypassing hook enforcement for archive commits, not affecting normal development commits.
> 
> **Overview**
> Workspace archiving now commits pending changes with `git commit --no-verify`, preventing pre-commit hooks (lint/type-check, etc.) from failing and blocking the archive cleanup.
> 
> The change is isolated to `GitOpsService.commitIfNeeded()` and only affects the commit created during archive operations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3bf48313a543af6db8803df084bb9d37a5b7eaa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->