### PR TITLE
Fix queued messages disappearing when switching workspaces

### DIFF
--- a/src/components/chat/chat-reducer.test.ts
+++ b/src/components/chat/chat-reducer.test.ts
@@ -927,7 +927,8 @@ describe('chatReducer', () => {
       expect(newState.gitBranch).toBeNull();
       expect(newState.pendingRequest).toEqual({ type: 'none' });
       expect(newState.sessionStatus).toEqual({ phase: 'loading' });
-      expect(newState.queuedMessages.size).toBe(0);
+      // Queued messages are preserved during switch to avoid visual disappearance
+      expect(newState.queuedMessages.size).toBe(1);
       expect(newState.toolUseIdToIndex.size).toBe(0);
       expect(newState.latestThinking).toBeNull();
     });

--- a/src/components/chat/reducer/slices/session.ts
+++ b/src/components/chat/reducer/slices/session.ts
@@ -79,6 +79,9 @@ export function reduceSessionSlice(state: ChatState, action: ChatAction): ChatSt
       return {
         ...state,
         ...createSessionSwitchResetState(),
+        // Preserve queued messages - they will be reconstructed from replay events,
+        // but preserving them ensures they remain visible during session switch.
+        queuedMessages: state.queuedMessages,
       };
     case 'SESSION_LOADING_START':
       return withRuntime(state, {

--- a/src/components/chat/reducer/state.ts
+++ b/src/components/chat/reducer/state.ts
@@ -52,8 +52,10 @@ function createBaseResetState(): Pick<
 }
 
 /**
- * Creates extended reset state for session switches, which also clears
- * queue, session status, and slashCommands (since different sessions may have different commands).
+ * Creates extended reset state for session switches.
+ * Note: queuedMessages is included in the type but cleared in this function.
+ * The SESSION_SWITCH_START reducer preserves queuedMessages from the previous state
+ * to avoid visual disappearance until the replay batch replaces them.
  */
 function createSessionSwitchResetState(): Pick<
   ChatState,

--- a/src/components/chat/use-chat-state.test.ts
+++ b/src/components/chat/use-chat-state.test.ts
@@ -559,7 +559,7 @@ describe('removeQueuedMessage pattern', () => {
 // =============================================================================
 
 describe('session switching queue behavior', () => {
-  it('should clear queue on SESSION_SWITCH_START', () => {
+  it('should preserve queue on SESSION_SWITCH_START until replay batch arrives', () => {
     const state = createInitialChatState({
       queuedMessages: toQueuedMessagesMap([
         createQueuedMessage('Queued 1'),
@@ -569,7 +569,9 @@ describe('session switching queue behavior', () => {
 
     const newState = chatReducer(state, { type: 'SESSION_SWITCH_START' });
 
-    expect(newState.queuedMessages.size).toBe(0);
+    // Queued messages are preserved during switch to avoid visual disappearance
+    // They will be replaced when the replay batch arrives from the backend
+    expect(newState.queuedMessages.size).toBe(2);
   });
 
   it('should clear queue on RESET_FOR_SESSION_SWITCH', () => {


### PR DESCRIPTION
When switching workspaces with a queued message, the message would disappear until the agent started. This was the same issue that was fixed for page refresh in commit db0eb7c5, but that fix only applied to `SESSION_REPLAY_BATCH` processing, not to workspace switching.

## Problem

When switching workspaces:
1. The `SESSION_SWITCH_START` action cleared `queuedMessages`
2. The WebSocket reconnected and sent a replay batch that included the queued messages
3. But there was a visual gap between clearing and restoration, causing messages to disappear

## Solution

Preserve queued messages during `SESSION_SWITCH_START`, just like we do during `SESSION_REPLAY_BATCH` processing (from commit db0eb7c5). The backend sends queued messages in the replay batch, so preserving them ensures they remain visible without flickering while the replay batch is processed.

## Changes

- **src/components/chat/reducer/slices/session.ts** - Preserve queued messages during session switch
- **src/components/chat/reducer/state.ts** - Updated comment to clarify preservation behavior
- **src/components/chat/use-chat-state.test.ts** - Updated test expectations
- **src/components/chat/chat-reducer.test.ts** - Updated test expectations

## Testing

- ✅ All chat reducer tests pass (125 tests)
- ✅ All chat state tests pass (42 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized state-reset behavior change in the chat reducer plus test updates; main risk is unintended persistence of stale queued messages if replay/reset flows don’t replace them as expected.
> 
> **Overview**
> Prevents queued chat messages from briefly disappearing during workspace/session switches by preserving `queuedMessages` in the `SESSION_SWITCH_START` reducer reset (instead of clearing them immediately).
> 
> Updates reducer/state comments and adjusts expectations in `chat-reducer.test.ts` and `use-chat-state.test.ts` to assert the queue remains visible until the backend replay batch rebuilds it; `RESET_FOR_SESSION_SWITCH` still clears the queue.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e970effb80bc7ddddebd7b8e5d3b82c7d8bf189f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->