### PR TITLE
Remove redundant init script banner

### DIFF
--- a/src/client/routes/projects/workspaces/use-workspace-detail-hooks.ts
+++ b/src/client/routes/projects/workspaces/use-workspace-detail-hooks.ts
@@ -49,16 +49,12 @@ export function useWorkspaceInitStatus(
 
   const status = workspaceInitStatus?.status;
 
-  // Non-blocking: worktree exists but script still running
-  const isScriptRunning = status === 'PROVISIONING' && hasWorktreePath;
-
   // Script failed after worktree was created — non-blocking banner with retry
   const isScriptFailed = status === 'FAILED' && hasWorktreePath;
 
   return {
     workspaceInitStatus,
     isInitStatusPending,
-    isScriptRunning,
     isScriptFailed,
   };
 }

--- a/src/client/routes/projects/workspaces/workspace-detail-container.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-container.tsx
@@ -36,7 +36,7 @@ export function WorkspaceDetailContainer() {
     { enabled: workspace?.hasHadSessions === true && workspace?.prState === 'NONE' }
   );
 
-  const { workspaceInitStatus, isScriptRunning, isScriptFailed } = useWorkspaceInitStatus(
+  const { workspaceInitStatus, isScriptFailed } = useWorkspaceInitStatus(
     workspaceId,
     workspace,
     utils
@@ -244,7 +244,6 @@ export function WorkspaceDetailContainer() {
       workspace={workspace}
       workspaceId={workspaceId}
       handleBackToWorkspaces={handleBackToWorkspaces}
-      isScriptRunning={isScriptRunning}
       isScriptFailed={isScriptFailed}
       workspaceInitStatus={workspaceInitStatus}
       archivePending={archiveWorkspace.isPending}

--- a/src/client/routes/projects/workspaces/workspace-detail-view.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-view.tsx
@@ -9,14 +9,13 @@ import type { useSessionManagement, useWorkspaceData } from './use-workspace-det
 import type { useWorkspaceInitStatus } from './use-workspace-detail-hooks';
 import { ChatContent } from './workspace-detail-chat-content';
 import { WorkspaceHeader } from './workspace-detail-header';
-import { ArchivingOverlay, ScriptFailedBanner, ScriptRunningBanner } from './workspace-overlays';
+import { ArchivingOverlay, ScriptFailedBanner } from './workspace-overlays';
 
 export interface WorkspaceDetailViewProps {
   workspaceLoading: boolean;
   workspace: ReturnType<typeof useWorkspaceData>['workspace'];
   workspaceId: string;
   handleBackToWorkspaces: () => void;
-  isScriptRunning: boolean;
   isScriptFailed: boolean;
   workspaceInitStatus: ReturnType<typeof useWorkspaceInitStatus>['workspaceInitStatus'];
   archivePending: boolean;
@@ -83,23 +82,13 @@ export interface WorkspaceDetailViewProps {
 
 function ScriptBanner({
   workspaceId,
-  isScriptRunning,
   isScriptFailed,
   workspaceInitStatus,
 }: {
   workspaceId: string;
-  isScriptRunning: boolean;
   isScriptFailed: boolean;
   workspaceInitStatus: WorkspaceDetailViewProps['workspaceInitStatus'];
 }) {
-  if (isScriptRunning) {
-    return (
-      <ScriptRunningBanner
-        initOutput={workspaceInitStatus?.initOutput ?? null}
-        hasStartupScript={workspaceInitStatus?.hasStartupScript ?? false}
-      />
-    );
-  }
   if (isScriptFailed) {
     return (
       <ScriptFailedBanner
@@ -118,7 +107,6 @@ export function WorkspaceDetailView({
   workspace,
   workspaceId,
   handleBackToWorkspaces,
-  isScriptRunning,
   isScriptFailed,
   workspaceInitStatus,
   archivePending,
@@ -217,7 +205,6 @@ export function WorkspaceDetailView({
 
       <ScriptBanner
         workspaceId={workspaceId}
-        isScriptRunning={isScriptRunning}
         isScriptFailed={isScriptFailed}
         workspaceInitStatus={workspaceInitStatus}
       />


### PR DESCRIPTION
## Summary

Removes the redundant "Running init script..." banner that appeared at the top of the workspace view while keeping the inline chat message that displays the same information.

## Changes

- Removed `ScriptRunningBanner` component usage from workspace detail view
- Removed `isScriptRunning` prop from component interfaces and hooks
- Kept inline chat message via `initBanner` prop for init script status
- Only the failed script banner is now shown at the top (when applicable)

## Testing

- ✅ TypeScript type checking passes
- ✅ Linter and formatter checks pass
- ✅ Dependency and unused export checks pass

The inline "Running init script..." message continues to display in the chat during workspace initialization, eliminating the duplicate banner at the top.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change that removes a single banner state/prop; no backend, auth, or data-flow changes.
> 
> **Overview**
> Removes the redundant top-of-page init status banner shown during provisioning by dropping the `isScriptRunning` state from `useWorkspaceInitStatus` and its `WorkspaceDetail*` prop chain.
> 
> The workspace detail view now only renders a banner when the init script *fails* (`ScriptFailedBanner`), reducing duplicate init-status UI during setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4054972c35efd7dcc3a5d3ac081681d7714e6e3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->