### PR TITLE
Auto-dispatch queued messages after prompt completion

### DIFF
--- a/src/backend/orchestration/domain-bridges.orchestrator.ts
+++ b/src/backend/orchestration/domain-bridges.orchestrator.ts
@@ -138,6 +138,9 @@ export function configureDomainBridges(): void {
       getWorkspaceInitPolicy: (input) => getWorkspaceInitPolicy(input as WorkspaceInitPolicyInput),
     },
   });
+  sessionService.setPromptTurnCompleteHandler((sessionId) =>
+    chatMessageHandlerService.tryDispatchNextMessage(sessionId)
+  );
 
   // === Run-script domain bridges ===
   startupScriptService.configure({


### PR DESCRIPTION
## Summary
- fix queued-message starvation by triggering dispatch attempts after every ACP prompt turn settles
- add a prompt-turn completion hook in sessionService and wire it to chatMessageHandlerService.tryDispatchNextMessage in domain bridge setup
- schedule the callback asynchronously to avoid colliding with in-flight dispatch guards
- add regression tests for lifecycle callback scheduling/failure handling and bridge wiring

## Root Cause
queue_message attempted dispatch once, but if the session was already working (or was started outside queue dispatch), no automatic retry occurred when the turn completed.

## Testing
- pnpm test src/backend/domains/session/lifecycle/session.service.test.ts src/backend/orchestration/domain-bridges.orchestrator.test.ts src/backend/domains/session/chat/chat-message-handlers.service.test.ts
- pnpm typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session lifecycle timing and adds new cross-domain callback wiring; risk is mainly around unexpected dispatch reentrancy/order changes, though the callback is async and failures are contained.
> 
> **Overview**
> Fixes queued-message starvation by introducing an optional `SessionService` *prompt-turn completion* hook that fires after every `sendAcpMessage` turn settles.
> 
> The hook is scheduled asynchronously (`setTimeout(…, 0)`) and wired in `configureDomainBridges` to call `chatMessageHandlerService.tryDispatchNextMessage(sessionId)`, with errors swallowed and logged to avoid breaking prompt flows. Adds tests covering callback scheduling, failure handling, and orchestrator wiring/mocking updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3062337511e05ad734f2bf892687b465e1905ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->