### PR TITLE
Improve test coverage for domain services with edge case tests

### DIFF
--- a/src/backend/domains/run-script/run-script.service.test.ts
+++ b/src/backend/domains/run-script/run-script.service.test.ts
@@ -122,4 +122,268 @@ describe('RunScriptService.stopRunScript', () => {
     expect(mockCompleteStopping).toHaveBeenCalledWith('ws-1');
     expect(mockFindById).toHaveBeenNthCalledWith(2, 'ws-1');
   });
+
+  it('returns error when workspace not found', async () => {
+    mockFindById.mockResolvedValue(null);
+
+    const service = new RunScriptService();
+    const result = await service.stopRunScript('ws-missing');
+
+    expect(result).toEqual({ success: false, error: 'Workspace not found' });
+  });
+
+  it('returns success immediately when already IDLE', async () => {
+    mockFindById.mockResolvedValue({ id: 'ws-1', runScriptStatus: 'IDLE' });
+
+    const service = new RunScriptService();
+    const result = await service.stopRunScript('ws-1');
+
+    expect(result).toEqual({ success: true });
+    expect(mockBeginStopping).not.toHaveBeenCalled();
+  });
+
+  it('returns success immediately when already STOPPING', async () => {
+    mockFindById.mockResolvedValue({ id: 'ws-1', runScriptStatus: 'STOPPING' });
+
+    const service = new RunScriptService();
+    const result = await service.stopRunScript('ws-1');
+
+    expect(result).toEqual({ success: true });
+    expect(mockBeginStopping).not.toHaveBeenCalled();
+  });
+
+  it('handles COMPLETED state by resetting to IDLE', async () => {
+    mockFindById.mockResolvedValue({
+      id: 'ws-1',
+      runScriptStatus: 'COMPLETED',
+      runScriptPid: null,
+    });
+    mockReset.mockResolvedValue(undefined);
+
+    const service = new RunScriptService();
+    const result = await service.stopRunScript('ws-1');
+
+    expect(result).toEqual({ success: true });
+    expect(mockReset).toHaveBeenCalledWith('ws-1');
+  });
+
+  it('handles FAILED state by resetting to IDLE', async () => {
+    mockFindById.mockResolvedValue({
+      id: 'ws-1',
+      runScriptStatus: 'FAILED',
+      runScriptPid: null,
+    });
+    mockReset.mockResolvedValue(undefined);
+
+    const service = new RunScriptService();
+    const result = await service.stopRunScript('ws-1');
+
+    expect(result).toEqual({ success: true });
+    expect(mockReset).toHaveBeenCalledWith('ws-1');
+  });
+
+  it('returns error when no process or PID available for RUNNING workspace', async () => {
+    mockFindById.mockResolvedValue({
+      id: 'ws-1',
+      runScriptStatus: 'RUNNING',
+      runScriptPid: null,
+    });
+
+    const service = new RunScriptService();
+    const result = await service.stopRunScript('ws-1');
+
+    expect(result).toEqual({ success: false, error: 'No run script is running' });
+  });
+
+  it('handles beginStopping race where state moved to COMPLETED', async () => {
+    mockFindById
+      .mockResolvedValueOnce({
+        id: 'ws-1',
+        runScriptStatus: 'RUNNING',
+        runScriptPid: 12_345,
+        runScriptCleanupCommand: null,
+        worktreePath: '/tmp/ws-1',
+        runScriptPort: null,
+      })
+      .mockResolvedValueOnce({
+        id: 'ws-1',
+        runScriptStatus: 'COMPLETED',
+      });
+    mockBeginStopping.mockRejectedValue(new Error('CAS failed'));
+
+    const service = new RunScriptService();
+    (service as unknown as StopHandlerCapable).runningProcesses.set('ws-1', { pid: 12_345 });
+    const result = await service.stopRunScript('ws-1');
+
+    expect(result).toEqual({ success: true });
+  });
+});
+
+describe('RunScriptService.handleProcessExit edge cases', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('marks COMPLETED on exit code 0 from RUNNING state', async () => {
+    mockFindById.mockResolvedValue({ id: 'ws-1', runScriptStatus: 'RUNNING' });
+    mockMarkCompleted.mockResolvedValue(undefined);
+
+    const service = new RunScriptService() as unknown as ExitHandlerCapable;
+    await service.handleProcessExit('ws-1', 12_345, 0, null);
+
+    expect(mockMarkCompleted).toHaveBeenCalledWith('ws-1');
+    expect(mockMarkFailed).not.toHaveBeenCalled();
+  });
+
+  it('marks FAILED on non-zero exit code from RUNNING state', async () => {
+    mockFindById.mockResolvedValue({ id: 'ws-1', runScriptStatus: 'RUNNING' });
+    mockMarkFailed.mockResolvedValue(undefined);
+
+    const service = new RunScriptService() as unknown as ExitHandlerCapable;
+    await service.handleProcessExit('ws-1', 12_345, 1, null);
+
+    expect(mockMarkFailed).toHaveBeenCalledWith('ws-1');
+    expect(mockMarkCompleted).not.toHaveBeenCalled();
+  });
+
+  it('marks FAILED on signal-killed process (null exit code)', async () => {
+    mockFindById.mockResolvedValue({ id: 'ws-1', runScriptStatus: 'RUNNING' });
+    mockMarkFailed.mockResolvedValue(undefined);
+
+    const service = new RunScriptService() as unknown as ExitHandlerCapable;
+    await service.handleProcessExit('ws-1', 12_345, null, 'SIGKILL');
+
+    expect(mockMarkFailed).toHaveBeenCalledWith('ws-1');
+  });
+
+  it('skips transition when already in IDLE state', async () => {
+    mockFindById.mockResolvedValue({ id: 'ws-1', runScriptStatus: 'IDLE' });
+
+    const service = new RunScriptService() as unknown as ExitHandlerCapable;
+    await service.handleProcessExit('ws-1', 12_345, 0, null);
+
+    expect(mockMarkCompleted).not.toHaveBeenCalled();
+    expect(mockMarkFailed).not.toHaveBeenCalled();
+    expect(mockCompleteStopping).not.toHaveBeenCalled();
+  });
+
+  it('skips transition when already in COMPLETED state', async () => {
+    mockFindById.mockResolvedValue({ id: 'ws-1', runScriptStatus: 'COMPLETED' });
+
+    const service = new RunScriptService() as unknown as ExitHandlerCapable;
+    await service.handleProcessExit('ws-1', 12_345, 0, null);
+
+    expect(mockMarkCompleted).not.toHaveBeenCalled();
+    expect(mockMarkFailed).not.toHaveBeenCalled();
+  });
+
+  it('skips transition when already in FAILED state', async () => {
+    mockFindById.mockResolvedValue({ id: 'ws-1', runScriptStatus: 'FAILED' });
+
+    const service = new RunScriptService() as unknown as ExitHandlerCapable;
+    await service.handleProcessExit('ws-1', 12_345, 1, null);
+
+    expect(mockMarkCompleted).not.toHaveBeenCalled();
+    expect(mockMarkFailed).not.toHaveBeenCalled();
+  });
+
+  it('swallows state machine errors during exit handling', async () => {
+    mockFindById.mockResolvedValue({ id: 'ws-1', runScriptStatus: 'RUNNING' });
+    mockMarkCompleted.mockRejectedValue(new Error('CAS conflict'));
+
+    const service = new RunScriptService() as unknown as ExitHandlerCapable;
+    await expect(service.handleProcessExit('ws-1', 12_345, 0, null)).resolves.toBeUndefined();
+  });
+});
+
+describe('RunScriptService.appendOutput', () => {
+  it('truncates output buffer when exceeding MAX_OUTPUT_BUFFER_SIZE', () => {
+    const service = new RunScriptService();
+    const appendOutput = (
+      service as unknown as { appendOutput: (id: string, data: string) => void }
+    ).appendOutput.bind(service);
+
+    // Build a string just over 500KB
+    const bigChunk = 'x'.repeat(400 * 1024);
+    appendOutput('ws-1', bigChunk);
+
+    const smallChunk = 'y'.repeat(200 * 1024);
+    appendOutput('ws-1', smallChunk);
+
+    const buffer = service.getOutputBuffer('ws-1');
+    // Buffer should be capped at 500KB
+    expect(buffer.length).toBe(500 * 1024);
+    // Should contain the latest data
+    expect(buffer.endsWith('y'.repeat(200 * 1024))).toBe(true);
+  });
+
+  it('notifies listeners on new output', () => {
+    const service = new RunScriptService();
+    const appendOutput = (
+      service as unknown as { appendOutput: (id: string, data: string) => void }
+    ).appendOutput.bind(service);
+    const listener = vi.fn();
+    service.subscribeToOutput('ws-1', listener);
+
+    appendOutput('ws-1', 'hello');
+    expect(listener).toHaveBeenCalledWith('hello');
+  });
+
+  it('returns empty string for unknown workspace', () => {
+    const service = new RunScriptService();
+    expect(service.getOutputBuffer('unknown')).toBe('');
+  });
+});
+
+describe('RunScriptService.subscribeToOutput', () => {
+  it('returns unsubscribe function that stops notifications', () => {
+    const service = new RunScriptService();
+    const appendOutput = (
+      service as unknown as { appendOutput: (id: string, data: string) => void }
+    ).appendOutput.bind(service);
+    const listener = vi.fn();
+    const unsub = service.subscribeToOutput('ws-1', listener);
+
+    appendOutput('ws-1', 'before');
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsub();
+    appendOutput('ws-1', 'after');
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('cleans up listener set when last listener unsubscribes', () => {
+    const service = new RunScriptService();
+    const outputListeners = (service as unknown as { outputListeners: Map<string, Set<unknown>> })
+      .outputListeners;
+
+    const unsub = service.subscribeToOutput('ws-1', vi.fn());
+    expect(outputListeners.has('ws-1')).toBe(true);
+
+    unsub();
+    expect(outputListeners.has('ws-1')).toBe(false);
+  });
+});
+
+describe('RunScriptService.cleanupSync', () => {
+  it('force kills all running processes and clears maps', () => {
+    const service = new RunScriptService();
+    const mockProcess = { killed: false, kill: vi.fn(), pid: 999 };
+    (service as unknown as StopHandlerCapable).runningProcesses.set('ws-1', mockProcess as never);
+
+    service.cleanupSync();
+
+    expect(mockProcess.kill).toHaveBeenCalledWith('SIGKILL');
+    expect((service as unknown as StopHandlerCapable).runningProcesses.size).toBe(0);
+  });
+
+  it('skips already-killed processes', () => {
+    const service = new RunScriptService();
+    const mockProcess = { killed: true, kill: vi.fn(), pid: 999 };
+    (service as unknown as StopHandlerCapable).runningProcesses.set('ws-1', mockProcess as never);
+
+    service.cleanupSync();
+
+    expect(mockProcess.kill).not.toHaveBeenCalled();
+  });
 });

--- a/src/backend/services/rate-limit-backoff.test.ts
+++ b/src/backend/services/rate-limit-backoff.test.ts
@@ -1,0 +1,283 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { isRateLimitMessage, RateLimitBackoff } from './rate-limit-backoff';
+
+const mockLogger = {
+  info: vi.fn(),
+  debug: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+describe('isRateLimitMessage', () => {
+  it('detects HTTP 429 message', () => {
+    expect(isRateLimitMessage('http 429 too many requests')).toBe(true);
+  });
+
+  it('detects rate limit message', () => {
+    expect(isRateLimitMessage('api rate limit exceeded')).toBe(true);
+  });
+
+  it('detects throttle message', () => {
+    expect(isRateLimitMessage('request throttled by github')).toBe(true);
+  });
+
+  it('does not flag unrelated errors', () => {
+    expect(isRateLimitMessage('network timeout')).toBe(false);
+  });
+
+  it('does not flag empty string', () => {
+    expect(isRateLimitMessage('')).toBe(false);
+  });
+});
+
+describe('RateLimitBackoff', () => {
+  let backoff: RateLimitBackoff;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    backoff = new RateLimitBackoff();
+  });
+
+  describe('initial state', () => {
+    it('starts with multiplier of 1', () => {
+      expect(backoff.currentMultiplier).toBe(1);
+    });
+
+    it('computes delay equal to base interval initially', () => {
+      expect(backoff.computeDelay(60_000)).toBe(60_000);
+    });
+  });
+
+  describe('beginCycle', () => {
+    it('resets the per-cycle flag', () => {
+      backoff.beginCycle();
+      // After beginCycle, a clean cycle reset should return false (multiplier is 1)
+      const reset = backoff.resetIfCleanCycle(mockLogger as never, 'test');
+      expect(reset).toBe(false);
+    });
+  });
+
+  describe('handleError', () => {
+    it('doubles multiplier on first rate limit error', () => {
+      backoff.beginCycle();
+      const isRateLimit = backoff.handleError(
+        new Error('HTTP 429'),
+        mockLogger as never,
+        'test',
+        { workspaceId: 'ws-1', prUrl: 'https://github.com/o/r/pull/1' },
+        60_000
+      );
+
+      expect(isRateLimit).toBe(true);
+      expect(backoff.currentMultiplier).toBe(2);
+    });
+
+    it('does not double multiplier twice in same cycle', () => {
+      backoff.beginCycle();
+      backoff.handleError(
+        new Error('HTTP 429'),
+        mockLogger as never,
+        'test',
+        { workspaceId: 'ws-1', prUrl: 'url1' },
+        60_000
+      );
+      backoff.handleError(
+        new Error('rate limit'),
+        mockLogger as never,
+        'test',
+        { workspaceId: 'ws-2', prUrl: 'url2' },
+        60_000
+      );
+
+      expect(backoff.currentMultiplier).toBe(2);
+    });
+
+    it('doubles again in a new cycle', () => {
+      backoff.beginCycle();
+      backoff.handleError(
+        new Error('HTTP 429'),
+        mockLogger as never,
+        'test',
+        { workspaceId: 'ws-1', prUrl: 'url1' },
+        60_000
+      );
+      expect(backoff.currentMultiplier).toBe(2);
+
+      backoff.beginCycle();
+      backoff.handleError(
+        new Error('HTTP 429'),
+        mockLogger as never,
+        'test',
+        { workspaceId: 'ws-1', prUrl: 'url1' },
+        60_000
+      );
+      expect(backoff.currentMultiplier).toBe(4);
+    });
+
+    it('caps at maxMultiplier (default 4)', () => {
+      // Cycle 1: 1 -> 2
+      backoff.beginCycle();
+      backoff.handleError(
+        new Error('HTTP 429'),
+        mockLogger as never,
+        'test',
+        { workspaceId: 'ws-1', prUrl: 'url1' },
+        60_000
+      );
+
+      // Cycle 2: 2 -> 4
+      backoff.beginCycle();
+      backoff.handleError(
+        new Error('HTTP 429'),
+        mockLogger as never,
+        'test',
+        { workspaceId: 'ws-1', prUrl: 'url1' },
+        60_000
+      );
+
+      // Cycle 3: stays at 4
+      backoff.beginCycle();
+      backoff.handleError(
+        new Error('HTTP 429'),
+        mockLogger as never,
+        'test',
+        { workspaceId: 'ws-1', prUrl: 'url1' },
+        60_000
+      );
+
+      expect(backoff.currentMultiplier).toBe(4);
+    });
+
+    it('respects custom maxMultiplier', () => {
+      const smallBackoff = new RateLimitBackoff(2);
+      smallBackoff.beginCycle();
+      smallBackoff.handleError(
+        new Error('HTTP 429'),
+        mockLogger as never,
+        'test',
+        { workspaceId: 'ws-1', prUrl: 'url1' },
+        60_000
+      );
+      expect(smallBackoff.currentMultiplier).toBe(2);
+
+      smallBackoff.beginCycle();
+      smallBackoff.handleError(
+        new Error('HTTP 429'),
+        mockLogger as never,
+        'test',
+        { workspaceId: 'ws-1', prUrl: 'url1' },
+        60_000
+      );
+      // Should stay at 2
+      expect(smallBackoff.currentMultiplier).toBe(2);
+    });
+
+    it('returns false and logs error for non-rate-limit errors', () => {
+      backoff.beginCycle();
+      const isRateLimit = backoff.handleError(
+        new Error('network timeout'),
+        mockLogger as never,
+        'test',
+        { workspaceId: 'ws-1', prUrl: 'url1' },
+        60_000
+      );
+
+      expect(isRateLimit).toBe(false);
+      expect(backoff.currentMultiplier).toBe(1);
+      expect(mockLogger.error).toHaveBeenCalled();
+    });
+
+    it('handles non-Error objects', () => {
+      backoff.beginCycle();
+      const isRateLimit = backoff.handleError(
+        'string error',
+        mockLogger as never,
+        'test',
+        { workspaceId: 'ws-1', prUrl: 'url1' },
+        60_000
+      );
+
+      expect(isRateLimit).toBe(false);
+    });
+
+    it('handles non-Error objects that contain rate limit text', () => {
+      backoff.beginCycle();
+      const isRateLimit = backoff.handleError(
+        'HTTP 429 rate limit',
+        mockLogger as never,
+        'test',
+        { workspaceId: 'ws-1', prUrl: 'url1' },
+        60_000
+      );
+
+      expect(isRateLimit).toBe(true);
+      expect(backoff.currentMultiplier).toBe(2);
+    });
+  });
+
+  describe('resetIfCleanCycle', () => {
+    it('resets multiplier after a clean cycle', () => {
+      // Build up multiplier
+      backoff.beginCycle();
+      backoff.handleError(
+        new Error('HTTP 429'),
+        mockLogger as never,
+        'test',
+        { workspaceId: 'ws-1', prUrl: 'url1' },
+        60_000
+      );
+      expect(backoff.currentMultiplier).toBe(2);
+
+      // New clean cycle
+      backoff.beginCycle();
+      const wasReset = backoff.resetIfCleanCycle(mockLogger as never, 'test');
+
+      expect(wasReset).toBe(true);
+      expect(backoff.currentMultiplier).toBe(1);
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'test check succeeded, resetting backoff',
+        expect.objectContaining({ previousMultiplier: 2 })
+      );
+    });
+
+    it('returns false when multiplier is already 1', () => {
+      backoff.beginCycle();
+      const wasReset = backoff.resetIfCleanCycle(mockLogger as never, 'test');
+
+      expect(wasReset).toBe(false);
+      expect(backoff.currentMultiplier).toBe(1);
+    });
+
+    it('does not reset if rate limit was hit this cycle', () => {
+      backoff.beginCycle();
+      backoff.handleError(
+        new Error('HTTP 429'),
+        mockLogger as never,
+        'test',
+        { workspaceId: 'ws-1', prUrl: 'url1' },
+        60_000
+      );
+
+      const wasReset = backoff.resetIfCleanCycle(mockLogger as never, 'test');
+
+      expect(wasReset).toBe(false);
+      expect(backoff.currentMultiplier).toBe(2);
+    });
+  });
+
+  describe('computeDelay', () => {
+    it('returns base interval times multiplier', () => {
+      backoff.beginCycle();
+      backoff.handleError(
+        new Error('HTTP 429'),
+        mockLogger as never,
+        'test',
+        { workspaceId: 'ws-1', prUrl: 'url1' },
+        60_000
+      );
+
+      expect(backoff.computeDelay(60_000)).toBe(120_000);
+    });
+  });
+});


