### PR TITLE
Write server logs to file instead of terminal

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -12,6 +12,7 @@ import { Command } from 'commander';
 import { config } from 'dotenv';
 import open from 'open';
 import { runMigrations as runDbMigrations } from '@/backend/migrate';
+import { getLogFilePath } from '@/backend/services/logger.service';
 
 const execPromise = promisify(exec);
 
@@ -354,8 +355,7 @@ function printReadyBanner(opts: {
   }
   console.log(chalk.gray(`  Database:  ${opts.databasePath}`));
   console.log(chalk.gray(`  Mode:      ${opts.isDev ? 'development' : 'production'}`));
-  const baseDir = process.env.BASE_DIR || join(homedir(), 'factory-factory');
-  console.log(chalk.gray(`  Logs:      ${join(baseDir, 'logs', 'server.log')}`));
+  console.log(chalk.gray(`  Logs:      ${getLogFilePath()}`));
   console.log(chalk.gray('  ─────────────────────────────────────'));
 }
 


### PR DESCRIPTION
## Summary
- In production, server logs now write to `~/factory-factory/logs/server.log` instead of the terminal (only errors still echo to stderr)
- In development, logs write to both the console and the log file
- The startup banner now displays the log file path in both modes

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm check:fix` passes
- [x] `pnpm test` — all 1466 tests pass
- [ ] Run `ff serve` in production and verify logs go to file, not terminal
- [ ] Run `pnpm dev` and verify logs appear in both console and file
- [ ] Verify startup banner shows `Logs:` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)