### PR TITLE
Update changelog with post-0.3.0 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix symlink escape in isPathSafe (#917) (#1010)
+- Fix duplicate history replay after hydration (#1009)
+- Fix non-shell -c command previews (#1008)
+- Fix Run tool rendering in activity view (#1007)
+- Harden Claude history loader and bound retry cache (#1006)
 - Load session history without passive runtime startup (#1004)
 - Fix duplicate transcript injection from ACP user_message_chunk (#1003)
 - Fix session load/runtime UX and Codex chat-bar hydration (#1002)


### PR DESCRIPTION
## Summary
- update CHANGELOG.md with post-0.3.0 fixes merged in #1006 through #1010
- keep version at 0.3.0 (no version bump)

## Testing
- not run (documentation-only change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog update with no code or behavioral impact.
> 
> **Overview**
> Updates `CHANGELOG.md` under `0.3.0` to list additional recently-merged fixes (PRs `#1006`–`#1010`), including items like `isPathSafe` symlink-escape hardening, history hydration replay fixes, and UI/tool rendering corrections.
> 
> No runtime behavior changes are included; this is documentation-only and keeps the version at `0.3.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d618b900423fe9d1f0effc056f5033d1cda85c4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->