### PR TITLE
Fix quick action prompt not auto-sending

### DIFF
--- a/prompts/quick-actions/screenshots.md
+++ b/prompts/quick-actions/screenshots.md
@@ -4,18 +4,24 @@ description: Capture screenshots of the running dev app
 type: agent
 icon: camera
 ---
-Take a screenshot of the workspace's running development app to capture the current state of the UI.
+Take exactly one screenshot of the workspace's running development app to capture the current state of the UI.
 
 ## Step 1: Start the dev server
 
 1. Read `factory-factory.json` in the repo root for the `scripts.run` command
 2. Pick a free port and replace `{port}` in the command with it
-3. Start the dev server in the background and wait for it to be ready
+3. Start the dev server in the background with `BROWSER=none` set in the environment (do NOT open a browser window) and wait for it to be ready
 
-## Step 2: Take a screenshot
+## Step 2: Take a single screenshot
 
 1. `mkdir -p .factory-factory/screenshots`
 2. Use `browser_navigate` to visit the dev server URL
-3. Determine the most relevant screen that captures the current state of the app
-4. Use `browser_screenshot` to capture it
-5. Save to `.factory-factory/screenshots/` with a descriptive PNG filename
+3. Use `browser_screenshot` to capture the page
+4. Save to `.factory-factory/screenshots/` with a descriptive PNG filename
+
+## Step 3: Clean up
+
+1. Kill the dev server process you started in Step 1
+2. Close any browser pages you opened
+
+Do not take more than one screenshot. Do not open extra browser tabs or windows.

--- a/src/backend/domains/session/acp/acp-runtime-manager.ts
+++ b/src/backend/domains/session/acp/acp-runtime-manager.ts
@@ -611,7 +611,11 @@ export class AcpRuntimeManager {
       workingDir: options.workingDir,
     });
 
