### PR TITLE
Simplify workspace right-panel tabs

### DIFF
--- a/src/components/workspace/right-panel.tsx
+++ b/src/components/workspace/right-panel.tsx
@@ -86,11 +86,13 @@ function loadPersistedTopPanelState(workspaceId: string): PersistedTopPanelState
 
     const legacyChangesView = parseStoredChangesView(storedTop);
     if (legacyChangesView) {
+      const migratedChangesView = changesView ?? legacyChangesView;
       // Migrate legacy top-level tab values to the new "changes" tab key.
       localStorage.setItem(`${STORAGE_KEY_TOP_TAB_PREFIX}${workspaceId}`, 'changes');
+      localStorage.setItem(`${STORAGE_KEY_CHANGES_VIEW_PREFIX}${workspaceId}`, migratedChangesView);
       return {
         topTab: 'changes',
-        changesView: changesView ?? legacyChangesView,
+        changesView: migratedChangesView,
       };
     }
   } catch {


### PR DESCRIPTION
## Summary
- simplify workspace right-panel primary tabs to `Changes`, `Files`, and `Tasks`
- move screenshots access from a full top-level tab to a header action button
- add an in-panel toggle under `Changes` for `Unstaged` vs `Diff vs Main`
- preserve workspace-scoped persistence and migrate legacy stored top-tab values (`unstaged`/`diff-vs-main`) to the new model

## Validation
- `pnpm biome check src/components/workspace/right-panel.tsx`
- `pnpm typecheck`
- `pnpm test -- src/components/workspace/session-tab-runtime.test.ts`

Closes #1012

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI/state refactor limited to tab navigation and localStorage persistence; main risk is minor UX regressions or incorrect migration of previously stored tab values.
> 
> **Overview**
> Simplifies the right-panel top navigation by replacing separate `unstaged`/`diff-vs-main` top-level tabs with a single **`Changes`** tab that contains an in-panel toggle between *Unstaged* and *Diff vs Main*.
> 
> Moves screenshots access into a header action (camera button) and refactors the top panel UI into a `TopPanelArea` component.
> 
> Updates workspace-scoped persistence by storing the top tab and the `Changes` sub-view separately, including a migration path for legacy stored values (`unstaged`/`diff-vs-main`) to the new model.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01b583f4aea5ad81a4e592974e0c4eae4af9d2d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->