### PR TITLE
Fix chat scroll-to-bottom spacing on wider screens

### DIFF
--- a/src/client/routes/projects/workspaces/workspace-detail-chat-content.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-chat-content.tsx
@@ -248,7 +248,7 @@ export const ChatContent = memo(function ChatContent(props: ChatContentProps) {
       </div>
 
       {!props.isNearBottom && (
-        <div className="absolute bottom-32 left-1/2 z-10 -translate-x-1/2 sm:bottom-28">
+        <div className="absolute bottom-32 left-1/2 z-10 -translate-x-1/2">
           <Button
             variant="secondary"
             size="sm"


### PR DESCRIPTION
## Summary
- remove the responsive `sm:bottom-28` override for the chat "Scroll to bottom" button
- keep a consistent `bottom-32` offset across breakpoints in `workspace-detail-chat-content.tsx`
- prevent the button from touching the chat input on wider displays while preserving the preferred floating gap

## Testing
- not run (Tailwind class-only UI spacing change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Tailwind class-only UI spacing change that only affects positioning of the chat "Scroll to bottom" button.
> 
> **Overview**
> Adjusts the chat "Scroll to bottom" floating button positioning by removing the `sm:bottom-28` responsive override, keeping a consistent `bottom-32` offset across screen sizes to avoid the button crowding the input on wider displays.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d73ba62e824413ed3a2b28f9c6c1006ee7708e6f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->