### PR TITLE
Add provider CLI warning for missing installation or authentication

### DIFF
--- a/src/backend/services/constants.ts
+++ b/src/backend/services/constants.ts
@@ -10,6 +10,7 @@ export const SERVICE_LIMITS = Object.freeze({
 export const SERVICE_TIMEOUT_MS = Object.freeze({
   claudeCliVersionCheck: 5000,
   codexCliVersionCheck: 5000,
+  codexCliAuthCheck: 5000,
   startupScriptForceKillGrace: 5000,
   portLsof: 2000,
 } as const);

--- a/src/client/routes/admin-page.tsx
+++ b/src/client/routes/admin-page.tsx
@@ -22,6 +22,7 @@ import { RatchetWrenchIcon } from '@/components/workspace';
 import { DevServerSetupPanel } from '@/components/workspace/dev-server-setup-panel';
 import { Loading } from '@/frontend/components/loading';
 import { PageHeader } from '@/frontend/components/page-header';
+import { ProviderCliWarning } from '@/frontend/components/provider-cli-warning';
 import { useDownloadServerLog } from '@/frontend/hooks/use-download-server-log';
 import { downloadFile } from '@/frontend/lib/download-file';
 import { trpc } from '@/frontend/lib/trpc';
@@ -416,6 +417,7 @@ function ChatProviderDefaultsSection() {
             <SelectItem value="CODEX">Codex</SelectItem>
           </SelectContent>
         </Select>
+        <ProviderCliWarning provider={currentProvider} />
       </CardContent>
     </Card>
   );

--- a/src/client/routes/projects/workspaces/workspace-detail-header.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-header.tsx
@@ -36,11 +36,13 @@ import {
   RunScriptPortBadge,
   useWorkspacePanel,
 } from '@/components/workspace';
+import { ProviderCliWarning } from '@/frontend/components/provider-cli-warning';
 import { trpc } from '@/frontend/lib/trpc';
 import {
   EXPLICIT_SESSION_PROVIDER_OPTIONS,
   getWorkspaceDefaultOptionLabel,
   type NewSessionProviderSelection,
+  resolveEffectiveSessionProvider,
   resolveProviderSelection,
 } from '@/lib/session-provider-selection';
 import { cn } from '@/lib/utils';
@@ -281,6 +283,9 @@ function WorkspaceProviderSettings({
                 ))}
               </SelectContent>
             </Select>
+            <ProviderCliWarning
+              provider={resolveEffectiveSessionProvider(defaultProvider, userDefaultProvider)}
+            />
           </div>
           <div className="space-y-2">
             <Label htmlFor="workspace-ratchet-provider">Ratchet Session Provider</Label>
@@ -302,6 +307,12 @@ function WorkspaceProviderSettings({
                 ))}
               </SelectContent>
             </Select>
+            <ProviderCliWarning
+              provider={resolveEffectiveSessionProvider(
+                ratchetProvider === 'WORKSPACE_DEFAULT' ? defaultProvider : ratchetProvider,
+                userDefaultProvider
+              )}
+            />
           </div>
         </div>
         <DialogFooter>

--- a/src/frontend/components/provider-cli-warning.tsx
+++ b/src/frontend/components/provider-cli-warning.tsx
@@ -1,0 +1,115 @@
+import { AlertTriangle, ExternalLink, RefreshCw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { trpc } from '@/frontend/lib/trpc';
+
+const PROVIDER_INFO = {
+  CLAUDE: {
+    label: 'Claude',
+    installUrl: 'https://claude.ai/download',
+  },
+  CODEX: {
+    label: 'Codex',
+    installUrl: 'https://developers.openai.com/codex/app-server/',
+  },
+} as const;
+
+function getWarning(
+  provider: 'CLAUDE' | 'CODEX',
+  health: {
+    claude: { isInstalled: boolean };
+    codex: { isInstalled: boolean; isAuthenticated?: boolean };
+  }
+): { title: string; description: string; linkLabel?: string; linkUrl?: string } | null {
+  const info = PROVIDER_INFO[provider];
+
+  if (provider === 'CLAUDE') {
+    if (!health.claude.isInstalled) {
+      return {
+        title: `${info.label} CLI is not installed`,
+        description: `Install the ${info.label} CLI to use this provider.`,
+        linkLabel: 'Install',
+        linkUrl: info.installUrl,
+      };
+    }
+    return null;
+  }
+
+  // Codex
+  if (!health.codex.isInstalled) {
+    return {
+      title: `${info.label} CLI is not installed`,
+      description: `Install the ${info.label} CLI to use this provider.`,
+      linkLabel: 'Install',
+      linkUrl: info.installUrl,
+    };
+  }
+  if (health.codex.isAuthenticated === false) {
+    return {
+      title: `${info.label} CLI is not authenticated`,
+      description: 'Run `codex login` in your terminal to authenticate.',
+    };
+  }
+  return null;
+}
+
+/**
+ * Inline warning shown below a provider select when the selected provider's CLI
+ * is not installed or not authenticated.
+ * Shares the checkCLIHealth query cache with CLIHealthBanner.
+ */
+export function ProviderCliWarning({ provider }: { provider: 'CLAUDE' | 'CODEX' }) {
+  const utils = trpc.useUtils();
+  const { data: health, isRefetching } = trpc.admin.checkCLIHealth.useQuery(
+    { forceRefresh: false },
+    {
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      staleTime: 60_000,
+    }
+  );
+
+  if (!health) {
+    return null;
+  }
+
+  const warning = getWarning(provider, health);
+  if (!warning) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-start gap-2 rounded-lg border border-amber-500/50 bg-amber-50 p-3 text-sm dark:bg-amber-900/20">
+      <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+      <div className="flex-1 space-y-1">
+        <p className="text-amber-900 dark:text-amber-200">{warning.title}</p>
+        <p className="text-xs text-amber-800/80 dark:text-amber-300/80">
+          {warning.description}
+          {warning.linkUrl && (
+            <>
+              {' '}
+              <a
+                href={warning.linkUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-0.5 underline"
+              >
+                {warning.linkLabel}
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            </>
+          )}
+        </p>
+      </div>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-7 w-7 text-amber-600 hover:bg-amber-100 dark:text-amber-400 dark:hover:bg-amber-900/40"
+        onClick={() => utils.admin.checkCLIHealth.invalidate()}
+        disabled={isRefetching}
+      >
+        <RefreshCw className={`h-3.5 w-3.5 ${isRefetching ? 'animate-spin' : ''}`} />
+        <span className="sr-only">Recheck</span>
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **Codex CLI auth check**: Extends `CLIHealthService.checkCodexCLI()` to verify authentication via `codex login status`, adding an `isAuthenticated` field to the health status.
- **Inline provider warnings**: Adds a new `ProviderCliWarning` component that displays a contextual warning below provider selectors when the selected CLI is not installed or (for Codex) not authenticated.
- **UI integration**: Surfaces warnings in the admin default-provider settings and the workspace provider dialog (both default and ratchet provider selects).
- **Tests**: Adds a test case for the "installed but unauthenticated" Codex state and updates existing mocks.

## Screenshots
<img width="1467" height="991" alt="Pasted Graphic 59" src="https://github.com/user-attachments/assets/e83818ae-3469-4100-ba76-321beb1c5eee" />

