### PR TITLE
Refactor websocket handlers and queue policies

### DIFF
--- a/src/backend/routers/websocket/chat.handler.test.ts
+++ b/src/backend/routers/websocket/chat.handler.test.ts
@@ -1,0 +1,70 @@
+import type { IncomingMessage } from 'node:http';
+import type { Duplex } from 'node:stream';
+import { describe, expect, it, vi } from 'vitest';
+import type { WebSocket, WebSocketServer } from 'ws';
+import type { AppContext } from '../../app-context';
+import { createChatUpgradeHandler } from './chat.handler';
+
+describe('createChatUpgradeHandler', () => {
+  it('rejects invalid workingDir with 400 response before upgrade', () => {
+    const chatMessageHandlerService = {
+      setClientCreator: vi.fn(),
+      tryDispatchNextMessage: vi.fn(),
+      handleMessage: vi.fn(),
+    };
+    const sessionService = {
+      setOnClientCreated: vi.fn(),
+      getOrCreateClient: vi.fn(),
+      getSessionOptions: vi.fn(),
+    };
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    const appContext = {
+      services: {
+        chatConnectionService: {
+          values: vi.fn(() => []),
+          get: vi.fn(),
+          register: vi.fn(),
+          unregister: vi.fn(),
+        },
+        chatEventForwarderService: {
+          setupClientEvents: vi.fn(),
+          setupWorkspaceNotifications: vi.fn(),
+        },
+        chatMessageHandlerService,
+        configService: {
+          getDebugConfig: vi.fn(() => ({ chatWebSocket: false })),
+          getWorktreeBaseDir: vi.fn(),
+        },
+        createLogger: vi.fn(() => logger),
+        sessionFileLogger: {
+          initSession: vi.fn(),
+          log: vi.fn(),
+          closeSession: vi.fn(),
+        },
+        sessionService,
+      },
+    } as unknown as AppContext;
+
+    const handler = createChatUpgradeHandler(appContext);
+
+    const request = {} as IncomingMessage;
+    const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
+    const wss = { handleUpgrade: vi.fn() } as unknown as WebSocketServer;
+    const wsAliveMap = new WeakMap<WebSocket, boolean>();
+    const url = new URL('http://localhost/chat?workingDir=../outside');
+
+    handler(request, socket, Buffer.alloc(0), url, wss, wsAliveMap);
+
+    expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('400 Bad Request'));
+    expect(socket.destroy).toHaveBeenCalledTimes(1);
+    expect(wss.handleUpgrade).not.toHaveBeenCalled();
+    expect(chatMessageHandlerService.setClientCreator).toHaveBeenCalledTimes(1);
+    expect(sessionService.setOnClientCreated).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/backend/routers/websocket/dev-logs.handler.test.ts
+++ b/src/backend/routers/websocket/dev-logs.handler.test.ts
@@ -1,0 +1,78 @@
+import { EventEmitter } from 'node:events';
+import type { IncomingMessage } from 'node:http';
+import type { Duplex } from 'node:stream';
+import { describe, expect, it, vi } from 'vitest';
+import type { WebSocket, WebSocketServer } from 'ws';
+import { WS_READY_STATE } from '@/backend/constants';
+import type { AppContext } from '../../app-context';
+import { createDevLogsUpgradeHandler } from './dev-logs.handler';
+
+class MockWebSocket extends EventEmitter {
+  readyState: number = WS_READY_STATE.OPEN;
+  send = vi.fn();
+  close = vi.fn();
+  terminate = vi.fn();
+}
+
+describe('createDevLogsUpgradeHandler', () => {
+  it('streams buffered and live output only while socket is open', () => {
+    const workspaceId = 'workspace-1';
+
+    const runScriptService = {
+      getOutputBuffer: vi.fn(() => 'buffered logs\n'),
+      subscribeToOutput: vi.fn((_id: string, _callback: (data: string) => void) => vi.fn()),
+    };
+
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    const appContext = {
+      services: {
+        createLogger: vi.fn(() => logger),
+        runScriptService,
+      },
+    } as unknown as AppContext;
+
+    const handler = createDevLogsUpgradeHandler(appContext);
+    const ws = new MockWebSocket();
+
+    const wss = {
+      handleUpgrade: vi.fn(
+        (
+          _request: IncomingMessage,
+          _socket: Duplex,
+          _head: Buffer,
+          callback: (socket: WebSocket) => void
+        ) => callback(ws as unknown as WebSocket)
+      ),
+    } as unknown as WebSocketServer;
+
+    const request = {} as IncomingMessage;
+    const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
+    const wsAliveMap = new WeakMap<WebSocket, boolean>();
+    const url = new URL(`http://localhost/dev-logs?workspaceId=${workspaceId}`);
+
+    handler(request, socket, Buffer.alloc(0), url, wss, wsAliveMap);
+
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: 'output', data: 'buffered logs\n' })
+    );
+    const outputSubscriber = runScriptService.subscribeToOutput.mock.calls[0]?.[1] as
+      | ((data: string) => void)
+      | undefined;
+    if (!outputSubscriber) {
+      throw new Error('Expected subscribeToOutput callback to be registered');
+    }
+    outputSubscriber('live logs\n');
+    expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: 'output', data: 'live logs\n' }));
+
+    const callsBeforeClosed = ws.send.mock.calls.length;
+    ws.readyState = WS_READY_STATE.CLOSED;
+    outputSubscriber('dropped logs\n');
+    expect(ws.send.mock.calls.length).toBe(callsBeforeClosed);
+  });
+});

