### PR TITLE
Fix patchable Dependabot alerts (tar, ajv, qs)

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,13 +187,14 @@
     ],
     "overrides": {
       "@isaacs/brace-expansion": ">=5.0.1",
+      "@modelcontextprotocol/sdk>ajv": ">=8.18.0",
       "braces": ">=3.0.3",
       "micromatch": ">=4.0.8",
-      "tar": ">=7.5.0",
+      "tar": ">=7.5.8",
       "hono": ">=4.11.7",
       "lodash": ">=4.17.23",
       "lodash-es": ">=4.17.23",
-      "qs": ">=6.14.1",
+      "qs": ">=6.14.2",
       "form-data": ">=2.5.4",
       "tough-cookie": ">=4.1.3"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,13 +6,14 @@ settings:
 
 overrides:
   '@isaacs/brace-expansion': '>=5.0.1'
+  '@modelcontextprotocol/sdk>ajv': '>=8.18.0'
   braces: '>=3.0.3'
   micromatch: '>=4.0.8'
-  tar: '>=7.5.0'
+  tar: '>=7.5.8'
   hono: '>=4.11.7'
   lodash: '>=4.17.23'
   lodash-es: '>=4.17.23'
-  qs: '>=6.14.1'
+  qs: '>=6.14.2'
   form-data: '>=2.5.4'
   tough-cookie: '>=4.1.3'
 
@@ -2991,8 +2992,8 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
-  ajv@8.17.1:
-    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
   ansi-escapes@7.2.0:
     resolution: {integrity: sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==}
@@ -5912,10 +5913,6 @@ packages:
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
-  qs@6.14.1:
-    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
-    engines: {node: '>=0.6'}
-
   qs@6.14.2:
     resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
     engines: {node: '>=0.6'}
@@ -6626,8 +6623,8 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
-  tar@7.5.7:
-    resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
+  tar@7.5.9:
+    resolution: {integrity: sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==}
     engines: {node: '>=18'}
 
   temp-file@3.4.0:
@@ -7599,7 +7596,7 @@ snapshots:
       ora: 5.4.1
       read-binary-file-arch: 1.0.6
       semver: 7.7.4
-      tar: 7.5.7
+      tar: 7.5.9
       yargs: 17.7.2
     transitivePeerDependencies:
       - supports-color
@@ -7617,7 +7614,7 @@ snapshots:
       ora: 5.4.1
       read-binary-file-arch: 1.0.6
       semver: 7.7.3
-      tar: 7.5.7
+      tar: 7.5.9
       yargs: 17.7.2
     transitivePeerDependencies:
       - supports-color
@@ -8027,8 +8024,8 @@ snapshots:
   '@modelcontextprotocol/sdk@1.26.0(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.11.9)
-      ajv: 8.17.1
-      ajv-formats: 3.0.1(ajv@8.17.1)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
       cors: 2.8.6
       cross-spawn: 7.0.6
@@ -9857,9 +9854,9 @@ snapshots:
       ajv: 6.12.6
     optional: true
 
-  ajv-formats@3.0.1(ajv@8.17.1):
+  ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
-      ajv: 8.17.1
+      ajv: 8.18.0
 
   ajv-keywords@3.5.2(ajv@6.12.6):
     dependencies:
@@ -9872,7 +9869,7 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  ajv@8.17.1:
+  ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.1.0
@@ -9938,11 +9935,11 @@ snapshots:
       js-yaml: 4.1.1
       json5: 2.2.3
       lazy-val: 1.0.5
-      minimatch: 10.2.0
+      minimatch: 10.2.1
       plist: 3.1.0
       resedit: 1.7.2
       semver: 7.7.4
-      tar: 7.5.7
+      tar: 7.5.9
       temp-file: 3.4.0
       tiny-async-pool: 1.3.0
       which: 5.0.0
@@ -9985,7 +9982,7 @@ snapshots:
       proper-lockfile: 4.1.2
       resedit: 1.7.2
       semver: 7.7.4
-      tar: 7.5.7
+      tar: 7.5.9
       temp-file: 3.4.0
       tiny-async-pool: 1.3.0
       which: 5.0.0
@@ -10135,7 +10132,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.14.1
+      qs: 6.14.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -10345,7 +10342,7 @@ snapshots:
       minipass-pipeline: 1.2.4
       p-map: 7.0.4
       ssri: 12.0.0
-      tar: 7.5.7
+      tar: 7.5.9
       unique-filename: 4.0.0
 
   cacheable-lookup@5.0.4: {}
@@ -11423,7 +11420,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.14.1
+      qs: 6.14.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -13096,7 +13093,7 @@ snapshots:
       nopt: 8.1.0
       proc-log: 5.0.0
       semver: 7.7.3
-      tar: 7.5.7
+      tar: 7.5.9
       tinyglobby: 0.2.15
       which: 5.0.0
     transitivePeerDependencies:
@@ -13572,14 +13569,9 @@ snapshots:
 
   pure-rand@6.1.0: {}
 
-  qs@6.14.1:
-    dependencies:
-      side-channel: 1.1.0
-
   qs@6.14.2:
     dependencies:
       side-channel: 1.1.0
-    optional: true
 
   querystring-es3@0.2.1:
     optional: true
@@ -14413,7 +14405,7 @@ snapshots:
       formidable: 3.5.4
       methods: 1.1.2
       mime: 2.6.0
-      qs: 6.14.1
+      qs: 6.14.2
     transitivePeerDependencies:
       - supports-color
 
@@ -14469,7 +14461,7 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  tar@7.5.7:
+  tar@7.5.9:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0


### PR DESCRIPTION
## Summary
- update `pnpm.overrides` to force patched transitive versions for Dependabot alerts:
  - `tar` to `>=7.5.8`
  - `qs` to `>=6.14.2`
  - `@modelcontextprotocol/sdk>ajv` to `>=8.18.0`
- regenerate `pnpm-lock.yaml` so resolved versions move to:
  - `tar@7.5.9`
  - `qs@6.14.2`
  - `ajv@8.18.0`
- leave the `elliptic` alert open because there is currently no patched upstream release

## Validation
- `pnpm typecheck`
- pre-commit checks ran successfully (`biome`, typecheck, dependency-cruiser, knip)

## Notes
- this addresses the patchable Dependabot alerts (`tar`, `ajv`, `qs`) and intentionally does not attempt to force-replace `elliptic` without an upstream fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile/override-only dependency updates intended to address security advisories; minimal behavioral change risk aside from potential subtle differences in updated transitive packages.
> 
> **Overview**
> Updates `pnpm.overrides` to force patched transitive versions: `tar` to `>=7.5.8`, `qs` to `>=6.14.2`, and `@modelcontextprotocol/sdk>ajv` to `>=8.18.0`.
> 
> Regenerates `pnpm-lock.yaml` so the resolved dependency tree moves to patched versions (notably `tar@7.5.9`, `qs@6.14.2`, and `ajv@8.18.0`, plus related lockfile bumps).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f50cd2f4ca37b3a3da9f5fbae461c152d3493805. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->