### PR TITLE
Remove duplicated workspace session model defaults

### DIFF
--- a/src/backend/domains/workspace/lifecycle/creation.service.test.ts
+++ b/src/backend/domains/workspace/lifecycle/creation.service.test.ts
@@ -1,7 +1,6 @@
 import type { UserSettings, Workspace } from '@prisma-gen/client';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as worktreeLifecycleServiceModule from '@/backend/domains/workspace/worktree/worktree-lifecycle.service';
-import { resolveSessionModelForProvider } from '@/backend/lib/session-model';
 import * as agentSessionAccessorModule from '@/backend/resource_accessors/agent-session.accessor';
 import * as projectAccessorModule from '@/backend/resource_accessors/project.accessor';
 import * as userSettingsAccessorModule from '@/backend/resource_accessors/user-settings.accessor';
@@ -389,7 +388,6 @@ describe('WorkspaceCreationService', () => {
           workflow: 'followup',
           name: 'Chat 1',
           provider: 'CLAUDE',
-          model: resolveSessionModelForProvider(undefined, 'CLAUDE'),
           claudeProjectPath: null,
         });
       });
@@ -457,7 +455,6 @@ describe('WorkspaceCreationService', () => {
         expect(agentSessionAccessorModule.agentSessionAccessor.create).toHaveBeenCalledWith(
           expect.objectContaining({
             provider: 'CODEX',
-            model: resolveSessionModelForProvider(undefined, 'CODEX'),
             claudeProjectPath: null,
           })
         );

--- a/src/backend/domains/workspace/lifecycle/creation.service.ts
+++ b/src/backend/domains/workspace/lifecycle/creation.service.ts
@@ -13,10 +13,6 @@ import type { createLogger } from '@/backend/services/logger.service';
 
 type ConfigService = typeof configService;
 type Logger = ReturnType<typeof createLogger>;
-const DEFAULT_SESSION_MODEL_BY_PROVIDER: Record<SessionProvider, string> = {
-  CLAUDE: 'sonnet',
-  CODEX: 'gpt-5',
-};
 
 /**
  * Workspace creation source discriminated union.
@@ -253,7 +249,6 @@ export class WorkspaceCreationService {
         workflow: DEFAULT_FOLLOWUP,
         name: 'Chat 1',
         provider,
-        model: DEFAULT_SESSION_MODEL_BY_PROVIDER[provider],
         claudeProjectPath,
       });
       return true;


### PR DESCRIPTION
## Summary
- remove duplicate `DEFAULT_SESSION_MODEL_BY_PROVIDER` from workspace creation service
- stop passing an explicit model during default session provisioning
- rely on `agentSessionAccessor.create`, which already resolves provider defaults via `resolveSessionModelForProvider`
- update workspace creation tests to assert provider/path behavior instead of service-level model wiring

## Why
`creation.service.ts` had a local copy of provider defaults, which could silently drift from the canonical defaults in `src/backend/lib/session-model.ts`.

## Validation
- `pnpm test src/backend/domains/workspace/lifecycle/creation.service.test.ts`
- `pnpm typecheck`
- pre-commit checks: biome, typecheck, depcruise, knip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor that centralizes default model selection; behavior should remain the same but could change default-session model only if accessor defaults differ from the removed local map.
> 
> **Overview**
> Removes the workspace-creation service’s duplicated provider default model mapping and stops passing an explicit `model` when provisioning the initial agent session, relying on `agentSessionAccessor.create`/`resolveSessionModelForProvider` to apply canonical defaults.
> 
> Updates `WorkspaceCreationService` tests to stop asserting service-level model wiring and instead assert provider selection and `claudeProjectPath` behavior during default session creation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f510b198e78a12d8cd614068af08221746c05c0f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->