### PR TITLE
Show workspace initialization status immediately after creation

### DIFF
--- a/src/client/routes/projects/workspaces/new.tsx
+++ b/src/client/routes/projects/workspaces/new.tsx
@@ -11,6 +11,7 @@ import { Label } from '@/components/ui/label';
 import { Spinner } from '@/components/ui/spinner';
 import { Textarea } from '@/components/ui/textarea';
 import { Loading } from '@/frontend/components/loading';
+import { createOptimisticWorkspaceCacheData } from '@/frontend/lib/workspace-cache-helpers';
 import { trpc } from '../../../../frontend/lib/trpc';
 
 export default function NewWorkspacePage() {
@@ -39,19 +40,7 @@ export default function NewWorkspacePage() {
           return old;
         }
 
-        // Set minimal workspace data with computed fields matching workspace.get endpoint
-        return {
-          ...workspace,
-          claudeSessions: [],
-          terminalSessions: [],
-          sidebarStatus: {
-            activityState: 'IDLE' as const,
-            ciState: 'NONE' as const,
-          },
-          ratchetButtonAnimated: false,
-          flowPhase: 'NO_PR' as const,
-          ciObservation: 'NOT_FETCHED' as const,
-        };
+        return createOptimisticWorkspaceCacheData(workspace);
       });
 
       navigate(`/projects/${slug}/workspaces/${workspace.id}`);

--- a/src/frontend/components/kanban/issue-card.tsx
+++ b/src/frontend/components/kanban/issue-card.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { RatchetToggleButton } from '@/components/workspace';
 import { trpc } from '@/frontend/lib/trpc';
+import { createOptimisticWorkspaceCacheData } from '@/frontend/lib/workspace-cache-helpers';
 import type { GitHubIssue } from './kanban-context';
 
 interface IssueCardProps {
@@ -44,19 +45,7 @@ export function IssueCard({ issue, projectId, onClick }: IssueCardProps) {
           return old;
         }
 
-        // Set minimal workspace data with computed fields matching workspace.get endpoint
-        return {
-          ...workspace,
-          claudeSessions: [],
-          terminalSessions: [],
-          sidebarStatus: {
-            activityState: 'IDLE' as const,
-            ciState: 'NONE' as const,
-          },
-          ratchetButtonAnimated: false,
-          flowPhase: 'NO_PR' as const,
-          ciObservation: 'NOT_FETCHED' as const,
-        };
+        return createOptimisticWorkspaceCacheData(workspace);
       });
 
       // Invalidate workspace queries to refresh the board

--- a/src/frontend/hooks/use-create-workspace.ts
+++ b/src/frontend/hooks/use-create-workspace.ts
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router';
 import { toast } from 'sonner';
 import { generateUniqueWorkspaceName } from '@/shared/workspace-words';
 import { trpc } from '../lib/trpc';
+import { createOptimisticWorkspaceCacheData } from '../lib/workspace-cache-helpers';
 
 /**
  * Shared hook for creating workspaces with consistent behavior across the app.
@@ -51,19 +52,7 @@ export function useCreateWorkspace(
           return old;
         }
 
-        // Set minimal workspace data with computed fields matching workspace.get endpoint
-        return {
-          ...workspace,
-          claudeSessions: [],
-          terminalSessions: [],
-          sidebarStatus: {
-            activityState: 'IDLE' as const,
-            ciState: 'NONE' as const,
-          },
-          ratchetButtonAnimated: false,
-          flowPhase: 'NO_PR' as const,
-          ciObservation: 'NOT_FETCHED' as const,
-        };
+        return createOptimisticWorkspaceCacheData(workspace);
       });
 
       utils.workspace.list.invalidate({ projectId });

--- a/src/frontend/lib/workspace-cache-helpers.ts
+++ b/src/frontend/lib/workspace-cache-helpers.ts
@@ -1,0 +1,25 @@
+import type { Workspace } from '@prisma-gen/browser';
+
+/**
+ * Creates an enriched workspace object with computed fields for optimistic cache updates.
+ *
+ * When creating a workspace, we immediately populate the workspace.get query cache
+ * with this data so the detail page can show the workspace status (NEW/PROVISIONING)
+ * without waiting for the server response.
+ *
+ * This must match the shape returned by the backend workspace.get endpoint.
+ */
+export function createOptimisticWorkspaceCacheData(workspace: Workspace) {
+  return {
+    ...workspace,
+    claudeSessions: [],
+    terminalSessions: [],
+    sidebarStatus: {
+      activityState: 'IDLE' as const,
+      ciState: 'NONE' as const,
+    },
+    ratchetButtonAnimated: false,
+    flowPhase: 'NO_PR' as const,
+    ciObservation: 'NOT_FETCHED' as const,
+  };
+}


### PR DESCRIPTION
## Summary
- Populate workspace detail query cache optimistically after creation
- Show NEW/PROVISIONING status immediately instead of "Stopped"
- Apply fix to all workspace creation paths (hook, issue card, new workspace form)

## Problem
When creating a workspace (either ad-hoc via sidebar or from a GitHub issue), there was a multi-second delay where the workspace showed as "Stopped" with no visible indication that it was initializing. This happened because:

1. Workspace created with status `NEW`
2. Navigation to detail page occurs
3. Detail page loads workspace data from server
4. Brief delay before background initialization updates status to `PROVISIONING`

During this gap, users saw no feedback that workspace setup was starting.

## Solution
Optimistically populate the `workspace.get` query cache immediately after workspace creation with computed fields matching the server response structure. This ensures:

- Status indicator shows immediately when navigating to detail page
- No confusing "Stopped" state during initialization
- Consistent behavior across all workspace creation flows

## Changes
- Modified `useCreateWorkspace` hook to set query data after creation
- Updated issue card "Start" button handler
- Updated new workspace form page
- All include proper initial values for sidebarStatus, flowPhase, ciObservation

## Test plan
- [x] Create workspace via sidebar - status shows immediately
- [x] Create workspace from GitHub issue - status shows immediately
- [x] Create workspace via /new form - status shows immediately
- [x] Type checking passes
- [x] Linting passes
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches client-side caching for a core navigation path; if the optimistic cache shape diverges from `workspace.get`, the detail view could temporarily show incorrect/undefined fields until refetch.
> 
> **Overview**
> Workspace creation now *optimistically seeds* the `workspace.get` tRPC cache so the workspace detail page immediately reflects initialization state after navigation, instead of briefly appearing stopped.
> 
> This behavior is applied across all creation entry points (new workspace form, Kanban issue “Start”, and the shared `useCreateWorkspace` hook) via a new `createOptimisticWorkspaceCacheData` helper that fills in computed fields to match the `workspace.get` response shape.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f38d884985c2fc3bc0118d0c55f3198765cdca9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->