### PR TITLE
Unify ClaudeActiveProcessSummary type source

### DIFF
--- a/src/backend/domains/session/lifecycle/session.service.ts
+++ b/src/backend/domains/session/lifecycle/session.service.ts
@@ -5,6 +5,7 @@ import type { ResourceUsage } from '@/backend/domains/session/claude/process';
 import type { RegisteredProcess } from '@/backend/domains/session/claude/registry';
 import { SessionManager } from '@/backend/domains/session/claude/session';
 import {
+  type ClaudeActiveProcessSummary,
   claudeSessionProviderAdapter,
   type SessionProviderAdapter,
 } from '@/backend/domains/session/providers';
@@ -23,15 +24,6 @@ import { sessionRepository } from './session.repository';
 
 const logger = createLogger('session');
 const STALE_LOADING_RUNTIME_MAX_AGE_MS = 30_000;
-
-type ClaudeActiveProcessSummary = {
-  sessionId: string;
-  pid: number | undefined;
-  status: string;
-  isRunning: boolean;
-  resourceUsage: ResourceUsage | null;
-  idleTimeMs: number;
-};
 
 type ActiveSessionProviderAdapter = SessionProviderAdapter<
   ClaudeClient,

--- a/src/backend/domains/session/providers/claude-session-provider-adapter.ts
+++ b/src/backend/domains/session/providers/claude-session-provider-adapter.ts
@@ -18,7 +18,7 @@ import type {
   SessionProviderAdapter,
 } from './session-provider-adapter';
 
-type ClaudeActiveProcessSummary = {
+export type ClaudeActiveProcessSummary = {
   sessionId: string;
   pid: number | undefined;
   status: string;

--- a/src/backend/domains/session/providers/index.ts
+++ b/src/backend/domains/session/providers/index.ts
@@ -1,3 +1,4 @@
+export type { ClaudeActiveProcessSummary } from './claude-session-provider-adapter';
 export {
   ClaudeSessionProviderAdapter,
   claudeSessionProviderAdapter,


### PR DESCRIPTION
## Summary
- remove the duplicate `ClaudeActiveProcessSummary` declaration from `session.service.ts`
- export `ClaudeActiveProcessSummary` from `claude-session-provider-adapter.ts`
- re-export that type from the providers barrel so consumers keep importing via `@/backend/domains/session/providers`

## Why
Having two independent copies of this type allows silent drift and can cause subtle mismatches between the adapter implementation and `ActiveSessionProviderAdapter` typing.

## Validation
- `pnpm typecheck`
- `pnpm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk type-only refactor that centralizes a shared TS type; main risk is minor compile breakage if any imports relied on the removed local alias.
> 
> **Overview**
> Removes the duplicate `ClaudeActiveProcessSummary` type definition from `session.service.ts` and uses a single exported definition from `claude-session-provider-adapter.ts`.
> 
> Re-exports `ClaudeActiveProcessSummary` from the `providers` barrel (`providers/index.ts`) so existing consumers can continue importing it via `@/backend/domains/session/providers`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9ab9fc3c5226e51e8e9b33494ebb98b3f2384f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->