### PR TITLE
Enable parallel workspace archiving

### DIFF
--- a/src/client/routes/projects/workspaces/workspace-detail-view.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-view.tsx
@@ -270,7 +270,6 @@ export function WorkspaceDetailView({
         open={archiveDialogOpen}
         onOpenChange={setArchiveDialogOpen}
         hasUncommitted={hasUncommitted}
-        isPending={archivePending}
         onConfirm={handleArchive}
       />
     </div>

--- a/src/components/workspace/archive-workspace-dialog.tsx
+++ b/src/components/workspace/archive-workspace-dialog.tsx
@@ -22,7 +22,6 @@ export type ArchiveWorkspaceDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   hasUncommitted: boolean;
-  isPending: boolean;
   onConfirm: (commitUncommitted: boolean) => void;
   description?: string;
   warningText?: string;
@@ -33,7 +32,6 @@ export function ArchiveWorkspaceDialog({
   open,
   onOpenChange,
   hasUncommitted,
-  isPending,
   onConfirm,
   description = defaultDescription,
   warningText = defaultWarning,
@@ -69,14 +67,14 @@ export function ArchiveWorkspaceDialog({
           </label>
         </div>
         <AlertDialogFooter>
-          <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
           <AlertDialogAction
             onClick={(event) => {
               event.preventDefault();
               onConfirm(commitChangesChecked);
               onOpenChange(false);
             }}
-            disabled={isPending || (hasUncommitted && !commitChangesChecked)}
+            disabled={hasUncommitted && !commitChangesChecked}
             className={buttonVariants({ variant: 'destructive' })}
           >
             Archive

--- a/src/frontend/components/app-sidebar.tsx
+++ b/src/frontend/components/app-sidebar.tsx
@@ -528,11 +528,6 @@ export function AppSidebar({ mockData }: { mockData?: AppSidebarMockData }) {
         open={archiveDialogOpen}
         onOpenChange={setArchiveDialogOpen}
         hasUncommitted={archiveHasUncommitted}
-        isPending={
-          workspaceToArchive
-            ? workspaceList.find((w) => w.id === workspaceToArchive)?.uiState === 'archiving'
-            : false
-        }
         onConfirm={(commitUncommitted) => {
           if (workspaceToArchive) {
             executeArchive(workspaceToArchive, commitUncommitted);


### PR DESCRIPTION
## Summary

Enables parallel workspace archiving by removing the global `isPending` check that was blocking multiple archive operations. The archive button in the Archive Workspace modal is now never disabled when another workspace is archiving.

## Problem

Previously, when archiving workspace A, trying to archive workspace B would show the archive button as disabled. This was caused by tRPC mutations maintaining a single shared `isPending` state - when any workspace was being archived, all archive dialogs saw `isPending=true` and disabled their buttons.

## Solution

Removed the `isPending` prop from `ArchiveWorkspaceDialog` entirely. The key insight is that this global pending state was unnecessary:

1. **Dialog closes immediately**: When you click Archive, the dialog closes right away, so checking pending state in the dialog provides no value
2. **Optimistic UI handles feedback**: `useWorkspaceListState` already manages per-workspace archiving state independently via a Map, showing each workspace's status in the sidebar
3. **Detail view still protected**: The workspace detail view maintains its own overlay and disabled button based on that specific workspace's state

## Changes

- **archive-workspace-dialog.tsx**: Remove `isPending` prop and all related checks
- **app-sidebar.tsx**: Remove `isPending` calculation and prop passing  
- **workspace-detail-view.tsx**: Remove `isPending` from dialog (view keeps its own `archivePending` for overlay)

## Testing

- [x] Tests pass (`pnpm test` - 1508 tests)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Linter passes (`pnpm check:fix`)
- [x] Manual testing: Archive button never disabled when other workspaces archiving

## Acceptance Criteria

✅ In the "Archive Workspace" modal, the archive button is never disabled when another workspace is archiving

The button is now only disabled when:
- The workspace has uncommitted changes AND the "Commit uncommitted changes" checkbox is unchecked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change that relaxes a disabling condition in the archive dialog; risk is limited to potential duplicate archive clicks while a mutation is in-flight.
> 
> **Overview**
> Allows users to start archiving multiple workspaces in parallel by removing the shared `isPending` gating from `ArchiveWorkspaceDialog`.
> 
> The archive modal’s Cancel/Archive buttons are no longer disabled based on a global pending flag; the only remaining disable condition is when there are uncommitted changes and the “commit changes” checkbox is unchecked. Call sites in the sidebar and workspace detail view stop passing `isPending`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d759497ead9e4e348b9ab9dd7c39b8ecfc994a1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->