--- a/src/backend/routers/websocket/terminal.handler.test.ts
+++ b/src/backend/routers/websocket/terminal.handler.test.ts
@@ -1,0 +1,144 @@
+import { EventEmitter } from 'node:events';
+import type { IncomingMessage } from 'node:http';
+import type { Duplex } from 'node:stream';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WebSocket, WebSocketServer } from 'ws';
+import { WS_READY_STATE } from '@/backend/constants';
+import type { AppContext } from '../../app-context';
+import { createTerminalUpgradeHandler, terminalConnections } from './terminal.handler';
+
+const mockClearTerminalPid = vi.fn();
+
+vi.mock('@/backend/domains/session', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/backend/domains/session')>();
+  return {
+    ...actual,
+    sessionDataService: {
+      ...actual.sessionDataService,
+      clearTerminalPid: (...args: unknown[]) => mockClearTerminalPid(...args),
+      createTerminalSession: vi.fn(),
+    },
+  };
+});
+
+vi.mock('@/backend/domains/workspace', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/backend/domains/workspace')>();
+  return {
+    ...actual,
+    workspaceDataService: {
+      ...actual.workspaceDataService,
+      findById: vi.fn(),
+    },
+  };
+});
+
+class MockWebSocket extends EventEmitter {
+  readyState = WS_READY_STATE.OPEN;
+  send = vi.fn();
+  close = vi.fn();
+  terminate = vi.fn();
+}
+
+describe('createTerminalUpgradeHandler', () => {
+  beforeEach(() => {
+    terminalConnections.clear();
+    vi.clearAllMocks();
+    mockClearTerminalPid.mockResolvedValue(undefined);
+  });
+
+  it('keeps existing connections streaming when a new client connects', () => {
+    const workspaceId = 'workspace-1';
+    const terminalId = 'terminal-1';
+
+    const outputListeners = new Map<string, Set<(output: string) => void>>();
+    const exitListeners = new Map<string, Set<(exitCode: number) => void>>();
+
+    const terminalService = {
+      getTerminalsForWorkspace: vi.fn(() => [
+        {
+          id: terminalId,
+          createdAt: new Date('2026-02-11T00:00:00.000Z'),
+          outputBuffer: 'initial output',
+        },
+      ]),
+      onOutput: vi.fn((id: string, callback: (output: string) => void) => {
+        const listeners = outputListeners.get(id) ?? new Set();
+        listeners.add(callback);
+        outputListeners.set(id, listeners);
+        return () => listeners.delete(callback);
+      }),
+      onExit: vi.fn((id: string, callback: (exitCode: number) => void) => {
+        const listeners = exitListeners.get(id) ?? new Set();
+        listeners.add(callback);
+        exitListeners.set(id, listeners);
+        return () => listeners.delete(callback);
+      }),
+      createTerminal: vi.fn(),
+      writeToTerminal: vi.fn(),
+      resizeTerminal: vi.fn(),
+      destroyTerminal: vi.fn(),
+      setActiveTerminal: vi.fn(),
+    };
+
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    const appContext = {
+      services: {
+        terminalService,
+        createLogger: vi.fn(() => logger),
+      },
+    } as unknown as AppContext;
+
+    const handler = createTerminalUpgradeHandler(appContext);
+
+    const ws1 = new MockWebSocket();
+    const ws2 = new MockWebSocket();
+    const wsQueue = [ws1, ws2];
+
+    const wss = {
+      handleUpgrade: vi.fn(
+        (
+          _request: IncomingMessage,
+          _socket: Duplex,
+          _head: Buffer,
+          callback: (ws: WebSocket) => void
+        ) => {
+          const nextWs = wsQueue.shift();
+          if (!nextWs) {
+            throw new Error('No WebSocket available');
+          }
+          callback(nextWs as unknown as WebSocket);
+        }
+      ),
+    } as unknown as WebSocketServer;
+
+    const request = {} as IncomingMessage;
+    const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
+    const wsAliveMap = new WeakMap<WebSocket, boolean>();
+    const url = new URL(`http://localhost/terminal?workspaceId=${workspaceId}`);
+
+    handler(request, socket, Buffer.alloc(0), url, wss, wsAliveMap);
+    handler(request, socket, Buffer.alloc(0), url, wss, wsAliveMap);
+
+    const listeners = outputListeners.get(terminalId);
+    expect(listeners?.size).toBe(2);
+
+    for (const listener of listeners ?? []) {
+      listener('live output');
+    }
+
+    const outputMessage = JSON.stringify({
+      type: 'output',
+      terminalId,
+      data: 'live output',
+    });
+    expect(ws1.send).toHaveBeenCalledWith(outputMessage);
+    expect(ws2.send).toHaveBeenCalledWith(outputMessage);
+    expect(terminalConnections.get(workspaceId)?.size).toBe(2);
+  });
+});

