### PR TITLE
Follow-up #963: provider-neutralize session adapter seam

### DIFF
--- a/src/backend/domains/session/chat/chat-message-handlers/handlers/stop.handler.test.ts
+++ b/src/backend/domains/session/chat/chat-message-handlers/handlers/stop.handler.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  stopSession: vi.fn(),
+  clearPendingRequest: vi.fn(),
+}));
+
+vi.mock('@/backend/domains/session/lifecycle/session.service', () => ({
+  sessionService: {
+    stopSession: mocks.stopSession,
+  },
+}));
+
+vi.mock('@/backend/domains/session/chat/chat-event-forwarder.service', () => ({
+  chatEventForwarderService: {
+    clearPendingRequest: mocks.clearPendingRequest,
+  },
+}));
+
+import { createStopHandler } from './stop.handler';
+
+describe('createStopHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('stops via provider-neutral lifecycle API and clears pending request', async () => {
+    mocks.stopSession.mockResolvedValue(undefined);
+    const handler = createStopHandler();
+
+    await handler({
+      ws: { send: vi.fn() } as never,
+      sessionId: 'session-1',
+      workingDir: '/tmp/work',
+      message: { type: 'stop' } as never,
+    });
+
+    expect(mocks.stopSession).toHaveBeenCalledWith('session-1');
+    expect(mocks.clearPendingRequest).toHaveBeenCalledWith('session-1');
+  });
+});

