### PR TITLE
Clear queued messages from clients when stopping a session

### DIFF
--- a/src/backend/domains/session/lifecycle/session.service.test.ts
+++ b/src/backend/domains/session/lifecycle/session.service.test.ts
@@ -623,7 +623,7 @@ describe('SessionService', () => {
 
     await sessionService.stopSession('session-1');
 
-    expect(clearQueuedWorkSpy).toHaveBeenCalledWith('session-1', { emitSnapshot: false });
+    expect(clearQueuedWorkSpy).toHaveBeenCalledWith('session-1', { emitSnapshot: true });
   });
 
   it('still clears queued work and marks idle when runtime stop fails', async () => {
@@ -644,7 +644,7 @@ describe('SessionService', () => {
     expect(sessionRepository.updateSession).toHaveBeenCalledWith('session-1', {
       status: SessionStatus.IDLE,
     });
-    expect(clearQueuedWorkSpy).toHaveBeenCalledWith('session-1', { emitSnapshot: false });
+    expect(clearQueuedWorkSpy).toHaveBeenCalledWith('session-1', { emitSnapshot: true });
     expect(sessionRepository.clearRatchetActiveSession).not.toHaveBeenCalled();
     expect(sessionRepository.deleteSession).not.toHaveBeenCalled();
   });

--- a/src/backend/domains/session/lifecycle/session.service.ts
+++ b/src/backend/domains/session/lifecycle/session.service.ts
@@ -878,7 +878,9 @@ class SessionService {
       });
     } finally {
       await this.updateStoppedSessionState(sessionId);
-      sessionDomainService.clearQueuedWork(sessionId, { emitSnapshot: false });
+      // Manual stop should clear queued work and publish that change immediately
+      // so clients do not retain stale queued-message UI.
+      sessionDomainService.clearQueuedWork(sessionId, { emitSnapshot: true });
       sessionDomainService.setRuntimeSnapshot(sessionId, {
         phase: 'idle',
         processState: 'stopped',


### PR DESCRIPTION
## Summary
- clear queued work with snapshot emission during stop-session cleanup
- ensure connected clients receive an immediate empty queue snapshot after stop
- update lifecycle tests to assert queue-clear emits a snapshot

## Testing
- pnpm test src/backend/domains/session/lifecycle/session.service.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavior change limited to stop-session cleanup and corresponding tests; main risk is unintended extra snapshot/broadcast to clients during stop.
> 
> **Overview**
> Stopping a session now calls `sessionDomainService.clearQueuedWork` with `emitSnapshot: true` during stop cleanup so connected clients immediately receive an updated (emptied) queued-work snapshot and don’t keep stale queued-message UI.
> 
> Updates `session.service` lifecycle tests to assert snapshot emission both for normal manual stops and when the runtime stop fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 772f09c2ab5396c155b26a4dba7f70196b1ae72a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->