--- a/src/backend/routers/websocket/upgrade-utils.ts
+++ b/src/backend/routers/websocket/upgrade-utils.ts
@@ -1,0 +1,27 @@
+import type { Duplex } from 'node:stream';
+import type { WebSocket } from 'ws';
+
+export function sendBadRequest(socket: Duplex, message?: string): void {
+  const body = message ? `\r\n\r\n${message}` : '\r\n\r\n';
+  socket.write(`HTTP/1.1 400 Bad Request${body}`);
+  socket.destroy();
+}
+
+export function markWebSocketAlive(ws: WebSocket, wsAliveMap: WeakMap<WebSocket, boolean>): void {
+  wsAliveMap.set(ws, true);
+  ws.on('pong', () => wsAliveMap.set(ws, true));
+}
+
+export function getOrCreateConnectionSet<TKey>(
+  map: Map<TKey, Set<WebSocket>>,
+  key: TKey
+): Set<WebSocket> {
+  const existing = map.get(key);
+  if (existing) {
+    return existing;
+  }
+
+  const created = new Set<WebSocket>();
+  map.set(key, created);
+  return created;
+}

--- a/src/components/workspace/use-dev-logs.ts
+++ b/src/components/workspace/use-dev-logs.ts
@@ -69,6 +69,7 @@ export function useDevLogs(workspaceId: string): UseDevLogsResult {
     onMessage: handleMessage,
     onConnected: handleConnected,
     onDisconnected: handleDisconnected,
+    queuePolicy: 'drop',
   });
 
   return { connected, output, outputEndRef };

--- a/src/components/workspace/use-terminal-websocket.ts
+++ b/src/components/workspace/use-terminal-websocket.ts
@@ -106,6 +106,7 @@ export function useTerminalWebSocket({
   const { connected, send } = useWebSocketTransport({
     url,
     onMessage: handleMessage,
+    queuePolicy: 'drop',
   });
 
   const create = useCallback(


### PR DESCRIPTION
## Summary
- add shared websocket upgrade helpers for bad request responses, heartbeat registration, and connection set initialization
- fix terminal websocket behavior to support multiple concurrent viewers without disabling older connections
- deduplicate terminal listener wiring via a shared `attachTerminalListeners` path
- add transport queue policy support (`replay` | `drop`) and set terminal/dev-logs to `drop`
- refactor chat event forwarder repetitive event wiring into table-driven registration for cleaner maintenance
- align websocket ready-state checks and error-send guards for consistency
- add websocket handler coverage for chat/dev-logs/terminal plus queue policy coverage in transport tests

## Testing
- `pnpm typecheck`
- `pnpm test src/backend/routers/websocket/chat.handler.test.ts src/backend/routers/websocket/dev-logs.handler.test.ts src/backend/routers/websocket/terminal.handler.test.ts src/hooks/use-websocket-transport.test.ts src/backend/domains/session/chat/chat-event-forwarder.service.test.ts`
- `pnpm test` *(fails in existing `src/backend/migrate.test.ts` due local `better-sqlite3` native module ABI mismatch: built with `NODE_MODULE_VERSION 127`, runtime expects `141`)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core WebSocket upgrade and message-delivery paths; regressions could drop messages or break multi-connection streaming if edge cases around reconnect/readyState handling are missed.
> 
> **Overview**
> **WebSocket handlers are standardized and de-duplicated** by introducing `upgrade-utils` helpers for `400` responses, heartbeat/`pong` liveness tracking, and connection-set initialization, then adopting them across `chat`, `dev-logs`, and `terminal` upgrades.
> 
> **Terminal WebSocket behavior changes** to support multiple concurrent viewers by removing logic that cleaned up existing connections’ listeners when a new client connects, and by centralizing listener wiring in `attachTerminalListeners`.
> 
> **Client transport behavior changes** by adding a `queuePolicy` (`replay` default, or `drop`) to `useWebSocketTransport`; terminal and dev-logs now opt into `drop` so disconnected user input/log messages are not replayed after reconnect. Chat event forwarding is also refactored to table-driven registration for several event types, and chat error sends are guarded to only send when the socket is open. Added targeted tests covering the new upgrade behavior and queue policy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e428e48bc4c686425db496e3674c17bd3d07b5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->