### PR TITLE
Fix ratchet shutdown blocking graceful server stop

### DIFF
--- a/src/backend/domains/ratchet/ratchet.service.test.ts
+++ b/src/backend/domains/ratchet/ratchet.service.test.ts
@@ -1012,6 +1012,27 @@ describe('ratchet service (state-change + idle dispatch)', () => {
     });
   });
 
+  describe('shutdown behavior', () => {
+    it('stops immediately while monitor loop is sleeping', async () => {
+      vi.useFakeTimers();
+
+      vi.spyOn(ratchetService, 'checkAllWorkspaces').mockResolvedValue({
+        checked: 0,
+        stateChanges: 0,
+        actionsTriggered: 0,
+        results: [],
+      });
+
+      ratchetService.start();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      await expect(ratchetService.stop()).resolves.toBeUndefined();
+
+      vi.useRealTimers();
+    });
+  });
+
   describe('checkWorkspaceById', () => {
     it('returns null when shutting down', async () => {
       unsafeCoerce<{ isShuttingDown: boolean }>(ratchetService).isShuttingDown = true;


### PR DESCRIPTION
## Summary
- fix ratchet shutdown hang by making monitor-loop sleep interruptible
- wake the sleep immediately in `ratchetService.stop()` before awaiting loop completion
- add a regression test proving `stop()` resolves while loop is sleeping

## Root Cause
The backend shutdown path awaited `ratchetService.stop()`. The ratchet monitor loop could be sleeping for up to the poll interval (2 minutes), causing the server process to miss the CLI's 5s graceful shutdown window and get force-killed.

## Testing
- `pnpm vitest src/backend/domains/ratchet/ratchet.service.test.ts`
- Full `pnpm typecheck` currently fails on pre-existing repository issues unrelated to this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized lifecycle change that only affects shutdown timing; main risk is subtle timer/loop edge cases causing extra wakeups or missed delays.
> 
> **Overview**
> Fixes a graceful-shutdown hang in the `ratchetService` by making the monitor loop’s sleep interruptible.
> 
> `stop()` now wakes any in-progress sleep (tracking the pending timeout/resolve) so the monitor loop can exit immediately instead of waiting up to the poll interval. Adds a regression test asserting `stop()` resolves while the loop is sleeping (using fake timers).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fabf34a6430e9d208b8623fa4bb381540b61d75d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->