--- a/src/backend/domains/session/chat/chat-message-handlers/handlers/stop.handler.ts
+++ b/src/backend/domains/session/chat/chat-message-handlers/handlers/stop.handler.ts
@@ -5,7 +5,7 @@ import type { StopMessage } from '@/shared/websocket';
 
 export function createStopHandler(): ChatMessageHandler<StopMessage> {
   return async ({ sessionId }) => {
-    await sessionService.stopClaudeSession(sessionId);
+    await sessionService.stopSession(sessionId);
     // Only clear pending requests here - clientEventSetup cleanup happens in the exit handler
     // to avoid race conditions where a new client is created before the old one exits
     chatEventForwarderService.clearPendingRequest(sessionId);

--- a/src/backend/domains/session/lifecycle/session.service.test.ts
+++ b/src/backend/domains/session/lifecycle/session.service.test.ts
@@ -62,7 +62,7 @@ vi.mock('@/backend/domains/session/providers', () => ({
         ? ({ type: 'claude_message', data: event.data } as const)
         : ({ type: 'claude_message', data: event.data, order: event.order } as const)
     ),
-    getClaudeProcess: vi.fn(),
+    getSessionProcess: vi.fn(),
     isSessionRunning: vi.fn(),
     isSessionWorking: vi.fn(),
     isAnySessionWorking: vi.fn(),
@@ -567,7 +567,7 @@ describe('SessionService', () => {
 
     vi.mocked(sessionRepository.getSessionsByWorkspaceId).mockResolvedValue([session]);
     vi.mocked(claudeSessionProviderAdapter.getPendingClient).mockReturnValue(pendingClient);
-    vi.mocked(claudeSessionProviderAdapter.getClaudeProcess).mockReturnValue(undefined);
+    vi.mocked(claudeSessionProviderAdapter.getSessionProcess).mockReturnValue(undefined);
     vi.mocked(claudeSessionProviderAdapter.isStopInProgress).mockReturnValue(false);
     vi.mocked(claudeSessionProviderAdapter.stopClient).mockResolvedValue();
     vi.mocked(sessionRepository.updateSession).mockResolvedValue(session);

--- a/src/backend/domains/session/providers/claude-session-provider-adapter.test.ts
+++ b/src/backend/domains/session/providers/claude-session-provider-adapter.test.ts
@@ -81,6 +81,9 @@ describe('ClaudeSessionProviderAdapter', () => {
 
     await adapter.stopClient('s1');
     expect(runtimeManager.stopClient).toHaveBeenCalledWith('s1');
+
+    adapter.getSessionProcess('s1');
+    expect(runtimeManager.getClaudeProcess).toHaveBeenCalledWith('s1');
   });
 
   it('routes model/thinking/rewind and interactive responses through the active client', async () => {

--- a/src/backend/domains/session/providers/session-provider-adapter.ts
+++ b/src/backend/domains/session/providers/session-provider-adapter.ts
@@ -1,5 +1,3 @@
-import type { ClaudeMessage, SessionDeltaEvent } from '@/shared/claude';
-
 export type SessionProvider = 'CLAUDE' | 'CODEX';
 
 export type CanonicalAgentMessageKind =
@@ -11,15 +9,25 @@ export type CanonicalAgentMessageKind =
   | 'system'
   | 'provider_event';
 
-export interface CanonicalAgentMessageEvent {
+export interface CanonicalAgentMessageEvent<TData = unknown> {
   type: 'agent_message';
   provider: SessionProvider;
   kind: CanonicalAgentMessageKind;
   order?: number;
-  data: ClaudeMessage;
+  data: TData;
 }
 
-export interface SessionProviderAdapter<TClient, TOptions, THandlers> {
+export interface SessionProviderAdapter<
+  TClient,
+  TOptions,
+  THandlers,
+  TNativeMessage = unknown,
+  TPublicDeltaEvent = unknown,
+  TSendContent = unknown,
+  TRewindResponse = unknown,
+  TSessionProcess = unknown,
+  TActiveProcessSummary = unknown,
+> {
   setOnClientCreated(
     callback: (
       sessionId: string,
@@ -37,6 +45,26 @@ export interface SessionProviderAdapter<TClient, TOptions, THandlers> {
   getClient(sessionId: string): TClient | undefined;
   getPendingClient(sessionId: string): Promise<TClient> | undefined;
   stopClient(sessionId: string): Promise<void>;
-  toCanonicalAgentMessage(message: ClaudeMessage, order?: number): CanonicalAgentMessageEvent;
-  toPublicDeltaEvent(event: CanonicalAgentMessageEvent): SessionDeltaEvent;
+  sendMessage(sessionId: string, content: TSendContent): Promise<void>;
+  setModel(sessionId: string, model?: string): Promise<void>;
+  setThinkingBudget(sessionId: string, tokens: number | null): Promise<void>;
+  rewindFiles(sessionId: string, userMessageId: string, dryRun?: boolean): Promise<TRewindResponse>;
+  respondToPermission(sessionId: string, requestId: string, allow: boolean): void;
+  respondToQuestion(
+    sessionId: string,
+    requestId: string,
+    answers: Record<string, string | string[]>
+  ): void;
+  toCanonicalAgentMessage(
+    message: TNativeMessage,
+    order?: number
+  ): CanonicalAgentMessageEvent<TNativeMessage>;
+  toPublicDeltaEvent(event: CanonicalAgentMessageEvent<TNativeMessage>): TPublicDeltaEvent;
+  getSessionProcess(sessionId: string): TSessionProcess | undefined;
+  isSessionRunning(sessionId: string): boolean;
+  isSessionWorking(sessionId: string): boolean;
+  isAnySessionWorking(sessionIds: string[]): boolean;
+  getAllActiveProcesses(): TActiveProcessSummary[];
+  getAllClients(): IterableIterator<[string, TClient]>;
+  stopAllClients(timeoutMs?: number): Promise<void>;
 }


### PR DESCRIPTION
## Summary
Follow-up to #963 to finish the provider-neutral seam hardening tracked by #968.

### What changed
- Provider adapter base contract is now provider-neutral and generic:
  - `src/backend/domains/session/providers/session-provider-adapter.ts`
  - Removed Claude-specific type coupling from the base interface.
- Claude adapter now implements the generic contract with explicit Claude type bindings:
  - `src/backend/domains/session/providers/claude-session-provider-adapter.ts`
- `SessionService` now depends on adapter interface shape instead of concrete `ClaudeSessionProviderAdapter` class:
  - `src/backend/domains/session/lifecycle/session.service.ts`
- Remaining active internal stop path is now provider-neutral:
  - `src/backend/domains/session/chat/chat-message-handlers/handlers/stop.handler.ts`
  - switched `stopClaudeSession(...)` -> `stopSession(...)`
- Added focused test coverage for the stop-handler path:
  - `src/backend/domains/session/chat/chat-message-handlers/handlers/stop.handler.test.ts`
- Updated affected tests/mocks for renamed adapter inspection method (`getSessionProcess`):
  - `src/backend/domains/session/lifecycle/session.service.test.ts`
  - `src/backend/domains/session/providers/claude-session-provider-adapter.test.ts`

## Ticket Resolution Review (`#968`)
- [x] `session-provider-adapter` base contract has no Claude-specific imports.
- [x] `SessionService` is typed against interface seam (not concrete Claude adapter class).
- [x] Active internal chat stop path uses `stopSession`.
- [x] Existing public contracts remain unchanged (`startClaudeSession`/`stopClaudeSession` wrappers + tRPC/ws unchanged).
- [x] Tests and checks pass.

## Validation
- `pnpm check:fix`
- `pnpm typecheck`
- `pnpm deps:check`
- `pnpm test`

Part of #960
Closes #968

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core session lifecycle/adapter typing and process lookup paths; main risk is type/contract mismatches or missed call sites affecting stop/start behavior, though changes are mostly mechanical with added test coverage for the stop handler.
> 
> **Overview**
> Hardens the provider-neutral adapter seam by making `SessionProviderAdapter` fully generic (messages, deltas, send content, rewind response, process handles, and active-process summaries) and updating `SessionService` to depend on that interface shape rather than a Claude-specific adapter type.
> 
> Renames adapter process inspection to `getSessionProcess` and wires it through the Claude adapter + `SessionService` workspace-stop logic, updating mocks/tests accordingly. Updates the chat `stop` message handler to call `sessionService.stopSession` (instead of `stopClaudeSession`) and adds a focused unit test ensuring stop clears any pending forwarded request.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1b07c4ba67840c608ff2a1fad613514a0c49438. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->