### PR TITLE
Fix chat hydration auto-scroll dropping first message

### DIFF
--- a/src/components/chat/virtualized-message-list.test.tsx
+++ b/src/components/chat/virtualized-message-list.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+
+import { type ComponentProps, createElement, type ReactNode } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { GroupedMessageItem } from '@/lib/chat-protocol';
+import { VirtualizedMessageList } from './virtualized-message-list';
+
+const virtualizerMocks = vi.hoisted(() => ({
+  getVirtualItems: vi.fn(() => []),
+  getTotalSize: vi.fn(() => 0),
+  measureElement: vi.fn(),
+  scrollToIndex: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: vi.fn(() => ({
+    getVirtualItems: virtualizerMocks.getVirtualItems,
+    getTotalSize: virtualizerMocks.getTotalSize,
+    measureElement: virtualizerMocks.measureElement,
+    scrollToIndex: virtualizerMocks.scrollToIndex,
+  })),
+}));
+
+vi.mock('@/components/agent-activity', () => ({
+  GroupedMessageItemRenderer: () => null,
+  LoadingIndicator: () => null,
+}));
+
+vi.mock('@/components/agent-activity/message-renderers', () => ({
+  ThinkingCompletionProvider: ({ children }: { children: ReactNode }) => children,
+}));
+
+interface RenderHarness {
+  render: (overrides: Partial<ComponentProps<typeof VirtualizedMessageList>>) => void;
+  cleanup: () => void;
+}
+
+function makeMessage(id: string, order: number): GroupedMessageItem {
+  return {
+    id,
+    source: 'user',
+    text: `message-${order}`,
+    timestamp: '2026-02-15T00:00:00.000Z',
+    order,
+  };
+}
+
+function createHarness(
+  initialProps: Partial<ComponentProps<typeof VirtualizedMessageList>>
+): RenderHarness {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const viewport = document.createElement('div');
+  container.appendChild(viewport);
+  const root = createRoot(container);
+
+  const baseProps: ComponentProps<typeof VirtualizedMessageList> = {
+    messages: [],
+    running: false,
+    startingSession: false,
+    loadingSession: false,
+    scrollContainerRef: { current: viewport },
+  };
+
+  const render = (overrides: Partial<ComponentProps<typeof VirtualizedMessageList>>) => {
+    flushSync(() => {
+      root.render(createElement(VirtualizedMessageList, { ...baseProps, ...overrides }));
+    });
+  };
+
+  render(initialProps);
+
+  return {
+    render,
+    cleanup: () => {
+      root.unmount();
+      container.remove();
+    },
+  };
+}
+
+async function flushEffects(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+afterEach(() => {
+  virtualizerMocks.getVirtualItems.mockClear();
+  virtualizerMocks.getTotalSize.mockClear();
+  virtualizerMocks.measureElement.mockClear();
+  virtualizerMocks.scrollToIndex.mockClear();
+  document.body.innerHTML = '';
+});
+
+describe('VirtualizedMessageList auto-scroll behavior', () => {
+  it('does not auto-scroll while session hydration is loading', async () => {
+    const harness = createHarness({
+      loadingSession: true,
+      messages: [],
+    });
+
+    harness.render({
+      loadingSession: true,
+      messages: [makeMessage('m-1', 0)],
+    });
+    harness.render({
+      loadingSession: false,
+      messages: [makeMessage('m-1', 0)],
+    });
+
+    await flushEffects();
+
+    expect(virtualizerMocks.scrollToIndex).not.toHaveBeenCalled();
+
+    harness.cleanup();
+  });
+
+  it('auto-scrolls when new messages are appended outside hydration', async () => {
+    const harness = createHarness({
+      loadingSession: false,
+      messages: [],
+    });
+
+    harness.render({
+      loadingSession: false,
+      messages: [makeMessage('m-1', 0)],
+    });
+
+    await flushEffects();
+
+    expect(virtualizerMocks.scrollToIndex).toHaveBeenCalledTimes(1);
+    expect(virtualizerMocks.scrollToIndex).toHaveBeenCalledWith(0, {
+      align: 'end',
+      behavior: 'auto',
+    });
+
+    harness.cleanup();
+  });
+});

--- a/src/components/chat/virtualized-message-list.tsx
+++ b/src/components/chat/virtualized-message-list.tsx
@@ -162,6 +162,12 @@ export const VirtualizedMessageList = memo(function VirtualizedMessageList({
     const prevCount = prevMessageCountRef.current;
     prevMessageCountRef.current = currentCount;
 
+    // Let hydration/scroll-restore settle before auto-scroll logic runs.
+    // Running virtualizer scroll commands during loading can apply stale offsets.
+    if (loadingSession) {
+      return;
+    }
+
     // If messages were added and user is near bottom, scroll to bottom
     if (currentCount > prevCount && isNearBottomRef.current && scrollContainerRef.current) {
       isAutoScrollingRef.current = true;
@@ -178,7 +184,7 @@ export const VirtualizedMessageList = memo(function VirtualizedMessageList({
         isAutoScrollingRef.current = false;
       });
     }
-  }, [messages.length, virtualizer, scrollContainerRef]);
+  }, [loadingSession, messages.length, virtualizer, scrollContainerRef]);
 
   // Handle scroll events
   const handleScroll = useCallback(() => {


### PR DESCRIPTION
## Summary
- prevent hydration-time auto-scroll in `VirtualizedMessageList` by skipping virtualizer `scrollToIndex` while `loadingSession` is true
- avoid stale scroll offsets during reload/rehydration that can hide the earliest chat message in shorter histories
- add regression tests for hydration vs normal append auto-scroll behavior

## Testing
- `pnpm exec vitest run src/components/chat/virtualized-message-list.test.tsx`
- `pnpm exec biome check src/components/chat/virtualized-message-list.tsx src/components/chat/virtualized-message-list.test.tsx`
- `pnpm typecheck` (via pre-commit hooks)
- `pnpm deps:check` (via pre-commit hooks)
- `pnpm knip --include files,dependencies,unlisted` (via pre-commit hooks)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-scoped UI behavior change gated by `loadingSession`, with targeted regression tests; minimal risk beyond possible edge-case scroll behavior differences.
> 
> **Overview**
> Prevents `VirtualizedMessageList` from issuing `virtualizer.scrollToIndex` while `loadingSession` is true, avoiding stale scroll offsets during hydration/scroll-restore that can hide early messages.
> 
> Adds jsdom/Vitest regression tests that mock `@tanstack/react-virtual` to assert **no auto-scroll during hydration** and **auto-scroll on normal message append**.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa187ce023aad7f3b1ae270475b7a9fc20e151fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->