### PR TITLE
Fix intra-domain import in workspace creation service

### DIFF
--- a/src/backend/domains/workspace/lifecycle/creation.service.test.ts
+++ b/src/backend/domains/workspace/lifecycle/creation.service.test.ts
@@ -7,8 +7,8 @@ import * as workspaceAccessorModule from '@/backend/resource_accessors/workspace
 import type { configService } from '@/backend/services/config.service';
 import * as gitOpsServiceModule from '@/backend/services/git-ops.service';
 import type { createLogger } from '@/backend/services/logger.service';
-import * as worktreeLifecycleServiceModule from '@/backend/services/worktree-lifecycle.service';
 import { unsafeCoerce } from '@/test-utils/unsafe-coerce';
+import * as worktreeLifecycleServiceModule from '../worktree/worktree-lifecycle.service';
 import { WorkspaceCreationService, type WorkspaceCreationSource } from './creation.service';
 
 type ConfigService = typeof configService;
@@ -20,7 +20,7 @@ vi.mock('@/backend/resource_accessors/project.accessor');
 vi.mock('@/backend/resource_accessors/user-settings.accessor');
 vi.mock('@/backend/resource_accessors/claude-session.accessor');
 vi.mock('@/backend/services/git-ops.service');
-vi.mock('@/backend/services/worktree-lifecycle.service');
+vi.mock('../worktree/worktree-lifecycle.service');
 vi.mock('@/backend/trpc/workspace/init.trpc', () => ({
   initializeWorkspaceWorktree: vi.fn().mockResolvedValue(undefined),
 }));
@@ -149,7 +149,10 @@ describe('WorkspaceCreationService', () => {
       updatedAt: new Date(),
     });
 
-    vi.spyOn(worktreeLifecycleServiceModule, 'setWorkspaceInitMode').mockResolvedValue();
+    vi.spyOn(
+      worktreeLifecycleServiceModule.worktreeLifecycleService,
+      'setInitMode'
+    ).mockResolvedValue();
   });
 
   describe('create', () => {
@@ -250,11 +253,9 @@ describe('WorkspaceCreationService', () => {
           mockProject,
           'existing-branch'
         );
-        expect(worktreeLifecycleServiceModule.setWorkspaceInitMode).toHaveBeenCalledWith(
-          'ws-123',
-          true,
-          '/path/to/worktrees'
-        );
+        expect(
+          worktreeLifecycleServiceModule.worktreeLifecycleService.setInitMode
+        ).toHaveBeenCalledWith('ws-123', true, '/path/to/worktrees');
       });
 
       it('should use branch name as workspace name when name not provided', async () => {

--- a/src/backend/domains/workspace/lifecycle/creation.service.ts
+++ b/src/backend/domains/workspace/lifecycle/creation.service.ts
@@ -9,7 +9,7 @@ import { workspaceAccessor } from '@/backend/resource_accessors/workspace.access
 import type { configService } from '@/backend/services/config.service';
 import { gitOpsService } from '@/backend/services/git-ops.service';
 import type { createLogger } from '@/backend/services/logger.service';
-import { setWorkspaceInitMode } from '@/backend/services/worktree-lifecycle.service';
+import { worktreeLifecycleService } from '../worktree/worktree-lifecycle.service';
 
 type ConfigService = typeof configService;
 type Logger = ReturnType<typeof createLogger>;
@@ -97,7 +97,7 @@ export class WorkspaceCreationService {
 
     // Set initialization mode if resuming existing branch
     if (initMode) {
-      await setWorkspaceInitMode(
+      await worktreeLifecycleService.setInitMode(
         workspace.id,
         initMode.useExistingBranch,
         initMode.worktreeBasePath


### PR DESCRIPTION
## Summary

- Replace deprecated shim import of `setWorkspaceInitMode` free function with direct intra-domain import of `worktreeLifecycleService.setInitMode()` instance method
- Both `creation.service.ts` and `worktree-lifecycle.service.ts` are in the workspace domain, so this should be a relative intra-domain import, not a cross-layer shim reference

Addresses PR review comment from #887.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test src/backend/domains/workspace/lifecycle/creation.service.test.ts` — 12/12 pass
- [x] dep-cruiser: 712 modules, 0 violations
- [x] knip: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a mechanical import/API wiring change, switching from a legacy shim free function to the domain service method with no behavioral logic changes.
> 
> **Overview**
> Updates workspace creation to call `worktreeLifecycleService.setInitMode()` via a relative intra-domain import instead of the legacy `setWorkspaceInitMode` shim.
> 
> Adjusts the `WorkspaceCreationService` unit test to mock/spy on the service instance method and assert the new call site.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d20375754ea49f5047c79343abd98c08d5033c60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->