### PR TITLE
Temporarily hide issue tracking UI from admin panel

### DIFF
--- a/src/client/routes/admin-page.tsx
+++ b/src/client/routes/admin-page.tsx
@@ -28,7 +28,7 @@ import { downloadFile } from '@/frontend/lib/download-file';
 import { trpc } from '@/frontend/lib/trpc';
 import {
   ApiUsageSection,
-  IssueTrackingSection,
+  // IssueTrackingSection,
   ProcessesSection,
   ProcessesSectionSkeleton,
 } from './admin/index';
@@ -685,8 +685,8 @@ export default function AdminDashboardPage() {
         {/* Factory Configuration */}
         {projects && <FactoryConfigSection projects={projects} />}
 
-        {/* Issue Tracking */}
-        {projects && <IssueTrackingSection projects={projects} />}
+        {/* TODO: Re-enable once Linear integration is complete */}
+        {/* {projects && <IssueTrackingSection projects={projects} />} */}
 
         {/* User Settings */}
         <NotificationSettingsSection />


### PR DESCRIPTION
## Summary

- Comments out the `IssueTrackingSection` import and render in admin-page.tsx
- All Linear integration code remains intact — just not wired into the UI yet
- Uncomment two lines to re-enable when ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)