### PR TITLE
Fix Codex execution mode options when requirements are missing

### DIFF
--- a/src/backend/domains/session/acp/codex-app-server-adapter/codex-app-server-acp-adapter.test.ts
+++ b/src/backend/domains/session/acp/codex-app-server-adapter/codex-app-server-acp-adapter.test.ts
@@ -574,10 +574,25 @@ describe('CodexAppServerAcpAdapter', () => {
     const presetValues = executionModeOption.options.flatMap((option) =>
       'value' in option ? [option.value] : []
     );
+    const presetEntries = executionModeOption.options.flatMap((option) =>
+      'value' in option ? [option] : []
+    );
 
     expect(presetValues.length).toBeGreaterThan(1);
     expect(presetValues).toContain(JSON.stringify(['never', 'danger-full-access']));
     expect(presetValues).toContain(JSON.stringify(['on-failure', 'workspace-write']));
+    expect(presetEntries).toContainEqual(
+      expect.objectContaining({
+        value: JSON.stringify(['never', 'danger-full-access']),
+        name: 'YOLO (Full Access)',
+      })
+    );
+    expect(presetEntries).toContainEqual(
+      expect.objectContaining({
+        value: JSON.stringify(['on-request', 'workspace-write']),
+        name: 'On Request (Workspace Write)',
+      })
+    );
   });
 
   it('applies discovered execution mode and plan collaboration mode to turn/start', async () => {

--- a/src/backend/domains/session/acp/codex-app-server-adapter/codex-app-server-acp-adapter.ts
+++ b/src/backend/domains/session/acp/codex-app-server-adapter/codex-app-server-acp-adapter.ts
@@ -153,11 +153,59 @@ function dedupeStrings<T extends string>(values: Iterable<T>): T[] {
   return Array.from(new Set(values));
 }
 
+function humanizeToken(value: string): string {
+  return value
+    .split(/[-_]/)
+    .filter((part) => part.length > 0)
+    .map((part) => part.slice(0, 1).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
 function sanitizeModeName(mode: string): string {
   return mode
     .split('_')
     .map((part) => part.slice(0, 1).toUpperCase() + part.slice(1))
     .join(' ');
+}
+
+function formatApprovalPolicyLabel(policy: ApprovalPolicy): string {
+  if (policy === 'on-request') {
+    return 'On Request';
+  }
+  if (policy === 'on-failure') {
+    return 'On Failure';
+  }
+  if (policy === 'never') {
+    return 'Never Ask';
+  }
+  if (policy === 'untrusted') {
+    return 'Untrusted';
+  }
+  return humanizeToken(policy);
+}
+
+function formatSandboxModeLabel(mode: SandboxMode): string {
+  if (mode === 'workspace-write') {
+    return 'Workspace Write';
+  }
+  if (mode === 'read-only') {
+    return 'Read-only';
+  }
+  if (mode === 'danger-full-access') {
+    return 'Full Access';
+  }
+  return humanizeToken(mode);
+}
+
+function formatExecutionPresetName(
+  approvalPolicy: ApprovalPolicy,
+  sandboxMode: SandboxMode
+): string {
+  if (approvalPolicy === 'never' && sandboxMode === 'danger-full-access') {
+    return 'YOLO (Full Access)';
+  }
+
+  return `${formatApprovalPolicyLabel(approvalPolicy)} (${formatSandboxModeLabel(sandboxMode)})`;
 }
 
 function createWorkspaceWriteSandboxPolicy(cwd: string): Record<string, unknown> {
@@ -1324,7 +1372,7 @@ export class CodexAppServerAcpAdapter implements Agent {
       seen.add(id);
       presets.push({
         id,
-        name: `${approvalPolicy} + ${sandboxMode}`,
+        name: formatExecutionPresetName(approvalPolicy, sandboxMode),
         ...(description ? { description } : {}),
         approvalPolicy,
         sandboxMode,
@@ -1334,7 +1382,10 @@ export class CodexAppServerAcpAdapter implements Agent {
     addPreset(
       session.defaults.approvalPolicy,
       currentSandboxMode,
-      `Current session: ${session.defaults.approvalPolicy} + ${currentSandboxMode}`
+      `Current session: ${formatExecutionPresetName(
+        session.defaults.approvalPolicy,
+        currentSandboxMode
+      )}`
     );
     for (const policy of policies) {
       for (const sandboxMode of sandboxModes) {


### PR DESCRIPTION
## Summary
Factory Factory was collapsing Codex execution mode options to a single preset when `configRequirements/read` returned `requirements: null`.

This made the UI show only the current combo (for example `on-request + workspace-write`) even though Codex supports additional approval/sandbox combinations, including YOLO-like `never + danger-full-access`.

## Root Cause
The Codex ACP adapter only used `allowedApprovalPolicies` and `allowedSandboxModes` from `configRequirements/read`. When requirements were missing, both lists were empty, so execution presets fell back to the session's current policy/mode only.

## Changes
- Add adapter-level default approval policies and sandbox modes:
  - `on-failure`, `on-request`, `never`
  - `read-only`, `workspace-write`, `danger-full-access`
- Update `loadConfigRequirements()` to use these defaults only when requirements are absent (while still respecting explicitly provided arrays).
- Add a regression test that verifies multiple execution presets are exposed when `requirements` is `null`, including `never + danger-full-access`.

## Validation
- `pnpm test src/backend/domains/session/acp/codex-app-server-adapter/codex-app-server-acp-adapter.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to UI/config option enumeration and labeling when config requirements are missing; no auth or data-path changes, with test coverage added.
> 
> **Overview**
> Fixes `execution_mode` option generation in `CodexAppServerAcpAdapter` when `configRequirements/read` returns `requirements: null` by **falling back to adapter defaults** for approval policies and sandbox modes instead of collapsing to only the current session preset.
> 
> Also improves preset display names (e.g. `YOLO (Full Access)` / `On Request (Workspace Write)`) and adds a regression test ensuring multiple presets are exposed, including `never + danger-full-access`, when requirements are absent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a805fdb8ef67dd2809a0a346740184dae1a14056. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->