### PR TITLE
Fix stale CI running badge precedence

### DIFF
--- a/src/shared/workspace-sidebar-status.test.ts
+++ b/src/shared/workspace-sidebar-status.test.ts
@@ -43,24 +43,36 @@ describe('workspace-sidebar-status', () => {
     expect(result.ciState).toBe('MERGED');
   });
 
-  it('uses ratchet CI failure even when PR snapshot is stale', () => {
+  it('prefers PR snapshot CI failure over stale ratchet CI running', () => {
     const result = deriveWorkspaceSidebarStatus({
       isWorking: false,
       prUrl: 'https://github.com/o/r/pull/1',
       prState: 'OPEN',
-      prCiStatus: 'SUCCESS',
-      ratchetState: 'CI_FAILED',
+      prCiStatus: 'FAILURE',
+      ratchetState: 'CI_RUNNING',
     });
 
     expect(result.ciState).toBe('FAILING');
   });
 
-  it('uses ratchet CI running even when PR snapshot is stale', () => {
+  it('prefers PR snapshot CI passing over stale ratchet CI running', () => {
     const result = deriveWorkspaceSidebarStatus({
       isWorking: false,
       prUrl: 'https://github.com/o/r/pull/1',
       prState: 'OPEN',
       prCiStatus: 'SUCCESS',
+      ratchetState: 'CI_RUNNING',
+    });
+
+    expect(result.ciState).toBe('PASSING');
+  });
+
+  it('uses ratchet CI state as fallback when PR CI status is unknown', () => {
+    const result = deriveWorkspaceSidebarStatus({
+      isWorking: false,
+      prUrl: 'https://github.com/o/r/pull/1',
+      prState: 'OPEN',
+      prCiStatus: 'UNKNOWN',
       ratchetState: 'CI_RUNNING',
     });
 

--- a/src/shared/workspace-sidebar-status.ts
+++ b/src/shared/workspace-sidebar-status.ts
@@ -37,15 +37,18 @@ export function deriveWorkspaceSidebarStatus(
     return { activityState, ciState: 'MERGED' };
   }
 
-  if (input.ratchetState === 'CI_FAILED') {
-    return { activityState, ciState: 'FAILING' };
+  const ciStateFromSnapshot = deriveCiVisualStateFromPrCiStatus(input.prCiStatus);
+  if (ciStateFromSnapshot === 'UNKNOWN') {
+    if (input.ratchetState === 'CI_FAILED') {
+      return { activityState, ciState: 'FAILING' };
+    }
+
+    if (input.ratchetState === 'CI_RUNNING') {
+      return { activityState, ciState: 'RUNNING' };
+    }
   }
 
-  if (input.ratchetState === 'CI_RUNNING') {
-    return { activityState, ciState: 'RUNNING' };
-  }
-
-  return { activityState, ciState: deriveCiVisualStateFromPrCiStatus(input.prCiStatus) };
+  return { activityState, ciState: ciStateFromSnapshot };
 }
 
 export function getWorkspaceActivityTooltip(state: WorkspaceSidebarActivityState): string {


### PR DESCRIPTION
## Summary
- fix CI badge precedence so stale ratchet state does not override fresh PR snapshot CI status
- keep ratchet CI state as fallback only when PR snapshot CI status is unknown
- add tests covering stale-ratchet override and unknown fallback behavior

## Testing
- pnpm test src/shared/workspace-sidebar-status.test.ts src/backend/domains/workspace/state/flow-state.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adjusts workspace sidebar CI badge precedence logic and adds targeted tests; impact is limited to status display semantics with minimal blast radius.
> 
> **Overview**
> Fixes workspace sidebar CI badge precedence so the PR snapshot CI result wins over a stale ratchet `CI_RUNNING` state.
> 
> `deriveWorkspaceSidebarStatus` now uses ratchet CI states only as a fallback when the snapshot CI status resolves to `UNKNOWN`, and tests were updated/added to cover the new precedence and fallback behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fcc292224c7beab7d35bed8c72819a7e9777585. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->