### PR TITLE
Fix GitHub CLI bot comment validation error

### DIFF
--- a/src/backend/services/github-cli.service.ts
+++ b/src/backend/services/github-cli.service.ts
@@ -137,7 +137,7 @@ const fullPRDetailsSchema = z.object({
         author: z.object({ login: z.string() }),
         body: z.string(),
         createdAt: z.string(),
-        updatedAt: z.string(),
+        updatedAt: z.string().optional(),
         url: z.string(),
       })
       .passthrough()
@@ -267,7 +267,7 @@ function mapComments(comments: z.infer<typeof fullPRDetailsSchema>['comments']):
     author: comment.author,
     body: comment.body,
     createdAt: comment.createdAt,
-    updatedAt: comment.updatedAt,
+    updatedAt: comment.updatedAt ?? comment.createdAt,
     url: comment.url,
   }));
 }


### PR DESCRIPTION
## Summary

Fixes a validation error when fetching PR details that include bot comments (e.g., from `github-actions`).

## Problem

GitHub bot comments sometimes lack an `updatedAt` field in API responses, causing a Zod validation error:
```
Invalid input: expected string, received undefined
```

This error was logged when calling `getPRFullDetails()` for PRs with bot comments from automated systems like GitHub Actions.

## Solution

1. Made `updatedAt` optional in the comments schema
2. Added fallback to use `createdAt` when `updatedAt` is missing

## Test plan

- [x] All existing tests pass (1489 tests)
- [x] TypeScript type checking passes
- [x] Linting and formatting checks pass
- [x] Pre-commit hooks pass

## Impact

- Bot comments are now properly handled without validation errors
- Backward compatible with regular comments that have `updatedAt`
- Prevents error logs when auto-fix system processes PRs with bot comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized schema/mapping change that only affects how missing `updatedAt` is handled when parsing GitHub CLI responses.
> 
> **Overview**
> Fixes `getPRFullDetails()` failures when the GitHub CLI returns PR comments without an `updatedAt` field (commonly for bot comments).
> 
> The PR makes `comments[].updatedAt` optional in the Zod schema and updates comment mapping to fall back to `createdAt` when `updatedAt` is missing, preventing validation errors while keeping existing behavior for normal comments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2f7d59f12b494fbfbeb47c0bd8130c89b66f4fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->