### PR TITLE
Extract shared session hydrate key builder

### DIFF
--- a/src/backend/domains/session/chat/chat-message-handlers/handlers/load-session.handler.test.ts
+++ b/src/backend/domains/session/chat/chat-message-handlers/handlers/load-session.handler.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildHydrateKey } from '@/backend/domains/session/store/session-hydrate-key';
 
 const mocks = vi.hoisted(() => ({
   findById: vi.fn(),
@@ -94,7 +95,12 @@ describe('createLoadSessionHandler', () => {
     expect(mocks.setHydratedTranscript).toHaveBeenCalledWith(
       'session-1',
       expect.any(Array),
-      expect.objectContaining({ hydratedKey: 'none::none' })
+      expect.objectContaining({
+        hydratedKey: buildHydrateKey({
+          claudeSessionId: null,
+          claudeProjectPath: null,
+        }),
+      })
     );
     expect(mocks.subscribe).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/backend/domains/session/chat/chat-message-handlers/handlers/load-session.handler.ts
+++ b/src/backend/domains/session/chat/chat-message-handlers/handlers/load-session.handler.ts
@@ -2,6 +2,7 @@ import type { ChatMessageHandler } from '@/backend/domains/session/chat/chat-mes
 import { SessionManager } from '@/backend/domains/session/claude/session';
 import { sessionService } from '@/backend/domains/session/lifecycle/session.service';
 import { sessionDomainService } from '@/backend/domains/session/session-domain.service';
+import { buildHydrateKey } from '@/backend/domains/session/store/session-hydrate-key';
 import { slashCommandCacheService } from '@/backend/domains/session/store/slash-command-cache.service';
 import { agentSessionAccessor } from '@/backend/resource_accessors/agent-session.accessor';
 import type { LoadSessionMessage } from '@/shared/websocket';
@@ -64,8 +65,10 @@ async function hydrateCodexTranscriptIfAvailable(
   }
 
   sessionDomainService.setHydratedTranscript(sessionId, codexTranscript, {
-    // Matches the hydrator key derived from null claudeSessionId/projectPath.
-    hydratedKey: 'none::none',
+    hydratedKey: buildHydrateKey({
+      claudeSessionId: null,
+      claudeProjectPath: null,
+    }),
   });
 }
 

--- a/src/backend/domains/session/store/session-hydrate-key.test.ts
+++ b/src/backend/domains/session/store/session-hydrate-key.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { buildHydrateKey } from './session-hydrate-key';
+
+describe('buildHydrateKey', () => {
+  it('uses none placeholders for null values', () => {
+    expect(
+      buildHydrateKey({
+        claudeSessionId: null,
+        claudeProjectPath: null,
+      })
+    ).toBe('none::none');
+  });
+
+  it('builds key from provided values', () => {
+    expect(
+      buildHydrateKey({
+        claudeSessionId: 'session-123',
+        claudeProjectPath: '/tmp/project',
+      })
+    ).toBe('session-123::/tmp/project');
+  });
+});

--- a/src/backend/domains/session/store/session-hydrate-key.ts
+++ b/src/backend/domains/session/store/session-hydrate-key.ts
@@ -1,0 +1,8 @@
+export type HydrateKeyInput = {
+  claudeSessionId: string | null;
+  claudeProjectPath: string | null;
+};
+
+export function buildHydrateKey(options: HydrateKeyInput): string {
+  return `${options.claudeSessionId ?? 'none'}::${options.claudeProjectPath ?? 'none'}`;
+}

--- a/src/backend/domains/session/store/session-hydrator.ts
+++ b/src/backend/domains/session/store/session-hydrator.ts
@@ -1,5 +1,6 @@
 import { SessionManager } from '@/backend/domains/session/claude/session';
 import type { ChatMessage } from '@/shared/claude';
+import { buildHydrateKey, type HydrateKeyInput } from './session-hydrate-key';
 import type { SessionStore } from './session-store.types';
 import {
   buildTranscriptFromHistory,
@@ -14,11 +15,8 @@ export class SessionHydrator {
     private readonly onParityTrace: (sessionId: string, data: Record<string, unknown>) => void
   ) {}
 
-  async ensureHydrated(
-    store: SessionStore,
-    options: { claudeSessionId: string | null; claudeProjectPath: string | null }
-  ): Promise<void> {
-    const hydrateKey = `${options.claudeSessionId ?? 'none'}::${options.claudeProjectPath ?? 'none'}`;
+  async ensureHydrated(store: SessionStore, options: HydrateKeyInput): Promise<void> {
+    const hydrateKey = buildHydrateKey(options);
     if (store.initialized && store.hydratedKey === hydrateKey) {
       return;
     }


### PR DESCRIPTION
## Summary
- extracted shared `buildHydrateKey` helper into `src/backend/domains/session/store/session-hydrate-key.ts`
- updated `SessionHydrator` to derive hydrate keys via the helper
- replaced hardcoded `'none::none'` in `hydrateCodexTranscriptIfAvailable` with the same helper
- added focused unit coverage for the key builder and updated load-session handler test to assert via shared helper

## Why
`load-session.handler.ts` and `SessionHydrator` were implicitly coupled by duplicated hydrate-key format logic. If one changed independently, `subscribe` could miss the hydrated-key guard and overwrite CODEx transcript hydration with empty Claude hydration. Centralizing key derivation removes that fragility.

## Validation
- `pnpm vitest run src/backend/domains/session/store/session-hydrate-key.test.ts src/backend/domains/session/chat/chat-message-handlers/handlers/load-session.handler.test.ts`
- `pnpm biome check src/backend/domains/session/store/session-hydrate-key.ts src/backend/domains/session/store/session-hydrator.ts src/backend/domains/session/store/session-hydrate-key.test.ts src/backend/domains/session/chat/chat-message-handlers/handlers/load-session.handler.ts src/backend/domains/session/chat/chat-message-handlers/handlers/load-session.handler.test.ts`

## Notes
- repo-wide `pnpm typecheck` currently fails in this environment due pre-existing unresolved module/type issues unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes a string key format used to guard session hydration; behavior should remain the same but a mistake would impact transcript hydration caching/overwrite prevention.
> 
> **Overview**
> Extracts a shared `buildHydrateKey` helper (and `HydrateKeyInput` type) and switches both `SessionHydrator.ensureHydrated` and CODEX transcript pre-hydration in `load-session.handler` to use it instead of duplicating the `"<session>::<path>"`/`none::none` format.
> 
> Adds unit tests for the new helper and updates the load-session handler test to assert the derived key via `buildHydrateKey` rather than a hardcoded string.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13b624f17645ebc85acfaea5a196ab4199e7857a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->