### PR TITLE
Fix npx packaging crash, bump version to 0.3.3

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -56,16 +56,15 @@ jobs:
       - name: Pack npm tarball
         run: npm pack --silent
 
-      - name: Smoke test packed artifact with npm install
+      - name: Smoke test packed artifact with npm exec
         run: |
           set -euo pipefail
           ROOT_DIR="$PWD"
           TARBALL=$(ls factory-factory-*.tgz | head -n1)
           TMPDIR=$(mktemp -d)
           cd "$TMPDIR"
-          npm init -y >/dev/null 2>&1
-          npm install "$ROOT_DIR/$TARBALL"
-          npx --yes ff db:migrate --database-path "$TMPDIR/test.db"
+          npm exec --yes --package "$ROOT_DIR/$TARBALL" -- factory-factory serve --help
+          npm exec --yes --package "$ROOT_DIR/$TARBALL" -- factory-factory db:migrate --database-path "$TMPDIR/test.db"
 
       - name: Publish to npm (dry run)
         if: ${{ matrix.node-version == '20' && github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to Factory Factory will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.3] - 2026-02-14
+
+### Fixed
+
+- Fix `npx factory-factory@latest serve` failing during npm package linking (`Cannot destructure property 'package' of 'node.target' as it is null`) by removing the published `file:packages/core` dependency and in-package core import path
+
+### CI
+
+- Align npm publish workflow smoke test to use packed-tarball `npm exec --package ...` so npx/npm exec install-link failures are caught before release
+
 ## [0.3.2] - 2026-02-14
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "factory-factory",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Workspace-based coding environment for running multiple Claude Code and Codex sessions in parallel",
   "private": false,
   "license": "MIT",
@@ -37,8 +37,6 @@
   },
   "files": [
     "dist",
-    "packages/core/package.json",
-    "packages/core/dist",
     "prisma/migrations",
     "prisma/schema.prisma",
     "prompts",
@@ -82,7 +80,6 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@factory-factory/core": "file:packages/core",
     "@hookform/resolvers": "^5.2.2",
     "@prisma/adapter-better-sqlite3": "7.3.0",
     "@prisma/client": "7.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.2
         version: 3.2.2(react@19.2.4)
-      '@factory-factory/core':
-        specifier: file:packages/core
-        version: link:packages/core
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.71.1(react@19.2.4))

--- a/src/backend/domains/github/github-cli.service.ts
+++ b/src/backend/domains/github/github-cli.service.ts
@@ -1,7 +1,7 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import type { CIStatus, PRState } from '@factory-factory/core';
 import { createLogger } from '@/backend/services/logger.service';
+import type { CIStatus, PRState } from '@/shared/core';
 import type { PRWithFullDetails, ReviewAction } from '@/shared/github-types';
 import { GH_MAX_BUFFER_BYTES, GH_TIMEOUT_MS } from './github-cli/constants';
 import { classifyError, logGitHubCLIError } from './github-cli/errors';

--- a/src/backend/domains/github/github-cli/mappers.ts
+++ b/src/backend/domains/github/github-cli/mappers.ts
@@ -1,5 +1,5 @@
-import { CIStatus, PRState } from '@factory-factory/core';
 import type { z } from 'zod';
