### PR TITLE
Fix quick action auto-send and screenshot session issues

### DIFF
--- a/prompts/quick-actions/screenshots.md
+++ b/prompts/quick-actions/screenshots.md
@@ -4,18 +4,19 @@ description: Capture screenshots of the running dev app
 type: agent
 icon: camera
 ---
-Take a screenshot of the workspace's running development app to capture the current state of the UI.
+Take exactly one screenshot of the workspace's running development app to capture the current state of the UI.
 
 ## Step 1: Start the dev server
 
 1. Read `factory-factory.json` in the repo root for the `scripts.run` command
 2. Pick a free port and replace `{port}` in the command with it
-3. Start the dev server in the background and wait for it to be ready
+3. Start the dev server in the background with `BROWSER=none` set in the environment (do NOT open a browser window) and wait for it to be ready
 
-## Step 2: Take a screenshot
+## Step 2: Take a single screenshot
 
 1. `mkdir -p .factory-factory/screenshots`
 2. Use `browser_navigate` to visit the dev server URL
-3. Determine the most relevant screen that captures the current state of the app
-4. Use `browser_screenshot` to capture it
-5. Save to `.factory-factory/screenshots/` with a descriptive PNG filename
+3. Use `browser_screenshot` to capture the page
+4. Save to `.factory-factory/screenshots/` with a descriptive PNG filename
+
+Do not take more than one screenshot. Do not open extra browser tabs or windows.

--- a/src/backend/domains/run-script/run-script.service.ts
+++ b/src/backend/domains/run-script/run-script.service.ts
@@ -93,6 +93,7 @@ export class RunScriptService {
         cwd: workspace.worktreePath,
         detached: false,
         stdio: ['ignore', 'pipe', 'pipe'],
+        env: { ...process.env, BROWSER: 'none' },
       });
 
       const pid = childProcess.pid;

