### PR TITLE
Improve sidebar pending request indicators and Storybook coverage

### DIFF
--- a/src/frontend/components/app-sidebar.stories.tsx
+++ b/src/frontend/components/app-sidebar.stories.tsx
@@ -98,6 +98,15 @@ const mockData = {
   },
 };
 
+function withPendingRequests(
+  pendingByWorkspaceId: Partial<Record<string, ServerWorkspace['pendingRequestType']>>
+): ServerWorkspace[] {
+  return mockWorkspaces.map((workspace) => ({
+    ...workspace,
+    pendingRequestType: pendingByWorkspaceId[workspace.id] ?? null,
+  }));
+}
+
 function SidebarStoryFrame({ children }: { children: ReactNode }) {
   return (
     <ThemeProvider>
@@ -141,6 +150,51 @@ export const Empty: Story = {
       projectState: {
         workspaces: [],
         reviewCount: 0,
+      },
+    },
+  },
+};
+
+export const PermissionRequestNotification: Story = {
+  args: {
+    mockData: {
+      ...mockData,
+      projectState: {
+        ...mockData.projectState,
+        workspaces: withPendingRequests({
+          'ws-1': 'permission_request',
+        }),
+      },
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Shows the sidebar permission notification badge on a workspace row.',
+      },
+    },
+  },
+};
+
+export const PendingRequestVariants: Story = {
+  args: {
+    mockData: {
+      ...mockData,
+      projectState: {
+        ...mockData.projectState,
+        workspaces: withPendingRequests({
+          'ws-1': 'permission_request',
+          'ws-2': 'plan_approval',
+          'ws-3': 'user_question',
+        }),
+      },
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Shows all pending request badge variants used in the sidebar: permission request, plan approval, and user question.',
       },
     },
   },


### PR DESCRIPTION
## Summary
- add `AppSidebar` Storybook scenarios for sidebar pending-request states:
  - `PermissionRequestNotification`
  - `PendingRequestVariants`
- simplify workspace row pending UI in the sidebar by removing the inline pending badge text row
- show pending state directly in the status slot with colored icons + tooltip:
  - `permission_request`: orange shield
  - `plan_approval`: amber file-check
  - `user_question`: blue question
- keep existing working/idle dot behavior when there is no pending request

## Testing
- `pnpm typecheck`