+import { CIStatus, PRState } from '@/shared/core';
 import type {
   GitHubComment,
   GitHubLabel,

--- a/src/backend/domains/ratchet/bridges.ts
+++ b/src/backend/domains/ratchet/bridges.ts
@@ -4,7 +4,7 @@
  * The ratchet domain never imports from other domains directly.
  */
 
-import type { CIStatus } from '@factory-factory/core';
+import type { CIStatus } from '@/shared/core';
 
 // --- Session bridge ---
 

--- a/src/backend/domains/ratchet/ci-fixer.service.test.ts
+++ b/src/backend/domains/ratchet/ci-fixer.service.test.ts
@@ -1,5 +1,5 @@
-import { SessionStatus } from '@factory-factory/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SessionStatus } from '@/shared/core';
 import type { RatchetSessionBridge } from './bridges';
 
 vi.mock('./fixer-session.service', () => ({

--- a/src/backend/domains/ratchet/ci-fixer.service.ts
+++ b/src/backend/domains/ratchet/ci-fixer.service.ts
@@ -5,7 +5,6 @@
  * Prevents duplicate concurrent CI fixing sessions per workspace.
  */
 
-import type { SessionStatus } from '@factory-factory/core';
 import {
   dispatchFixWorkflow,
   isFixWorkflowInProgress,
@@ -13,6 +12,7 @@ import {
   runExclusiveWorkspaceOperation,
 } from '@/backend/services/fixer-workflow.service';
 import { createLogger } from '@/backend/services/logger.service';
+import type { SessionStatus } from '@/shared/core';
 import type { RatchetSessionBridge } from './bridges';
 import { fixerSessionService } from './fixer-session.service';
 

--- a/src/backend/domains/ratchet/ci-monitor.service.ts
+++ b/src/backend/domains/ratchet/ci-monitor.service.ts
@@ -5,13 +5,13 @@
  * Runs on a 3-minute polling interval with adaptive backoff on rate limits.
  */
 
-import { CIStatus, SessionStatus } from '@factory-factory/core';
 import pLimit from 'p-limit';
 import { agentSessionAccessor } from '@/backend/resource_accessors/agent-session.accessor';
 import { workspaceAccessor } from '@/backend/resource_accessors/workspace.accessor';
 import { SERVICE_CONCURRENCY, SERVICE_INTERVAL_MS } from '@/backend/services/constants';
 import { createLogger } from '@/backend/services/logger.service';
 import { RateLimitBackoff } from '@/backend/services/rate-limit-backoff';
+import { CIStatus, SessionStatus } from '@/shared/core';
 import type { RatchetGitHubBridge, RatchetPRSnapshotBridge, RatchetSessionBridge } from './bridges';
 import { ciFixerService } from './ci-fixer.service';
 

--- a/src/backend/domains/ratchet/fixer-session.service.test.ts
+++ b/src/backend/domains/ratchet/fixer-session.service.test.ts
@@ -1,5 +1,5 @@
-import { SessionStatus } from '@factory-factory/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SessionStatus } from '@/shared/core';
 import type { RatchetSessionBridge } from './bridges';
 
 vi.mock('@/backend/resource_accessors/workspace.accessor', () => ({

--- a/src/backend/domains/ratchet/fixer-session.service.ts
+++ b/src/backend/domains/ratchet/fixer-session.service.ts
@@ -1,8 +1,8 @@
-import { SessionStatus } from '@factory-factory/core';
 import { agentSessionAccessor } from '@/backend/resource_accessors/agent-session.accessor';
 import { workspaceAccessor } from '@/backend/resource_accessors/workspace.accessor';
 import { configService } from '@/backend/services/config.service';
 import { createLogger } from '@/backend/services/logger.service';
+import { SessionStatus } from '@/shared/core';
 import type { RatchetSessionBridge } from './bridges';
 import { ratchetProviderResolverService } from './ratchet-provider-resolver.service';
 

--- a/src/backend/domains/ratchet/ratchet.service.test.ts
+++ b/src/backend/domains/ratchet/ratchet.service.test.ts
@@ -1,5 +1,5 @@
-import { CIStatus, RatchetState, SessionStatus } from '@factory-factory/core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CIStatus, RatchetState, SessionStatus } from '@/shared/core';
 import { unsafeCoerce } from '@/test-utils/unsafe-coerce';
 import type { RatchetGitHubBridge, RatchetPRSnapshotBridge, RatchetSessionBridge } from './bridges';
 

--- a/src/backend/domains/ratchet/ratchet.service.ts
+++ b/src/backend/domains/ratchet/ratchet.service.ts
@@ -8,7 +8,6 @@
  */
 
 import { EventEmitter } from 'node:events';
-import { CIStatus, RatchetState, SessionStatus } from '@factory-factory/core';
 import type { SessionProvider } from '@prisma-gen/client';
 import pLimit from 'p-limit';
 import { buildRatchetDispatchPrompt } from '@/backend/prompts/ratchet-dispatch';
@@ -22,6 +21,7 @@ import {
 } from '@/backend/services/constants';
 import { createLogger } from '@/backend/services/logger.service';
 import { RateLimitBackoff } from '@/backend/services/rate-limit-backoff';
+import { CIStatus, RatchetState, SessionStatus } from '@/shared/core';
 import type { RatchetGitHubBridge, RatchetPRSnapshotBridge, RatchetSessionBridge } from './bridges';
 import { fixerSessionService } from './fixer-session.service';
 import { ratchetProviderResolverService } from './ratchet-provider-resolver.service';

--- a/src/backend/domains/ratchet/reconciliation.service.ts
+++ b/src/backend/domains/ratchet/reconciliation.service.ts
@@ -1,9 +1,9 @@
-import { SessionStatus } from '@factory-factory/core';
 import { initializeWorkspaceWorktree } from '@/backend/orchestration/workspace-init.orchestrator';
 import { terminalSessionAccessor } from '@/backend/resource_accessors/terminal-session.accessor';
 import { workspaceAccessor } from '@/backend/resource_accessors/workspace.accessor';
 import { SERVICE_INTERVAL_MS } from '@/backend/services/constants';
 import { createLogger } from '@/backend/services/logger.service';
+import { SessionStatus } from '@/shared/core';
 import type { RatchetWorkspaceBridge } from './bridges';
 
 const logger = createLogger('reconciliation');

--- a/src/backend/domains/run-script/run-script-state-machine.service.ts
+++ b/src/backend/domains/run-script/run-script-state-machine.service.ts
@@ -19,10 +19,10 @@
  */
 
 import { EventEmitter } from 'node:events';
-import type { RunScriptStatus } from '@factory-factory/core';
 import type { Prisma, Workspace } from '@prisma-gen/client';
 import { workspaceAccessor } from '@/backend/resource_accessors/workspace.accessor';
 import { createLogger } from '@/backend/services/logger.service';
+import type { RunScriptStatus } from '@/shared/core';
 
 const logger = createLogger('run-script-state-machine');
 

--- a/src/backend/domains/session/data/session-data.service.ts
+++ b/src/backend/domains/session/data/session-data.service.ts
@@ -1,10 +1,10 @@
-import type { SessionStatus } from '@factory-factory/core';
 import type { SessionProvider, TerminalSession } from '@prisma-gen/client';
 import {
   type AgentSessionRecord,
   agentSessionAccessor,
 } from '@/backend/resource_accessors/agent-session.accessor';
 import { terminalSessionAccessor } from '@/backend/resource_accessors/terminal-session.accessor';
+import type { SessionStatus } from '@/shared/core';
 
 class SessionDataService {
   // Agent sessions

--- a/src/backend/domains/session/lifecycle/session.service.test.ts
+++ b/src/backend/domains/session/lifecycle/session.service.test.ts
@@ -1,6 +1,6 @@
-import { SessionStatus } from '@factory-factory/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { sessionDomainService } from '@/backend/domains/session/session-domain.service';
+import { SessionStatus } from '@/shared/core';
 import { unsafeCoerce } from '@/test-utils/unsafe-coerce';
 
 vi.mock('@/backend/services/logger.service', () => ({

--- a/src/backend/domains/session/lifecycle/session.service.ts
+++ b/src/backend/domains/session/lifecycle/session.service.ts
@@ -1,5 +1,4 @@
 import type { SessionConfigOption } from '@agentclientprotocol/sdk';
-import { SessionStatus } from '@factory-factory/core';
 import type { AcpClientOptions, AcpProcessHandle } from '@/backend/domains/session/acp';
 import {
   AcpEventTranslator,
@@ -22,6 +21,7 @@ import type {
 } from '@/shared/acp-protocol';
 import { extractPlanText } from '@/shared/acp-protocol/plan-content';
 import { type ChatBarCapabilities, EMPTY_CHAT_BAR_CAPABILITIES } from '@/shared/chat-capabilities';
+import { SessionStatus } from '@/shared/core';
 import {
   createInitialSessionRuntimeState,
   type SessionRuntimeState,

--- a/src/backend/domains/workspace/lifecycle/data.service.ts
+++ b/src/backend/domains/workspace/lifecycle/data.service.ts
@@ -1,6 +1,6 @@
-import type { WorkspaceStatus } from '@factory-factory/core';
 import type { Workspace, WorkspaceProviderSelection } from '@prisma-gen/client';
 import { workspaceAccessor } from '@/backend/resource_accessors/workspace.accessor';
+import type { WorkspaceStatus } from '@/shared/core';
 
 class WorkspaceDataService {
   findById(id: string) {

--- a/src/backend/domains/workspace/lifecycle/state-machine.service.ts
+++ b/src/backend/domains/workspace/lifecycle/state-machine.service.ts
@@ -16,10 +16,10 @@
  */
 
 import { EventEmitter } from 'node:events';
-import type { WorkspaceStatus } from '@factory-factory/core';
 import type { Prisma, Workspace } from '@prisma-gen/client';
 import { workspaceAccessor } from '@/backend/resource_accessors/workspace.accessor';
 import { createLogger } from '@/backend/services/logger.service';
+import type { WorkspaceStatus } from '@/shared/core';
 
 const logger = createLogger('workspace-state-machine');
 

--- a/src/backend/domains/workspace/query/workspace-query.service.ts
+++ b/src/backend/domains/workspace/query/workspace-query.service.ts
@@ -1,4 +1,3 @@
-import { type KanbanColumn, WorkspaceStatus } from '@factory-factory/core';
 import pLimit from 'p-limit';
 import type {
   WorkspaceGitHubBridge,
@@ -12,6 +11,7 @@ import { workspaceAccessor } from '@/backend/resource_accessors/workspace.access
 import { FactoryConfigService } from '@/backend/services/factory-config.service';
 import { gitOpsService } from '@/backend/services/git-ops.service';
 import { createLogger } from '@/backend/services/logger.service';
+import { type KanbanColumn, WorkspaceStatus } from '@/shared/core';
 import { deriveWorkspaceSidebarStatus } from '@/shared/workspace-sidebar-status';
 
 const logger = createLogger('workspace-query');

--- a/src/backend/domains/workspace/state/flow-state.test.ts
+++ b/src/backend/domains/workspace/state/flow-state.test.ts
@@ -1,5 +1,5 @@
-import { CIStatus, PRState, RatchetState } from '@factory-factory/core';
 import { describe, expect, it } from 'vitest';
+import { CIStatus, PRState, RatchetState } from '@/shared/core';
 import { deriveWorkspaceFlowState, deriveWorkspaceFlowStateFromWorkspace } from './flow-state';
 
 describe('deriveWorkspaceFlowState', () => {

--- a/src/backend/domains/workspace/state/flow-state.ts
+++ b/src/backend/domains/workspace/state/flow-state.ts
@@ -1,4 +1,4 @@
-import { CIStatus, PRState, RatchetState } from '@factory-factory/core';
+import { CIStatus, PRState, RatchetState } from '@/shared/core';
 
 export type WorkspaceFlowPhase =
   | 'NO_PR'

--- a/src/backend/domains/workspace/state/init-policy.ts
+++ b/src/backend/domains/workspace/state/init-policy.ts
@@ -1,4 +1,4 @@
-import type { WorkspaceStatus } from '@factory-factory/core';
+import type { WorkspaceStatus } from '@/shared/core';
 import type { WorkspaceInitBanner, WorkspaceInitPhase } from '@/shared/workspace-init';
 
 export interface WorkspaceInitPolicyInput {

--- a/src/backend/domains/workspace/state/kanban-state.ts
+++ b/src/backend/domains/workspace/state/kanban-state.ts
@@ -1,8 +1,8 @@
-import { KanbanColumn, PRState, WorkspaceStatus } from '@factory-factory/core';
 import type { Workspace } from '@prisma-gen/client';
 import type { WorkspaceSessionBridge } from '@/backend/domains/workspace/bridges';
 import { workspaceAccessor } from '@/backend/resource_accessors/workspace.accessor';
 import { createLogger } from '@/backend/services/logger.service';
+import { KanbanColumn, PRState, WorkspaceStatus } from '@/shared/core';
 import { deriveWorkspaceFlowStateFromWorkspace } from './flow-state';
 import { deriveWorkspaceRuntimeState } from './workspace-runtime-state';
 

--- a/src/backend/domains/workspace/worktree/worktree-init.test.ts
+++ b/src/backend/domains/workspace/worktree/worktree-init.test.ts
@@ -1,8 +1,8 @@
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { SessionStatus } from '@factory-factory/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { resolveSelectedModel } from '@/shared/acp-protocol';
+import { SessionStatus } from '@/shared/core';
 
 const mocks = vi.hoisted(() => ({
   findById: vi.fn(),

--- a/src/backend/lib/session-summaries.ts
+++ b/src/backend/lib/session-summaries.ts
@@ -1,5 +1,5 @@
-import type { SessionStatus as DbSessionStatus } from '@factory-factory/core';
 import type { WorkspaceSessionSummary } from '@/backend/services/workspace-snapshot-store.service';
+import type { SessionStatus as DbSessionStatus } from '@/shared/core';
 import type { SessionRuntimeState } from '@/shared/session-runtime';
 
 interface SessionLike {

--- a/src/backend/orchestration/data-backup.service.test.ts
+++ b/src/backend/orchestration/data-backup.service.test.ts
@@ -1,13 +1,4 @@
 import {
-  CIStatus,
-  KanbanColumn,
-  PRState,
-  RatchetState,
-  RunScriptStatus,
-  WorkspaceCreationSource,
-  WorkspaceStatus,
-} from '@factory-factory/core';
-import {
   type AgentSession,
   type Project,
   SessionProvider,
@@ -17,6 +8,15 @@ import {
   WorkspaceProviderSelection,
 } from '@prisma-gen/client';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  CIStatus,
+  KanbanColumn,
+  PRState,
+  RatchetState,
+  RunScriptStatus,
+  WorkspaceCreationSource,
+  WorkspaceStatus,
+} from '@/shared/core';
 import type { ExportData } from '@/shared/schemas/export-data.schema';
 import { exportDataSchema } from '@/shared/schemas/export-data.schema';
 

--- a/src/backend/orchestration/event-collector.orchestrator.ts
+++ b/src/backend/orchestration/event-collector.orchestrator.ts
@@ -16,7 +16,6 @@
  * - NOT re-exported from orchestration/index.ts (circular dep risk)
  */
 
-import type { CIStatus, PRState } from '@factory-factory/core';
 import {
   PR_SNAPSHOT_UPDATED,
   type PRSnapshotUpdatedEvent,
@@ -48,6 +47,7 @@ import {
   type SnapshotUpdateInput,
   workspaceSnapshotStore,
 } from '@/backend/services/workspace-snapshot-store.service';
+import type { CIStatus, PRState } from '@/shared/core';
 
 // ---------------------------------------------------------------------------
 // Types

--- a/src/backend/orchestration/workspace-init.orchestrator.test.ts
+++ b/src/backend/orchestration/workspace-init.orchestrator.test.ts
@@ -1,5 +1,5 @@
-import { SessionStatus } from '@factory-factory/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SessionStatus } from '@/shared/core';
 import { unsafeCoerce } from '@/test-utils/unsafe-coerce';
 
 // --- Module mocks (before imports) ---

--- a/src/backend/orchestration/workspace-init.orchestrator.ts
+++ b/src/backend/orchestration/workspace-init.orchestrator.ts
@@ -1,4 +1,3 @@
-import { SessionStatus } from '@factory-factory/core';
 import { githubCLIService } from '@/backend/domains/github';
 import { startupScriptService } from '@/backend/domains/run-script';
 import {
@@ -15,6 +14,7 @@ import { FactoryConfigService } from '@/backend/services/factory-config.service'
 import { gitOpsService } from '@/backend/services/git-ops.service';
 import { createLogger } from '@/backend/services/logger.service';
 import { MessageState, resolveSelectedModel } from '@/shared/acp-protocol';
+import { SessionStatus } from '@/shared/core';
 import type { WorkspaceWithProject } from './types';
 
 const logger = createLogger('workspace-init-orchestrator');

--- a/src/backend/resource_accessors/agent-session.accessor.ts
+++ b/src/backend/resource_accessors/agent-session.accessor.ts
@@ -1,7 +1,7 @@
-import { SessionStatus } from '@factory-factory/core';
 import { type AgentSession, Prisma, type SessionProvider } from '@prisma-gen/client';
 import { prisma } from '@/backend/db';
 import { resolveSessionModelForProvider } from '@/backend/lib/session-model';
+import { SessionStatus } from '@/shared/core';
 
 export type AgentSessionRecord = AgentSession;
 

--- a/src/backend/resource_accessors/terminal-session.accessor.ts
+++ b/src/backend/resource_accessors/terminal-session.accessor.ts
@@ -1,6 +1,6 @@
-import type { SessionStatus } from '@factory-factory/core';
 import type { Prisma, TerminalSession } from '@prisma-gen/client';
 import { prisma } from '@/backend/db';
+import type { SessionStatus } from '@/shared/core';
 
 interface CreateTerminalSessionInput {
   workspaceId: string;

--- a/src/backend/resource_accessors/workspace.accessor.ts
+++ b/src/backend/resource_accessors/workspace.accessor.ts
@@ -1,3 +1,5 @@
+import type { Prisma, Workspace, WorkspaceProviderSelection } from '@prisma-gen/client';
+import { prisma } from '@/backend/db';
 import type {
   CIStatus,
   KanbanColumn,
@@ -5,9 +7,7 @@ import type {
   RatchetState,
   RunScriptStatus,
   WorkspaceStatus,
-} from '@factory-factory/core';
-import type { Prisma, Workspace, WorkspaceProviderSelection } from '@prisma-gen/client';
-import { prisma } from '@/backend/db';
+} from '@/shared/core';
 
 /**
  * Threshold for considering a PROVISIONING workspace as stale.

--- a/src/backend/services/workspace-snapshot-store.service.test.ts
+++ b/src/backend/services/workspace-snapshot-store.service.test.ts
@@ -12,7 +12,7 @@ vi.mock('./logger.service', () => ({
   }),
 }));
 
-import { KanbanColumn } from '@factory-factory/core';
+import { KanbanColumn } from '@/shared/core';
 import {
   SNAPSHOT_CHANGED,
   SNAPSHOT_REMOVED,

--- a/src/backend/services/workspace-snapshot-store.service.ts
+++ b/src/backend/services/workspace-snapshot-store.service.ts
@@ -21,7 +21,7 @@ import type {
   RatchetState,
   RunScriptStatus,
   WorkspaceStatus,
-} from '@factory-factory/core';
+} from '@/shared/core';
 import type { WorkspaceSidebarStatus } from '@/shared/workspace-sidebar-status';
 import { createLogger } from './logger.service';
 

--- a/src/backend/trpc/admin.trpc.ts
+++ b/src/backend/trpc/admin.trpc.ts
@@ -7,7 +7,6 @@
 import { createReadStream } from 'node:fs';
 import { open, stat } from 'node:fs/promises';
 import { createInterface } from 'node:readline';
-import { SessionStatus } from '@factory-factory/core';
 import type { DecisionLog } from '@prisma-gen/client';
 import { z } from 'zod';
 import { acpRuntimeManager, sessionDataService } from '@/backend/domains/session';
@@ -15,6 +14,7 @@ import { workspaceDataService } from '@/backend/domains/workspace';
 import { dataBackupService } from '@/backend/orchestration/data-backup.service';
 import { decisionLogQueryService } from '@/backend/orchestration/decision-log-query.service';
 import { getLogFilePath } from '@/backend/services/logger.service';
+import { SessionStatus } from '@/shared/core';
 import { exportDataSchema } from '@/shared/schemas/export-data.schema';
 import { type Context, publicProcedure, router } from './trpc';
 

--- a/src/backend/trpc/session.trpc.ts
+++ b/src/backend/trpc/session.trpc.ts
@@ -1,9 +1,9 @@
-import { SessionStatus } from '@factory-factory/core';
 import { SessionProvider } from '@prisma-gen/client';
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 import { sessionDataService, sessionProviderResolverService } from '@/backend/domains/session';
 import { getQuickAction, listQuickActions } from '@/backend/prompts/quick-actions';
+import { SessionStatus } from '@/shared/core';
 import { publicProcedure, router } from './trpc';
 
 export const sessionRouter = router({

--- a/src/backend/trpc/workspace.trpc.ts
+++ b/src/backend/trpc/workspace.trpc.ts
@@ -1,4 +1,3 @@
-import { KanbanColumn, WorkspaceStatus } from '@factory-factory/core';
 import { WorkspaceProviderSelection } from '@prisma-gen/client';
 import { z } from 'zod';
 import { ratchetService } from '@/backend/domains/ratchet';
@@ -15,6 +14,7 @@ import {
 } from '@/backend/lib/session-summaries';
 import { archiveWorkspace } from '@/backend/orchestration/workspace-archive.orchestrator';
 import { initializeWorkspaceWorktree } from '@/backend/orchestration/workspace-init.orchestrator';
+import { KanbanColumn, WorkspaceStatus } from '@/shared/core';
 import { deriveWorkspaceSidebarStatus } from '@/shared/workspace-sidebar-status';
 import { type Context, publicProcedure, router } from './trpc';
 import { workspaceFilesRouter } from './workspace/files.trpc';

--- a/src/client/routes/projects/workspaces/components/workspaces-table-view.tsx
+++ b/src/client/routes/projects/workspaces/components/workspaces-table-view.tsx
@@ -1,4 +1,3 @@
-import type { CIStatus, WorkspaceStatus } from '@factory-factory/core';
 import type { Workspace } from '@prisma-gen/browser';
 import { GitBranch } from 'lucide-react';
 import { Link } from 'react-router';
@@ -26,6 +25,7 @@ import { Loading } from '@/frontend/components/loading';
 import { PageHeader } from '@/frontend/components/page-header';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { formatStatusLabel } from '@/lib/formatters';
+import type { CIStatus, WorkspaceStatus } from '@/shared/core';
 import { NewWorkspaceButton } from './new-workspace-button';
 import { ResumeBranchButton } from './resume-branch-button';
 import type { ViewMode } from './types';

--- a/src/client/routes/projects/workspaces/list.tsx
+++ b/src/client/routes/projects/workspaces/list.tsx
@@ -1,10 +1,10 @@
-import type { WorkspaceStatus } from '@factory-factory/core';
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { toast } from 'sonner';
 import { Loading } from '@/frontend/components/loading';
 import { useCreateWorkspace } from '@/frontend/hooks/use-create-workspace';
 import { trpc } from '@/frontend/lib/trpc';
+import type { WorkspaceStatus } from '@/shared/core';
 import { generateUniqueWorkspaceName } from '@/shared/workspace-words';
 import {
   ResumeBranchDialog,

--- a/src/components/chat/palette-and-tabbar-regressions.test.tsx
+++ b/src/components/chat/palette-and-tabbar-regressions.test.tsx
@@ -3,7 +3,7 @@
 // Mock Prisma client to avoid node: module imports in jsdom - must be before imports
 import { vi } from 'vitest';
 
-vi.mock('@factory-factory/core', async (importOriginal) => {
+vi.mock('@/shared/core', async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
   return {
     ...actual,
@@ -16,12 +16,12 @@ vi.mock('@factory-factory/core', async (importOriginal) => {
   };
 });
 
-import { SessionStatus } from '@factory-factory/core';
 import { createElement, createRef } from 'react';
 import { flushSync } from 'react-dom';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, describe, expect, it } from 'vitest';
 import type { CommandInfo } from '@/lib/chat-protocol';
+import { SessionStatus } from '@/shared/core';
 import { type SessionData, SessionTabBar } from './session-tab-bar';
 import { SlashCommandPalette, type SlashCommandPaletteHandle } from './slash-command-palette';
 

--- a/src/components/chat/session-tab-bar.tsx
+++ b/src/components/chat/session-tab-bar.tsx
@@ -1,4 +1,3 @@
-import type { SessionStatus } from '@factory-factory/core';
 import {
   Activity,
   CheckCircle2,
@@ -11,9 +10,9 @@ import {
   XCircle,
 } from 'lucide-react';
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
-
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
+import type { SessionStatus } from '@/shared/core';
 
 // =============================================================================
 // Types

--- a/src/components/shared/ci-status-chip.tsx
+++ b/src/components/shared/ci-status-chip.tsx
@@ -1,7 +1,7 @@
-import type { PRState } from '@factory-factory/core';
 import { CheckCircle2, Circle, type LucideIcon, XCircle } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
+import type { PRState } from '@/shared/core';
 import {
   getWorkspaceCiLabel,
   getWorkspaceCiTooltip,

--- a/src/components/workspace/main-view-tab-bar.tsx
+++ b/src/components/workspace/main-view-tab-bar.tsx
@@ -1,7 +1,5 @@
-import type { SessionStatus as DbSessionStatus } from '@factory-factory/core';
 import { Camera, FileCode, FileDiff, Plus } from 'lucide-react';
 import type { Dispatch, SetStateAction } from 'react';
-
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select';
 import { TabButton } from '@/components/ui/tab-button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -11,6 +9,7 @@ import {
   type SessionProviderValue,
 } from '@/lib/session-provider-selection';
 import { cn } from '@/lib/utils';
+import type { SessionStatus as DbSessionStatus } from '@/shared/core';
 
 import { RatchetWrenchIcon } from './ratchet-wrench-icon';
 import {

--- a/src/components/workspace/ratchet-state.ts
+++ b/src/components/workspace/ratchet-state.ts
@@ -1,4 +1,4 @@
-import type { RatchetState } from '@factory-factory/core';
+import type { RatchetState } from '@/shared/core';
 
 export type RatchetVisualState = 'off' | 'idle' | 'processing';
 export type RatchetStateLike = RatchetState | string | null | undefined;

--- a/src/components/workspace/session-tab-runtime.ts
+++ b/src/components/workspace/session-tab-runtime.ts
@@ -1,4 +1,3 @@
-import type { SessionStatus as DbSessionStatus } from '@factory-factory/core';
 import {
   Activity,
   CheckCircle2,
@@ -8,6 +7,7 @@ import {
   type LucideIcon,
   XCircle,
 } from 'lucide-react';
+import type { SessionStatus as DbSessionStatus } from '@/shared/core';
 import type { SessionSummary } from '@/shared/session-runtime';
 
 export type WorkspaceSessionRuntimeSummary = SessionSummary;

--- a/src/components/workspace/workspace-status-badge.tsx
+++ b/src/components/workspace/workspace-status-badge.tsx
@@ -1,8 +1,8 @@
-import type { WorkspaceStatus } from '@factory-factory/core';
 import { AlertCircle, Clock, Loader2 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
+import type { WorkspaceStatus } from '@/shared/core';
 
 export type { WorkspaceStatus };
 

--- a/src/frontend/components/ci-failure-warning.tsx
+++ b/src/frontend/components/ci-failure-warning.tsx
@@ -1,6 +1,6 @@
-import type { CIStatus } from '@factory-factory/core';
 import { AlertTriangle } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import type { CIStatus } from '@/shared/core';
 
 interface CIFailureWarningProps {
   ciStatus: CIStatus;

--- a/src/frontend/components/kanban/kanban-board.stories.tsx
+++ b/src/frontend/components/kanban/kanban-board.stories.tsx
@@ -1,5 +1,5 @@
-import type { KanbanColumn as KanbanColumnType } from '@factory-factory/core';
 import type { Meta, StoryObj } from '@storybook/react';
+import type { KanbanColumn as KanbanColumnType } from '@/shared/core';
 import type { WorkspaceWithKanban } from './kanban-card';
 import { KANBAN_COLUMNS, KanbanColumn } from './kanban-column';
 

--- a/src/frontend/components/kanban/kanban-board.tsx
+++ b/src/frontend/components/kanban/kanban-board.tsx
@@ -1,10 +1,10 @@
-import type { KanbanColumn as KanbanColumnType } from '@factory-factory/core';
 import { RefreshCw } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
+import type { KanbanColumn as KanbanColumnType } from '@/shared/core';
 import { IssueCard } from './issue-card';
 import { IssueDetailsSheet } from './issue-details-sheet';
 import type { WorkspaceWithKanban } from './kanban-card';

--- a/src/frontend/components/kanban/kanban-card.tsx
+++ b/src/frontend/components/kanban/kanban-card.tsx
@@ -1,4 +1,3 @@
-import type { KanbanColumn, WorkspaceStatus } from '@factory-factory/core';
 import type { Workspace } from '@prisma-gen/browser';
 import {
   Archive,
@@ -15,6 +14,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { RatchetToggleButton, WorkspaceStatusBadge } from '@/components/workspace';
 import { cn } from '@/lib/utils';
+import type { KanbanColumn, WorkspaceStatus } from '@/shared/core';
 import { deriveWorkspaceSidebarStatus } from '@/shared/workspace-sidebar-status';
 
 export interface WorkspaceWithKanban extends Workspace {

--- a/src/frontend/components/kanban/kanban-column.tsx
+++ b/src/frontend/components/kanban/kanban-column.tsx
@@ -1,5 +1,5 @@
-import type { KanbanColumn as KanbanColumnType } from '@factory-factory/core';
 import { Badge } from '@/components/ui/badge';
+import type { KanbanColumn as KanbanColumnType } from '@/shared/core';
 import { KanbanCard, type WorkspaceWithKanban } from './kanban-card';
 
 // UI column IDs include ISSUES (UI-only) plus the database enum values

--- a/src/frontend/components/use-workspace-list-state.ts
+++ b/src/frontend/components/use-workspace-list-state.ts
@@ -1,5 +1,5 @@
-import type { CIStatus, PRState, RatchetState, RunScriptStatus } from '@factory-factory/core';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { CIStatus, PRState, RatchetState, RunScriptStatus } from '@/shared/core';
 import type { SessionSummary } from '@/shared/session-runtime';
 import type { WorkspaceSidebarStatus } from '@/shared/workspace-sidebar-status';
 

--- a/src/frontend/lib/snapshot-to-sidebar.ts
+++ b/src/frontend/lib/snapshot-to-sidebar.ts
@@ -7,6 +7,8 @@
  * but only includes fields needed for mapping.
  */
 
+import { z } from 'zod';
+import type { ServerWorkspace } from '@/frontend/components/use-workspace-list-state';
 import {
   CIStatus,
   KanbanColumn,
@@ -14,9 +16,7 @@ import {
   RatchetState,
   RunScriptStatus,
   SessionStatus,
-} from '@factory-factory/core';
-import { z } from 'zod';
-import type { ServerWorkspace } from '@/frontend/components/use-workspace-list-state';
+} from '@/shared/core';
 
 // =============================================================================
 // Snapshot message types (client-side mirror of server messages)

--- a/src/shared/ci-status.ts
+++ b/src/shared/ci-status.ts
@@ -3,4 +3,4 @@ export {
   deriveCiVisualStateFromChecks,
   deriveCiVisualStateFromPrCiStatus,
   getCiVisualLabel,
-} from '@factory-factory/core';
+} from '@/shared/core';

--- a/src/shared/core/ci-status.ts
+++ b/src/shared/core/ci-status.ts
@@ -1,0 +1,63 @@
+import type { CIStatus } from './enums.js';
+
+export type CiVisualState = 'PASSING' | 'FAILING' | 'RUNNING' | 'UNKNOWN' | 'NONE';
+
+interface CheckLike {
+  conclusion: string | null;
+  status: string;
+}
+
+export function deriveCiVisualStateFromPrCiStatus(
+  status: CIStatus | null | undefined
+): CiVisualState {
+  if (status === 'SUCCESS') {
+    return 'PASSING';
+  }
+  if (status === 'FAILURE') {
+    return 'FAILING';
+  }
+  if (status === 'PENDING') {
+    return 'RUNNING';
+  }
+  if (status === 'UNKNOWN') {
+    return 'UNKNOWN';
+  }
+  return 'UNKNOWN';
+}
+
+export function deriveCiVisualStateFromChecks(
+  checks: CheckLike[] | null | undefined
+): CiVisualState {
+  if (!checks || checks.length === 0) {
+    return 'NONE';
+  }
+
+  const hasFailure = checks.some((check) => check.conclusion === 'FAILURE');
+  if (hasFailure) {
+    return 'FAILING';
+  }
+
+  const hasPending = checks.some(
+    (check) => check.status !== 'COMPLETED' || check.conclusion === null
+  );
+  if (hasPending) {
+    return 'RUNNING';
+  }
+
+  return 'PASSING';
+}
+
+export function getCiVisualLabel(state: CiVisualState): string {
+  switch (state) {
+    case 'PASSING':
+      return 'CI Passing';
+    case 'FAILING':
+      return 'CI Failing';
+    case 'RUNNING':
+      return 'CI Running';
+    case 'UNKNOWN':
+      return 'CI Unknown';
+    case 'NONE':
+      return 'No checks';
+  }
+}

--- a/src/shared/core/enums.ts
+++ b/src/shared/core/enums.ts
@@ -1,0 +1,71 @@
+export const WorkspaceStatus = {
+  NEW: 'NEW',
+  PROVISIONING: 'PROVISIONING',
+  READY: 'READY',
+  FAILED: 'FAILED',
+  ARCHIVED: 'ARCHIVED',
+} as const;
+export type WorkspaceStatus = (typeof WorkspaceStatus)[keyof typeof WorkspaceStatus];
+
+export const SessionStatus = {
+  IDLE: 'IDLE',
+  RUNNING: 'RUNNING',
+  PAUSED: 'PAUSED',
+  COMPLETED: 'COMPLETED',
+  FAILED: 'FAILED',
+} as const;
+export type SessionStatus = (typeof SessionStatus)[keyof typeof SessionStatus];
+
+export const PRState = {
+  NONE: 'NONE',
+  DRAFT: 'DRAFT',
+  OPEN: 'OPEN',
+  CHANGES_REQUESTED: 'CHANGES_REQUESTED',
+  APPROVED: 'APPROVED',
+  MERGED: 'MERGED',
+  CLOSED: 'CLOSED',
+} as const;
+export type PRState = (typeof PRState)[keyof typeof PRState];
+
+export const CIStatus = {
+  UNKNOWN: 'UNKNOWN',
+  PENDING: 'PENDING',
+  SUCCESS: 'SUCCESS',
+  FAILURE: 'FAILURE',
+} as const;
+export type CIStatus = (typeof CIStatus)[keyof typeof CIStatus];
+
+export const KanbanColumn = {
+  WORKING: 'WORKING',
+  WAITING: 'WAITING',
+  DONE: 'DONE',
+} as const;
+export type KanbanColumn = (typeof KanbanColumn)[keyof typeof KanbanColumn];
+
+export const RatchetState = {
+  IDLE: 'IDLE',
+  CI_RUNNING: 'CI_RUNNING',
+  CI_FAILED: 'CI_FAILED',
+  REVIEW_PENDING: 'REVIEW_PENDING',
+  READY: 'READY',
+  MERGED: 'MERGED',
+} as const;
+export type RatchetState = (typeof RatchetState)[keyof typeof RatchetState];
+
+export const WorkspaceCreationSource = {
+  MANUAL: 'MANUAL',
+  RESUME_BRANCH: 'RESUME_BRANCH',
+  GITHUB_ISSUE: 'GITHUB_ISSUE',
+} as const;
+export type WorkspaceCreationSource =
+  (typeof WorkspaceCreationSource)[keyof typeof WorkspaceCreationSource];
+
+export const RunScriptStatus = {
+  IDLE: 'IDLE',
+  STARTING: 'STARTING',
+  RUNNING: 'RUNNING',
+  STOPPING: 'STOPPING',
+  COMPLETED: 'COMPLETED',
+  FAILED: 'FAILED',
+} as const;
+export type RunScriptStatus = (typeof RunScriptStatus)[keyof typeof RunScriptStatus];

--- a/src/shared/core/index.ts
+++ b/src/shared/core/index.ts
@@ -1,0 +1,28 @@
+export {
+  type CiVisualState,
+  deriveCiVisualStateFromChecks,
+  deriveCiVisualStateFromPrCiStatus,
+  getCiVisualLabel,
+} from './ci-status.js';
+export {
+  CIStatus,
+  KanbanColumn,
+  PRState,
+  RatchetState,
+  RunScriptStatus,
+  SessionStatus,
+  WorkspaceCreationSource,
+  WorkspaceStatus,
+} from './enums.js';
+
+export {
+  deriveWorkspaceSidebarStatus,
+  getWorkspaceActivityTooltip,
+  getWorkspaceCiLabel,
+  getWorkspaceCiTooltip,
+  getWorkspacePrTooltipSuffix,
+  type WorkspaceSidebarActivityState,
+  type WorkspaceSidebarCiState,
+  type WorkspaceSidebarStatus,
+  type WorkspaceSidebarStatusInput,
+} from './workspace-sidebar-status.js';

--- a/src/shared/core/workspace-sidebar-status.ts
+++ b/src/shared/core/workspace-sidebar-status.ts
@@ -1,0 +1,117 @@
+import { deriveCiVisualStateFromPrCiStatus } from './ci-status.js';
+import type { CIStatus, PRState, RatchetState } from './enums.js';
+
+export type WorkspaceSidebarActivityState = 'WORKING' | 'IDLE';
+
+export type WorkspaceSidebarCiState =
+  | 'NONE'
+  | 'RUNNING'
+  | 'FAILING'
+  | 'PASSING'
+  | 'UNKNOWN'
+  | 'MERGED';
+
+export interface WorkspaceSidebarStatus {
+  activityState: WorkspaceSidebarActivityState;
+  ciState: WorkspaceSidebarCiState;
+}
+
+export interface WorkspaceSidebarStatusInput {
+  isWorking: boolean;
+  prUrl: string | null;
+  prState: PRState | null;
+  prCiStatus: CIStatus | null;
+  ratchetState: RatchetState | null;
+}
+
+export function deriveWorkspaceSidebarStatus(
+  input: WorkspaceSidebarStatusInput
+): WorkspaceSidebarStatus {
+  const activityState: WorkspaceSidebarActivityState = input.isWorking ? 'WORKING' : 'IDLE';
+
+  if (!input.prUrl) {
+    return { activityState, ciState: 'NONE' };
+  }
+
+  if (input.prState === 'MERGED' || input.ratchetState === 'MERGED') {
+    return { activityState, ciState: 'MERGED' };
+  }
+
+  const ciStateFromSnapshot = deriveCiVisualStateFromPrCiStatus(input.prCiStatus);
+  if (ciStateFromSnapshot === 'UNKNOWN') {
+    if (input.ratchetState === 'CI_FAILED') {
+      return { activityState, ciState: 'FAILING' };
+    }
+
+    if (input.ratchetState === 'CI_RUNNING') {
+      return { activityState, ciState: 'RUNNING' };
+    }
+  }
+
+  return { activityState, ciState: ciStateFromSnapshot };
+}
+
+export function getWorkspaceActivityTooltip(state: WorkspaceSidebarActivityState): string {
+  return state === 'WORKING' ? 'Claude is working' : 'Claude is idle';
+}
+
+export function getWorkspaceCiLabel(state: WorkspaceSidebarCiState): string {
+  switch (state) {
+    case 'NONE':
+      return 'No PR';
+    case 'RUNNING':
+      return 'CI Running';
+    case 'FAILING':
+      return 'CI Failing';
+    case 'PASSING':
+      return 'CI Passing';
+    case 'UNKNOWN':
+      return 'CI Unknown';
+    case 'MERGED':
+      return 'Merged';
+  }
+}
+
+export function getWorkspaceCiTooltip(
+  ciState: WorkspaceSidebarCiState,
+  prState: PRState | null
+): string {
+  if (ciState === 'RUNNING') {
+    return 'CI checks are running';
+  }
+  if (ciState === 'FAILING') {
+    return 'CI checks are failing';
+  }
+  if (ciState === 'PASSING') {
+    return 'CI checks are passing';
+  }
+  if (ciState === 'MERGED') {
+    return 'PR is merged';
+  }
+  if (ciState === 'UNKNOWN') {
+    return prState === 'CLOSED' ? 'PR is closed' : 'CI status is unknown';
+  }
+  return 'No PR attached';
+}
+
+export function getWorkspacePrTooltipSuffix(
+  ciState: WorkspaceSidebarCiState,
+  prState: PRState | null
+): string {
+  if (prState === 'CLOSED') {
+    return ' · Closed';
+  }
+  if (ciState === 'MERGED') {
+    return ' · Merged';
+  }
+  if (ciState === 'FAILING') {
+    return ' · CI failing';
+  }
+  if (ciState === 'RUNNING') {
+    return ' · CI running';
+  }
+  if (ciState === 'PASSING') {
+    return ' · CI passing';
+  }
+  return '';
+}

--- a/src/shared/schemas/export-data.schema.test.ts
+++ b/src/shared/schemas/export-data.schema.test.ts
@@ -5,6 +5,8 @@
  * If Prisma schema enums are modified, these tests will fail, prompting updates to the
  * shared schema to prevent backup import failures.
  */
+
+import { describe, expect, it } from 'vitest';
 import {
   CIStatus as PrismaCIStatus,
   KanbanColumn as PrismaKanbanColumn,
@@ -14,8 +16,7 @@ import {
   SessionStatus as PrismaSessionStatus,
   WorkspaceCreationSource as PrismaWorkspaceCreationSource,
   WorkspaceStatus as PrismaWorkspaceStatus,
-} from '@factory-factory/core';
-import { describe, expect, it } from 'vitest';
+} from '@/shared/core';
 import { exportedAgentSessionSchema, exportedWorkspaceSchema } from './export-data.schema';
 
 type DefWithType = {

--- a/src/shared/schemas/export-data.schema.ts
+++ b/src/shared/schemas/export-data.schema.ts
@@ -8,6 +8,7 @@
  * Prisma client into the browser bundle.
  */
 
+import { z } from 'zod';
 import {
   CIStatus as CoreCIStatus,
   KanbanColumn as CoreKanbanColumn,
@@ -17,8 +18,7 @@ import {
   SessionStatus as CoreSessionStatus,
   WorkspaceCreationSource as CoreWorkspaceCreationSource,
   WorkspaceStatus as CoreWorkspaceStatus,
-} from '@factory-factory/core';
-import { z } from 'zod';
+} from '@/shared/core';
 
 function enumValues<const T extends Record<string, string>>(enumObject: T) {
   return Object.values(enumObject) as [T[keyof T], ...T[keyof T][]];

--- a/src/shared/session-runtime.ts
+++ b/src/shared/session-runtime.ts
@@ -1,4 +1,4 @@
-import type { SessionStatus } from '@factory-factory/core';
+import type { SessionStatus } from '@/shared/core';
 
 export type SessionRuntimePhase =
   | 'loading'

--- a/src/shared/workspace-sidebar-status.ts
+++ b/src/shared/workspace-sidebar-status.ts
@@ -8,4 +8,4 @@ export {
   type WorkspaceSidebarCiState,
   type WorkspaceSidebarStatus,
   type WorkspaceSidebarStatusInput,
-} from '@factory-factory/core';
+} from '@/shared/core';


### PR DESCRIPTION
## Summary
- fix `npx factory-factory@latest serve` install-time crash caused by published `file:packages/core` dependency metadata
- move runtime imports from `@factory-factory/core` to in-repo `@/shared/core` and add `src/shared/core/*` as the local source of truth
- remove `@factory-factory/core` from root package dependencies and packaged `files`
- bump package version to `0.3.3` and update changelog
- update npm publish workflow smoke test to use packed-tarball `npm exec --package ...` (same code path as `npx`/`npm exec`)

## Why this fixes the issue
`factory-factory@0.3.2` was published with a local file dependency (`@factory-factory/core: file:packages/core`), which triggers npm arborist linking behavior that fails in npm exec/npx flows. Removing that published dependency and using local in-package shared core modules avoids the broken link path.

## Validation
- `pnpm typecheck`
- local smoke: `npm pack` + `npm exec --yes --package <tarball> -- factory-factory --help`

## Notes
- Per request, the additional packaging smoke coverage was kept in `npm-publish.yml` only (not added to every PR CI run).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide import-path rewiring and packaging metadata changes could surface at runtime only in distributed npm installs, though logic changes are minimal and CI adds a tarball-based smoke test to reduce release risk.
> 
> **Overview**
> Fixes `npx factory-factory@latest` install/link crashes by removing the published `@factory-factory/core: file:packages/core` dependency and excluding `packages/core` artifacts from the published `files`, replacing usages across backend/frontend/tests with imports from new in-repo `@/shared/core`.
> 
> Introduces `src/shared/core` as the single source of truth for shared enums and sidebar/CI helpers, updates the npm publish workflow smoke test to run the packed tarball via `npm exec --package ...` (including `serve --help` and `db:migrate`), and bumps the release to `0.3.3` with changelog entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e297ac1385ffdb655a4c623ac0c3db583e46fca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->