### PR TITLE
Rename Admin to Admin Dashboard and add back-navigation

### DIFF
--- a/src/client/routes/admin-page.tsx
+++ b/src/client/routes/admin-page.tsx
@@ -1,4 +1,5 @@
 import {
+  ArrowLeft,
   CheckCircle2,
   Download,
   ExternalLink,
@@ -28,9 +29,8 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Switch } from '@/components/ui/switch';
 import { RatchetWrenchIcon } from '@/components/workspace';
 import { DevServerSetupPanel } from '@/components/workspace/dev-server-setup-panel';
-import { useAppHeader } from '@/frontend/components/app-header-context';
+import { HeaderLeftExtraSlot, useAppHeader } from '@/frontend/components/app-header-context';
 import { Loading } from '@/frontend/components/loading';
-import { PageHeader } from '@/frontend/components/page-header';
 import { ProviderCliWarning } from '@/frontend/components/provider-cli-warning';
 import { useDownloadServerLog } from '@/frontend/hooks/use-download-server-log';
 import { downloadFile } from '@/frontend/lib/download-file';
@@ -732,7 +732,7 @@ function ServerLogsSection() {
 }
 
 export default function AdminDashboardPage() {
-  useAppHeader({ title: 'Admin' });
+  useAppHeader({ title: 'Admin Dashboard' });
 
   const {
     data: stats,
@@ -758,6 +758,8 @@ export default function AdminDashboardPage() {
     },
   });
 
+  const projectSlug = projects?.[0]?.slug;
+
   // Show full loading only when stats are loading (first load)
   if (isLoadingStats) {
     return <Loading message="Loading admin dashboard..." />;
@@ -765,9 +767,18 @@ export default function AdminDashboardPage() {
 
   return (
     <div className="h-full overflow-y-auto">
+      {projectSlug && (
+        <HeaderLeftExtraSlot>
+          <Button variant="ghost" size="sm" className="shrink-0 text-muted-foreground" asChild>
+            <Link to={`/projects/${projectSlug}/workspaces`}>
+              <ArrowLeft className="h-3.5 w-3.5" />
+              <span className="hidden sm:inline">Back to Workspaces Board</span>
+              <span className="sm:hidden">Board</span>
+            </Link>
+          </Button>
+        </HeaderLeftExtraSlot>
+      )}
       <div className="space-y-6 p-3 md:p-6">
-        <PageHeader title="Admin Dashboard" description="System monitoring and management" />
-
         <ApiUsageSection
           apiUsage={stats?.apiUsage}
           onReset={() => resetApiStats.mutate()}

--- a/src/client/routes/logs.tsx
+++ b/src/client/routes/logs.tsx
@@ -269,7 +269,7 @@ export default function LogsPage() {
           <Link to="/admin">
             <Button variant="ghost" size="sm">
               <ArrowLeft className="w-4 h-4 mr-1" />
-              Admin
+              Admin Dashboard
             </Button>
           </Link>
         </PageHeader>

--- a/src/frontend/components/hamburger-menu.tsx
+++ b/src/frontend/components/hamburger-menu.tsx
@@ -130,7 +130,7 @@ function MenuContent({ navData, onClose }: HamburgerMenuProps & { onClose: () =>
                 }`}
               >
                 <Settings className="h-4 w-4" />
-                <span>Admin</span>
+                <span>Admin Dashboard</span>
               </Link>
             </SheetClose>
             <ThemeToggle />


### PR DESCRIPTION
## Summary
- Rename "Admin" to "Admin Dashboard" across the app header, hamburger menu, and logs page back-button
- Replace the inline `PageHeader` on the Admin page with a "Back to Workspaces Board" navigation button using `HeaderLeftExtraSlot`
- Consistent labeling makes the admin section easier to identify; the back-navigation button improves discoverability of the Workspaces Board from the admin page

## Test plan
- [ ] Navigate to Admin Dashboard and verify the header says "Admin Dashboard"
- [ ] Verify the "Back to Workspaces Board" button appears and links to the correct project workspaces page
- [ ] Open the hamburger menu and confirm it shows "Admin Dashboard"
- [ ] Navigate to the Logs page and confirm the back button says "Admin Dashboard"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
