### PR TITLE
Hide Codex thinking blocks when replaying past sessions

### DIFF
--- a/src/backend/domains/session/data/codex-session-history-loader.service.test.ts
+++ b/src/backend/domains/session/data/codex-session-history-loader.service.test.ts
@@ -150,11 +150,6 @@ describe('codexSessionHistoryLoaderService', () => {
         timestamp: '2026-02-14T00:00:02.000Z',
       },
       {
-        type: 'thinking',
-        content: 'reasoning text',
-        timestamp: '2026-02-14T00:00:03.000Z',
-      },
-      {
         type: 'tool_use',
         content: '',
         timestamp: '2026-02-14T00:00:04.000Z',
@@ -221,7 +216,7 @@ describe('codexSessionHistoryLoaderService', () => {
     ]);
   });
 
-  it('ignores response_item reasoning because event_msg reasoning is the source of thought history', async () => {
+  it('ignores Codex reasoning entries during history hydration', async () => {
     const providerSessionId = 'session-reasoning-1';
     const cwd = '/Users/test/project';
     writeSessionFile({
@@ -234,6 +229,14 @@ describe('codexSessionHistoryLoaderService', () => {
           payload: {
             id: providerSessionId,
             cwd,
+          },
+        },
+        {
+          timestamp: '2026-02-15T00:00:03.000Z',
+          type: 'event_msg',
+          payload: {
+            type: 'agent_reasoning',
+            text: 'internal reasoning',
           },
         },
         {

--- a/src/backend/domains/session/data/codex-session-history-loader.service.ts
+++ b/src/backend/domains/session/data/codex-session-history-loader.service.ts
@@ -141,19 +141,6 @@ function parseCodexEventMessage(
     };
   }
 
-  if (eventType === 'agent_reasoning') {
-    const text = entry.payload.text;
-    if (typeof text !== 'string' || text.trim().length === 0) {
-      return null;
-    }
-
-    return {
-      type: 'thinking',
-      content: text,
-      timestamp,
-    };
-  }
-
   return null;
 }
 


### PR DESCRIPTION
## Summary
- stop mapping Codex `event_msg` entries of type `agent_reasoning` into transcript history messages during load-session hydration
- keep Codex replay focused on user/assistant/tool events so previously saved sessions no longer render internal thinking blocks
- update Codex session history loader tests to assert reasoning entries are ignored

## Testing
- pnpm test src/backend/domains/session/data/codex-session-history-loader.service.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to session history normalization plus test updates; risk is limited to potentially hiding reasoning content some consumers expected.
> 
> **Overview**
> Stops hydrating Codex session history with internal reasoning by removing the `event_msg` → `agent_reasoning` mapping to `HistoryMessage` `thinking` entries.
> 
> Updates the Codex session history loader tests to assert `agent_reasoning` (and `response_item` reasoning) lines are ignored, keeping replay history limited to user/assistant/tool events.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53ae5ba89be3f0c1a85539bd3068f47d2870352a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->