### PR TITLE
Ratchet should @ mention reviewers when responding to comments

### DIFF
--- a/prompts/ratchet/dispatch.md
+++ b/prompts/ratchet/dispatch.md
@@ -22,7 +22,7 @@ Required Sequence:
 3. Check for unaddressed code review comments and address them.
 4. Run build/lint/test and fix any resulting failures.
 5. Push your changes.
-6. Comment briefly on addressed review comments and resolve them.
+6. Comment briefly on addressed review comments and resolve them. IMPORTANT: When responding to a comment, explicitly @ mention the person who made the comment (e.g., "@username - fixed as suggested").
 7. Request re-review from reviewers whose comments you addressed using `gh pr edit {{PR_NUMBER}} --add-reviewer <login>`.
 
 Completion Criteria:


### PR DESCRIPTION
## Summary
- Updates the ratchet dispatch prompt to explicitly @ mention comment authors when responding to review feedback
- This ensures automated re-review bots are triggered appropriately

## Changes
- Modified `prompts/ratchet/dispatch.md` step 6 to include instruction: "IMPORTANT: When responding to a comment, explicitly @ mention the person who made the comment (e.g., '@username - fixed as suggested')."

## Test plan
- Deploy and observe ratchet responses on PRs with review comments
- Verify that automated re-review bots are triggered when ratchet addresses feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)