### PR TITLE
Hydrate Codex sessions from thread/read

### DIFF
--- a/src/backend/domains/session/chat/chat-message-handlers/handlers/load-session.handler.test.ts
+++ b/src/backend/domains/session/chat/chat-message-handlers/handlers/load-session.handler.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  findById: vi.fn(),
+  getRuntimeSnapshot: vi.fn(),
+  getChatBarCapabilities: vi.fn(),
+  tryHydrateCodexTranscript: vi.fn(),
+  subscribe: vi.fn(),
+  emitDelta: vi.fn(),
+  setHydratedTranscript: vi.fn(),
+  getCachedCommands: vi.fn(),
+}));
+
+vi.mock('@/backend/resource_accessors/agent-session.accessor', () => ({
+  agentSessionAccessor: {
+    findById: mocks.findById,
+  },
+}));
+
+vi.mock('@/backend/domains/session/lifecycle/session.service', () => ({
+  sessionService: {
+    getRuntimeSnapshot: mocks.getRuntimeSnapshot,
+    getChatBarCapabilities: mocks.getChatBarCapabilities,
+    tryHydrateCodexTranscript: mocks.tryHydrateCodexTranscript,
+  },
+}));
+
+vi.mock('@/backend/domains/session/session-domain.service', () => ({
+  sessionDomainService: {
+    subscribe: mocks.subscribe,
+    emitDelta: mocks.emitDelta,
+    setHydratedTranscript: mocks.setHydratedTranscript,
+  },
+}));
+
+vi.mock('@/backend/domains/session/store/slash-command-cache.service', () => ({
+  slashCommandCacheService: {
+    getCachedCommands: mocks.getCachedCommands,
+  },
+}));
+
+import { createLoadSessionHandler } from './load-session.handler';
+
+describe('createLoadSessionHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getRuntimeSnapshot.mockReturnValue({
+      phase: 'idle',
+      processState: 'alive',
+      activity: 'IDLE',
+      updatedAt: '2026-02-13T00:00:00.000Z',
+    });
+    mocks.getChatBarCapabilities.mockResolvedValue({
+      provider: 'CODEX',
+      model: { enabled: false, options: [] },
+      reasoning: { enabled: false, options: [] },
+      thinking: { enabled: false },
+      planMode: { enabled: true },
+      attachments: { enabled: false, kinds: [] },
+      slashCommands: { enabled: false },
+      usageStats: { enabled: false, contextWindow: false },
+      rewind: { enabled: false },
+    });
+    mocks.getCachedCommands.mockResolvedValue(null);
+  });
+
+  it('hydrates CODEX transcript from thread/read before subscribe replay', async () => {
+    mocks.findById.mockResolvedValue({
+      provider: 'CODEX',
+      workspace: { worktreePath: '/tmp/worktree' },
+      claudeSessionId: null,
+      claudeProjectPath: null,
+    });
+    mocks.tryHydrateCodexTranscript.mockResolvedValue([
+      {
+        id: 'codex-turn-1-item-1',
+        source: 'user',
+        text: 'hello',
+        timestamp: '2026-02-13T00:00:00.000Z',
+        order: 0,
+      },
+    ]);
+
+    const handler = createLoadSessionHandler();
+    const ws = { send: vi.fn() } as unknown as { send: (payload: string) => void };
+    await handler({
+      ws: ws as never,
+      sessionId: 'session-1',
+      workingDir: '/tmp/worktree',
+      message: { type: 'load_session', loadRequestId: 'load-1' } as never,
+    });
+
+    expect(mocks.tryHydrateCodexTranscript).toHaveBeenCalledWith('session-1');
+    expect(mocks.setHydratedTranscript).toHaveBeenCalledWith(
+      'session-1',
+      expect.any(Array),
+      expect.objectContaining({ hydratedKey: 'none::none' })
+    );
+    expect(mocks.subscribe).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'session-1',
+        claudeSessionId: null,
+        claudeProjectPath: null,
+        loadRequestId: 'load-1',
+      })
+    );
+  });
+
+  it('skips transcript replacement when no CODEX hydration data is available', async () => {
+    mocks.findById.mockResolvedValue({
+      provider: 'CODEX',
+      workspace: { worktreePath: '/tmp/worktree' },
+      claudeSessionId: null,
+      claudeProjectPath: null,
+    });
+    mocks.tryHydrateCodexTranscript.mockResolvedValue(null);
+
+    const handler = createLoadSessionHandler();
+    const ws = { send: vi.fn() } as unknown as { send: (payload: string) => void };
+    await handler({
+      ws: ws as never,
+      sessionId: 'session-1',
+      workingDir: '/tmp/worktree',
+      message: { type: 'load_session' } as never,
+    });
+
+    expect(mocks.setHydratedTranscript).not.toHaveBeenCalled();
+    expect(mocks.subscribe).toHaveBeenCalled();
+  });
+});

