### PR TITLE
Move New Workspace button into Kanban Issues column and rename labels

### DIFF
--- a/src/client/routes/projects/workspaces/components/workspaces-board-view.tsx
+++ b/src/client/routes/projects/workspaces/components/workspaces-board-view.tsx
@@ -1,20 +1,12 @@
 import { HeaderRightSlot, useAppHeader } from '@/frontend/components/app-header-context';
 import { KanbanBoard, KanbanControls, KanbanProvider } from '@/frontend/components/kanban';
-import { NewWorkspaceButton } from './new-workspace-button';
 
-function BoardHeaderSlot({
-  onCreateWorkspace,
-  isCreatingWorkspace,
-}: {
-  onCreateWorkspace: () => void;
-  isCreatingWorkspace: boolean;
-}) {
+function BoardHeaderSlot() {
   useAppHeader({ title: 'Workspaces Board' });
 
   return (
     <HeaderRightSlot>
       <KanbanControls />
-      <NewWorkspaceButton onClick={onCreateWorkspace} isCreating={isCreatingWorkspace} />
     </HeaderRightSlot>
   );
 }
@@ -33,11 +25,14 @@ export function WorkspacesBoardView({
   isCreatingWorkspace: boolean;
 }) {
   return (
-    <KanbanProvider projectId={projectId} projectSlug={slug} issueProvider={issueProvider}>
-      <BoardHeaderSlot
-        onCreateWorkspace={onCreateWorkspace}
-        isCreatingWorkspace={isCreatingWorkspace}
-      />
+    <KanbanProvider
+      projectId={projectId}
+      projectSlug={slug}
+      issueProvider={issueProvider}
+      onCreateWorkspace={onCreateWorkspace}
+      isCreatingWorkspace={isCreatingWorkspace}
+    >
+      <BoardHeaderSlot />
       <div className="flex flex-col h-full p-3 md:p-6 gap-3 md:gap-4">
         <div className="flex-1 min-h-0">
           <KanbanBoard />

--- a/src/frontend/components/kanban/kanban-board.tsx
+++ b/src/frontend/components/kanban/kanban-board.tsx
@@ -1,4 +1,4 @@
-import { RefreshCw } from 'lucide-react';
+import { Loader2, Plus, RefreshCw } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -50,6 +50,8 @@ export function KanbanBoard() {
     togglingWorkspaceId,
     archiveWorkspace,
     archivingWorkspaceId,
+    onCreateWorkspace,
+    isCreatingWorkspace,
   } = useKanban();
 
   const isMobile = useIsMobile();
@@ -172,7 +174,13 @@ export function KanbanBoard() {
         {/* Active column content */}
         <div className="flex-1 min-h-0 overflow-y-auto">
           {activeColumn.id === 'ISSUES' ? (
-            <IssuesColumn column={activeColumn} issues={issues ?? []} projectId={projectId} />
+            <IssuesColumn
+              column={activeColumn}
+              issues={issues ?? []}
+              projectId={projectId}
+              onCreateWorkspace={onCreateWorkspace}
+              isCreatingWorkspace={isCreatingWorkspace}
+            />
           ) : (
             <KanbanColumn
               column={activeColumn}
@@ -200,6 +208,8 @@ export function KanbanBoard() {
               column={column}
               issues={issues ?? []}
               projectId={projectId}
+              onCreateWorkspace={onCreateWorkspace}
+              isCreatingWorkspace={isCreatingWorkspace}
             />
           );
         }
@@ -228,9 +238,17 @@ interface IssuesColumnProps {
   column: ColumnConfig;
   issues: KanbanIssue[];
   projectId: string;
+  onCreateWorkspace?: () => void;
+  isCreatingWorkspace?: boolean;
 }
 
-function IssuesColumn({ column, issues, projectId }: IssuesColumnProps) {
+function IssuesColumn({
+  column,
+  issues,
+  projectId,
+  onCreateWorkspace,
+  isCreatingWorkspace,
+}: IssuesColumnProps) {
   const isEmpty = issues.length === 0;
   const [selectedIssue, setSelectedIssue] = useState<KanbanIssue | null>(null);
   const [isSheetOpen, setIsSheetOpen] = useState(false);
@@ -263,6 +281,21 @@ function IssuesColumn({ column, issues, projectId }: IssuesColumnProps) {
 
         {/* Column Content */}
         <div className="flex flex-col gap-3 flex-1 overflow-y-auto p-3 min-h-0 rounded-lg md:rounded-t-none bg-muted/30">
+          {onCreateWorkspace && (
+            <button
+              type="button"
+              onClick={onCreateWorkspace}
+              disabled={isCreatingWorkspace}
+              className="shrink-0 flex items-center gap-2 rounded-lg border border-dashed border-white/40 px-3 py-5 text-sm text-white hover:border-white/70 transition-colors disabled:opacity-50 cursor-pointer"
+            >
+              {isCreatingWorkspace ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Plus className="h-4 w-4" />
+              )}
+              New Workspace
+            </button>
+          )}
           {isEmpty ? (
             <div className="flex items-center justify-center h-[60px] md:h-[150px] text-muted-foreground text-sm">
               {column.description}

--- a/src/frontend/components/kanban/kanban-column.tsx
+++ b/src/frontend/components/kanban/kanban-column.tsx
@@ -12,7 +12,7 @@ export interface ColumnConfig {
 }
 
 export const KANBAN_COLUMNS: ColumnConfig[] = [
-  { id: 'ISSUES', label: 'GitHub Issues', description: 'Issues assigned to you' },
+  { id: 'ISSUES', label: 'Todo · GitHub', description: 'Issues assigned to you' },
   { id: 'WORKING', label: 'Working', description: 'Agent is working' },
   { id: 'WAITING', label: 'Waiting', description: 'Waiting for input' },
   { id: 'DONE', label: 'Done', description: 'PR merged' },
@@ -22,7 +22,7 @@ export function getKanbanColumns(issueProvider: string): ColumnConfig[] {
   return [
     {
       id: 'ISSUES',
-      label: issueProvider === 'LINEAR' ? 'Linear Issues' : 'GitHub Issues',
+      label: issueProvider === 'LINEAR' ? 'Todo · Linear' : 'Todo · GitHub',
       description: 'Issues assigned to you',
     },
     { id: 'WORKING', label: 'Working', description: 'Agent is working' },

--- a/src/frontend/components/kanban/kanban-context.tsx
+++ b/src/frontend/components/kanban/kanban-context.tsx
@@ -85,6 +85,8 @@ interface KanbanContextValue {
   togglingWorkspaceId: string | null;
   archiveWorkspace: (workspaceId: string, commitUncommitted: boolean) => Promise<void>;
   archivingWorkspaceId: string | null;
+  onCreateWorkspace?: () => void;
+  isCreatingWorkspace?: boolean;
 }
 
 const KanbanContext = createContext<KanbanContextValue | null>(null);
@@ -101,6 +103,8 @@ interface KanbanProviderProps {
   projectId: string;
   projectSlug: string;
   issueProvider: string;
+  onCreateWorkspace?: () => void;
+  isCreatingWorkspace?: boolean;
   children: ReactNode;
 }
 
@@ -108,6 +112,8 @@ export function KanbanProvider({
   projectId,
   projectSlug,
   issueProvider,
+  onCreateWorkspace,
+  isCreatingWorkspace,
   children,
 }: KanbanProviderProps) {
   const utils = trpc.useUtils();
@@ -241,6 +247,8 @@ export function KanbanProvider({
         togglingWorkspaceId,
         archiveWorkspace,
         archivingWorkspaceId,
+        onCreateWorkspace,
+        isCreatingWorkspace,
       }}
     >
       {children}


### PR DESCRIPTION
## Summary

- Rename Kanban "GitHub Issues" / "Linear Issues" column headers to "Todo · GitHub" / "Todo · Linear" for clearer intent
- Add a dashed "New Workspace" button at the top of the Issues (Todo) column so users can create workspaces directly from the board
- Thread `onCreateWorkspace` / `isCreatingWorkspace` through `KanbanContext` instead of the header slot, removing the button from the top-right controls

## Test plan

- [ ] Verify the Issues column header reads "Todo · GitHub" (or "Todo · Linear" for Linear projects)
- [ ] Click the "New Workspace" button in the Issues column and confirm a workspace is created
- [ ] Verify the button shows a loading spinner while creating
- [ ] Check mobile view: the button appears in the active column when Issues/Todo is selected
- [ ] Confirm the top-right header area no longer shows the "New Workspace" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)
