### PR TITLE
Fix #1102: Remove navigation from sidebar logo click

### DIFF
--- a/src/frontend/components/hamburger-menu.tsx
+++ b/src/frontend/components/hamburger-menu.tsx
@@ -39,9 +39,7 @@ function MenuContent({ navData, onClose }: HamburgerMenuProps & { onClose: () =>
     <div className="flex flex-col h-full gap-1">
       {/* Logo + Project Selector */}
       <div className="px-2 py-1">
-        <Link to="/projects" onClick={onClose}>
-          <LogoText className="text-xl" />
-        </Link>
+        <LogoText className="text-xl" />
         <div className="mt-1">
           <ProjectSelectorDropdown
             selectedProjectSlug={navData.selectedProjectSlug}


### PR DESCRIPTION
## Summary
- Remove the navigation link from the Factory Factory logo in the sidebar hamburger menu
- Previously, clicking the logo navigated to `/projects`; now it's non-interactive

## Changes
- **`src/frontend/components/hamburger-menu.tsx`**: Replaced `<Link to="/projects">` wrapper around `<LogoText>` with just `<LogoText>` directly, removing the click-to-navigate behavior

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Lint passes (`pnpm check:fix`)
- [x] Manual testing: Open hamburger menu, click the Factory Factory logo — no navigation occurs

Closes #1102

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
