### PR TITLE
Reset ratchet dispatch tracking when fixer session dies

### DIFF
--- a/src/backend/domains/github/pr-snapshot.service.ts
+++ b/src/backend/domains/github/pr-snapshot.service.ts
@@ -47,7 +47,7 @@ interface CIObservationInput {
 }
 
 interface ReviewCheckInput {
-  checkedAt?: Date;
+  checkedAt?: Date | null;
   latestCommentId?: string;
 }
 
@@ -98,8 +98,9 @@ class PRSnapshotService extends EventEmitter {
    * Record PR review polling checkpoint.
    */
   async recordReviewCheck(workspaceId: string, input: ReviewCheckInput = {}): Promise<void> {
+    const checkedAt = input.checkedAt === null ? null : (input.checkedAt ?? new Date());
     await workspaceAccessor.update(workspaceId, {
-      prReviewLastCheckedAt: input.checkedAt ?? new Date(),
+      prReviewLastCheckedAt: checkedAt,
       ...(input.latestCommentId !== undefined
         ? { prReviewLastCommentId: input.latestCommentId }
         : {}),

--- a/src/backend/domains/ratchet/bridges.ts
+++ b/src/backend/domains/ratchet/bridges.ts
@@ -68,7 +68,7 @@ export interface RatchetPRSnapshotBridge {
     observedAt?: Date;
   }): Promise<void>;
   recordCINotification(workspaceId: string, notifiedAt?: Date): Promise<void>;
-  recordReviewCheck(workspaceId: string, checkedAt?: Date): Promise<void>;
+  recordReviewCheck(workspaceId: string, checkedAt?: Date | null): Promise<void>;
 }
 
 // --- Workspace bridge ---

--- a/src/backend/services/constants.ts
+++ b/src/backend/services/constants.ts
@@ -41,6 +41,7 @@ export const SERVICE_CONCURRENCY = Object.freeze({
 
 export const SERVICE_THRESHOLDS = Object.freeze({
   schedulerStaleMinutes: 2,
+  ratchetReviewCheckStaleMs: 10 * 60_000, // 10min: treat prReviewLastCheckedAt as stale if no active session
 } as const);
 
 export const SERVICE_TTL_SECONDS = Object.freeze({


### PR DESCRIPTION
## Summary

- When the ratchet dispatches a fixer session that then crashes silently (e.g., Claude process dies immediately after spawn), the dispatch tracking timestamps (`prReviewLastCheckedAt`, `ratchetLastCiRunId`) are now reset so the next poll cycle re-evaluates and re-dispatches
- Adds a 10-minute staleness self-heal: if `prReviewLastCheckedAt` is old and there's no active fixer session, treat review activity as new — catches any unanticipated path that leaves the workspace permanently stuck
- Root cause from PR #974: Claude process (PID 45823) died ~4 seconds after spawning, but `prReviewLastCheckedAt` was already stamped, so all subsequent polls returned "PR is clean"

## Test plan

- [x] 69 ratchet service tests pass (including 4 new/updated tests for orphan recovery and staleness self-heal)
- [x] `pnpm typecheck` passes
- [x] `pnpm check:fix` clean
- [ ] Manual: kill a ratchet fixer process immediately after dispatch, verify re-dispatch happens on next poll cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)
