### PR TITLE
Fix queued messages disappearing on page refresh

### DIFF
--- a/src/components/chat/reducer/index.ts
+++ b/src/components/chat/reducer/index.ts
@@ -86,7 +86,9 @@ function createReplayBaseState(state: ChatState): ChatState {
     ...createBaseResetState(),
     // Preserve optimistic pending sends that are not yet reflected in replayed events.
     pendingMessages: state.pendingMessages,
-    queuedMessages: new Map(),
+    // Preserve queued messages - they will be reconstructed from replay events,
+    // but preserving them ensures they remain visible during replay processing.
+    queuedMessages: state.queuedMessages,
     sessionStatus: { phase: 'loading' },
     processStatus: { state: 'unknown' },
     sessionRuntime: {


### PR DESCRIPTION
## Summary
Fixes an issue where queued messages would disappear when the page is refreshed, only reappearing once the agent starts.

## Problem
When a user sends a message while the agent is starting and then refreshes the page:
1. The queued message disappears from the UI
2. It only reappears once the agent actually starts processing

This creates a confusing user experience where it appears the message was lost.

## Root Cause
When the page refreshes and the WebSocket reconnects:
1. The backend sends a `SESSION_REPLAY_BATCH` message to restore session state
2. The frontend's `createReplayBaseState` function was clearing `queuedMessages` to an empty Map
3. While queued messages were eventually reconstructed from replay events, they would flicker/disappear during replay processing

## Solution
Modified `createReplayBaseState` in `src/components/chat/reducer/index.ts` to preserve `queuedMessages`, similar to how it already preserves `pendingMessages`. Both represent optimistic UI state that should remain visible during replay processing.

## Changes
- Changed `queuedMessages: new Map()` to `queuedMessages: state.queuedMessages`
- Added explanatory comment for clarity

## Testing
- ✅ All existing tests pass
- ✅ TypeScript type checking passes
- ✅ Linting passes

## Test plan
1. Start a session with an agent that takes time to start
2. Send a message while the agent is starting (it should be queued)
3. Refresh the page
4. Verify the queued message remains visible throughout the reconnection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small reducer change in UI state initialization during `SESSION_REPLAY_BATCH`; risk is limited to potential stale/duplicated queued-message display during replay.
> 
> **Overview**
> Fixes queued chat messages briefly disappearing after a refresh/reconnect by changing `createReplayBaseState` to preserve `queuedMessages` (instead of resetting to an empty `Map`) while session replay events are processed.
> 
> Adds clarifying comments alongside existing `pendingMessages` preservation to document the optimistic-UI intent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9266d3e327441ce8a7a015a532102b12e8dd587c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->