### PR TITLE
Fix workspace not updating after PR creation detected

### DIFF
--- a/src/backend/domains/github/pr-snapshot.service.test.ts
+++ b/src/backend/domains/github/pr-snapshot.service.test.ts
@@ -288,6 +288,30 @@ describe('PRSnapshotService', () => {
       });
     });
 
+    it('does not include prUrl in event when applySnapshot is called without prUrl options', async () => {
+      const events: PRSnapshotUpdatedEvent[] = [];
+      prSnapshotService.on(PR_SNAPSHOT_UPDATED, (event: PRSnapshotUpdatedEvent) => {
+        events.push(event);
+      });
+
+      await prSnapshotService.applySnapshot('ws-plain', {
+        prNumber: 11,
+        prState: 'OPEN',
+        prCiStatus: 'SUCCESS',
+        prReviewState: null,
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        workspaceId: 'ws-plain',
+        prNumber: 11,
+        prState: 'OPEN',
+        prCiStatus: 'SUCCESS',
+        prReviewState: null,
+      });
+      expect(events[0]).not.toHaveProperty('prUrl');
+    });
+
     it('emits pr_snapshot_updated on refreshWorkspace when snapshot succeeds', async () => {
       mockFindById.mockResolvedValue({
         id: 'ws-2',

--- a/src/backend/domains/github/pr-snapshot.service.ts
+++ b/src/backend/domains/github/pr-snapshot.service.ts
@@ -33,7 +33,7 @@ export const PR_SNAPSHOT_UPDATED = 'pr_snapshot_updated' as const;
 
 export interface PRSnapshotUpdatedEvent {
   workspaceId: string;
-  prUrl: string | null;
+  prUrl?: string | null;
   prNumber: number;
   prState: string;
   prCiStatus: string;
@@ -232,7 +232,7 @@ class PRSnapshotService extends EventEmitter {
     snapshot: SnapshotData,
     options: ApplySnapshotOptions = {}
   ): Promise<void> {
-    const eventPrUrl = options.eventPrUrl ?? options.persistPrUrl ?? null;
+    const eventPrUrl = options.eventPrUrl ?? options.persistPrUrl;
 
     await workspaceAccessor.update(workspaceId, {
       prNumber: snapshot.prNumber,
@@ -247,7 +247,7 @@ class PRSnapshotService extends EventEmitter {
 
     this.emit(PR_SNAPSHOT_UPDATED, {
       workspaceId,
-      prUrl: eventPrUrl,
+      ...(eventPrUrl !== undefined ? { prUrl: eventPrUrl } : {}),
       prNumber: snapshot.prNumber,
       prState: snapshot.prState,
       prCiStatus: snapshot.prCiStatus,

--- a/src/backend/orchestration/event-collector.orchestrator.ts
+++ b/src/backend/orchestration/event-collector.orchestrator.ts
@@ -236,16 +236,14 @@ export function configureEventCollector(): void {
 
   // 2. PR snapshot updates
   prSnapshotService.on(PR_SNAPSHOT_UPDATED, (event: PRSnapshotUpdatedEvent) => {
-    coalescer.enqueue(
-      event.workspaceId,
-      {
-        prUrl: event.prUrl,
-        prNumber: event.prNumber,
-        prState: event.prState as PRState,
-        prCiStatus: event.prCiStatus as CIStatus,
-      },
-      'event:pr_snapshot_updated'
-    );
+    const snapshotUpdate: SnapshotUpdateInput = {
+      ...(event.prUrl !== undefined ? { prUrl: event.prUrl } : {}),
+      prNumber: event.prNumber,
+      prState: event.prState as PRState,
+      prCiStatus: event.prCiStatus as CIStatus,
+    };
+
+    coalescer.enqueue(event.workspaceId, snapshotUpdate, 'event:pr_snapshot_updated');
   });
 
   // 3. Ratchet state changes


### PR DESCRIPTION
## Summary
Fixes a bug where the workspace and side panel didn't update after the PR detection interceptor recognized that a PR was created via `gh pr create`.

## Root Cause
The `PRSnapshotUpdatedEvent` interface was missing the `prUrl` field. When the event collector processed PR snapshot updates from the interceptor, it only updated `prNumber`, `prState`, and `prCiStatus` in the workspace snapshot store, but NOT the `prUrl`. This meant the UI never received the PR URL update.

## Changes
- Added `prUrl` field to `PRSnapshotUpdatedEvent` interface
- Updated `applySnapshot()` to fetch workspace and emit current `prUrl` value in the event
- Updated event collector to propagate `prUrl` to the snapshot store
- Updated all tests to verify `prUrl` is included in emitted events

## Test Plan
- [x] All existing tests pass
- [x] Added test coverage for `prUrl` in event emissions
- [x] Manual testing: create a PR with `gh pr create` and verify workspace UI updates with PR URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small event-payload and mapping changes with added tests; primary risk is consumers relying on the prior `applySnapshot` signature or assumptions about `prUrl` presence.
> 
> **Overview**
> Fixes workspace snapshot propagation after PR creation by extending `PRSnapshotUpdatedEvent` to optionally include `prUrl` and threading that value through `PRSnapshotService.applySnapshot()` via new `eventPrUrl`/`persistPrUrl` options.
> 
> Updates the event collector to forward `prUrl` into `workspaceSnapshotStore` **only when explicitly provided** (avoiding accidental overwrites), and adds/updates tests to assert both inclusion and non-overwrite behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6196600bc944a4d0230c6b858902906b7b7f9297. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->