### PR TITLE
Fix PR comment updatedAt validation error

### DIFF
--- a/src/backend/services/github-cli.service.ts
+++ b/src/backend/services/github-cli.service.ts
@@ -138,7 +138,7 @@ const fullPRDetailsSchema = z.object({
         author: z.object({ login: z.string() }),
         body: z.string(),
         createdAt: z.string(),
-        updatedAt: z.string().optional(),
+        updatedAt: z.string().nullish(),
         url: z.string(),
       })
       .passthrough()


### PR DESCRIPTION
## Summary

Fixes validation errors that were occurring when fetching PR details via GitHub CLI.

## Problem

The ratchet service was encountering repeated validation errors:
```
Invalid input: expected string, received undefined (path: comments[N].updatedAt)
```

This happened because GitHub CLI sometimes returns PR comments without an `updatedAt` field or with `undefined` value.

## Solution

Changed the Zod schema for PR comments from `z.string().optional()` to `z.string().nullish()`. 

The difference:
- `.optional()` allows the field to be absent, but if present, must be a string
- `.nullish()` allows the field to be absent, null, or undefined

The existing `mapComments` function already handles this correctly with `comment.updatedAt ?? comment.createdAt`, falling back to creation time when update time is unavailable.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm check:fix` passes  
- [x] All git hooks pass
- [ ] Verify ratchet service no longer logs validation errors for PR comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema loosening only affects validation of `gh` CLI JSON and doesn’t change auth or data writes; main risk is masking unexpected upstream payload issues.
> 
> **Overview**
> Fixes GitHub CLI PR-details parsing by allowing `comments[].updatedAt` to be `null`/`undefined` via `z.string().nullish()` in `fullPRDetailsSchema`, preventing Zod validation failures when the field is missing from `gh` output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73b33f36b7bfbbd6036e7f3f305818dd8ad1f57c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->