### PR TITLE
Fix false not-pushed indicators in workspace changes

### DIFF
--- a/src/backend/trpc/workspace/git.trpc.ts
+++ b/src/backend/trpc/workspace/git.trpc.ts
@@ -138,7 +138,9 @@ export const workspaceGitRouter = router({
       }
 
       const diffResult = await gitCommand(
-        ['diff', '--name-only', `${upstreamRef}..HEAD`],
+        // Use three-dot to capture only changes introduced by local commits
+        // since divergence from upstream (exclude remote-only changes).
+        ['diff', '--name-only', `${upstreamRef}...HEAD`],
         result.worktreePath
       );
       if (diffResult.code !== 0) {

--- a/src/components/workspace/change-panel-shared.tsx
+++ b/src/components/workspace/change-panel-shared.tsx
@@ -25,12 +25,14 @@ interface ChangeListProps {
   entries: ChangeListEntry[];
   onFileClick: (path: string) => void;
   className?: string;
+  indicatorLabel?: string;
 }
 
 export const ChangeList = memo(function ChangeList({
   entries,
   onFileClick,
   className = 'space-y-0.5',
+  indicatorLabel,
 }: ChangeListProps) {
   return (
     <div className={className}>
@@ -41,6 +43,7 @@ export const ChangeList = memo(function ChangeList({
           kind={entry.kind}
           statusCode={entry.statusCode}
           showIndicatorDot={entry.showIndicatorDot}
+          indicatorLabel={indicatorLabel}
           onClick={() => onFileClick(entry.path)}
         />
       ))}
@@ -82,6 +85,7 @@ interface VirtualizedChangeListProps {
   onFileClick: (path: string) => void;
   className?: string;
   contentClassName?: string;
+  indicatorLabel?: string;
 }
 
 export const VirtualizedChangeList = memo(function VirtualizedChangeList({
@@ -89,6 +93,7 @@ export const VirtualizedChangeList = memo(function VirtualizedChangeList({
   onFileClick,
   className,
   contentClassName,
+  indicatorLabel,
 }: VirtualizedChangeListProps) {
   const parentRef = useRef<HTMLDivElement>(null);
 
@@ -129,6 +134,7 @@ export const VirtualizedChangeList = memo(function VirtualizedChangeList({
                 kind={entry.kind}
                 statusCode={entry.statusCode}
                 showIndicatorDot={entry.showIndicatorDot}
+                indicatorLabel={indicatorLabel}
                 onClick={() => onFileClick(entry.path)}
               />
             </div>

--- a/src/components/workspace/combined-changes-panel.test.ts
+++ b/src/components/workspace/combined-changes-panel.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { buildCombinedEntries, getPartialDataWarning } from './combined-changes-panel';
+import {
+  buildCombinedEntries,
+  getIndicatorLabel,
+  getPartialDataWarning,
+} from './combined-changes-panel';
 
 describe('buildCombinedEntries', () => {
   it('does not mark main-relative files as not pushed when upstream is in sync', () => {
@@ -59,5 +63,15 @@ describe('getPartialDataWarning', () => {
     expect(warning).toBe(
       'Diff vs main and not-pushed detection unavailable; showing working tree changes only.'
     );
+  });
+});
+
+describe('getIndicatorLabel', () => {
+  it('returns staged-only label when no upstream is configured', () => {
+    expect(getIndicatorLabel(false)).toBe('Staged');
+  });
+
+  it('returns staged-or-unpushed label when upstream is configured', () => {
+    expect(getIndicatorLabel(true)).toBe('Staged or not pushed to remote');
   });
 });

--- a/src/components/workspace/combined-changes-panel.tsx
+++ b/src/components/workspace/combined-changes-panel.tsx
@@ -34,7 +34,7 @@ interface CombinedChangesPanelProps {
 interface CombinedChangesContentProps {
   entries: ChangeListEntry[];
   noMergeBase: boolean;
-  hasUpstream: boolean;
+  indicatorLabel: string;
   partialDataWarning?: string;
   onFileClick: (path: string) => void;
 }
@@ -96,14 +96,18 @@ function NoMergeBaseState() {
   );
 }
 
+export function getIndicatorLabel(hasUpstream: boolean): string {
+  return hasUpstream ? 'Staged or not pushed to remote' : 'Staged';
+}
+
 function ChangesDecorators({
   noMergeBase,
-  hasUpstream,
+  indicatorLabel,
   hasIndicatorEntries,
   partialDataWarning,
 }: {
   noMergeBase: boolean;
-  hasUpstream: boolean;
+  indicatorLabel: string;
   hasIndicatorEntries: boolean;
   partialDataWarning?: string;
 }) {
@@ -128,7 +132,7 @@ function ChangesDecorators({
       {hasIndicatorEntries && (
         <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
           <span className="h-1.5 w-1.5 rounded-full bg-sky-500 shrink-0" />
-          <span>{hasUpstream ? 'Staged or not pushed to remote' : 'Staged'}</span>
+          <span>{indicatorLabel}</span>
         </div>
       )}
     </div>
@@ -175,7 +179,7 @@ export function buildCombinedEntries(
 function CombinedChangesContent({
   entries,
   noMergeBase,
-  hasUpstream,
+  indicatorLabel,
   partialDataWarning,
   onFileClick,
 }: CombinedChangesContentProps) {
@@ -195,7 +199,7 @@ function CombinedChangesContent({
   const decorators = (
     <ChangesDecorators
       noMergeBase={noMergeBase}
-      hasUpstream={hasUpstream}
+      indicatorLabel={indicatorLabel}
       hasIndicatorEntries={hasIndicatorEntries}
       partialDataWarning={partialDataWarning}
     />
@@ -207,7 +211,12 @@ function CombinedChangesContent({
         {(noMergeBase || hasIndicatorEntries || partialDataWarning) && (
           <div className="p-2 border-b">{decorators}</div>
         )}
-        <VirtualizedChangeList entries={entries} onFileClick={onFileClick} className="flex-1" />
+        <VirtualizedChangeList
+          entries={entries}
+          onFileClick={onFileClick}
+          className="flex-1"
+          indicatorLabel={indicatorLabel}
+        />
       </div>
     );
   }
@@ -216,7 +225,7 @@ function CombinedChangesContent({
     <ScrollArea className="h-full">
       <div className="p-2 space-y-2">
         {decorators}
-        <ChangeList entries={entries} onFileClick={onFileClick} />
+        <ChangeList entries={entries} onFileClick={onFileClick} indicatorLabel={indicatorLabel} />
       </div>
     </ScrollArea>
   );
@@ -266,6 +275,7 @@ export function CombinedChangesPanel({ workspaceId }: CombinedChangesPanelProps)
   const gitFiles: GitStatusFile[] = gitError ? [] : (gitData?.files ?? []);
   const snapshot = getDiffSnapshot(diffData, diffError);
   const partialDataWarning = getPartialDataWarning({ gitError, diffError, unpushedError });
+  const indicatorLabel = getIndicatorLabel(unpushedData?.hasUpstream ?? false);
   const unpushedFiles = new Set(unpushedError ? [] : (unpushedData?.files ?? []));
   const entries = buildCombinedEntries(
     gitFiles,
@@ -277,7 +287,7 @@ export function CombinedChangesPanel({ workspaceId }: CombinedChangesPanelProps)
     <CombinedChangesContent
       entries={entries}
       noMergeBase={snapshot.noMergeBase}
-      hasUpstream={unpushedData?.hasUpstream ?? false}
+      indicatorLabel={indicatorLabel}
       partialDataWarning={partialDataWarning}
       onFileClick={openDiffTab}
     />

--- a/src/components/workspace/file-change-item.tsx
+++ b/src/components/workspace/file-change-item.tsx
@@ -75,6 +75,7 @@ interface FileChangeItemProps {
   onClick: () => void;
   statusCode?: string;
   showIndicatorDot?: boolean;
+  indicatorLabel?: string;
 }
 
 export const FileChangeItem = memo(function FileChangeItem({
@@ -83,6 +84,7 @@ export const FileChangeItem = memo(function FileChangeItem({
   onClick,
   statusCode,
   showIndicatorDot = false,
+  indicatorLabel = 'Staged or not pushed to remote',
 }: FileChangeItemProps) {
   const statusColor = getStatusColorClass(kind);
   const fileName = path.split('/').pop() ?? path;
@@ -97,7 +99,7 @@ export const FileChangeItem = memo(function FileChangeItem({
         'hover:bg-muted/50 rounded-md transition-colors',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
       )}
-      title={`${getStatusLabel(kind)}: ${path}${showIndicatorDot ? ' (staged or not pushed to remote)' : ''}`}
+      title={`${getStatusLabel(kind)}: ${path}${showIndicatorDot ? ` (${indicatorLabel})` : ''}`}
     >
       <span className={statusColor}>{getStatusIcon(kind)}</span>
       <span className="flex-1 truncate">
@@ -105,10 +107,7 @@ export const FileChangeItem = memo(function FileChangeItem({
         {dirPath && <span className="text-muted-foreground ml-1 text-xs">{dirPath}</span>}
       </span>
       {showIndicatorDot && (
-        <span
-          className="h-1.5 w-1.5 rounded-full bg-sky-500 shrink-0"
-          title="Staged or not pushed to remote"
-        />
+        <span className="h-1.5 w-1.5 rounded-full bg-sky-500 shrink-0" title={indicatorLabel} />
       )}
       {statusCode && (
         <span className={cn('text-xs font-mono uppercase', statusColor)}>{statusCode}</span>


### PR DESCRIPTION
## Summary
- add `workspace.getUnpushedFiles` to compute file paths in commits that exist on `HEAD` but not on the branch upstream (`@{upstream}..HEAD`)
- update `CombinedChangesPanel` to drive the blue indicator dot from `staged || unpushed`, instead of using `diff vs main` as a proxy for push state
- make indicator copy explicit (`Staged or not pushed to remote`) and fall back to `Staged` when no upstream is configured
- add regression tests for `buildCombinedEntries` to verify that main-relative-only files are not marked as unpushed

## Root Cause
The indicator logic treated any file present in `diff vs main` as "not pushed". That is incorrect when a branch is fully pushed to its upstream but intentionally diverges from `main`.

## Validation
- `pnpm exec biome check src/components/workspace/combined-changes-panel.tsx src/components/workspace/combined-changes-panel.test.ts src/components/workspace/file-change-item.tsx src/backend/trpc/workspace/git.trpc.ts`
- `pnpm typecheck`
- `pnpm test -- src/components/workspace/combined-changes-panel.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches both backend git command execution and UI logic for change aggregation, so incorrect upstream detection or error handling could mislabel changes or degrade the panel experience.
> 
> **Overview**
> Fixes false “not pushed” blue-dot indicators in the workspace changes panel by basing them on actual divergence from the branch’s upstream, rather than `diff vs main`.
> 
> Adds a new TRPC endpoint `workspace.getUnpushedFiles` that resolves `@{upstream}` and returns `git diff --name-only upstream...HEAD` results (with a safe fallback when no upstream is configured). Updates `CombinedChangesPanel` to combine git status, diff-vs-main, and unpushed-file data, including clearer indicator copy (`Staged` vs `Staged or not pushed to remote`) and improved partial-data warnings; `FileChangeItem`/change lists now accept a configurable indicator tooltip/label. Adds unit tests for `buildCombinedEntries`, `getPartialDataWarning`, and `getIndicatorLabel` to prevent regressions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5202e9be03867dba4b1eff40ad324f363e27a46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->