### PR TITLE
Fix queued messages not restarting agent after stop

### DIFF
--- a/src/backend/domains/session/chat/chat-message-handlers/handlers/stop.handler.test.ts
+++ b/src/backend/domains/session/chat/chat-message-handlers/handlers/stop.handler.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   stopSession: vi.fn(),
   clearPendingRequest: vi.fn(),
+  tryDispatchNextMessage: vi.fn(),
 }));
 
 vi.mock('@/backend/domains/session/lifecycle/session.service', () => ({
@@ -26,7 +27,11 @@ describe('createStopHandler', () => {
 
   it('stops via provider-neutral lifecycle API and clears pending request', async () => {
     mocks.stopSession.mockResolvedValue(undefined);
-    const handler = createStopHandler();
+    const handler = createStopHandler({
+      getClientCreator: () => null,
+      tryDispatchNextMessage: mocks.tryDispatchNextMessage,
+      setManualDispatchResume: vi.fn(),
+    });
 
     await handler({
       ws: { send: vi.fn() } as never,
@@ -37,5 +42,6 @@ describe('createStopHandler', () => {
 
     expect(mocks.stopSession).toHaveBeenCalledWith('session-1');
     expect(mocks.clearPendingRequest).toHaveBeenCalledWith('session-1');
+    expect(mocks.tryDispatchNextMessage).toHaveBeenCalledWith('session-1');
   });
 });

--- a/src/backend/domains/session/chat/chat-message-handlers/handlers/stop.handler.ts
+++ b/src/backend/domains/session/chat/chat-message-handlers/handlers/stop.handler.ts
@@ -1,13 +1,21 @@
 import { chatEventForwarderService } from '@/backend/domains/session/chat/chat-event-forwarder.service';
-import type { ChatMessageHandler } from '@/backend/domains/session/chat/chat-message-handlers/types';
+import type {
+  ChatMessageHandler,
+  HandlerRegistryDependencies,
+} from '@/backend/domains/session/chat/chat-message-handlers/types';
 import { sessionService } from '@/backend/domains/session/lifecycle/session.service';
 import type { StopMessage } from '@/shared/websocket';
 
-export function createStopHandler(): ChatMessageHandler<StopMessage> {
+export function createStopHandler(
+  deps: HandlerRegistryDependencies
+): ChatMessageHandler<StopMessage> {
   return async ({ sessionId }) => {
     await sessionService.stopSession(sessionId);
     // Only clear pending requests here - clientEventSetup cleanup happens in the exit handler
     // to avoid race conditions where a new client is created before the old one exits
     chatEventForwarderService.clearPendingRequest(sessionId);
+    // If messages were queued while stop was in-flight, retry dispatch now that
+    // lifecycle state has settled.
+    await deps.tryDispatchNextMessage(sessionId);
   };
 }

--- a/src/backend/domains/session/chat/chat-message-handlers/registry.ts
+++ b/src/backend/domains/session/chat/chat-message-handlers/registry.ts
@@ -29,7 +29,7 @@ export function createChatMessageHandlerRegistry(
     queue_message: createQueueMessageHandler(deps),
     remove_queued_message: createRemoveQueuedMessageHandler(),
     resume_queued_messages: createResumeQueuedMessagesHandler(deps),
-    stop: createStopHandler(),
+    stop: createStopHandler(deps),
     load_session: createLoadSessionHandler(deps),
     permission_response: createPermissionResponseHandler(),
     set_model: createSetModelHandler(),


### PR DESCRIPTION
## Summary
- fix a stop/queue race where user messages queued while a session was stopping could remain queued with no automatic retry
- update the stop chat handler to retry queued dispatch immediately after `stopSession` completes
- wire stop handler dependencies through the chat handler registry and extend unit coverage

## Root Cause
During a stop-in-progress window, queued dispatch can be skipped or fail and the message is requeued. The stop flow did not trigger a follow-up dispatch attempt after lifecycle state settled, so the queued message could stay stuck until manual action.

## Testing
- `pnpm test src/backend/domains/session/chat/chat-message-handlers/handlers/stop.handler.test.ts src/backend/domains/session/chat/chat-message-handlers.service.test.ts`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session stop flow and message queue dispatch ordering; a mistake could cause duplicate dispatch attempts or regress stop/queue behavior, though changes are small and covered by unit tests.
> 
> **Overview**
> Fixes a stop/queue race by having the `stop` chat handler call `tryDispatchNextMessage(sessionId)` after `stopSession` completes and pending requests are cleared, so messages queued during an in-flight stop are retried automatically.
> 
> Wires `HandlerRegistryDependencies` into `createStopHandler` via the handler registry and updates the unit test to assert the new dispatch retry behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93504c6e540d282bc285c68f1ea4b98f8ce1abda. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->