--- a/src/backend/domains/session/codex/codex-thread-read-transcript.test.ts
+++ b/src/backend/domains/session/codex/codex-thread-read-transcript.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { parseCodexThreadReadTranscript } from './codex-thread-read-transcript';
+
+describe('parseCodexThreadReadTranscript', () => {
+  it('parses user and assistant messages from thread/read turns', () => {
+    const transcript = parseCodexThreadReadTranscript({
+      thread: {
+        turns: [
+          {
+            id: 'turn-1',
+            items: [
+              {
+                type: 'userMessage',
+                id: 'item-1',
+                content: [{ type: 'text', text: 'hello' }],
+              },
+              {
+                type: 'agentMessage',
+                id: 'item-2',
+                text: 'world',
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(transcript).toHaveLength(2);
+    expect(transcript[0]).toMatchObject({
+      id: 'codex-turn-1-item-1',
+      source: 'user',
+      text: 'hello',
+      order: 0,
+    });
+    expect(transcript[1]).toMatchObject({
+      id: 'codex-turn-1-item-2',
+      source: 'claude',
+      order: 1,
+      message: {
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'world' }],
+        },
+      },
+    });
+  });
+
+  it('supports PascalCase item types and content-based assistant text', () => {
+    const transcript = parseCodexThreadReadTranscript({
+      thread: {
+        turns: [
+          {
+            id: 'turn-2',
+            items: [
+              {
+                type: 'UserMessage',
+                id: 'item-a',
+                content: [{ type: 'text', text: 'question' }],
+              },
+              {
+                type: 'AgentMessage',
+                id: 'item-b',
+                content: [{ type: 'text', text: 'answer' }],
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(transcript).toHaveLength(2);
+    expect(transcript[0]).toMatchObject({ source: 'user', text: 'question', order: 0 });
+    expect(transcript[1]).toMatchObject({
+      source: 'claude',
+      order: 1,
+      message: {
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'answer' }],
+        },
+      },
+    });
+  });
+
+  it('ignores unsupported item types and malformed payloads', () => {
+    const transcript = parseCodexThreadReadTranscript({
+      thread: {
+        turns: [
+          {
+            id: 'turn-3',
+            items: [
+              { type: 'reasoning', id: 'skip-1' },
+              { type: 'toolCall', id: 'skip-2' },
+              { type: 'agentMessage', id: 'empty', text: '' },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(transcript).toHaveLength(0);
+    expect(parseCodexThreadReadTranscript(null)).toEqual([]);
+    expect(parseCodexThreadReadTranscript({})).toEqual([]);
+  });
+});

--- a/src/backend/domains/session/codex/codex-thread-read-transcript.ts
+++ b/src/backend/domains/session/codex/codex-thread-read-transcript.ts
@@ -1,0 +1,167 @@
+import type { ChatMessage, ClaudeMessage } from '@/shared/claude';
+
+interface ThreadReadItemRecord {
+  type?: unknown;
+  id?: unknown;
+  text?: unknown;
+  content?: unknown;
+}
+
+interface ThreadReadTurnRecord {
+  id?: unknown;
+  items?: unknown;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function normalizeItemType(value: unknown): string {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+function extractTextFromContent(content: unknown): string {
+  if (!Array.isArray(content)) {
+    return '';
+  }
+  const parts: string[] = [];
+  for (const block of content) {
+    const item = asRecord(block);
+    if (!item) {
+      continue;
+    }
+    const text = item.text;
+    if (typeof text === 'string' && text.trim().length > 0) {
+      parts.push(text.trim());
+    }
+  }
+  return parts.join('\n\n');
+}
+
+function extractUserText(item: ThreadReadItemRecord): string {
+  const fromContent = extractTextFromContent(item.content);
+  if (fromContent.length > 0) {
+    return fromContent;
+  }
+  return typeof item.text === 'string' ? item.text.trim() : '';
+}
+
+function extractAssistantText(item: ThreadReadItemRecord): string {
+  if (typeof item.text === 'string' && item.text.trim().length > 0) {
+    return item.text.trim();
+  }
+  return extractTextFromContent(item.content);
+}
+
+function toAssistantMessage(text: string): ClaudeMessage {
+  return {
+    type: 'assistant',
+    message: {
+      role: 'assistant',
+      content: [{ type: 'text', text }],
+    },
+  };
+}
+
+function buildMessageId(turnId: unknown, itemId: unknown, fallback: string): string {
+  const safeTurnId = typeof turnId === 'string' && turnId.length > 0 ? turnId : 'unknown-turn';
+  const safeItemId = typeof itemId === 'string' && itemId.length > 0 ? itemId : fallback;
+  return `codex-${safeTurnId}-${safeItemId}`;
+}
+
+function createUserChatMessage(
+  id: string,
+  item: ThreadReadItemRecord,
+  nowIso: string,
+  order: number
+): ChatMessage | null {
+  const text = extractUserText(item);
+  if (text.length === 0) {
+    return null;
+  }
+  return {
+    id,
+    source: 'user',
+    text,
+    timestamp: nowIso,
+    order,
+  };
+}
+
+function createAssistantChatMessage(
+  id: string,
+  item: ThreadReadItemRecord,
+  nowIso: string,
+  order: number
+): ChatMessage | null {
+  const text = extractAssistantText(item);
+  if (text.length === 0) {
+    return null;
+  }
+  return {
+    id,
+    source: 'claude',
+    message: toAssistantMessage(text),
+    timestamp: nowIso,
+    order,
+  };
+}
+
+function createMessageFromThreadItem(
+  turnId: unknown,
+  item: ThreadReadItemRecord,
+  fallbackId: string,
+  nowIso: string,
+  order: number
+): ChatMessage | null {
+  const itemType = normalizeItemType(item.type);
+  const id = buildMessageId(turnId, item.id, fallbackId);
+  if (itemType === 'usermessage' || itemType === 'user_message') {
+    return createUserChatMessage(id, item, nowIso, order);
+  }
+  if (itemType === 'agentmessage' || itemType === 'agent_message') {
+    return createAssistantChatMessage(id, item, nowIso, order);
+  }
+  return null;
+}
+
+function collectTurnMessages(turns: unknown[], nowIso: string): ChatMessage[] {
+  const messages: ChatMessage[] = [];
+  let order = 0;
+  for (const [turnIndex, turnValue] of turns.entries()) {
+    const turn = asRecord(turnValue) as ThreadReadTurnRecord | null;
+    if (!turn) {
+      continue;
+    }
+    const items = Array.isArray(turn.items) ? turn.items : [];
+    for (const [itemIndex, itemValue] of items.entries()) {
+      const item = asRecord(itemValue) as ThreadReadItemRecord | null;
+      if (!item) {
+        continue;
+      }
+      const message = createMessageFromThreadItem(
+        turn.id,
+        item,
+        `item-${turnIndex}-${itemIndex}`,
+        nowIso,
+        order
+      );
+      if (!message) {
+        continue;
+      }
+      messages.push(message);
+      order += 1;
+    }
+  }
+  return messages;
+}
+
+export function parseCodexThreadReadTranscript(payload: unknown): ChatMessage[] {
+  const root = asRecord(payload);
+  const thread = asRecord(root?.thread);
+  const turns = Array.isArray(thread?.turns) ? thread.turns : [];
+  return collectTurnMessages(turns, new Date().toISOString());
+}


### PR DESCRIPTION
## Summary
- Wire Codex session hydration to call app-server `thread/read` during `load_session`
- Parse `thread/read` turn items into chat transcript messages (user + assistant)
- Seed the in-memory session transcript before replay so reconnect/load returns Codex history

## Why
`load_session` already hydrated Claude from persisted session history, but Codex had no equivalent runtime call site even though `CodexSessionProviderAdapter.hydrateSession()` existed. This caused Codex replay hydration to miss thread history.

## What changed
- Added `parseCodexThreadReadTranscript()` to map `thread/read` payloads to `ChatMessage[]`
  - File: `src/backend/domains/session/codex/codex-thread-read-transcript.ts`
- Added `sessionService.tryHydrateCodexTranscript(sessionId)`
  - Calls adapter `hydrateSession()` when a Codex client exists
  - Parses payload into transcript
  - File: `src/backend/domains/session/lifecycle/session.service.ts`
- Updated `load_session` handler to hydrate Codex transcript before `sessionDomainService.subscribe(...)`
  - File: `src/backend/domains/session/chat/chat-message-handlers/handlers/load-session.handler.ts`
- Added `sessionDomainService.setHydratedTranscript(...)` for pre-replay transcript seeding
  - File: `src/backend/domains/session/session-domain.service.ts`

## Validation
- Verified real app-server response shape with a live probe (`codex app-server` + `initialize`, `thread/start`, `turn/start`, `thread/read`)
- Added tests:
  - `src/backend/domains/session/codex/codex-thread-read-transcript.test.ts`
  - `src/backend/domains/session/chat/chat-message-handlers/handlers/load-session.handler.test.ts`
- Ran:
  - `pnpm vitest run src/backend/domains/session/codex/codex-thread-read-transcript.test.ts src/backend/domains/session/chat/chat-message-handlers/handlers/load-session.handler.test.ts`
  - `pnpm deps:check`
  - `pnpm biome check` on modified files

## Notes
- `pnpm typecheck` currently fails in this environment due pre-existing workspace/module resolution issues (e.g. `@factory-factory/core` unresolved across many files), unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session load/hydration and transcript state initialization; incorrect parsing or ordering could cause missing/duplicated history on reconnect, but the changes are provider-scoped (Codex) and covered by unit tests.
> 
> **Overview**
> Codex sessions now hydrate their transcript on `load_session` by calling the Codex adapter’s `thread/read` hydration path and seeding the in-memory transcript *before* `subscribe` replays events, so reconnects return prior Codex history.
> 
> This introduces a defensive `parseCodexThreadReadTranscript()` mapper for `thread/read` turn/items payloads, adds `sessionService.tryHydrateCodexTranscript()` (waits for any pending client creation, no-ops if no client, logs failures), and adds `sessionDomainService.setHydratedTranscript()` to replace/sort transcript and reset ordering/state. New Vitest coverage validates transcript parsing and that hydration occurs (or is skipped) ahead of replay in `load-session.handler`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51d6ab0dc358819e47f481b4fd02bb819a058243. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->