### PR TITLE
Add Linear issue prompt builder and state sync wiring (D4/D5)

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -208,7 +208,7 @@ module.exports = {
       from: {
         path: '^src/backend/orchestration/',
         pathNot:
-          '^src/backend/orchestration/(workspace-init\\.orchestrator|snapshot-reconciliation\\.orchestrator|scheduler\\.service|health\\.service|decision-log-query\\.service|data-backup\\.service|types)\\.ts$|^src/backend/orchestration/.*\\.test\\.ts$',
+          '^src/backend/orchestration/(workspace-init\\.orchestrator|snapshot-reconciliation\\.orchestrator|scheduler\\.service|health\\.service|decision-log-query\\.service|data-backup\\.service|linear-config\\.helper|types)\\.ts$|^src/backend/orchestration/.*\\.test\\.ts$',
       },
       to: { path: '^src/backend/resource_accessors/' },
     },

--- a/src/backend/orchestration/event-collector.orchestrator.ts
+++ b/src/backend/orchestration/event-collector.orchestrator.ts
@@ -21,6 +21,7 @@ import {
   type PRSnapshotUpdatedEvent,
   prSnapshotService,
 } from '@/backend/domains/github';
+import { linearStateSyncService } from '@/backend/domains/linear';
 import {
   RATCHET_STATE_CHANGED,
   type RatchetStateChangedEvent,
@@ -48,6 +49,7 @@ import {
   workspaceSnapshotStore,
 } from '@/backend/services/workspace-snapshot-store.service';
 import type { CIStatus, PRState } from '@/shared/core';
+import { getWorkspaceLinearContext } from './linear-config.helper';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -211,6 +213,30 @@ async function refreshWorkspaceSessionSummaries(
 }
 
 // ---------------------------------------------------------------------------
+// Linear state sync on PR merge
+// ---------------------------------------------------------------------------
+
+async function handleLinearIssueCompletedOnMerge(workspaceId: string): Promise<void> {
+  try {
+    const ctx = await getWorkspaceLinearContext(workspaceId);
+    if (!ctx) {
+      return;
+    }
+
+    await linearStateSyncService.markIssueCompleted(ctx.apiKey, ctx.linearIssueId);
+    logger.info('Marked Linear issue as completed on PR merge', {
+      workspaceId,
+      linearIssueId: ctx.linearIssueId,
+    });
+  } catch (error) {
+    logger.warn('Failed to mark Linear issue as completed on PR merge', {
+      workspaceId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
 // configureEventCollector
 // ---------------------------------------------------------------------------
 
@@ -248,6 +274,11 @@ export function configureEventCollector(): void {
     };
 
     coalescer.enqueue(event.workspaceId, snapshotUpdate, 'event:pr_snapshot_updated');
+
+    // Transition linked Linear issue to completed when PR is merged
+    if (event.prState === 'MERGED') {
+      void handleLinearIssueCompletedOnMerge(event.workspaceId);
+    }
   });
 
   // 3. Ratchet state changes

--- a/src/backend/orchestration/linear-config.helper.ts
+++ b/src/backend/orchestration/linear-config.helper.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared helpers for decrypting a project's Linear configuration.
+ * Used by orchestrators that need to call Linear API methods.
+ */
+
+import { workspaceAccessor } from '@/backend/resource_accessors/workspace.accessor';
+import { cryptoService } from '@/backend/services/crypto.service';
+import { IssueTrackerConfigSchema } from '@/shared/schemas/issue-tracker-config.schema';
+
+export function getDecryptedLinearConfig(
+  issueTrackerConfig: unknown
+): { apiKey: string; teamId: string } | null {
+  const parsed = IssueTrackerConfigSchema.safeParse(issueTrackerConfig);
+  if (!(parsed.success && parsed.data.linear)) {
+    return null;
+  }
+  const { linear } = parsed.data;
+  return { apiKey: cryptoService.decrypt(linear.apiKey), teamId: linear.teamId };
+}
+
+/**
+ * Look up a workspace + project, then return the Linear config if the workspace
+ * is linked to a Linear issue. Returns null if workspace not found, has no
+ * Linear issue, or project has no Linear config.
+ */
+export async function getWorkspaceLinearContext(
+  workspaceId: string
+): Promise<{ apiKey: string; linearIssueId: string } | null> {
+  const workspace = await workspaceAccessor.findByIdWithProject(workspaceId);
+  if (!workspace?.linearIssueId) {
+    return null;
+  }
+
+  const linearConfig = getDecryptedLinearConfig(workspace.project.issueTrackerConfig);
+  if (!linearConfig) {
+    return null;
+  }
+
+  return { apiKey: linearConfig.apiKey, linearIssueId: workspace.linearIssueId };
+}


### PR DESCRIPTION
## Summary
- Add initial prompt builder for Linear issues so agents receive issue content when starting from a Linear issue (mirrors the existing GitHub issue prompt)
- Wire Linear state sync: auto-transition issues to "started" on workspace init and "completed" on PR merge
- Extract shared `getDecryptedLinearConfig` helper for the orchestration layer

## Changes
- **`workspace-init.orchestrator.ts`**: Add `buildInitialPromptFromLinearIssue()` (mirrors GitHub version), `markLinearIssueStartedIfApplicable()`, update `startDefaultAgentSession()` to try both prompt builders
- **`event-collector.orchestrator.ts`**: Add `handleLinearIssueCompletedOnMerge()`, wire to `PR_SNAPSHOT_UPDATED` event when `prState === 'MERGED'`
- **`linear-config.helper.ts`** (new): Shared helpers for parsing + decrypting Linear config from project's `issueTrackerConfig`
- **`.dependency-cruiser.cjs`**: Allowlist `linear-config.helper` for accessor imports

## Testing
- [x] Types pass (`pnpm typecheck`)
- [x] Lint passes (`pnpm check:fix`)
- [x] Tests pass (`pnpm test` — 2101 tests)
- [x] Dependency-cruiser passes (`pnpm deps:check`)
- [ ] Manual: Create workspace from Linear issue → verify agent receives issue prompt
- [ ] Manual: Verify Linear issue transitions to "started" on workspace init
- [ ] Manual: Merge a PR → verify Linear issue transitions to "completed"