-    const spawnEnv = isCodex ? { ...process.env, DOTENV_CONFIG_QUIET: 'true' } : { ...process.env };
+    const spawnEnv = {
+      ...process.env,
+      BROWSER: 'none',
+      ...(isCodex ? { DOTENV_CONFIG_QUIET: 'true' } : {}),
+    };
 
     // Spawn subprocess (CRITICAL: detached MUST be false for orphan prevention)
     const child: ChildProcess = spawn(spawnCommand.command, spawnCommand.args, {

--- a/src/backend/domains/session/chat/chat-message-handlers/registry.ts
+++ b/src/backend/domains/session/chat/chat-message-handlers/registry.ts
@@ -30,7 +30,7 @@ export function createChatMessageHandlerRegistry(
     remove_queued_message: createRemoveQueuedMessageHandler(),
     resume_queued_messages: createResumeQueuedMessagesHandler(deps),
     stop: createStopHandler(),
-    load_session: createLoadSessionHandler(),
+    load_session: createLoadSessionHandler(deps),
     permission_response: createPermissionResponseHandler(),
     set_model: createSetModelHandler(),
     set_thinking_budget: createSetThinkingBudgetHandler(),

--- a/src/backend/trpc/session.trpc.ts
+++ b/src/backend/trpc/session.trpc.ts
@@ -1,7 +1,11 @@
 import { SessionProvider } from '@prisma-gen/client';
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
-import { sessionDataService, sessionProviderResolverService } from '@/backend/domains/session';
+import {
+  sessionDataService,
+  sessionDomainService,
+  sessionProviderResolverService,
+} from '@/backend/domains/session';
 import { getQuickAction, listQuickActions } from '@/backend/prompts/quick-actions';
 import { SessionStatus } from '@/shared/core';
 import { publicProcedure, router } from './trpc';
@@ -67,6 +71,7 @@ export const sessionRouter = router({
         workflow: z.string(),
         model: z.string().optional(),
         provider: z.nativeEnum(SessionProvider).optional(),
+        initialMessage: z.string().optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -95,6 +100,9 @@ export const sessionRouter = router({
         model: input.model,
         provider,
       });
+      if (input.initialMessage) {
+        sessionDomainService.storeInitialMessage(session.id, input.initialMessage);
+      }
       return session;
     }),
 

--- a/src/client/routes/projects/workspaces/use-workspace-detail.ts
+++ b/src/client/routes/projects/workspaces/use-workspace-detail.ts
@@ -90,7 +90,6 @@ interface UseSessionManagementOptions {
   workspaceId: string;
   slug: string;
   sessions: ReturnType<typeof useWorkspaceData>['sessions'];
-  sendMessage: (text: string) => void;
   inputRef: React.RefObject<HTMLTextAreaElement | null>;
   selectedDbSessionId: string | null;
   setSelectedDbSessionId: (id: string | null) => void;
@@ -98,8 +97,6 @@ interface UseSessionManagementOptions {
   selectedModel: string;
   /** Provider selection for newly created sessions */
   selectedProvider: SessionProviderValue;
-  /** Whether the session is ready to receive messages (session_loaded received) */
-  isSessionReady: boolean;
 }
 
 export type { NewSessionProviderSelection };
@@ -128,6 +125,7 @@ export interface UseSessionManagementReturn {
       model: string;
       name: string;
       provider?: SessionProviderValue;
+      initialMessage?: string;
     },
     { id: string }
   >;
@@ -146,35 +144,14 @@ export function useSessionManagement({
   workspaceId,
   slug,
   sessions,
-  sendMessage,
   inputRef,
   selectedDbSessionId,
   setSelectedDbSessionId,
   selectedModel,
   selectedProvider,
-  isSessionReady,
 }: UseSessionManagementOptions): UseSessionManagementReturn {
   const navigate = useNavigate();
   const utils = trpc.useUtils();
-
-  // Ref to store pending quick action prompt (to send after session is ready)
-  const pendingQuickActionRef = useRef<{ dbSessionId: string; prompt: string } | null>(null);
-
-  // Effect to send pending quick action prompt when session is ready
-  // We track the previous isSessionReady value to detect the transition from false -> true
-  const wasSessionReadyRef = useRef(isSessionReady);
-  useEffect(() => {
-    const pending = pendingQuickActionRef.current;
-    const transitionedToReady = !wasSessionReadyRef.current && isSessionReady;
-
-    // Send pending prompt when session transitions from not-ready to ready
-    if (pending && pending.dbSessionId === selectedDbSessionId && transitionedToReady) {
-      pendingQuickActionRef.current = null;
-      sendMessage(pending.prompt);
-    }
-
-    wasSessionReadyRef.current = isSessionReady;
-  }, [selectedDbSessionId, sendMessage, isSessionReady]);
 
   const createSession = trpc.session.createSession.useMutation({
     onSuccess: (_data) => {
@@ -327,21 +304,18 @@ export function useSessionManagement({
       const model = provider === 'CODEX' ? undefined : selectedModel || undefined;
       const previousSessionId = selectedDbSessionId;
       createSession.mutate(
-        { workspaceId, workflow: 'followup', name, model, provider },
+        { workspaceId, workflow: 'followup', name, model, provider, initialMessage: prompt },
         {
           onSuccess: (session) => {
             startSession.mutate(
               { id: session.id, initialPrompt: '' },
               {
                 onSuccess: () => {
-                  // Store the pending prompt to be sent once the session state settles
-                  pendingQuickActionRef.current = { dbSessionId: session.id, prompt };
                   // Setting the new session ID triggers WebSocket reconnection automatically
                   setSelectedDbSessionId(session.id);
                 },
                 onError: (error) => {
                   toast.error(error.message || 'Failed to start session');
-                  pendingQuickActionRef.current = null;
                   setSelectedDbSessionId(previousSessionId);
                 },
               }

--- a/src/client/routes/projects/workspaces/workspace-detail-container.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-container.tsx
@@ -203,7 +203,6 @@ export function WorkspaceDetailContainer() {
   });
 
   const loadingSession = sessionStatus.phase === 'loading';
-  const isSessionReady = sessionStatus.phase === 'ready' || sessionStatus.phase === 'running';
   const isIssueAutoStartPending =
     workspace?.creationSource === 'GITHUB_ISSUE' &&
     selectedDbSessionId !== null &&
@@ -281,13 +280,11 @@ export function WorkspaceDetailContainer() {
     workspaceId: workspaceId,
     slug: slug,
     sessions,
-    sendMessage,
     inputRef,
     selectedDbSessionId,
     setSelectedDbSessionId,
     selectedModel: chatSettings.selectedModel,
     selectedProvider,
-    isSessionReady,
   });
 
   const handleArchiveError = useCallback((error: unknown) => {


### PR DESCRIPTION
## Summary
- **Quick action auto-send**: Move initial message handling to the backend — store on `createSession`, auto-enqueue on `load_session` through the normal message queue pipeline. Eliminates the fragile frontend `useEffect` transition detection that relied on React batching order.
- **Dispatch stall fix**: Skip `isSessionWorking()` requeue check after auto-starting the Claude client, since the "working" state comes from the startup itself, not a prior user message.
- **Screenshot cleanup**: Suppress dev server browser windows (`BROWSER=none` in spawn env), limit to one screenshot, and add a cleanup step to kill the dev server and close browser pages after capture.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm check:fix` passes
- [x] `pnpm test` passes (2065 tests, including new positive test for auto-enqueue)
- [ ] Manual: Click "Take Screenshots" quick action → prompt auto-sends without user intervention
- [ ] Manual: Regular "New Chat" still works (no `initialMessage` passed)
- [ ] Manual: No extra browser windows opened during screenshots
- [ ] Manual: Dev server is killed after screenshot is taken

🤖 Generated with [Claude Code](https://claude.com/claude-code)