### PR TITLE
Fix chat auto-scroll when large messages expand

### DIFF
--- a/src/components/chat/virtualized-message-list.test.tsx
+++ b/src/components/chat/virtualized-message-list.test.tsx
@@ -389,6 +389,44 @@ describe('VirtualizedMessageList auto-scroll behavior', () => {
     harness.cleanup();
   });
 
+  it('cancels pending growth pin RAF when session transitions to loading', async () => {
+    const harness = createHarness({
+      loadingSession: false,
+      messages: [makeMessage('m-1', 0)],
+      isNearBottom: true,
+    });
+
+    let scrollHeight = 640;
+    Object.defineProperty(harness.viewport, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight,
+    });
+    Object.defineProperty(harness.viewport, 'clientHeight', {
+      configurable: true,
+      value: 500,
+    });
+    harness.viewport.scrollTop = 120;
+
+    await flushEffects();
+
+    triggerResize(220);
+    triggerResize(300);
+    harness.render({
+      loadingSession: true,
+      messages: [makeMessage('m-1', 0)],
+      isNearBottom: true,
+    });
+    await flushAnimationFrame();
+
+    expect(harness.viewport.scrollTop).toBe(120);
+
+    scrollHeight = 920;
+    await flushAnimationFrame();
+    expect(harness.viewport.scrollTop).toBe(120);
+
+    harness.cleanup();
+  });
+
   it('does not pin content growth when isNearBottom prop is stale during scroll restore', async () => {
     const harness = createHarness({
       loadingSession: false,


### PR DESCRIPTION
## Summary
- fix chat auto-scroll reliability when new messages append and rendered content grows after initial virtualization measurement
- keep the viewport pinned to the true bottom only when the user is already near bottom
- add regression coverage for large-content growth and non-pinning behavior when the user has scrolled up

## Root Cause
`scrollToIndex` could run before final measured heights settled for large messages, leaving the viewport slightly above the real bottom.

## Changes
- refactor bottom pinning into a shared `stickToBottom` helper in `VirtualizedMessageList`
- after `scrollToIndex`, add a follow-up RAF pin-to-bottom pass to correct post-measure/layout growth
- observe content container size with `ResizeObserver` and re-pin on growth while `isNearBottom` is true
- add cleanup for pending RAF callbacks
- extend `virtualized-message-list` tests with ResizeObserver-backed growth scenarios

## Validation
- `pnpm exec biome check src/components/chat/virtualized-message-list.tsx src/components/chat/virtualized-message-list.test.tsx`
- `pnpm test src/components/chat/virtualized-message-list.test.tsx`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts chat viewport scrolling/pinning logic using RAF and `ResizeObserver`, which can subtly affect user scroll behavior and timing during hydration. Changes are localized but involve async scheduling and cancellation edge cases.
> 
> **Overview**
> Improves chat auto-scroll reliability in `VirtualizedMessageList` by adding a shared `stickToBottom` helper and a follow-up `requestAnimationFrame` bottom pin after `scrollToIndex`, so appends stay pinned even when virtualized content finishes measuring later.
> 
> Adds `ResizeObserver`-based pinning to keep the viewport at the true bottom when message content grows (e.g., large renders) *only if* the user was already near the bottom (thresholded), and cancels any pending pins when entering `loadingSession` or unmounting.
> 
> Extends unit tests with a `ResizeObserver` mock and new scenarios covering append-pin scheduling/cancellation and growth pinning vs. non-pinning when the user is away from the bottom or `isNearBottom` is stale.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3887d475d320816ecaab0e3bf969c9b91ab460a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->