### PR TITLE
Fix PUR-1764: Fix PR label tag text centering

### DIFF
--- a/src/frontend/components/pr-detail-panel.tsx
+++ b/src/frontend/components/pr-detail-panel.tsx
@@ -126,7 +126,7 @@ function PRHeader({ pr }: PRHeaderProps) {
           {pr.labels.map((label) => (
             <span
               key={label.name}
-              className="text-xs px-1.5 py-0.5 rounded"
+              className="inline-flex items-center text-xs px-1.5 py-0.5 rounded"
               style={{
                 backgroundColor: `#${label.color}20`,
                 color: `#${label.color}`,


### PR DESCRIPTION
## Summary
- Fix PR label tags not properly centering text within the badge element
- Labels defined at the organization/repo level now display correctly in the PR detail panel

## Changes
- **PR Detail Panel**: Added `inline-flex items-center` to the label `<span>` element so text is properly centered both horizontally and vertically within each tag

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Open the PR review panel on any PR with labels and verify the label tags display with properly centered text and equal spacing on both sides

Closes PUR-1764

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
