### PR TITLE
Fix non-shell -c command previews

### DIFF
--- a/src/components/agent-activity/tool-renderers/tool-display-utils.test.ts
+++ b/src/components/agent-activity/tool-renderers/tool-display-utils.test.ts
@@ -32,6 +32,14 @@ describe('tool-display-utils', () => {
 
       expect(preview).toBe('git push -u origin release/v0.3.0');
     });
+
+    it('does not treat non-shell -c as a shell script flag', () => {
+      const preview = extractCommandPreviewFromInput({
+        command: ['uv', 'run', 'python', '-c', 'print("hello")'],
+      });
+
+      expect(preview).toBe('uv run python -c print("hello")');
+    });
   });
 
   describe('getDisplayToolName', () => {
@@ -53,6 +61,14 @@ describe('tool-display-utils', () => {
       });
 
       expect(display).toBe('Run cat > /tmp/pr-body.md <<EOF hello EOF');
+    });
+
+    it('keeps non-shell -c flags in detail mode', () => {
+      const display = getDisplayToolName('Run uv run python -c', {
+        command: ['uv', 'run', 'python', '-c', 'print("hello")'],
+      });
+
+      expect(display).toBe('Run uv run python -c print("hello")');
     });
 
     it('truncates long non-run names in summary mode', () => {


### PR DESCRIPTION
## Summary
- Fix `extractCommandPreviewFromInput` so `-c` / `-lc` is treated as a shell script flag only when the executable is a known shell.
- Preserve full argv previews for non-shell commands that legitimately include `-c`.
- Add regressions for both preview extraction and run display name rendering.

## Verification
- Added a regression test with `['uv', 'run', 'python', '-c', 'print("hello")']` that failed before this change (`Received: print("hello")`) and now passes.
- `pnpm vitest run src/components/agent-activity/tool-renderers/tool-display-utils.test.ts`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-scoped change to UI command preview rendering with added tests; minimal risk beyond slightly altering displayed labels for some commands.
> 
> **Overview**
> Fixes `extractCommandPreviewFromInput` so `-c`/`-lc` is only treated as a *shell script payload* when the argv executable is a known shell (e.g., `bash`, `zsh`), otherwise preserving the full joined argv for tools that legitimately use `-c`.
> 
> Adds regression tests covering non-shell `-c` previews and ensuring `getDisplayToolName` detail mode retains the full non-shell command preview.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e888ab24776343795fbd09dc666b164e35eb29f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->