### PR TITLE
Change default theme from system to dark

### DIFF
--- a/src/frontend/components/theme-provider.tsx
+++ b/src/frontend/components/theme-provider.tsx
@@ -8,7 +8,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
   return (
     <NextThemesProvider
       attribute="class"
-      defaultTheme="system"
+      defaultTheme="dark"
       enableSystem
       disableTransitionOnChange
     >


### PR DESCRIPTION
## Summary
- Changes the default theme in `ThemeProvider` from `"system"` to `"dark"`, so new users see dark mode by default instead of following their OS preference.

## Test plan
- [ ] Verify the app loads with dark theme by default on first visit (no stored preference)
- [ ] Verify users can still switch themes manually
- [ ] Verify the `enableSystem` option still works when a user explicitly selects system theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)