### PR TITLE
Add Factory Factory signature to agent-created PRs

### DIFF
--- a/prompts/workflows/bugfix.md
+++ b/prompts/workflows/bugfix.md
@@ -43,11 +43,26 @@ You are fixing a bug. Follow this workflow to ensure the fix is correct and does
 ### 7. Create Pull Request
 - Commit with a descriptive message referencing the bug
 - Push your branch: `git push -u origin HEAD`
-- Create the PR using the GitHub CLI:
+- Create the PR using the GitHub CLI with a body file to preserve formatting:
   ```bash
-  gh pr create --title "Fix: Brief description" --body "Description with reproduction steps and fix explanation"
+  cat > /tmp/pr-body.md << 'EOF'
+  ## Bug Fix
+  [Description of the bug and how it was fixed]
+
+  ## Reproduction Steps
+  1. [Steps to reproduce the original bug]
+
+  ## Fix Explanation
+  [Technical explanation of the fix]
+
+  ## Testing
+  - [How to verify the fix works]
+
+  ---
+  🏭 Forged in [Factory Factory](https://factoryfactory.ai)
+  EOF
+  gh pr create --title "Fix: Brief description" --body-file /tmp/pr-body.md
   ```
-- Include reproduction steps and fix explanation in the PR body
 
 ## Guidelines
 

--- a/prompts/workflows/feature.md
+++ b/prompts/workflows/feature.md
@@ -40,11 +40,23 @@ You are implementing a new feature. Follow this workflow to deliver high-quality
 ### 6. Create Pull Request
 - Commit all changes with descriptive messages
 - Push your branch: `git push -u origin HEAD`
-- Create the PR using the GitHub CLI:
+- Create the PR using the GitHub CLI with a body file to preserve formatting:
   ```bash
-  gh pr create --title "Your PR title" --body "Description of changes"
+  cat > /tmp/pr-body.md << 'EOF'
+  ## Summary
+  [Clear description of what this PR accomplishes]
+
+  ## Changes
+  - [List of key changes]
+
+  ## Testing
+  - [How to test the changes]
+
+  ---
+  🏭 Forged in [Factory Factory](https://factoryfactory.ai)
+  EOF
+  gh pr create --title "Your PR title" --body-file /tmp/pr-body.md
   ```
-- Include a clear summary, what changed, and how to test it in the PR body
 
 ## Guidelines
 

--- a/src/backend/lib/constants.ts
+++ b/src/backend/lib/constants.ts
@@ -6,3 +6,8 @@ export const LIB_LIMITS = Object.freeze({
   shellDefaultMaxBufferBytes: 10 * 1024 * 1024,
   osascriptEscapedMaxChars: 200,
 } as const);
+
+/**
+ * Factory Factory signature for PRs created by agents.
+ */
+export const FACTORY_SIGNATURE = '🏭 Forged in [Factory Factory](https://factoryfactory.ai)';

--- a/src/backend/orchestration/workspace-init.orchestrator.ts
+++ b/src/backend/orchestration/workspace-init.orchestrator.ts
@@ -8,6 +8,7 @@ import {
 } from '@/backend/domains/session';
 import { workspaceStateMachine } from '@/backend/domains/workspace/lifecycle/state-machine.service';
 import { worktreeLifecycleService } from '@/backend/domains/workspace/worktree/worktree-lifecycle.service';
+import { FACTORY_SIGNATURE } from '@/backend/lib/constants';
 import { claudeSessionAccessor } from '@/backend/resource_accessors/claude-session.accessor';
 import { workspaceAccessor } from '@/backend/resource_accessors/workspace.accessor';
 import { SERVICE_CACHE_TTL_MS } from '@/backend/services/constants';
@@ -345,6 +346,9 @@ Update TodoWrite with any additional fix tasks discovered.
    - [ ] Manual testing: [How to verify this change works]
 
    Closes #${issue.number}
+
+   ---
+   ${FACTORY_SIGNATURE}
    \`\`\`
 
 3. **Create the PR:**


### PR DESCRIPTION
## Summary
- Adds a "Forged in Factory Factory" signature to all PRs created by agents
- Introduces a shared `FACTORY_SIGNATURE` constant in `src/backend/lib/constants.ts`
- Updates workflow prompt templates (bugfix and feature) to use `--body-file` for PR creation and include the signature
- Updates the workspace init orchestrator to append the signature to agent-generated PR body templates

## Changes
- **`src/backend/lib/constants.ts`**: New `FACTORY_SIGNATURE` constant with branded link
- **`src/backend/orchestration/workspace-init.orchestrator.ts`**: Appends signature to the PR body template used when agents create PRs from GitHub issues
- **`prompts/workflows/bugfix.md`**: Switches PR creation to `--body-file` pattern with structured template including signature
- **`prompts/workflows/feature.md`**: Same `--body-file` update with structured template and signature

## Testing
- `pnpm typecheck` passes
- `pnpm check:fix` passes
- Dependency cruiser confirms no cross-domain import violations
