### PR TITLE
Handle Codex commandExecution payloads in PR detector

### DIFF
--- a/src/backend/interceptors/pr-detection.interceptor.test.ts
+++ b/src/backend/interceptors/pr-detection.interceptor.test.ts
@@ -107,6 +107,24 @@ describe('prDetectionInterceptor', () => {
     );
   });
 
+  it('falls back to title when command is present but not gh pr create', async () => {
+    const event = createEvent({
+      toolName: 'commandExecution',
+      input: {
+        command: 'echo "run wrapper"',
+        title: '/bin/zsh -lc \'gh pr create --title "Fix bug" --body-file /tmp/body.md\'',
+        aggregatedOutput: 'https://github.com/purplefish-ai/factory-factory/pull/1039\n',
+      },
+    });
+
+    await prDetectionInterceptor.onToolComplete!(event, context);
+
+    expect(mockAttachAndRefreshPR).toHaveBeenCalledWith(
+      'workspace-1',
+      'https://github.com/purplefish-ai/factory-factory/pull/1039'
+    );
+  });
+
   it('ignores non-create gh commands', async () => {
     const event = createEvent({
       toolName: 'commandExecution',

--- a/src/backend/interceptors/pr-detection.interceptor.ts
+++ b/src/backend/interceptors/pr-detection.interceptor.ts
@@ -20,12 +20,12 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function extractCommand(event: ToolEvent): string | undefined {
   const directCommand = extractInputValue(event.input, 'command', isString, event.toolName, logger);
-  if (directCommand) {
+  if (directCommand && GH_PR_CREATE_REGEX.test(directCommand)) {
     return directCommand;
   }
 
   const title = extractInputValue(event.input, 'title', isString, event.toolName, logger);
-  if (title) {
+  if (title && GH_PR_CREATE_REGEX.test(title)) {
     return title;
   }
 
@@ -34,7 +34,7 @@ function extractCommand(event: ToolEvent): string | undefined {
     return event.toolName;
   }
 
-  return undefined;
+  return directCommand ?? title;
 }
 
 function extractPrUrlFromEvent(event: ToolEvent): string | null {


### PR DESCRIPTION
## Summary
- update PR detection to handle Codex-style `commandExecution` events in addition to Bash events
- detect `gh pr create` commands across multiple event shapes (`command`, `title`, and command-like `toolName`)
- extract PR URLs from `output.content`, `aggregatedOutput`, and nested `rawOutput` payloads

## Tests
- `pnpm test -- src/backend/interceptors/pr-detection.interceptor.test.ts`
- commit hooks also ran: lint-staged (`biome check --write`), `pnpm typecheck`, dependency-cruiser, and knip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes broaden when the interceptor runs (all tools) and how it parses loosely-typed tool payloads, which could introduce false positives/negatives in PR attachment behavior.
> 
> **Overview**
> The PR detection interceptor is broadened from `tools: ['Bash']` to `tools: '*'` and now identifies `gh pr create` invocations across more event shapes (preferring `input.command`, but falling back to `input.title` or command-like `toolName`).
> 
> PR URL extraction is hardened to search multiple output locations (`output.content`, `input.aggregatedOutput`, and nested `input.rawOutput` structures) using shared regex helpers, and a new Vitest suite validates these scenarios and ensures non-`create` `gh` commands are ignored.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d64e113809355103afdef6d12c909383cd97a71. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->