### PR TITLE
Show actual error in Mermaid diagram preview

### DIFF
--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -42,9 +42,10 @@ function MermaidDiagram({ chart }: { chart: string }) {
           if (ref.current) {
             ref.current.innerHTML = svg;
           }
-        } catch {
-          // Safely handle error without innerHTML injection
-          setError('Error rendering diagram');
+        } catch (err) {
+          // Capture the actual error message for debugging
+          const errorMessage = err instanceof Error ? err.message : String(err);
+          setError(errorMessage);
         }
       };
       renderDiagram();
@@ -54,7 +55,8 @@ function MermaidDiagram({ chart }: { chart: string }) {
   if (error) {
     return (
       <div className="my-4 p-3 bg-destructive/10 border border-destructive/20 rounded-md">
-        <pre className="text-destructive text-xs">{error}</pre>
+        <div className="text-destructive text-sm font-medium mb-2">Error rendering diagram:</div>
+        <pre className="text-destructive text-xs overflow-x-auto whitespace-pre-wrap">{error}</pre>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- Display the actual Mermaid error message when a diagram fails to render in markdown preview mode, instead of the generic "Error rendering diagram" text
- Adds a clear header and proper text wrapping for long error messages

## Test plan
- [ ] Open a markdown file with a valid Mermaid diagram in preview mode — renders normally
- [ ] Open a markdown file with an invalid Mermaid diagram — shows the specific parse/syntax error from Mermaid

🤖 Generated with [Claude Code](https://claude.com/claude-code)
