### PR TITLE
Make mobile app header use single row when space allows

### DIFF
--- a/src/frontend/components/app-header.tsx
+++ b/src/frontend/components/app-header.tsx
@@ -7,11 +7,13 @@ export function AppHeader() {
   const navData = useAppNavigationData();
 
   return (
-    <header className="flex shrink-0 items-center gap-2 border-b bg-background px-2 h-12 pt-[env(safe-area-inset-top)]">
+    <header className="flex shrink-0 flex-wrap items-center gap-x-2 gap-y-1 border-b bg-background px-2 min-h-12 pt-[env(safe-area-inset-top)]">
       <HamburgerMenu navData={navData} />
-      <span className="text-sm font-semibold truncate">{title}</span>
-      <div ref={setLeftExtraSlot} className="flex items-center gap-1" />
-      <div ref={setRightSlot} className="ml-auto flex items-center gap-1 shrink-0" />
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        <span className="min-w-0 flex-1 truncate text-sm font-semibold">{title}</span>
+        <div ref={setLeftExtraSlot} className="flex shrink-0 items-center gap-1" />
+      </div>
+      <div ref={setRightSlot} className="ml-auto flex shrink-0 items-center gap-1" />
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- update the shared app header layout to use wrapping flex behavior instead of a fixed single-row height
- keep title and left-slot content in a flexible container so they can shrink/truncate correctly
- keep right-side actions right-aligned while allowing them to move to a second line only when horizontal space is constrained

## Why
On mobile, the workspace branch/title and action controls were consistently split across two rows. With this change, they now stay on one row when space allows and only wrap when needed.

## Validation
- pnpm typecheck
- pnpm test src/frontend/components/hamburger-menu.test.tsx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized CSS/layout change to the header; risk is limited to potential visual regressions in responsive breakpoints.
> 
> **Overview**
> Adjusts `AppHeader` layout from a fixed-height single-row header to a `flex-wrap` container with `min-h-12` so content can flow to a second line only under horizontal constraint.
> 
> Groups the title and left-extra slot into a `min-w-0` flex container to ensure proper shrinking/truncation, while keeping the right-side slot right-aligned and non-shrinking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6880cf4f45373a67b62c532e9313798a499baaec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->