### PR TITLE
Fix mobile chat reconnect getting stuck on Connecting

### DIFF
--- a/src/hooks/use-websocket-transport.ts
+++ b/src/hooks/use-websocket-transport.ts
@@ -222,8 +222,11 @@ export function useWebSocketTransport(
       return;
     }
 
-    // If already connected, no recovery needed.
-    if (wsRef.current?.readyState === WebSocket.OPEN) {
+    // If already connected or connecting, no recovery needed.
+    if (
+      wsRef.current?.readyState === WebSocket.OPEN ||
+      wsRef.current?.readyState === WebSocket.CONNECTING
+    ) {
       return;
     }
 
@@ -274,8 +277,10 @@ export function useWebSocketTransport(
         recoverConnection();
       }
     };
-    const handlePageShow = () => {
-      recoverConnection();
+    const handlePageShow = (event: PageTransitionEvent) => {
+      if (event.persisted) {
+        recoverConnection();
+      }
     };
     const handleOnline = () => {
       recoverConnection();


### PR DESCRIPTION
## Summary
- recover chat websocket connections when the app returns from background/sleep on mobile
- add lifecycle-triggered reconnect recovery on `visibilitychange`, `pageshow`, and `online`
- reset reconnect attempt budget for lifecycle recovery without dropping queued outbound messages
- add transport tests covering lifecycle recovery after max retries and offline guard behavior

## Problem
On mobile, when the browser tab was backgrounded long enough to exhaust reconnect attempts, returning to the app could leave chat in a perpetual "Connecting..." state.

## Validation
- `pnpm exec biome check src/hooks/use-websocket-transport.ts src/hooks/use-websocket-transport.test.ts`
- `pnpm exec vitest run src/hooks/use-websocket-transport.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts WebSocket reconnection behavior by resetting retry state and reconnecting on browser lifecycle/network events, which could change connection churn and retry semantics in production.
> 
> **Overview**
> Prevents the chat WebSocket from getting stuck after mobile background/sleep by adding a `recoverConnection` path that resets the reconnect budget and forces a reconnect when the tab returns to the foreground or the network comes back.
> 
> Adds listeners for `visibilitychange`, `pageshow` (bfcache restores only), and `online`, with guards to avoid reconnecting while offline or when the socket is already `OPEN`/`CONNECTING`, and extends transport tests to cover these lifecycle-recovery cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a64008ca023c8683aa759f82559132ce107acef6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->