### PR TITLE
Fix knip false positives for CLI/backend entrypoints

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -4,6 +4,8 @@
     ".": {
       "entry": [
         "src/client/main.tsx",
+        "src/cli/index.ts",
+        "src/backend/index.ts",
         "src/backend/server.ts",
         "src/backend/migrate.ts",
         "electron/main/index.ts",


### PR DESCRIPTION
## Summary
- add `src/cli/index.ts` and `src/backend/index.ts` to `knip.json` workspace `entry`
- ensure knip treats CLI/backend entrypoints as reachable roots
- stop recurring false positives for deps used only through those entrypoints (for example `commander` and `open`)

## Validation
- `pnpm run typecheck` (via pre-commit)
- `pnpm run deps:check` (via pre-commit)
- `pnpm run knip` (via pre-commit)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to static analysis entrypoints; no runtime or production code behavior changes.
> 
> **Overview**
> Updates `knip.json` to treat `src/cli/index.ts` and `src/backend/index.ts` as workspace entrypoints, ensuring dependency reachability analysis includes CLI/backend roots.
> 
> This reduces Knip false positives for dependencies only referenced through those entry files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 664ab386773146fc1699d5ace2ae502ec079dccb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->