### PR TITLE
Release v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to Factory Factory will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.6] - 2026-02-08
+
+### Fixed
+
+- Fix #824: Skip branch rename for additional Claude sessions (#832)
+- Fix tool call message rendering (#834)
+- Fix session hydration and live message parity (#818)
+- Fix tool preview height clipping in live activity box (#817)
+- Fix #810: Adjust tool preview height in resizable live activity box (#813)
+- Fix #802: Indicate factory-factory.json detection during project import (#814)
+
+### Changed
+
+- Harden transcript hydration, lineage guards, and streaming consistency (#836)
+- Show workspace initialization status immediately after creation (#833)
+- Unify chat state with a single SessionStoreService (#827)
+- Simplify and clarify ratcheting UI and documentation (#821)
+- Disable partial assistant message streaming (#829)
+
+### Refactored
+
+- Remove legacy message state bypass APIs and protocol artifacts (#830)
+- Skip pre-commit hooks when archiving workspaces (#828)
+- Fix ratchet to only dispatch when CI is in terminal state (#823)
+- Treat idle non-ratchet sessions as idle for ratchet (#816)
+- Refactor ratchet decision flow and diagnostics (#811)
+
+### Added
+
+- Add visual indicators for pending plan approval and user questions (#771) (#815)
+
 ## [0.2.5] - 2026-02-07
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "factory-factory",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Workspace-based coding environment for running multiple Claude Code sessions in parallel",
   "private": false,
   "license": "MIT",


### PR DESCRIPTION
## Summary

Patch release v0.2.6 with bug fixes, improvements, and refactoring since v0.2.5.

### Fixed
- Fix #824: Skip branch rename for additional Claude sessions (#832)
- Fix tool call message rendering (#834)
- Fix session hydration and live message parity (#818)
- Fix tool preview height clipping in live activity box (#817)
- Fix #810: Adjust tool preview height in resizable live activity box (#813)
- Fix #802: Indicate factory-factory.json detection during project import (#814)

### Changed
- Show workspace initialization status immediately after creation (#833)
- Unify chat state with a single SessionStoreService (#827)
- Simplify and clarify ratcheting UI and documentation (#821)
- Disable partial assistant message streaming (#829)

### Refactored
- Remove legacy message state bypass APIs and protocol artifacts (#830)
- Skip pre-commit hooks when archiving workspaces (#828)
- Fix ratchet to only dispatch when CI is in terminal state (#823)
- Treat idle non-ratchet sessions as idle for ratchet (#816)
- Refactor ratchet decision flow and diagnostics (#811)

### Added
- Add visual indicators for pending plan approval and user questions (#771) (#815)

## Test plan
- [x] Version bumped to 0.2.6 in package.json
- [x] CHANGELOG.md updated with all changes since v0.2.5
- [x] Pre-commit hooks passed
- [ ] Verify release workflow will tag and publish correctly after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release bookkeeping only (version bump + changelog update) with no functional code changes.
> 
> **Overview**
> Prepares the `0.2.6` release by bumping `package.json` version from `0.2.5` to `0.2.6`.
> 
> Updates `CHANGELOG.md` with a new `0.2.6` section summarizing the fixes, behavior changes, refactors, and one UI addition included in this patch release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf4b7be6297b225ab40c3b755fb2ed4dfdeccf5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->