### PR TITLE
Group new-session controls and clarify provider affordance

### DIFF
--- a/src/components/workspace/main-view-tab-bar.tsx
+++ b/src/components/workspace/main-view-tab-bar.tsx
@@ -278,7 +278,7 @@ export function MainViewTabBar({
                 className={cn(
                   'flex h-[30px] w-[30px] items-center justify-center rounded-none',
                   'text-muted-foreground hover:bg-sidebar-accent hover:text-foreground',
-                  'transition-colors disabled:pointer-events-none'
+                  'transition-colors disabled:pointer-events-none disabled:opacity-50'
                 )}
                 aria-label={`New ${providerTriggerLabel} session`}
               >


### PR DESCRIPTION
## Summary
- Group the session provider selector and `+` action into a single visual control in the workspace tab bar.
- Keep existing provider/session language, but make the `+` tooltip and aria label provider-specific (for example, `New Codex session` or `New Claude session`).
- Reduce extra whitespace by shrinking the provider trigger to content width and hiding its chevron in this grouped control.
- Match the grouped control height to session tab height for visual consistency.

## Testing
- `pnpm -s typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change to the workspace tab bar; main risk is minor layout/accessibility regressions in the new grouped control and tooltip/label text.
> 
> **Overview**
> Updates `MainViewTabBar` to **group the session provider selector and “+” new-session action into a single bordered control** with consistent height and reduced whitespace.
> 
> Makes the create-session button’s *tooltip and `aria-label` provider-specific* (e.g. “New Claude session”), and tightens the provider trigger styling (content-width, hides chevron, removes extra borders) while keeping existing limit/disabled behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59b791da7f67aed0881f4067a0f15138fbd99f5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->