### PR TITLE
Fix infinite loading when session loads from history

### DIFF
--- a/src/components/chat/chat-reducer.test.ts
+++ b/src/components/chat/chat-reducer.test.ts
@@ -1631,6 +1631,78 @@ describe('chatReducer', () => {
       expect(newState.messages[0]!.id).not.toBe('old-msg');
       expect(newState.sessionStatus).toEqual({ phase: 'running' });
     });
+
+    it('should clear loading state after replay completes if still loading', () => {
+      const state: ChatState = {
+        ...initialState,
+        sessionStatus: { phase: 'loading' },
+        sessionRuntime: {
+          phase: 'loading',
+          processState: 'unknown',
+          activity: 'IDLE',
+          updatedAt: '2026-02-08T00:00:00.000Z',
+        },
+      };
+
+      const action: ChatAction = {
+        type: 'SESSION_REPLAY_BATCH',
+        payload: {
+          replayEvents: [
+            {
+              type: 'message_state_changed',
+              id: 'msg-1',
+              newState: MessageState.ACCEPTED,
+              userMessage: {
+                text: 'Hello from history',
+                timestamp: '2024-01-01T00:00:00.000Z',
+                order: 0,
+              },
+            },
+          ],
+        },
+      };
+
+      const newState = chatReducer(state, action);
+
+      expect(newState.messages).toHaveLength(1);
+      expect(newState.sessionStatus).toEqual({ phase: 'ready' });
+      expect(newState.sessionRuntime.phase).toBe('idle');
+    });
+
+    it('should not clear loading state if runtime update changes phase during replay', () => {
+      const state: ChatState = {
+        ...initialState,
+        sessionStatus: { phase: 'loading' },
+        sessionRuntime: {
+          phase: 'loading',
+          processState: 'unknown',
+          activity: 'IDLE',
+          updatedAt: '2026-02-08T00:00:00.000Z',
+        },
+      };
+
+      const action: ChatAction = {
+        type: 'SESSION_REPLAY_BATCH',
+        payload: {
+          replayEvents: [
+            {
+              type: 'session_runtime_updated',
+              sessionRuntime: {
+                phase: 'running',
+                processState: 'alive',
+                activity: 'WORKING',
+                updatedAt: '2026-02-08T00:00:00.000Z',
+              },
+            },
+          ],
+        },
+      };
+
+      const newState = chatReducer(state, action);
+
+      expect(newState.sessionStatus).toEqual({ phase: 'running' });
+      expect(newState.sessionRuntime.phase).toBe('running');
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/src/components/chat/reducer/index.ts
+++ b/src/components/chat/reducer/index.ts
@@ -114,6 +114,11 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
       }
       nextState = reduceSingleAction(nextState, replayAction);
     }
+    // Clear loading state after replay completes
+    // Only clear if still in loading phase (runtime updates during replay may have already changed it)
+    if (nextState.sessionStatus.phase === 'loading') {
+      nextState = reduceSingleAction(nextState, { type: 'SESSION_LOADING_END' });
+    }
     return nextState;
   }
 


### PR DESCRIPTION
## Summary

Fixes a bug where sessions would show "Loading session..." infinitely when reconnecting to a dead Claude process.

## Problem

When a Claude session died and the UI reconnected:
1. User navigates back to the agent tab
2. UI shows "Loading session..." spinner
3. Spinner never goes away, stuck forever
4. Only workaround: send a message, which triggers state updates

## Root Cause

When loading from history (no live Claude process):
- Frontend dispatches `SESSION_LOADING_START` and requests session data
- Backend responds with `SESSION_REPLAY_BATCH` containing historical events from `.claudecode/history`
- Frontend replays historical events to reconstruct state
- **BUG**: None of the replayed events transition out of 'loading' phase
- UI remains stuck showing "Loading session..." forever

## Solution

After processing `SESSION_REPLAY_BATCH`, dispatch `SESSION_LOADING_END` if still in loading phase. This ensures:
- Proper transition to 'ready' state when loading from history
- Runtime updates from live processes still take precedence

## Changes

- **src/components/chat/reducer/index.ts**: Clear loading state after replay completes if no runtime update changed it
- **src/components/chat/chat-reducer.test.ts**: Added tests for both scenarios (loading from history and with runtime updates)

## Testing

- ✅ All 125 chat reducer tests pass
- ✅ Added test: loading state clears after replay from history
- ✅ Added test: runtime updates during replay take precedence
- ✅ Manual testing: session now loads properly when Claude process is dead

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted state-transition change confined to `SESSION_REPLAY_BATCH` handling with explicit tests; minimal risk aside from potential edge-case phase expectations.
> 
> **Overview**
> Prevents the chat UI from getting stuck in an infinite "Loading session…" state when a session is reconstructed purely from history.
> 
> After processing `SESSION_REPLAY_BATCH`, the reducer now dispatches `SESSION_LOADING_END` *only if* the session is still in the `loading` phase, so any `session_runtime_updated` events replayed in the same batch can still drive the final phase. Adds coverage to ensure loading clears for history-only replays and remains `running` when a runtime update is present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 262f55b1fc5a408aceb09bc9a88d85603344c857. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->