### PR TITLE
Fix mobile menu closing for active workspace selection

### DIFF
--- a/src/frontend/components/hamburger-menu.test.tsx
+++ b/src/frontend/components/hamburger-menu.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+
+import type { ComponentProps } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot, type Root } from 'react-dom/client';
+import { MemoryRouter } from 'react-router';
+import { afterEach, describe, expect, it } from 'vitest';
+import { HamburgerMenu } from './hamburger-menu';
+
+Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
+  configurable: true,
+  writable: true,
+  value: true,
+});
+
+type NavigationData = ComponentProps<typeof HamburgerMenu>['navData'];
+
+function renderInDom(render: (root: Root) => void): () => void {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  render(root);
+  return () => {
+    root.unmount();
+    container.remove();
+  };
+}
+
+function createNavData(): NavigationData {
+  return {
+    projects: [{ id: 'project-1', slug: 'demo', name: 'Demo Project' }],
+    selectedProjectSlug: 'demo',
+    selectedProjectId: 'project-1',
+    serverWorkspaces: [
+      {
+        id: 'workspace-1',
+        name: 'Workspace One',
+        cachedKanbanColumn: 'WORKING',
+        isWorking: true,
+        pendingRequestType: null,
+      },
+      {
+        id: 'workspace-2',
+        name: 'Workspace Two',
+        cachedKanbanColumn: 'WAITING',
+        isWorking: false,
+        pendingRequestType: null,
+      },
+    ],
+    reviewCount: 0,
+    handleProjectChange: () => undefined,
+    needsAttention: () => false,
+    clearAttention: () => undefined,
+    currentWorkspaceId: 'workspace-1',
+  } as unknown as NavigationData;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('HamburgerMenu', () => {
+  it('closes when clicking the active workspace link', () => {
+    const cleanup = renderInDom((root) => {
+      flushSync(() => {
+        root.render(
+          <MemoryRouter initialEntries={['/projects/demo/workspaces/workspace-1']}>
+            <HamburgerMenu navData={createNavData()} />
+          </MemoryRouter>
+        );
+      });
+    });
+
+    const openButton = document.querySelector('button[aria-label="Menu"]');
+    expect(openButton).not.toBeNull();
+    flushSync(() => {
+      openButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(document.querySelector('[role="dialog"]')).not.toBeNull();
+
+    const activeWorkspaceLink = document.querySelector(
+      'a[href="/projects/demo/workspaces/workspace-1"]'
+    );
+    expect(activeWorkspaceLink).not.toBeNull();
+    flushSync(() => {
+      activeWorkspaceLink?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+    cleanup();
+  });
+});

--- a/src/frontend/components/hamburger-menu.tsx
+++ b/src/frontend/components/hamburger-menu.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import {
   Sheet,
+  SheetClose,
   SheetContent,
   SheetDescription,
   SheetHeader,
@@ -62,19 +63,19 @@ function MenuContent({ navData, onClose }: HamburgerMenuProps & { onClose: () =>
           </p>
           <div className="flex flex-col gap-0.5">
             {activeWorkspaces.map((workspace) => (
-              <Link
-                key={workspace.id}
-                to={`/projects/${navData.selectedProjectSlug}/workspaces/${workspace.id}`}
-                onClick={onClose}
-                className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors"
-                data-active={workspace.id === navData.currentWorkspaceId || undefined}
-              >
-                <WorkspaceStatusIcon
-                  pendingRequestType={workspace.pendingRequestType}
-                  isWorking={workspace.isWorking}
-                />
-                <span className="truncate">{workspace.name}</span>
-              </Link>
+              <SheetClose key={workspace.id} asChild>
+                <Link
+                  to={`/projects/${navData.selectedProjectSlug}/workspaces/${workspace.id}`}
+                  className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors"
+                  data-active={workspace.id === navData.currentWorkspaceId || undefined}
+                >
+                  <WorkspaceStatusIcon
+                    pendingRequestType={workspace.pendingRequestType}
+                    isWorking={workspace.isWorking}
+                  />
+                  <span className="truncate">{workspace.name}</span>
+                </Link>
+              </SheetClose>
             ))}
           </div>
         </div>
@@ -84,51 +85,54 @@ function MenuContent({ navData, onClose }: HamburgerMenuProps & { onClose: () =>
       <div className="mt-auto flex flex-col gap-1">
         <Separator />
         <div className="flex flex-col gap-0.5">
-          <Link
-            to={`/projects/${navData.selectedProjectSlug}/workspaces`}
-            onClick={onClose}
-            className={`flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors ${
-              pathname?.startsWith(`/projects/${navData.selectedProjectSlug}/workspaces`)
-                ? 'bg-accent'
-                : 'hover:bg-accent'
-            }`}
-          >
-            <Kanban className="h-4 w-4" />
-            <span>Workspaces Board</span>
-          </Link>
-          <Link
-            to="/reviews"
-            onClick={onClose}
-            className={`flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors ${
-              pathname === '/reviews' || pathname?.startsWith('/reviews/')
-                ? 'bg-accent'
-                : 'hover:bg-accent'
-            }`}
-          >
-            <GitPullRequest className="h-4 w-4" />
-            <span>Reviews</span>
-            {navData.reviewCount > 0 && (
-              <Badge
-                variant="secondary"
-                className="ml-auto h-5 min-w-5 px-1.5 text-xs bg-orange-500/20 text-orange-600 border-orange-500/30"
-              >
-                {navData.reviewCount}
-              </Badge>
-            )}
-          </Link>
-          <div className="flex items-center gap-1">
+          <SheetClose asChild>
             <Link
-              to="/admin"
-              onClick={onClose}
-              className={`flex flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors ${
-                pathname === '/admin' || pathname?.startsWith('/admin/')
+              to={`/projects/${navData.selectedProjectSlug}/workspaces`}
+              className={`flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors ${
+                pathname?.startsWith(`/projects/${navData.selectedProjectSlug}/workspaces`)
                   ? 'bg-accent'
                   : 'hover:bg-accent'
               }`}
             >
-              <Settings className="h-4 w-4" />
-              <span>Admin</span>
+              <Kanban className="h-4 w-4" />
+              <span>Workspaces Board</span>
             </Link>
+          </SheetClose>
+          <SheetClose asChild>
+            <Link
+              to="/reviews"
+              className={`flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors ${
+                pathname === '/reviews' || pathname?.startsWith('/reviews/')
+                  ? 'bg-accent'
+                  : 'hover:bg-accent'
+              }`}
+            >
+              <GitPullRequest className="h-4 w-4" />
+              <span>Reviews</span>
+              {navData.reviewCount > 0 && (
+                <Badge
+                  variant="secondary"
+                  className="ml-auto h-5 min-w-5 px-1.5 text-xs bg-orange-500/20 text-orange-600 border-orange-500/30"
+                >
+                  {navData.reviewCount}
+                </Badge>
+              )}
+            </Link>
+          </SheetClose>
+          <div className="flex items-center gap-1">
+            <SheetClose asChild>
+              <Link
+                to="/admin"
+                className={`flex flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors ${
+                  pathname === '/admin' || pathname?.startsWith('/admin/')
+                    ? 'bg-accent'
+                    : 'hover:bg-accent'
+                }`}
+              >
+                <Settings className="h-4 w-4" />
+                <span>Admin</span>
+              </Link>
+            </SheetClose>
             <ThemeToggle />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- fix the mobile hamburger menu so tapping an already-active workspace still closes the sheet
- wrap workspace and bottom navigation links with `SheetClose` so close behavior does not depend on a route change
- add a regression test for the active-workspace case in the hamburger menu

## Testing
- `pnpm exec vitest run src/frontend/components/hamburger-menu.test.tsx`
- pre-commit hooks passed (Biome, typecheck, dependency-cruiser, knip)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI behavior change limited to hamburger menu link interactions, plus a focused regression test; minimal impact outside the sheet close behavior.
> 
> **Overview**
> Fixes a mobile navigation bug where tapping the *already-active* workspace link would not close the hamburger `Sheet`.
> 
> Workspace links and bottom nav links are now wrapped in `SheetClose` so the sheet closes on click even when no route change occurs, and a new Vitest/JSDOM regression test asserts the dialog closes when clicking the active workspace link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1a96bb58b24378ff39896cd9d68a2546b1c4f72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->