### PR TITLE
Redirect archived active workspace back to project

### DIFF
--- a/src/client/routes/projects/workspaces/use-workspace-detail.ts
+++ b/src/client/routes/projects/workspaces/use-workspace-detail.ts
@@ -188,7 +188,7 @@ export function useSessionManagement({
 
   const archiveWorkspace = trpc.workspace.archive.useMutation({
     onSuccess: () => {
-      void navigate(`/projects/${slug}/workspaces`);
+      void navigate(`/projects/${slug}`, { replace: true });
     },
   });
 

--- a/src/client/routes/projects/workspaces/workspace-detail-container.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-container.tsx
@@ -116,6 +116,19 @@ export function WorkspaceDetailContainer() {
   const { workspace, workspaceLoading, sessions, initialDbSessionId, maxSessions } =
     useWorkspaceData({ workspaceId: workspaceId });
 
+  useEffect(() => {
+    if (workspace?.status !== 'ARCHIVED') {
+      return;
+    }
+
+    if (slug) {
+      void navigate(`/projects/${slug}`, { replace: true });
+      return;
+    }
+
+    void navigate('/projects', { replace: true });
+  }, [workspace?.status, slug, navigate]);
+
   const { rightPanelVisible, setRightPanelVisible, activeTabId, clearScrollState } =
     useWorkspacePanel();
   const { data: userSettings } = trpc.userSettings.get.useQuery();

--- a/src/frontend/components/app-sidebar.tsx
+++ b/src/frontend/components/app-sidebar.tsx
@@ -444,11 +444,19 @@ export function AppSidebar({ mockData }: { mockData?: AppSidebarMockData }) {
   const archiveWorkspace = trpc.workspace.archive.useMutation({
     onSuccess: (_data, variables) => {
       utils.workspace.getProjectSummaryState.invalidate({ projectId: selectedProjectId });
-      // If we archived the currently viewed workspace, navigate to the workspaces list
+      // If we archived the currently viewed workspace, leave the detail route.
       const currentId = pathname.match(/\/workspaces\/([^/]+)/)?.[1];
-      if (variables.id === currentId) {
-        void navigate(`/projects/${selectedProjectSlug}/workspaces`);
+      if (variables.id !== currentId) {
+        return;
       }
+
+      const projectSlug = getProjectSlugFromPath(pathname) ?? selectedProjectSlug;
+      if (projectSlug) {
+        void navigate(`/projects/${projectSlug}`, { replace: true });
+        return;
+      }
+
+      void navigate('/projects', { replace: true });
     },
     onError: (error, variables) => {
       cancelArchiving(variables.id);


### PR DESCRIPTION
## Summary
- redirect away from workspace detail when archiving from the workspace page, using `replace` navigation
- handle sidebar archive of the currently open workspace by routing back to the project page instead of leaving a stale detail view
- add a defensive redirect in workspace detail so any workspace that transitions to `ARCHIVED` exits the detail route immediately

## Testing
- pnpm typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side navigation-only changes around archiving; main risk is incorrect redirect targets or unexpected back-button behavior due to `replace`.
> 
> **Overview**
> Ensures the UI exits the workspace detail view immediately after a workspace is archived, avoiding stale detail routes.
> 
> Archiving from the workspace detail flow now navigates back to the project page using `navigate(..., { replace: true })`, and the sidebar archive action only redirects when the archived workspace is currently being viewed (falling back to `/projects` if no slug can be determined). A defensive `useEffect` in `WorkspaceDetailContainer` also auto-redirects if the loaded workspace transitions to `ARCHIVED`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d70905f99b486c19e1a3e87e747a47165ba4e914. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->