### PR TITLE
Fix ratchet to check for any working session, not just non-ratchet ones

### DIFF
--- a/src/backend/services/ratchet.service.test.ts
+++ b/src/backend/services/ratchet.service.test.ts
@@ -193,7 +193,7 @@ describe('ratchet service (state-change + idle dispatch)', () => {
     expect(result).toMatchObject({
       action: {
         type: 'WAITING',
-        reason: 'Workspace is not idle (active non-ratchet chat session)',
+        reason: 'Workspace is not idle (active session)',
       },
     });
   });
@@ -251,7 +251,7 @@ describe('ratchet service (state-change + idle dispatch)', () => {
     expect(finalUpdatePayload).toHaveProperty('prReviewLastCheckedAt');
   });
 
-  it('does dispatch when non-ratchet session is running but idle', async () => {
+  it('does dispatch when session is running but idle', async () => {
     const workspace = {
       id: 'ws-idle-session',
       prUrl: 'https://github.com/example/repo/pull/44',

--- a/src/backend/services/ratchet.service.ts
+++ b/src/backend/services/ratchet.service.ts
@@ -518,7 +518,7 @@ class RatchetService {
 
     return {
       activeRatchetSession: null,
-      hasOtherActiveSession: await this.hasNonRatchetActiveSession(workspace.id),
+      hasOtherActiveSession: await this.hasActiveSession(workspace.id),
     };
   }
 
@@ -576,7 +576,7 @@ class RatchetService {
         type: 'RETURN_ACTION',
         action: {
           type: 'WAITING',
-          reason: 'Workspace is not idle (active non-ratchet chat session)',
+          reason: 'Workspace is not idle (active session)',
         },
       };
     }
@@ -670,14 +670,9 @@ class RatchetService {
     return { type: 'FIXER_ACTIVE', sessionId: workspace.ratchetActiveSessionId };
   }
 
-  private async hasNonRatchetActiveSession(workspaceId: string): Promise<boolean> {
+  private async hasActiveSession(workspaceId: string): Promise<boolean> {
     const sessions = await claudeSessionAccessor.findByWorkspaceId(workspaceId);
-    return sessions.some((session) => {
-      if (session.workflow === RATCHET_WORKFLOW) {
-        return false;
-      }
-      return sessionService.isSessionWorking(session.id);
-    });
+    return sessions.some((session) => sessionService.isSessionWorking(session.id));
   }
 
   private resolveRatchetPrContext(


### PR DESCRIPTION
Previously, hasNonRatchetActiveSession explicitly skipped ratchet workflow
sessions when checking if the workspace was busy. This meant a ratchet
session could be missed if its ID wasn't tracked in ratchetActiveSessionId,
allowing a duplicate fixer to be dispatched. Now checks all sessions.

https://claude.ai/code/session_015aJ5YX5XND5NYEWv5wGp5Y

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ratchet dispatch gating logic, which can alter when/if fixers are triggered; risk is limited to ratchet scheduling behavior with straightforward test updates.
> 
> **Overview**
> Prevents duplicate ratchet/fixer dispatches by treating *any* working Claude session in a workspace (including `ratchet` workflow sessions not recorded in `ratchetActiveSessionId`) as making the workspace non-idle.
> 
> Renames and simplifies the session-idle check (`hasNonRatchetActiveSession` → `hasActiveSession`) and updates the waiting reason text and corresponding tests to reflect the broader “active session” condition.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 155734e453ca82648dee13e35b0099576406ef12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->