### PR TITLE
Play notification sound when agent requests permission or asks a question

### DIFF
--- a/src/components/chat/reducer/index.ts
+++ b/src/components/chat/reducer/index.ts
@@ -460,6 +460,7 @@ const messageHandlers: MessageHandlerMap = {
   compacting_start: () => ({ type: 'SDK_COMPACTING_START' }),
   compacting_end: () => ({ type: 'SDK_COMPACTING_END' }),
   workspace_notification_request: null,
+  workspace_input_required_notification: null,
   slash_commands: handleSlashCommandsMessage,
   user_message_uuid: handleUserMessageUuidMessage,
   config_options_update: handleConfigOptionsUpdateMessage,

--- a/src/shared/acp-protocol/protocol/websocket.ts
+++ b/src/shared/acp-protocol/protocol/websocket.ts
@@ -202,6 +202,12 @@ interface WebSocketMessagePayloadByType {
     sessionCount?: number;
     finishedAt?: string;
   };
+  workspace_input_required_notification: {
+    workspaceId?: string;
+    workspaceName?: string;
+    sessionId?: string;
+    requestType?: 'permission_request' | 'user_question';
+  };
   slash_commands: {
     slashCommands?: CommandInfo[];
   };
@@ -281,6 +287,7 @@ const WEBSOCKET_MESSAGE_TYPE_MAP: Record<WebSocketMessage['type'], true> = {
   compacting_start: true,
   compacting_end: true,
   workspace_notification_request: true,
+  workspace_input_required_notification: true,
   slash_commands: true,
   user_message_uuid: true,
   chat_capabilities: true,


### PR DESCRIPTION
## Summary
- Plays the workspace-complete notification sound and triggers the red glow attention indicator when an agent requests permission or asks a user question
- Works even when the user is viewing a different workspace, by broadcasting a new `workspace_input_required_notification` WebSocket message to all connections
- Reuses the existing `playSoundOnComplete` user setting and browser notification infrastructure

## Test plan
- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes (2098 tests)
- [ ] `pnpm check:fix` passes
- [ ] Start a workspace session with default permission mode, trigger a tool use requiring permission — verify sound plays and red glow appears on the workspace card
- [ ] While viewing a different workspace, trigger a permission request — verify sound + glow still fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)
