### PR TITLE
[DNM] Fake PR to test ratcheting

### DIFF
--- a/src/client/routes/projects/workspaces/components/new-workspace-button.tsx
+++ b/src/client/routes/projects/workspaces/components/new-workspace-button.tsx
@@ -5,7 +5,7 @@ import { useIsMobile } from '@/hooks/use-mobile';
 export function NewWorkspaceButton({
   onClick,
   isCreating,
-  children = 'New Workspace',
+  children = 'Workspace',
 }: {
   onClick: () => void;
   isCreating: boolean;


### PR DESCRIPTION
## Summary
- Shorten the default label of the new-workspace button from "New Workspace" to "Workspace" for a more concise UI

## Test plan
- [ ] Verify the button renders with the label "Workspace" on the workspaces page
- [ ] Verify that callers passing a custom `children` prop still override the default label

🤖 Generated with [Claude Code](https://claude.com/claude-code)
