### PR TITLE
Fix session loading stuck on cold start

### DIFF
--- a/src/backend/services/session.service.test.ts
+++ b/src/backend/services/session.service.test.ts
@@ -556,6 +556,26 @@ describe('SessionService', () => {
     });
   });
 
+  it('keeps recent loading runtime when no process is active', () => {
+    vi.spyOn(sessionDomainService, 'getRuntimeSnapshot').mockReturnValue({
+      phase: 'loading',
+      processState: 'unknown',
+      activity: 'IDLE',
+      updatedAt: new Date().toISOString(),
+    });
+    vi.mocked(sessionProcessManager.getClient).mockReturnValue(undefined);
+    vi.mocked(sessionProcessManager.getPendingClient).mockReturnValue(undefined);
+    vi.mocked(sessionProcessManager.isStopInProgress).mockReturnValue(false);
+
+    const runtime = sessionService.getRuntimeSnapshot('session-1');
+
+    expect(runtime).toMatchObject({
+      phase: 'loading',
+      processState: 'unknown',
+      activity: 'IDLE',
+    });
+  });
+
   it('getOrCreateClient and startClaudeSession produce identical DB state', async () => {
     const session = unsafeCoerce<
       NonNullable<Awaited<ReturnType<typeof sessionRepository.getSessionById>>>


### PR DESCRIPTION
## Summary
- fix cold-start workspace chat loading getting stuck on `Loading session...`
- normalize stale session runtime snapshots that report `loading` even when no process is active
- add a websocket load timeout guard so missed hydration events cannot leave UI in indefinite loading
- add regression coverage for stale runtime normalization

## Root Cause
For some sessions after cold start, runtime snapshots could remain at `loading` in memory despite no active or pending Claude process. Combined with reconnect/load request churn, this could keep the UI in a persistent loading state.

## Changes
- `src/backend/services/session.service.ts`
  - In `getRuntimeSnapshot`, normalize stale `loading` to `idle/stopped` when no client/pending client/stop-in-progress exists.
- `src/components/chat/use-chat-websocket.ts`
  - Track per-load timeout and clear loading state after 10s if no matching `session_snapshot`/`session_replay_batch` arrives.
  - Clear timeout on hydration or disconnect.
- `src/backend/services/session.service.test.ts`
  - add test: `normalizes stale loading runtime to idle when no process is active`.

## Validation
- pre-commit hooks passed:
  - `pnpm typecheck`
  - `pnpm deps:check`
  - `pnpm knip --include files,dependencies,unlisted`
- test run:
  - `pnpm test -- src/backend/services/session.service.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session runtime normalization and WebSocket hydration retries; mistakes could mask legitimate `loading` states or increase reconnect traffic, impacting UX and state accuracy.
> 
> **Overview**
> Fixes cases where chat can remain stuck on *“Loading session…”* after cold start by hardening both backend and frontend session state handling.
> 
> On the backend, `SessionService.getRuntimeSnapshot` now *normalizes stale* persisted `loading` snapshots (older than 30s and with no active/pending process) to `idle`/`stopped`, with new unit coverage to ensure stale vs recent `loading` is handled correctly.
> 
> On the frontend, `useChatWebSocket` adds a 10s hydration retry/timeout loop for `load_session`, clearing the timer on matching `session_snapshot`/`session_replay_batch`, disconnect, or unmount to prevent indefinite loading when hydration events are missed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b777c6814313deee67a9da93ea713349d4dfa8c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->