### PR TITLE
Add Playwright MCP screenshots with quick action and viewer UI

### DIFF
--- a/prompts/quick-actions/screenshots.md
+++ b/prompts/quick-actions/screenshots.md
@@ -1,0 +1,21 @@
+---
+name: Take Screenshots
+description: Capture screenshots of the running dev app
+type: agent
+icon: camera
+---
+Take a screenshot of the workspace's running development app to capture the current state of the UI.
+
+## Step 1: Start the dev server
+
+1. Read `factory-factory.json` in the repo root for the `scripts.run` command
+2. Pick a free port and replace `{port}` in the command with it
+3. Start the dev server in the background and wait for it to be ready
+
+## Step 2: Take a screenshot
+
+1. `mkdir -p .factory-factory/screenshots`
+2. Use `browser_navigate` to visit the dev server URL
+3. Determine the most relevant screen that captures the current state of the app
+4. Use `browser_screenshot` to capture it
+5. Save to `.factory-factory/screenshots/` with a descriptive PNG filename

--- a/prompts/workflows/bugfix.md
+++ b/prompts/workflows/bugfix.md
@@ -40,7 +40,19 @@ You are fixing a bug. Follow this workflow to ensure the fix is correct and does
 - Run `pnpm check:fix` to fix linting issues
 - Ensure the build passes
 
-### 7. Create Pull Request
+### 7. Capture UI Screenshots (if applicable)
+
+If your changes affect the UI:
+
+1. Read `factory-factory.json` for the `scripts.run` command, pick a free port, replace `{port}`, and start it in the background.
+2. Use `browser_navigate` to visit the dev server URL
+3. Determine the most relevant screen showing your changes and capture a screenshot
+4. Save screenshots to `.factory-factory/screenshots/` with descriptive names
+5. Commit the screenshots
+6. Reference them in the PR body using raw GitHub URLs:
+   `![Description](https://raw.githubusercontent.com/{owner}/{repo}/{branch}/.factory-factory/screenshots/filename.png)`
+
+### 8. Create Pull Request
 - Commit with a descriptive message referencing the bug
 - Push your branch: `git push -u origin HEAD`
 - Create the PR using the GitHub CLI with a body file to preserve formatting:

--- a/prompts/workflows/feature.md
+++ b/prompts/workflows/feature.md
@@ -37,7 +37,19 @@ You are implementing a new feature. Follow this workflow to deliver high-quality
 - Run `pnpm check:fix` to fix linting issues
 - Ensure the build passes (`pnpm build:all`)
 
-### 6. Create Pull Request
+### 6. Capture UI Screenshots (if applicable)
+
+If your changes affect the UI:
+
+1. Read `factory-factory.json` for the `scripts.run` command, pick a free port, replace `{port}`, and start it in the background.
+2. Use `browser_navigate` to visit the dev server URL
+3. Determine the most relevant screen showing your changes and capture a screenshot
+4. Save screenshots to `.factory-factory/screenshots/` with descriptive names
+5. Commit the screenshots
+6. Reference them in the PR body using raw GitHub URLs:
+   `![Description](https://raw.githubusercontent.com/{owner}/{repo}/{branch}/.factory-factory/screenshots/filename.png)`
+
+### 7. Create Pull Request
 - Commit all changes with descriptive messages
 - Push your branch: `git push -u origin HEAD`
 - Create the PR using the GitHub CLI with a body file to preserve formatting:

