### PR TITLE
Fix duplicate assistant messages from partial streaming

### DIFF
--- a/src/backend/services/session.service.test.ts
+++ b/src/backend/services/session.service.test.ts
@@ -123,7 +123,7 @@ describe('SessionService', () => {
         systemPrompt: 'system',
         model: 'sonnet',
         permissionMode: 'bypassPermissions',
-        includePartialMessages: true,
+        includePartialMessages: false,
         sessionId: 'session-1',
       }),
       expect.any(Object),

--- a/src/backend/services/session.service.ts
+++ b/src/backend/services/session.service.ts
@@ -391,7 +391,7 @@ class SessionService {
       systemPrompt: sessionContext.systemPrompt,
       model: options?.model ?? sessionContext.model,
       permissionMode: options?.permissionMode ?? 'bypassPermissions',
-      includePartialMessages: true,
+      includePartialMessages: false,
       thinkingEnabled: options?.thinkingEnabled,
       initialPrompt: options?.initialPrompt,
       sessionId,


### PR DESCRIPTION
## Summary
- disable partial assistant message emission from Claude client startup
- keep stream-event flow for tool/thinking updates unchanged
- update session service test expectation

## Why
With partial assistant messages enabled, the backend forwarded token-chunk assistant messages and then the final assistant message, which caused fragmented rendering and duplicate final content in chat.

## Validation
- pnpm vitest src/backend/services/session.service.test.ts
- pnpm typecheck
- pnpm check
- pnpm test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, localized configuration change that only affects message streaming behavior at Claude client startup; main risk is reduced responsiveness for partial output if consumers relied on it.
> 
> **Overview**
> Disables partial assistant message emission when creating Claude clients by setting `includePartialMessages` to `false` in `SessionService.buildClientOptions`, preventing duplicate/final assistant message rendering caused by forwarding both token chunks and the final message.
> 
> Updates the `session.service.test.ts` expectation to match the new client option.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e26d93d0597cc7e35f24565e274cc1de8453c861. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->