### PR TITLE
Allow provider preselect while sessions are running

### DIFF
--- a/src/client/routes/projects/workspaces/workspace-detail-header.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-header.tsx
@@ -405,7 +405,7 @@ export function WorkspaceHeader({
         <NewSessionProviderSelect
           selectedProvider={selectedProvider}
           setSelectedProvider={setSelectedProvider}
-          disabled={running || isCreatingSession}
+          disabled={isCreatingSession}
         />
         <WorkspaceProviderSettings workspace={workspace} workspaceId={workspaceId} />
         <RatchetingToggle workspace={workspace} workspaceId={workspaceId} />


### PR DESCRIPTION
## Summary
- verified `NewSessionProviderSelect` was disabled whenever any session was running
- updated the header to keep provider preselection enabled while sessions are active
- selector now disables only while a new session is actively being created (`isCreatingSession`)

## Why
`NewSessionProviderSelect` is a pre-configuration control for the next session and does not trigger side effects by itself, so it should remain usable during active sessions.

## Verification
- `pnpm exec biome check src/client/routes/projects/workspaces/workspace-detail-header.tsx`
- local commit hook `pnpm typecheck` still fails due existing repo-wide unresolved types/imports (e.g. `@factory-factory/core`), unrelated to this one-line UI condition change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line UI state change that only affects when a select control is disabled; no backend, auth, or data-handling logic is modified.
> 
> **Overview**
> Updates the workspace header so `NewSessionProviderSelect` is disabled only while a new session is actively being created (`isCreatingSession`), instead of being disabled whenever any session is running.
> 
> Other session controls (e.g. `QuickActionsMenu`) remain disabled during `running || isCreatingSession`, so this change is limited to the provider preselection UI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c41e8264cb379dcdf81b31c63bcabf30abc3ed2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->