### PR TITLE
Fix session process manager race condition

### DIFF
--- a/src/backend/services/session.process-manager.ts
+++ b/src/backend/services/session.process-manager.ts
@@ -73,7 +73,7 @@ export class SessionProcessManager {
         const pending = this.pendingCreation.get(sessionId);
         if (pending) {
           logger.debug('Waiting for pending client creation', { sessionId });
-          return pending;
+          return await pending;
         }
 
         // No existing or pending - create new client


### PR DESCRIPTION
## Summary

Fixes a race condition in `SessionProcessManager.getOrCreateClient()` where concurrent WebSocket connections starting the same session could bypass the pending creation check and spawn duplicate Claude client processes.

## Problem

The previous implementation had a window between checking `pendingCreation.get()` (line 52) and setting it (line 60) where two concurrent callers could both:
1. See no pending promise
2. Both proceed to create new client processes  
3. One would overwrite the other's promise in the map

This could happen when multiple WebSocket connections attempt to start the same session simultaneously.

## Solution

- **Use `p-limit`** (already in dependencies) to create per-session mutexes with concurrency=1
- **Serialize creation attempts** by wrapping the check-and-create logic inside `lock()`
- **Clean up locks** when clients stop or during shutdown to prevent memory leaks
- **Update test** to account for async mutex behavior (10ms wait for queue processing)

## Changes

- `session.process-manager.ts:42`: Add per-session mutex using p-limit
- `session.process-manager.ts:125`: Clean up lock on client stop
- `session.process-manager.ts:172`: Clean up all locks on shutdown
- `session.process-manager.test.ts:39`: Add timing wait for mutex test

## Testing

- ✅ All session tests pass (163 tests)
- ✅ TypeScript compilation passes
- ✅ Linting passes  
- ✅ Pre-commit hooks pass

## Impact

Low risk - maintains existing behavior while eliminating edge case race condition. The mutex ensures only one creation attempt proceeds at a time per session ID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches concurrency and lifecycle management in `SessionProcessManager`, so regressions could impact session startup/shutdown behavior under load. Changes are localized and backed by additional race-condition tests.
> 
> **Overview**
> Prevents duplicate Claude client processes when multiple callers concurrently start the same session by serializing `getOrCreateClient()` with a per-session `p-limit(1)` mutex and moving the *check/pending/create* logic inside the lock.
> 
> Adds reference-counted cleanup for per-session locks, clears `pendingCreation` on client `exit`, and ensures `stopAllClients()` fully resets lock state. Expands tests to cover concurrent creation, client exit during queued operations, and shutdown/cleanup edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14488eaf119d530cee785f0cdf9cb03b6b6ca460. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->