--- a/src/backend/domains/session/chat/chat-message-handlers/handlers/load-session.handler.test.ts
+++ b/src/backend/domains/session/chat/chat-message-handlers/handlers/load-session.handler.test.ts
@@ -9,7 +9,9 @@ const mocks = vi.hoisted(() => ({
   subscribe: vi.fn(),
   emitDelta: vi.fn(),
   setHydratedTranscript: vi.fn(),
+  consumeInitialMessage: vi.fn(),
   getCachedCommands: vi.fn(),
+  tryDispatchNextMessage: vi.fn(),
 }));
 
 vi.mock('@/backend/resource_accessors/agent-session.accessor', () => ({
@@ -31,6 +33,7 @@ vi.mock('@/backend/domains/session/session-domain.service', () => ({
     subscribe: mocks.subscribe,
     emitDelta: mocks.emitDelta,
     setHydratedTranscript: mocks.setHydratedTranscript,
+    consumeInitialMessage: mocks.consumeInitialMessage,
   },
 }));
 
@@ -82,7 +85,11 @@ describe('createLoadSessionHandler', () => {
       },
     ]);
 
-    const handler = createLoadSessionHandler();
+    const handler = createLoadSessionHandler({
+      getClientCreator: () => null,
+      tryDispatchNextMessage: mocks.tryDispatchNextMessage,
+      setManualDispatchResume: vi.fn(),
+    });
     const ws = { send: vi.fn() } as unknown as { send: (payload: string) => void };
     await handler({
       ws: ws as never,
@@ -121,7 +128,11 @@ describe('createLoadSessionHandler', () => {
     });
     mocks.tryHydrateCodexTranscript.mockResolvedValue(null);
 
-    const handler = createLoadSessionHandler();
+    const handler = createLoadSessionHandler({
+      getClientCreator: () => null,
+      tryDispatchNextMessage: mocks.tryDispatchNextMessage,
+      setManualDispatchResume: vi.fn(),
+    });
     const ws = { send: vi.fn() } as unknown as { send: (payload: string) => void };
     await handler({
       ws: ws as never,

--- a/src/backend/domains/session/chat/chat-message-handlers/handlers/load-session.handler.ts
+++ b/src/backend/domains/session/chat/chat-message-handlers/handlers/load-session.handler.ts
@@ -1,10 +1,15 @@
-import type { ChatMessageHandler } from '@/backend/domains/session/chat/chat-message-handlers/types';
+import type {
+  ChatMessageHandler,
+  HandlerRegistryDependencies,
+} from '@/backend/domains/session/chat/chat-message-handlers/types';
+import { buildQueuedMessage } from '@/backend/domains/session/chat/chat-message-handlers/utils';
 import { SessionManager } from '@/backend/domains/session/claude/session';
 import { sessionService } from '@/backend/domains/session/lifecycle/session.service';
 import { sessionDomainService } from '@/backend/domains/session/session-domain.service';
 import { buildHydrateKey } from '@/backend/domains/session/store/session-hydrate-key';
 import { slashCommandCacheService } from '@/backend/domains/session/store/slash-command-cache.service';
 import { agentSessionAccessor } from '@/backend/resource_accessors/agent-session.accessor';
+import { MessageState, resolveSelectedModel } from '@/shared/claude';
 import type { LoadSessionMessage } from '@/shared/websocket';
 
 type PersistedSession = NonNullable<Awaited<ReturnType<typeof agentSessionAccessor.findById>>>;
@@ -72,7 +77,9 @@ async function hydrateCodexTranscriptIfAvailable(
   });
 }
 
-export function createLoadSessionHandler(): ChatMessageHandler<LoadSessionMessage> {
+export function createLoadSessionHandler(
+  deps: HandlerRegistryDependencies
+): ChatMessageHandler<LoadSessionMessage> {
   return async ({ ws, sessionId, message }) => {
     const dbSession = await agentSessionAccessor.findById(sessionId);
     if (!dbSession) {
@@ -99,7 +106,45 @@ export function createLoadSessionHandler(): ChatMessageHandler<LoadSessionMessag
     });
 
     await sendCachedSlashCommandsIfNeeded(sessionId, dbSession.provider);
+
+    // Auto-enqueue initial message if one was stored during session creation
+    await enqueueInitialMessageIfPresent(sessionId, deps);
   };
+}
+
+async function enqueueInitialMessageIfPresent(
+  sessionId: string,
+  deps: HandlerRegistryDependencies
+): Promise<void> {
+  const text = sessionDomainService.consumeInitialMessage(sessionId);
+  if (!text) {
+    return;
+  }
+
+  const id = `msg-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+  const queuedMsg = buildQueuedMessage(id, { id, text, type: 'queue_message' }, text);
+  const result = sessionDomainService.enqueue(sessionId, queuedMsg);
+  if ('error' in result) {
+    return;
+  }
+
+  sessionDomainService.emitDelta(sessionId, {
+    type: 'message_state_changed',
+    id,
+    newState: MessageState.ACCEPTED,
+    queuePosition: result.position,
+    userMessage: {
+      text: queuedMsg.text,
+      timestamp: queuedMsg.timestamp,
+      settings: {
+        ...queuedMsg.settings,
+        selectedModel: resolveSelectedModel(queuedMsg.settings.selectedModel),
+        reasoningEffort: queuedMsg.settings.reasoningEffort,
+      },
+    },
+  });
+
+  await deps.tryDispatchNextMessage(sessionId);
 }
 
 async function sendCachedSlashCommandsIfNeeded(

--- a/src/backend/domains/session/chat/chat-message-handlers/registry.ts
+++ b/src/backend/domains/session/chat/chat-message-handlers/registry.ts
@@ -33,7 +33,7 @@ export function createChatMessageHandlerRegistry(
     remove_queued_message: createRemoveQueuedMessageHandler(),
     resume_queued_messages: createResumeQueuedMessagesHandler(deps),
     stop: createStopHandler(),
-    load_session: createLoadSessionHandler(),
+    load_session: createLoadSessionHandler(deps),
     question_response: createQuestionResponseHandler(),
     permission_response: createPermissionResponseHandler(),
     set_model: createSetModelHandler(),

--- a/src/backend/domains/session/claude/process.ts
+++ b/src/backend/domains/session/claude/process.ts
@@ -91,6 +91,7 @@ export class ClaudeProcess extends EventEmitter {
         ...process.env,
         FORCE_COLOR: '0',
         NO_COLOR: '1',
+        BROWSER: 'none',
       },
       detached: true,
     });

--- a/src/backend/domains/session/lifecycle/session.service.ts
+++ b/src/backend/domains/session/lifecycle/session.service.ts
@@ -1102,7 +1102,7 @@ class SessionService {
       mcpServers: {
         playwright: {
           command: 'npx',
-          args: ['@playwright/mcp@latest', '--viewport-size=1920,1080'],
+          args: ['@playwright/mcp@latest', '--headless', '--isolated', '--viewport-size=1920,1080'],
         },
       },
     });

--- a/src/backend/domains/session/session-domain.service.ts
+++ b/src/backend/domains/session/session-domain.service.ts
@@ -32,6 +32,22 @@ class SessionDomainService {
   private readonly registry = new SessionStoreRegistry();
   private readonly publisher = new SessionPublisher();
   private readonly nowIso = () => new Date().toISOString();
+
+  /** In-memory store for initial messages to auto-enqueue on first load_session */
+  private readonly initialMessages = new Map<string, string>();
+
+  storeInitialMessage(sessionId: string, text: string): void {
+    this.initialMessages.set(sessionId, text);
+  }
+
+  consumeInitialMessage(sessionId: string): string | null {
+    const text = this.initialMessages.get(sessionId);
+    if (text !== undefined) {
+      this.initialMessages.delete(sessionId);
+      return text;
+    }
+    return null;
+  }
   private readonly parityLogger = this.publisher.getParityLogger();
 
   private readonly runtimeMachine = new SessionRuntimeMachine((sessionId, runtime) => {

--- a/src/backend/trpc/session.trpc.ts
+++ b/src/backend/trpc/session.trpc.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import {
   SessionManager,
   sessionDataService,
+  sessionDomainService,
   sessionProviderResolverService,
 } from '@/backend/domains/session';
 import { workspaceDataService } from '@/backend/domains/workspace';
@@ -72,6 +73,7 @@ export const sessionRouter = router({
         workflow: z.string(),
         model: z.string().optional(),
         provider: z.nativeEnum(SessionProvider).optional(),
+        initialMessage: z.string().optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -106,6 +108,9 @@ export const sessionRouter = router({
         provider,
         claudeProjectPath,
       });
+      if (input.initialMessage) {
+        sessionDomainService.storeInitialMessage(session.id, input.initialMessage);
+      }
       return session;
     }),
 

--- a/src/client/routes/projects/workspaces/workspace-detail-container.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-container.tsx
@@ -104,7 +104,6 @@ export function WorkspaceDetailContainer() {
   });
 
   const loadingSession = sessionStatus.phase === 'loading';
-  const isSessionReady = sessionStatus.phase === 'ready' || sessionStatus.phase === 'running';
   const isIssueAutoStartPending =
     workspace?.creationSource === 'GITHUB_ISSUE' &&
     selectedDbSessionId !== null &&
@@ -141,13 +140,11 @@ export function WorkspaceDetailContainer() {
     workspaceId: workspaceId,
     slug: slug,
     sessions,
-    sendMessage,
     inputRef,
     selectedDbSessionId,
     setSelectedDbSessionId,
     selectedModel: chatSettings.selectedModel,
     selectedProvider,
-    isSessionReady,
   });
 
   const handleArchiveError = useCallback((error: unknown) => {


### PR DESCRIPTION
## Summary
- Move quick action initial message handling from fragile frontend `useEffect` transition detection to the backend — `createSession` accepts `initialMessage`, stores it in-memory, and `load_session` auto-enqueues it on first WebSocket connect
- Fix dispatch stall after auto-start by skipping the requeue check when the client was just created (the "working" state comes from startup, not a prior user message)
- Run Playwright MCP in headless isolated mode to prevent cross-session browser lock conflicts and suppress dev server browser auto-open via `BROWSER=none`
- Tighten screenshot prompt to exactly one capture with explicit constraints

## Test plan
- [ ] `pnpm typecheck` passes
- [ ] `pnpm check:fix` passes
- [ ] `pnpm test` passes (2245 tests)
- [ ] Click "Take Screenshots" quick action → new session created → prompt auto-sends without manual follow-up
- [ ] Regular "New Chat" still works (no `initialMessage` passed)
- [ ] No browser windows open during screenshot flow
- [ ] Multiple screenshot sessions don't conflict (isolated browser profiles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)