### PR TITLE
Move provider select next to session + button

### DIFF
--- a/src/client/routes/projects/workspaces/use-workspace-detail.ts
+++ b/src/client/routes/projects/workspaces/use-workspace-detail.ts
@@ -3,6 +3,11 @@ import { useNavigate } from 'react-router';
 import { toast } from 'sonner';
 
 import { trpc } from '@/frontend/lib/trpc';
+import {
+  type NewSessionProviderSelection,
+  resolveExplicitSessionProvider,
+  type SessionProviderValue,
+} from '@/lib/session-provider-selection';
 
 // =============================================================================
 // Helpers
@@ -97,14 +102,8 @@ interface UseSessionManagementOptions {
   isSessionReady: boolean;
 }
 
-type SessionProviderValue = 'CLAUDE' | 'CODEX';
-export type NewSessionProviderSelection = SessionProviderValue | 'WORKSPACE_DEFAULT';
-
-export function resolveExplicitSessionProvider(
-  selectedProvider: NewSessionProviderSelection
-): SessionProviderValue | undefined {
-  return selectedProvider === 'WORKSPACE_DEFAULT' ? undefined : selectedProvider;
-}
+export type { NewSessionProviderSelection };
+export { resolveExplicitSessionProvider };
 
 /** Minimal mutation interface exposing only the properties we use */
 interface MutationLike<TInput, TOutput = unknown, TError = unknown> {

--- a/src/client/routes/projects/workspaces/workspace-detail-container.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-container.tsx
@@ -5,6 +5,7 @@ import { useChatWebSocket } from '@/components/chat';
 import { usePersistentScroll, useWorkspacePanel } from '@/components/workspace';
 import { trpc } from '@/frontend/lib/trpc';
 import { useAutoScroll } from '@/hooks/use-auto-scroll';
+import { resolveEffectiveSessionProvider } from '@/lib/session-provider-selection';
 import { forgetResumeWorkspace } from './resume-workspace-storage';
 import {
   type NewSessionProviderSelection,
@@ -28,6 +29,7 @@ export function WorkspaceDetailContainer() {
     useWorkspaceData({ workspaceId: workspaceId });
 
   const { rightPanelVisible, activeTabId, clearScrollState } = useWorkspacePanel();
+  const { data: userSettings } = trpc.userSettings.get.useQuery();
 
   const { data: hasChanges } = trpc.workspace.hasChanges.useQuery(
     { workspaceId },
@@ -52,6 +54,10 @@ export function WorkspaceDetailContainer() {
   const [archiveDialogOpen, setArchiveDialogOpen] = useState(false);
   const [selectedProvider, setSelectedProvider] =
     useState<NewSessionProviderSelection>('WORKSPACE_DEFAULT');
+  const effectiveDefaultProvider = resolveEffectiveSessionProvider(
+    workspace?.defaultSessionProvider,
+    userSettings?.defaultSessionProvider
+  );
 
   const { data: gitStatus } = trpc.workspace.getGitStatus.useQuery(
     { workspaceId },
@@ -289,8 +295,6 @@ export function WorkspaceDetailContainer() {
         openInIde,
         handleArchiveRequest,
         handleQuickAction,
-        selectedProvider,
-        setSelectedProvider,
         running: workspaceRunning,
         isCreatingSession: createSession.isPending,
         hasChanges,
@@ -305,6 +309,9 @@ export function WorkspaceDetailContainer() {
         handleCloseChatSession,
         maxSessions,
         hasWorktreePath: !!workspace?.worktreePath,
+        selectedProvider,
+        setSelectedProvider,
+        effectiveDefaultProvider,
       }}
       chat={chatViewModel}
       rightPanelVisible={rightPanelVisible}

--- a/src/client/routes/projects/workspaces/workspace-detail-view.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-view.tsx
@@ -4,6 +4,7 @@ import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/componen
 import { ArchiveWorkspaceDialog, RightPanel, WorkspaceContentView } from '@/components/workspace';
 import type { WorkspaceSessionRuntimeSummary } from '@/components/workspace/session-tab-runtime';
 import { Loading } from '@/frontend/components/loading';
+import type { SessionProviderValue } from '@/lib/session-provider-selection';
 import type {
   NewSessionProviderSelection,
   useSessionManagement,
@@ -30,8 +31,6 @@ interface HeaderProps {
   openInIde: ReturnType<typeof useSessionManagement>['openInIde'];
   handleArchiveRequest: () => void;
   handleQuickAction: ReturnType<typeof useSessionManagement>['handleQuickAction'];
-  selectedProvider: NewSessionProviderSelection;
-  setSelectedProvider: Dispatch<SetStateAction<NewSessionProviderSelection>>;
   running: boolean;
   isCreatingSession: boolean;
   hasChanges: boolean | undefined;
@@ -47,6 +46,9 @@ interface SessionTabsProps {
   handleCloseChatSession: ReturnType<typeof useSessionManagement>['handleCloseSession'];
   maxSessions: ReturnType<typeof useWorkspaceData>['maxSessions'];
   hasWorktreePath: boolean;
+  selectedProvider: NewSessionProviderSelection;
+  setSelectedProvider: Dispatch<SetStateAction<NewSessionProviderSelection>>;
+  effectiveDefaultProvider: SessionProviderValue;
 }
 
 interface ArchiveDialogProps {
@@ -123,8 +125,6 @@ export function WorkspaceDetailView({
         archivePending={header.archivePending}
         onArchiveRequest={header.handleArchiveRequest}
         handleQuickAction={header.handleQuickAction}
-        selectedProvider={header.selectedProvider}
-        setSelectedProvider={header.setSelectedProvider}
         running={header.running}
         isCreatingSession={header.isCreatingSession}
         hasChanges={header.hasChanges}
@@ -156,6 +156,9 @@ export function WorkspaceDetailView({
               onCloseSession={sessionTabs.handleCloseChatSession}
               maxSessions={sessionTabs.maxSessions}
               hasWorktreePath={sessionTabs.hasWorktreePath}
+              selectedProvider={sessionTabs.selectedProvider}
+              setSelectedProvider={sessionTabs.setSelectedProvider}
+              effectiveDefaultProvider={sessionTabs.effectiveDefaultProvider}
             >
               <ChatContent {...chat} />
             </WorkspaceContentView>

--- a/src/components/workspace/workspace-content-view.stories.tsx
+++ b/src/components/workspace/workspace-content-view.stories.tsx
@@ -30,6 +30,9 @@ const meta = {
     onCloseSession: fn(),
     maxSessions: 5,
     hasWorktreePath: true,
+    selectedProvider: 'WORKSPACE_DEFAULT',
+    setSelectedProvider: fn(),
+    effectiveDefaultProvider: 'CLAUDE',
     children: <div className="p-4">Chat content</div>,
   },
 } satisfies Meta<typeof WorkspaceContentView>;

--- a/src/components/workspace/workspace-content-view.tsx
+++ b/src/components/workspace/workspace-content-view.tsx
@@ -1,6 +1,10 @@
 import type { inferRouterOutputs } from '@trpc/server';
-import type { ReactNode } from 'react';
+import type { Dispatch, ReactNode, SetStateAction } from 'react';
 import type { AppRouter } from '@/frontend/lib/trpc';
+import type {
+  NewSessionProviderSelection,
+  SessionProviderValue,
+} from '@/lib/session-provider-selection';
 
 import { MainViewContent } from './main-view-content';
 import { MainViewTabBar } from './main-view-tab-bar';
@@ -28,6 +32,9 @@ interface WorkspaceContentViewProps {
   maxSessions?: number;
   /** Whether the workspace has a worktree path (required for sessions) */
   hasWorktreePath: boolean;
+  selectedProvider: NewSessionProviderSelection;
+  setSelectedProvider: Dispatch<SetStateAction<NewSessionProviderSelection>>;
+  effectiveDefaultProvider: SessionProviderValue;
 }
 
 // =============================================================================
@@ -54,6 +61,9 @@ export function WorkspaceContentView({
   children,
   maxSessions,
   hasWorktreePath,
+  selectedProvider,
+  setSelectedProvider,
+  effectiveDefaultProvider,
 }: WorkspaceContentViewProps) {
   const hasNoSessions = sessions && sessions.length === 0;
 
@@ -71,6 +81,9 @@ export function WorkspaceContentView({
           onCloseSession={onCloseSession}
           disabled={isCreatingSession || isDeletingSession || !hasWorktreePath}
           maxSessions={maxSessions}
+          selectedProvider={selectedProvider}
+          setSelectedProvider={setSelectedProvider}
+          effectiveDefaultProvider={effectiveDefaultProvider}
         />
       </div>
 

--- a/src/lib/session-provider-selection.ts
+++ b/src/lib/session-provider-selection.ts
@@ -1,0 +1,34 @@
+export type SessionProviderValue = 'CLAUDE' | 'CODEX';
+export type NewSessionProviderSelection = SessionProviderValue | 'WORKSPACE_DEFAULT';
+
+export const EXPLICIT_SESSION_PROVIDER_OPTIONS = [
+  { value: 'CLAUDE', label: 'Claude' },
+  { value: 'CODEX', label: 'Codex' },
+] as const;
+
+export function resolveProviderSelection(value: unknown): NewSessionProviderSelection {
+  if (value === 'CLAUDE' || value === 'CODEX' || value === 'WORKSPACE_DEFAULT') {
+    return value;
+  }
+  return 'WORKSPACE_DEFAULT';
+}
+
+export function resolveExplicitSessionProvider(
+  selectedProvider: NewSessionProviderSelection
+): SessionProviderValue | undefined {
+  return selectedProvider === 'WORKSPACE_DEFAULT' ? undefined : selectedProvider;
+}
+
+export function resolveEffectiveSessionProvider(
+  workspaceDefaultProvider: unknown,
+  userDefaultProvider: unknown
+): SessionProviderValue {
+  if (workspaceDefaultProvider === 'CLAUDE' || workspaceDefaultProvider === 'CODEX') {
+    return workspaceDefaultProvider;
+  }
+  return userDefaultProvider === 'CODEX' ? 'CODEX' : 'CLAUDE';
+}
+
+export function getSessionProviderLabel(provider: SessionProviderValue): string {
+  return provider === 'CODEX' ? 'Codex' : 'Claude';
+}


### PR DESCRIPTION
## Summary
- move the new-session provider selector (`Claude`/`Codex`) from the workspace header into the session tab bar
- render the selector directly beside the `+` button used to create sessions
- keep provider resolution behavior unchanged (`WORKSPACE_DEFAULT` still resolves via workspace/user defaults)
- extract shared provider-selection helpers/types into `src/lib/session-provider-selection.ts`

## Testing
- pnpm typecheck
- pnpm test -- src/client/routes/projects/workspaces/use-workspace-detail.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI refactor that repositions the provider selector and centralizes helper logic, with minimal behavioral change beyond prop wiring.
> 
> **Overview**
> Moves the **new-session provider selector** (Claude/Codex vs `WORKSPACE_DEFAULT`) out of `WorkspaceHeader` and into the session tab bar (`MainViewTabBar`), placing it beside the `+` session button and disabling it when session creation is disabled/at max sessions.
> 
> Extracts and reuses provider selection/types/resolution utilities into `src/lib/session-provider-selection.ts`, and updates `WorkspaceDetailContainer`/`WorkspaceContentView` prop plumbing to compute and pass the effective default provider (workspace default falling back to user default).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83315a92eefc976ca35d6ec1cde9a11c495e0edf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->