### PR TITLE
Fix npm/npx install failure from workspace dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Factory Factory will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-02-14
+
+### Fixed
+
+- Fix npm/npx installation failure by replacing `workspace:*` dependency resolution for `@factory-factory/core` with publish-safe packaging
+
 ## [0.3.0] - 2026-02-14
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "factory-factory",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Workspace-based coding environment for running multiple Claude Code and Codex sessions in parallel",
   "private": false,
   "license": "MIT",
@@ -34,6 +34,8 @@
   },
   "files": [
     "dist",
+    "packages/core/package.json",
+    "packages/core/dist",
     "prisma/migrations",
     "prisma/schema.prisma",
     "prompts",
@@ -77,7 +79,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@factory-factory/core": "workspace:*",
+    "@factory-factory/core": "file:packages/core",
     "@hookform/resolvers": "^5.2.2",
     "@prisma/adapter-better-sqlite3": "^7.3.0",
     "@prisma/client": "^7.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,7 +33,7 @@ importers:
         specifier: ^3.2.2
         version: 3.2.2(react@19.2.4)
       '@factory-factory/core':
-        specifier: workspace:*
+        specifier: file:packages/core
         version: link:packages/core
       '@hookform/resolvers':
         specifier: ^5.2.2


### PR DESCRIPTION
## Summary
- fix `npm`/`npx` install failures caused by publishing a `workspace:*` dependency
- switch `@factory-factory/core` to `file:packages/core` in `package.json` so published metadata is npm-compatible
- include `packages/core/package.json` and `packages/core/dist` in published files so runtime imports resolve after install
- bump release to `0.3.1` and document the fix in `CHANGELOG.md`

## Validation
- `pnpm install --frozen-lockfile`
- `npm pack`
- `npm exec --yes --package <packed-tarball> factory-factory -- --help`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging/metadata-only changes; main risk is broken publishing or missing bundled core artifacts rather than runtime behavior changes.
> 
> **Overview**
> Fixes `npm`/`npx` install failures caused by publishing a `workspace:*` dependency for `@factory-factory/core`.
> 
> Bumps version to `0.3.1`, switches `@factory-factory/core` from `workspace:*` to `file:packages/core`, and ensures the published package includes `packages/core/package.json` and `packages/core/dist` so runtime imports resolve after install. Updates `pnpm-lock.yaml` and documents the fix in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80979182963b6a9899599a63ee8bea1c1facf0e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->