--- a/src/backend/domains/session/claude/client.ts
+++ b/src/backend/domains/session/claude/client.ts
@@ -62,6 +62,8 @@ export interface ClaudeClientOptions {
   permissionHandler?: PermissionHandler;
   /** Hook configuration for PreToolUse and Stop hooks */
   hooks?: HooksConfig;
+  /** MCP server configuration JSON string (passed via --mcp-config) */
+  mcpConfig?: string;
   /** Tools to disallow */
   disallowedTools?: string[];
   /** Initial prompt to send via -p flag */
@@ -159,6 +161,7 @@ export class ClaudeClient extends EventEmitter {
       systemPrompt: options.systemPrompt,
       permissionMode: options.permissionMode,
       hooks: options.hooks,
+      mcpConfig: options.mcpConfig,
       disallowedTools: options.disallowedTools,
       initialPrompt: options.initialPrompt,
       includePartialMessages: options.includePartialMessages,

--- a/src/backend/domains/session/claude/process.ts
+++ b/src/backend/domains/session/claude/process.ts
@@ -33,6 +33,8 @@ export interface ClaudeProcessOptions {
   disallowedTools?: string[];
   initialPrompt?: string;
   hooks?: HooksConfig;
+  /** MCP server configuration JSON string (passed via --mcp-config) */
+  mcpConfig?: string;
   thinkingEnabled?: boolean;
   resourceMonitoring?: ResourceMonitoringOptions;
   sessionId?: string;
@@ -363,6 +365,10 @@ export class ClaudeProcess extends EventEmitter {
 
     if (options.permissionMode) {
       args.push('--permission-mode', options.permissionMode);
+    }
+
+    if (options.mcpConfig) {
+      args.push('--mcp-config', options.mcpConfig);
     }
 
     return args;

--- a/src/backend/domains/session/lifecycle/session.prompt-builder.ts
+++ b/src/backend/domains/session/lifecycle/session.prompt-builder.ts
@@ -9,6 +9,7 @@ export type BuildPromptInput = {
     hasHadSessions?: boolean;
     name: string;
     description?: string | null;
+    runScriptPort?: number | null;
   };
   project?: { githubOwner?: string | null } | null;
 };
@@ -64,6 +65,11 @@ export class SessionPromptBuilder {
       });
       systemPrompt = branchRenameInstruction + (workflowPrompt ?? '');
       injectedBranchRename = true;
+    }
+
+    if (workspace.runScriptPort) {
+      const devServerInfo = `\n\n## Dev Server\nA development server is running at http://localhost:${workspace.runScriptPort}. You can use Playwright MCP tools (browser_navigate, browser_screenshot) to capture screenshots of UI changes.\n`;
+      systemPrompt = (systemPrompt ?? '') + devServerInfo;
     }
 
     return { workflowPrompt, systemPrompt, injectedBranchRename };

--- a/src/backend/domains/session/lifecycle/session.service.ts
+++ b/src/backend/domains/session/lifecycle/session.service.ts
@@ -787,6 +787,15 @@ class SessionService {
     const claudeProjectPath = SessionManager.getProjectPath(sessionContext.workingDir);
     await this.repository.updateSession(sessionId, { claudeProjectPath });
 
+    const mcpConfig = JSON.stringify({
+      mcpServers: {
+        playwright: {
+          command: 'npx',
+          args: ['@playwright/mcp@latest', '--viewport-size=1920,1080'],
+        },
+      },
+    });
+
     const clientOptions: ClaudeClientOptions = {
       workingDir: sessionContext.workingDir,
       resumeClaudeSessionId: sessionContext.resumeClaudeSessionId,
@@ -796,6 +805,7 @@ class SessionService {
       includePartialMessages: false,
       thinkingEnabled: options?.thinkingEnabled,
       initialPrompt: options?.initialPrompt,
+      mcpConfig,
       sessionId,
     };
 

--- a/src/backend/orchestration/workspace-init.orchestrator.ts
+++ b/src/backend/orchestration/workspace-init.orchestrator.ts
@@ -312,6 +312,22 @@ Update TodoWrite with any additional fix tasks discovered.
    git status  # should show clean working directory
    \`\`\`
 
+## Phase 4.5: Capture UI Screenshots (if applicable)
+
+If your changes affect the UI:
+
+1. Read \`factory-factory.json\` for the \`scripts.run\` command, pick a free port, replace \`{port}\`, and start it in the background.
+2. Use \`browser_navigate\` to visit the dev server URL
+3. Determine the most relevant screen showing your changes and capture a screenshot
+4. Save screenshots:
+   \`\`\`bash
+   mkdir -p .factory-factory/screenshots
+   \`\`\`
+   Save with descriptive names (e.g., \`dashboard-new-widget.png\`)
+5. Commit the screenshots with your changes
+6. Reference them in the PR body using raw GitHub URLs:
+   \`![Description](https://raw.githubusercontent.com/${project.githubOwner}/${project.githubRepo}/\${branch}/.factory-factory/screenshots/filename.png)\`
+
 ## Phase 5: Create Pull Request [REQUIRED - DO NOT SKIP]
 
 **Pre-flight checklist before creating PR:**

--- a/src/client/routes/projects/workspaces/workspace-detail-view.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-view.tsx
@@ -167,7 +167,16 @@ export function WorkspaceDetailView({
             <ResizableHandle />
             <ResizablePanel defaultSize="30%" minSize="15%" maxSize="50%">
               <div className="h-full border-l">
-                <RightPanel workspaceId={workspaceState.workspaceId} messages={chat.messages} />
+                <RightPanel
+                  workspaceId={workspaceState.workspaceId}
+                  messages={chat.messages}
+                  onTakeScreenshots={() =>
+                    header.handleQuickAction(
+                      'Take Screenshots',
+                      'Take a screenshot of the workspace dev app using Playwright MCP tools. Read factory-factory.json for the scripts.run command, pick a free port, replace {port}, and start the dev server in the background. Once ready, determine the most relevant screen and save a screenshot to .factory-factory/screenshots/ with a descriptive filename.'
+                    )
+                  }
+                />
               </div>
             </ResizablePanel>
           </>

--- a/src/components/workspace/index.ts
+++ b/src/components/workspace/index.ts
@@ -14,6 +14,8 @@ export * from './ratchet-wrench-icon';
 export * from './right-panel';
 export * from './run-script-button';
 export * from './run-script-port-badge';
+export * from './screenshot-viewer-tab';
+export * from './screenshots-panel';
 export * from './terminal-instance';
 export * from './terminal-panel';
 export * from './terminal-tab-bar';

--- a/src/components/workspace/main-view-content.tsx
+++ b/src/components/workspace/main-view-content.tsx
@@ -2,6 +2,7 @@ import { cn } from '@/lib/utils';
 
 import { DiffViewer } from './diff-viewer';
 import { FileViewer } from './file-viewer';
+import { ScreenshotViewerTab } from './screenshot-viewer-tab';
 import { useWorkspacePanel } from './workspace-panel-context';
 
 // =============================================================================
@@ -23,6 +24,7 @@ export function MainViewContent({ workspaceId, children, className }: MainViewCo
   const showChat = !activeTab || activeTab.type === 'chat';
   const filePath = activeTab?.type === 'file' ? activeTab.path : undefined;
   const diffPath = activeTab?.type === 'diff' ? activeTab.path : undefined;
+  const screenshotPath = activeTab?.type === 'screenshot' ? activeTab.path : undefined;
   const activeTabKey = activeTab?.id;
 
   return (
@@ -35,6 +37,13 @@ export function MainViewContent({ workspaceId, children, className }: MainViewCo
       )}
       {diffPath && activeTabKey && (
         <DiffViewer workspaceId={workspaceId} filePath={diffPath} tabId={activeTabKey} />
+      )}
+      {screenshotPath && activeTabKey && (
+        <ScreenshotViewerTab
+          workspaceId={workspaceId}
+          screenshotPath={screenshotPath}
+          tabId={activeTabKey}
+        />
       )}
     </div>
   );

--- a/src/components/workspace/main-view-tab-bar.tsx
+++ b/src/components/workspace/main-view-tab-bar.tsx
@@ -1,5 +1,5 @@
 import type { SessionStatus as DbSessionStatus } from '@factory-factory/core';
-import { FileCode, FileDiff, Plus } from 'lucide-react';
+import { Camera, FileCode, FileDiff, Plus } from 'lucide-react';
 
 import { TabButton } from '@/components/ui/tab-button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -36,6 +36,8 @@ function getTabIcon(type: MainViewTab['type']) {
       return FileCode;
     case 'diff':
       return FileDiff;
+    case 'screenshot':
+      return Camera;
   }
 }
 

--- a/src/components/workspace/quick-actions-menu.tsx
+++ b/src/components/workspace/quick-actions-menu.tsx
@@ -1,5 +1,6 @@
 import type { inferRouterOutputs } from '@trpc/server';
 import {
+  Camera,
   Check,
   Eye,
   GitBranch,
@@ -45,6 +46,7 @@ const ICON_MAP: Record<string, LucideIcon> = {
   play: Play,
   terminal: Terminal,
   check: Check,
+  camera: Camera,
   'git-branch': GitBranch,
 };
 

--- a/src/components/workspace/right-panel.tsx
+++ b/src/components/workspace/right-panel.tsx
@@ -1,4 +1,13 @@
-import { FileQuestion, Files, GitCompare, ListTodo, Play, Plus, Terminal } from 'lucide-react';
+import {
+  Camera,
+  FileQuestion,
+  Files,
+  GitCompare,
+  ListTodo,
+  Play,
+  Plus,
+  Terminal,
+} from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import type { ChatMessage } from '@/components/chat';
@@ -11,6 +20,7 @@ import { cn } from '@/lib/utils';
 import { DevLogsPanel } from './dev-logs-panel';
 import { DiffVsMainPanel } from './diff-vs-main-panel';
 import { FileBrowserPanel } from './file-browser-panel';
+import { ScreenshotsPanel } from './screenshots-panel';
 import { SetupLogsPanel } from './setup-logs-panel';
 import { TerminalPanel, type TerminalPanelRef, type TerminalTabState } from './terminal-panel';
 import { TerminalTabBar } from './terminal-tab-bar';
@@ -29,7 +39,7 @@ const STORAGE_KEY_TOP_TAB_PREFIX = 'workspace-right-panel-tab-';
 // Types
 // =============================================================================
 
-type TopPanelTab = 'unstaged' | 'diff-vs-main' | 'files' | 'tasks';
+type TopPanelTab = 'unstaged' | 'diff-vs-main' | 'files' | 'tasks' | 'screenshots';
 
 // =============================================================================
 // Main Component
@@ -39,9 +49,15 @@ interface RightPanelProps {
   workspaceId: string;
   className?: string;
   messages?: ChatMessage[];
+  onTakeScreenshots?: () => void;
 }
 
-export function RightPanel({ workspaceId, className, messages = [] }: RightPanelProps) {
+export function RightPanel({
+  workspaceId,
+  className,
+  messages = [],
+  onTakeScreenshots,
+}: RightPanelProps) {
   // Track which workspaceId has been loaded to handle workspace changes
   const loadedForWorkspaceRef = useRef<string | null>(null);
   const [activeTopTab, setActiveTopTab] = useState<TopPanelTab>('unstaged');
@@ -101,7 +117,8 @@ export function RightPanel({ workspaceId, className, messages = [] }: RightPanel
         storedTop === 'unstaged' ||
         storedTop === 'diff-vs-main' ||
         storedTop === 'files' ||
-        storedTop === 'tasks'
+        storedTop === 'tasks' ||
+        storedTop === 'screenshots'
       ) {
         setActiveTopTab(storedTop);
       }
@@ -131,6 +148,11 @@ export function RightPanel({ workspaceId, className, messages = [] }: RightPanel
     },
     [setActiveBottomTab]
   );
+
+  const handleTakeScreenshots = useCallback(() => {
+    setActiveTopTab('screenshots');
+    onTakeScreenshots?.();
+  }, [onTakeScreenshots]);
 
   return (
     <ResizablePanelGroup
@@ -162,6 +184,12 @@ export function RightPanel({ workspaceId, className, messages = [] }: RightPanel
               onSelect={() => handleTabChange('files')}
             />
             <TabButton
+              label="Screenshots"
+              icon={<Camera className="h-3.5 w-3.5" />}
+              isActive={activeTopTab === 'screenshots'}
+              onSelect={() => handleTabChange('screenshots')}
+            />
+            <TabButton
               label="Tasks"
               icon={<ListTodo className="h-3.5 w-3.5" />}
               isActive={activeTopTab === 'tasks'}
@@ -175,6 +203,12 @@ export function RightPanel({ workspaceId, className, messages = [] }: RightPanel
             {activeTopTab === 'diff-vs-main' && <DiffVsMainPanel workspaceId={workspaceId} />}
             {activeTopTab === 'files' && <FileBrowserPanel workspaceId={workspaceId} />}
             {activeTopTab === 'tasks' && <TodoPanelContainer messages={messages} />}
+            {activeTopTab === 'screenshots' && (
+              <ScreenshotsPanel
+                workspaceId={workspaceId}
+                onTakeScreenshots={handleTakeScreenshots}
+              />
+            )}
           </div>
         </div>
       </ResizablePanel>

--- a/src/components/workspace/screenshot-viewer-tab.tsx
+++ b/src/components/workspace/screenshot-viewer-tab.tsx
@@ -1,0 +1,42 @@
+import { Loader2 } from 'lucide-react';
+
+import { trpc } from '@/frontend/lib/trpc';
+
+interface ScreenshotViewerTabProps {
+  workspaceId: string;
+  screenshotPath: string;
+  tabId: string;
+}
+
+export function ScreenshotViewerTab({ workspaceId, screenshotPath }: ScreenshotViewerTabProps) {
+  const { data, isLoading } = trpc.workspace.readScreenshot.useQuery(
+    { workspaceId, path: screenshotPath },
+    { staleTime: 60_000 }
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
+        Failed to load screenshot
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center justify-center h-full p-4 overflow-auto">
+      <img
+        src={`data:${data.mimeType};base64,${data.data}`}
+        alt={data.name}
+        className="max-w-full max-h-full object-contain rounded-md"
+      />
+    </div>
+  );
+}

--- a/src/components/workspace/screenshots-panel.tsx
+++ b/src/components/workspace/screenshots-panel.tsx
@@ -1,0 +1,176 @@
+import { Camera, Loader2, X } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { trpc } from '@/frontend/lib/trpc';
+
+import { useWorkspacePanel } from './workspace-panel-context';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+interface ScreenshotsPanelProps {
+  workspaceId: string;
+  onTakeScreenshots?: () => void;
+}
+
+// =============================================================================
+// Main Component
+// =============================================================================
+
+export function ScreenshotsPanel({ workspaceId, onTakeScreenshots }: ScreenshotsPanelProps) {
+  const { openTab } = useWorkspacePanel();
+  const utils = trpc.useUtils();
+  const [isTaking, setIsTaking] = useState(false);
+  const prevCountRef = useRef(0);
+
+  const deleteMutation = trpc.workspace.deleteScreenshot.useMutation({
+    onSuccess: () => {
+      void utils.workspace.listScreenshots.invalidate({ workspaceId });
+    },
+  });
+
+  const { data, isLoading } = trpc.workspace.listScreenshots.useQuery(
+    { workspaceId },
+    { refetchInterval: isTaking ? 3000 : 10_000, staleTime: isTaking ? 1000 : 5000 }
+  );
+
+  const screenshots = data?.screenshots ?? [];
+
+  // Clear isTaking when new screenshots appear
+  useEffect(() => {
+    if (isTaking && screenshots.length > prevCountRef.current) {
+      setIsTaking(false);
+    }
+    prevCountRef.current = screenshots.length;
+  }, [screenshots.length, isTaking]);
+
+  const handleTakeScreenshots = useCallback(() => {
+    setIsTaking(true);
+    onTakeScreenshots?.();
+  }, [onTakeScreenshots]);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (screenshots.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full text-center p-4 gap-3">
+        <Camera className="h-8 w-8 text-muted-foreground" />
+        <div>
+          {isTaking ? (
+            <>
+              <p className="text-sm font-medium text-muted-foreground">Taking Screenshots...</p>
+              <p className="text-xs text-muted-foreground/70 mt-1">
+                The agent is capturing the dev app
+              </p>
+            </>
+          ) : (
+            <>
+              <p className="text-sm font-medium text-muted-foreground">No screenshots yet</p>
+              <p className="text-xs text-muted-foreground/70 mt-1">
+                Capture screenshots of the running dev app
+              </p>
+            </>
+          )}
+        </div>
+        {isTaking ? (
+          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+        ) : (
+          onTakeScreenshots && (
+            <Button variant="outline" size="sm" onClick={handleTakeScreenshots} className="gap-1.5">
+              <Camera className="h-3.5 w-3.5" />
+              Take Screenshots
+            </Button>
+          )
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <ScrollArea className="h-full">
+      <div className="p-2 grid grid-cols-2 gap-2">
+        {screenshots.map((screenshot) => (
+          <ScreenshotThumbnail
+            key={screenshot.path}
+            workspaceId={workspaceId}
+            screenshot={screenshot}
+            onClick={() => openTab('screenshot', screenshot.path, screenshot.name)}
+            onDelete={() => deleteMutation.mutate({ workspaceId, path: screenshot.path })}
+          />
+        ))}
+      </div>
+    </ScrollArea>
+  );
+}
+
+// =============================================================================
+// Thumbnail Component
+// =============================================================================
+
+interface ScreenshotThumbnailProps {
+  workspaceId: string;
+  screenshot: { name: string; path: string; size: number };
+  onClick: () => void;
+  onDelete: () => void;
+}
+
+function ScreenshotThumbnail({
+  workspaceId,
+  screenshot,
+  onClick,
+  onDelete,
+}: ScreenshotThumbnailProps) {
+  const { data, isLoading } = trpc.workspace.readScreenshot.useQuery(
+    { workspaceId, path: screenshot.path },
+    { staleTime: 60_000 }
+  );
+
+  const handleDelete = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      onDelete();
+    },
+    [onDelete]
+  );
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="group relative aspect-video rounded-md border bg-muted/30 overflow-hidden hover:border-primary/50 transition-colors cursor-pointer"
+    >
+      {isLoading ? (
+        <div className="flex items-center justify-center h-full">
+          <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+        </div>
+      ) : data ? (
+        <img
+          src={`data:${data.mimeType};base64,${data.data}`}
+          alt={screenshot.name}
+          className="absolute inset-0 w-full h-full object-cover"
+        />
+      ) : null}
+      <div className="absolute top-1 right-1 opacity-0 group-hover:opacity-100 transition-opacity">
+        <button
+          type="button"
+          onClick={handleDelete}
+          className="h-5 w-5 flex items-center justify-center rounded-full bg-black/60 text-white hover:bg-red-600 transition-colors"
+        >
+          <X className="h-3 w-3" />
+        </button>
+      </div>
+      <div className="absolute bottom-0 left-0 right-0 bg-black/60 px-1.5 py-0.5 text-[10px] text-white truncate">
+        {screenshot.name}
+      </div>
+    </button>
+  );
+}

--- a/src/components/workspace/workspace-panel-context.tsx
+++ b/src/components/workspace/workspace-panel-context.tsx
@@ -26,7 +26,7 @@ export type BottomPanelTab = 'terminal' | 'dev-logs' | 'setup-logs';
 
 export interface MainViewTab {
   id: string;
-  type: 'chat' | 'file' | 'diff';
+  type: 'chat' | 'file' | 'diff' | 'screenshot';
   path?: string; // for file/diff tabs
   label: string;
 }
@@ -82,7 +82,7 @@ function isValidTab(tab: unknown): tab is MainViewTab {
   if (typeof t.label !== 'string') {
     return false;
   }
-  if (!['chat', 'file', 'diff'].includes(t.type as string)) {
+  if (!['chat', 'file', 'diff', 'screenshot'].includes(t.type as string)) {
     return false;
   }
 


### PR DESCRIPTION
## Summary

- Integrate Playwright MCP (`@playwright/mcp`, 1920x1080 viewport) into Claude CLI sessions so agents can capture UI screenshots of workspace dev apps
- Add "Take Screenshots" quick action that starts the dev server from `factory-factory.json` and captures the most relevant screen
- Add Screenshots tab (4th position) in the right panel with thumbnail previews, delete buttons, and a "Taking Screenshots..." loading state
- Clicking a screenshot opens it as a tab in the main workspace view, following the same pattern as file diffs
- Add screenshot capture steps to feature/bugfix workflow prompts and workspace init orchestrator

## Screenshots

https://github.com/user-attachments/assets/09987655-9f25-4b9e-88c2-ae1a4dfc5484