### PR DESCRIPTION
Add ~100 new tests across 6 service files, covering edge cases and
previously untested code paths:

- GitHubCLIService: computeCIStatus edge cases (ACTION_REQUIRED, IN_PROGRESS,
  CANCELLED, legacy state fields), computePRState priority logic, findPRForBranch
  fallback behavior, rate limit re-throw, reviewDecision normalization,
  getAuthenticatedUsername, getReviewComments mapping, checkHealth version parsing
- RatchetService: determineRatchetState for all PR/CI states, snapshot key
  generation and stability, computeLatestReviewActivityAtMs filtering,
  processWorkspace error paths (null fetchPRState, shutdown, thrown errors),
  checkAllWorkspaces/checkWorkspaceById guards, decideRatchetAction for
  merged/closed/active-session/blocked states, getActiveRatchetSession cleanup,
  triggerFixer error handling for all acquireAndDispatch result types
- RunScriptService: handleProcessExit for all terminal states (RUNNING,
  IDLE, COMPLETED, FAILED), stopRunScript for all entry states, output buffer
  truncation at 500KB, subscribeToOutput lifecycle, cleanupSync force-kill
- TerminalService: output buffer truncation at 100KB, exit auto-cleanup,
  active terminal cleared on destroy, multiple listeners, listener cleanup
  after terminal destroy
- RunScriptStateMachine: verifyRunning race conditions, exhaustive invalid
  transition rejection (23 cases)
- RateLimitBackoff: new test file covering isRateLimitMessage detection,
  exponential backoff with cycle boundaries, maxMultiplier capping,
  clean cycle reset, non-Error object handling

https://claude.ai/code/session_01N2YxuBtN8WLBJzdpARKVCC

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that broaden coverage for edge cases and race conditions without modifying production behavior; main risk is increased test brittleness/CI time.
> 
> **Overview**
> **Significantly expands backend test coverage** across `GitHubCLIService`, `ratchetService`, run-script services/state machine, `TerminalService`, and rate-limit backoff.
> 
> The new tests focus on edge cases and failure modes: CI/PR state normalization (including legacy check formats), rate-limit rethrow behavior, PR discovery fallbacks, review comment mapping, health/version parsing, ratchet decision/state transitions and shutdown/error paths, run-script lifecycle races and output buffering/listener cleanup, terminal output buffer truncation and auto-cleanup on exit, plus a new `rate-limit-backoff.test.ts` covering `isRateLimitMessage` and backoff multiplier/reset behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3a88269685ff742b620bcc2a6aaaf11654bf061. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->