### PR TITLE
Fix Docker image crash from Prisma 7.x .ts imports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,14 @@ COPY . .
 ENV NODE_ENV=production
 RUN pnpm build
 
+# Prisma 7.x generates .ts imports in client.js (e.g. "./internal/class.ts").
+# TypeScript with moduleResolution:"bundler" doesn't rewrite these to .js,
+# so Node.js can't resolve them. Copy the raw .ts source files into dist/
+# alongside the compiled .js so the imports resolve at runtime.
+RUN cp -r prisma/generated/*.ts dist/prisma/generated/ \
+ && cp -r prisma/generated/internal/*.ts dist/prisma/generated/internal/ \
+ && cp -r prisma/generated/models/*.ts dist/prisma/generated/models/
+
 # ============================================================================
 # Stage 3: Production runner
 # ============================================================================


### PR DESCRIPTION
## Summary
- Fix Docker image crash caused by Prisma 7.x generating `.ts` import extensions in `client.js`
- TypeScript with `moduleResolution: "bundler"` doesn't rewrite `.ts` → `.js`, so Node.js can't resolve the imports at runtime
- Copy raw `.ts` source files into `dist/prisma/generated/` after build so the imports resolve

## Test plan
- [x] Built Docker image locally with fix
- [x] Container starts without crash (`docker logs factoryfactory` shows healthy startup)
- [x] Health endpoint responds: `curl http://localhost:3001/health` returns `{"status":"ok"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
