### PR TITLE
Fix resume modes file write race condition with atomic rename

### DIFF
--- a/src/backend/services/worktree-lifecycle.service.ts
+++ b/src/backend/services/worktree-lifecycle.service.ts
@@ -84,7 +84,14 @@ async function writeResumeModes(
   const targetPath = path.join(worktreeBasePath, RESUME_MODE_FILENAME);
   const tmpPath = `${targetPath}.${crypto.randomUUID()}.tmp`;
   await fs.writeFile(tmpPath, JSON.stringify(modes), 'utf-8');
-  await fs.rename(tmpPath, targetPath);
+  try {
+    await fs.rename(tmpPath, targetPath);
+  } catch (err) {
+    await fs.unlink(tmpPath).catch(() => {
+      // Best-effort cleanup; nothing to do if the temp file is already gone
+    });
+    throw err;
+  }
 }
 
 async function updateResumeModes(


### PR DESCRIPTION
## Summary
- Fix race condition in `writeResumeModes()` where non-atomic `fs.writeFile` could leave a corrupt/partial file on disk if the process crashes mid-write

## Changes
- **`src/backend/services/worktree-lifecycle.service.ts`**: Replace direct `fs.writeFile` with temp-file + `fs.rename` pattern for atomic writes. The temp file uses `process.pid` suffix to avoid collisions.

## Testing
- [x] Tests pass (`pnpm test` — 1477 passing)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (pre-commit hooks ran typecheck, dep-cruise, knip)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to file-write mechanics; risk is mainly platform/filesystem edge cases around `rename`/permissions and temp-file cleanup.
> 
> **Overview**
> Prevents corruption of the `.ff-resume-modes.json` sidecar by making `writeResumeModes()` write to a uniquely-named temp file and then `rename` it into place (atomic replace), with best-effort cleanup on failure.
> 
> Adds `node:crypto` usage for `randomUUID()` to avoid temp-file name collisions while keeping the existing in-process lock behavior unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c490c0b9a361ec5eabefa7f137dc7098a6d99309. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->