### PR TITLE
Keep quick actions available while agent is running

### DIFF
--- a/src/client/routes/projects/workspaces/workspace-detail-header.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-header.tsx
@@ -703,7 +703,6 @@ function WorkspaceHeaderOverflowMenu({
   archivePending,
   onArchiveRequest,
   handleQuickAction,
-  running,
   isCreatingSession,
 }: {
   workspace: NonNullable<ReturnType<typeof useWorkspaceData>['workspace']>;
@@ -714,7 +713,6 @@ function WorkspaceHeaderOverflowMenu({
   archivePending: boolean;
   onArchiveRequest: () => void;
   handleQuickAction: ReturnType<typeof useSessionManagement>['handleQuickAction'];
-  running: boolean;
   isCreatingSession: boolean;
 }) {
   const [providerSettingsOpen, setProviderSettingsOpen] = useState(false);
@@ -764,7 +762,7 @@ function WorkspaceHeaderOverflowMenu({
           />
           <WorkspaceQuickActionsSubmenu
             handleQuickAction={handleQuickAction}
-            disabled={running || isCreatingSession}
+            disabled={isCreatingSession}
           />
           <DropdownMenuSeparator />
           <ArchiveActionButton
@@ -842,7 +840,6 @@ export function WorkspaceHeader({
               archivePending={archivePending}
               onArchiveRequest={onArchiveRequest}
               handleQuickAction={handleQuickAction}
-              running={running}
               isCreatingSession={isCreatingSession}
             />
           </>
@@ -857,7 +854,7 @@ export function WorkspaceHeader({
                   handleQuickAction(action.name, action.content);
                 }
               }}
-              disabled={running || isCreatingSession}
+              disabled={isCreatingSession}
             />
             <OpenInIdeAction
               workspaceId={workspaceId}


### PR DESCRIPTION
## Summary
- keep workspace quick actions available while an agent session is running
- continue disabling quick actions only while a new session is being created
- remove the now-unused `running` prop from `WorkspaceHeaderOverflowMenu`

## Testing
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI gating change limited to enabling/disabling quick actions; no backend, auth, or data-handling logic is affected.
> 
> **Overview**
> Quick actions in the workspace header are no longer disabled when an agent is *running*; they now remain available and are only disabled while a session is being created (`isCreatingSession`).
> 
> This removes the unused `running` prop from `WorkspaceHeaderOverflowMenu` and updates the disabled conditions for both the desktop `QuickActionsMenu` and the mobile overflow quick-actions submenu accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0ffed4745161582da744c310c0684c2858abfa0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->