### PR TITLE
Fix false frontend force-kill log on shutdown

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -362,7 +362,11 @@ function createShutdownHandler(
       try {
         await Promise.allSettled(termPromises);
 
-        const alive = processes.filter(({ proc }) => proc.exitCode === null);
+        // A child that exits from a signal has `exitCode === null` and `signalCode !== null`.
+        // Treat those as already exited to avoid false "force killing" logs.
+        const alive = processes.filter(
+          ({ proc }) => proc.exitCode === null && proc.signalCode === null
+        );
 
         if (alive.length > 0) {
           console.log(


### PR DESCRIPTION
## Summary
- fix a false-positive shutdown warning: `Force killing remaining processes: frontend`
- root cause: child processes that exit via signal can have `exitCode === null` with `signalCode !== null`
- update shutdown liveness check to treat those signal-exited children as already terminated

## Change
- `src/cli/index.ts`
  - before: process considered alive when `proc.exitCode === null`
  - after: process considered alive only when `proc.exitCode === null && proc.signalCode === null`

## Validation
- reproduced `pnpm dev` + `Ctrl+C` shutdown path before fix (warning appeared)
- verified same path after fix (warning no longer appears)
- pre-commit checks passed during commit:
  - `biome check --write`
  - `pnpm typecheck`
  - `pnpm deps:check`
  - `pnpm knip --include files,dependencies,unlisted`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to shutdown bookkeeping in `src/cli/index.ts` with minimal behavioral impact beyond logging/kill decisions.
> 
> **Overview**
> Fixes a false-positive shutdown warning in the CLI: processes that exited due to a signal are no longer treated as “still alive” during the post-`SIGTERM` liveness check.
> 
> `createShutdownHandler` now considers a child alive only when `proc.exitCode === null && proc.signalCode === null`, preventing unnecessary “Force killing remaining processes” logs (and attempted `SIGKILL`) for already-terminated children.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5aa36210e3ec4056e29e926a07681ec1e0c5623. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->