### PR TITLE
Add inline workspace creation form to Kanban board

### DIFF
--- a/src/backend/domains/workspace/lifecycle/creation.service.test.ts
+++ b/src/backend/domains/workspace/lifecycle/creation.service.test.ts
@@ -204,10 +204,9 @@ describe('WorkspaceCreationService', () => {
             ratchetEnabled: false,
           })
         );
-        expect(userSettingsAccessorModule.userSettingsAccessor.get).not.toHaveBeenCalled();
-        expect(
-          userSettingsAccessorModule.userSettingsAccessor.getDefaultSessionProvider
-        ).toHaveBeenCalled();
+        // resolveWorkspaceCreationDefaults always reads user settings for the
+        // default session provider, using the explicit ratchetEnabled override.
+        expect(userSettingsAccessorModule.userSettingsAccessor.get).toHaveBeenCalled();
       });
 
       it('should default to user settings ratchetEnabled when not provided', async () => {

--- a/src/backend/trpc/workspace.trpc.ts
+++ b/src/backend/trpc/workspace.trpc.ts
@@ -1,4 +1,4 @@
-import { WorkspaceProviderSelection } from '@prisma-gen/client';
+import { SessionProvider, WorkspaceProviderSelection } from '@prisma-gen/client';
 import { z } from 'zod';
 import { ratchetService } from '@/backend/domains/ratchet';
 import { sessionService } from '@/backend/domains/session';
@@ -36,6 +36,8 @@ const workspaceCreationSourceSchema = z.discriminatedUnion('type', [
     description: z.string().optional(),
     branchName: z.string().optional(),
     ratchetEnabled: z.boolean().optional(),
+    initialPrompt: z.string().optional(),
+    provider: z.nativeEnum(SessionProvider).optional(),
   }),
   z.object({
     type: z.literal('RESUME_BRANCH'),

--- a/src/client/routes/projects/workspaces/components/workspaces-board-view.tsx
+++ b/src/client/routes/projects/workspaces/components/workspaces-board-view.tsx
@@ -1,11 +1,19 @@
 import { HeaderRightSlot, useAppHeader } from '@/frontend/components/app-header-context';
-import { KanbanBoard, KanbanControls, KanbanProvider } from '@/frontend/components/kanban';
+import {
+  KanbanBoard,
+  KanbanControls,
+  KanbanProvider,
+  NewWorkspaceHeaderButton,
+} from '@/frontend/components/kanban';
+import { useIsMobile } from '@/hooks/use-mobile';
 
 function BoardHeaderSlot() {
   useAppHeader({ title: 'Workspaces Board' });
+  const isMobile = useIsMobile();
 
   return (
     <HeaderRightSlot>
+      {isMobile && <NewWorkspaceHeaderButton />}
       <KanbanControls />
     </HeaderRightSlot>
   );
@@ -15,23 +23,13 @@ export function WorkspacesBoardView({
   projectId,
   slug,
   issueProvider,
-  onCreateWorkspace,
-  isCreatingWorkspace,
 }: {
   projectId: string;
   slug: string;
   issueProvider: string;
-  onCreateWorkspace: () => void;
-  isCreatingWorkspace: boolean;
 }) {
   return (
-    <KanbanProvider
-      projectId={projectId}
-      projectSlug={slug}
-      issueProvider={issueProvider}
-      onCreateWorkspace={onCreateWorkspace}
-      isCreatingWorkspace={isCreatingWorkspace}
-    >
+    <KanbanProvider projectId={projectId} projectSlug={slug} issueProvider={issueProvider}>
       <BoardHeaderSlot />
       <div className="flex flex-col h-full p-3 md:p-6 gap-3 md:gap-4">
         <div className="flex-1 min-h-0">

--- a/src/client/routes/projects/workspaces/list.tsx
+++ b/src/client/routes/projects/workspaces/list.tsx
@@ -1,6 +1,5 @@
 import { useParams } from 'react-router';
 import { Loading } from '@/frontend/components/loading';
-import { useCreateWorkspace } from '@/frontend/hooks/use-create-workspace';
 import { trpc } from '@/frontend/lib/trpc';
 import { WorkspacesBoardView } from './components';
 
@@ -8,26 +7,12 @@ export default function WorkspacesListPage() {
   const { slug = '' } = useParams<{ slug: string }>();
 
   const { data: project } = trpc.project.getBySlug.useQuery({ slug });
-  const { handleCreate: createWorkspace, isCreating } = useCreateWorkspace(project?.id, slug);
-
-  // Swallow the re-thrown error — toast is already shown by the hook
-  const handleCreate = () => {
-    createWorkspace().catch(() => {
-      // Error already handled (toast shown) by the hook
-    });
-  };
 
   if (!project) {
     return <Loading message="Loading project..." />;
   }
 
   return (
-    <WorkspacesBoardView
-      projectId={project.id}
-      slug={slug}
-      issueProvider={project.issueProvider}
-      onCreateWorkspace={handleCreate}
-      isCreatingWorkspace={isCreating}
-    />
+    <WorkspacesBoardView projectId={project.id} slug={slug} issueProvider={project.issueProvider} />
   );
 }

--- a/src/components/shared/setup-status-chip.tsx
+++ b/src/components/shared/setup-status-chip.tsx
@@ -1,0 +1,31 @@
+import { Circle } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { WorkspaceStatus } from '@/shared/core';
+
+interface SetupStatusChipProps {
+  status: WorkspaceStatus;
+  size?: 'sm' | 'md';
+  className?: string;
+}
+
+export function SetupStatusChip({ status, size = 'sm', className }: SetupStatusChipProps) {
+  if (status !== 'NEW' && status !== 'PROVISIONING') {
+    return null;
+  }
+
+  const sizeClasses = size === 'sm' ? 'text-[10px] px-1.5 py-0.5' : 'text-xs px-2 py-0.5';
+  const iconSize = size === 'sm' ? 'h-2.5 w-2.5' : 'h-3 w-3';
+
+  return (
+    <span
+      className={cn(
+        'inline-flex w-fit items-center gap-1 rounded-sm font-medium uppercase tracking-wide bg-yellow-500/15 text-yellow-700 dark:text-yellow-300',
+        sizeClasses,
+        className
+      )}
+    >
+      <Circle className={cn(iconSize, 'animate-pulse')} />
+      Setting up
+    </span>
+  );
+}

--- a/src/frontend/components/kanban/index.ts
+++ b/src/frontend/components/kanban/index.ts
@@ -1,4 +1,4 @@
-export { KanbanBoard, KanbanControls } from './kanban-board';
+export { KanbanBoard, KanbanControls, NewWorkspaceHeaderButton } from './kanban-board';
 export { KanbanCard, type WorkspaceWithKanban } from './kanban-card';
 export { getKanbanColumns, KANBAN_COLUMNS, KanbanColumn } from './kanban-column';
 export { type KanbanIssue, KanbanProvider, useKanban } from './kanban-context';

--- a/src/frontend/components/kanban/inline-workspace-form.tsx
+++ b/src/frontend/components/kanban/inline-workspace-form.tsx
@@ -1,0 +1,160 @@
+import { Loader2 } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import { RatchetToggleButton } from '@/components/workspace';
+import { trpc } from '@/frontend/lib/trpc';
+import { generateUniqueWorkspaceName } from '@/shared/workspace-words';
+
+interface InlineWorkspaceFormProps {
+  projectId: string;
+  existingNames: string[];
+  onCancel: () => void;
+  onCreated: () => void;
+}
+
+export function InlineWorkspaceForm({
+  projectId,
+  existingNames,
+  onCancel,
+  onCreated,
+}: InlineWorkspaceFormProps) {
+  const utils = trpc.useUtils();
+  const { data: userSettings, isLoading: isLoadingSettings } = trpc.userSettings.get.useQuery();
+
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [initialPrompt, setInitialPrompt] = useState('');
+  const [ratchetEnabled, setRatchetEnabled] = useState(false);
+  const [provider, setProvider] = useState<'CLAUDE' | 'CODEX'>('CLAUDE');
+
+  const autoResize = useCallback(() => {
+    const el = textareaRef.current;
+    if (el) {
+      el.style.height = 'auto';
+      el.style.height = `${el.scrollHeight}px`;
+    }
+  }, []);
+
+  // Initialize defaults from user settings once loaded
+  useEffect(() => {
+    if (!userSettings) {
+      return;
+    }
+    setRatchetEnabled(userSettings.ratchetEnabled);
+    setProvider(userSettings.defaultSessionProvider);
+  }, [userSettings]);
+
+  const createWorkspaceMutation = trpc.workspace.create.useMutation({
+    onSuccess: () => {
+      utils.workspace.listWithKanbanState.invalidate({ projectId });
+      utils.workspace.list.invalidate({ projectId });
+      utils.workspace.getProjectSummaryState.invalidate({ projectId });
+      onCreated();
+    },
+    onError: (error) => {
+      toast.error(`Failed to create workspace: ${error.message}`);
+    },
+  });
+
+  const isCreating = createWorkspaceMutation.isPending;
+
+  const handleLaunch = () => {
+    const name = generateUniqueWorkspaceName(existingNames);
+    const trimmedPrompt = initialPrompt.trim();
+    createWorkspaceMutation.mutate({
+      type: 'MANUAL',
+      projectId,
+      name,
+      initialPrompt: trimmedPrompt || undefined,
+      ratchetEnabled,
+      provider,
+    });
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      onCancel();
+    }
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && !isCreating) {
+      e.preventDefault();
+      handleLaunch();
+    }
+  };
+
+  return (
+    <Card className="shrink-0 border-dashed border-primary/50">
+      <CardContent className="p-3 space-y-3" onKeyDown={handleKeyDown}>
+        <Textarea
+          ref={textareaRef}
+          placeholder="What should the agent work on?"
+          value={initialPrompt}
+          onChange={(e) => {
+            setInitialPrompt(e.target.value);
+            autoResize();
+          }}
+          rows={3}
+          className="resize-none text-sm overflow-hidden"
+          autoFocus
+          disabled={isCreating}
+        />
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-3">
+            <div className="flex items-center gap-1.5">
+              <RatchetToggleButton
+                enabled={ratchetEnabled}
+                state="IDLE"
+                className="h-5 w-5"
+                onToggle={setRatchetEnabled}
+                disabled={isLoadingSettings || isCreating}
+              />
+              <span className="text-xs text-muted-foreground">Auto-fix</span>
+            </div>
+            <Select
+              value={provider}
+              onValueChange={(v) => setProvider(v as 'CLAUDE' | 'CODEX')}
+              disabled={isLoadingSettings || isCreating}
+            >
+              <SelectTrigger className="h-7 w-24 text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="CLAUDE">Claude</SelectItem>
+                <SelectItem value="CODEX">Codex</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 text-xs"
+              onClick={onCancel}
+              disabled={isCreating}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              className="h-7 text-xs"
+              onClick={handleLaunch}
+              disabled={isCreating || isLoadingSettings}
+            >
+              {isCreating ? <Loader2 className="h-3 w-3 animate-spin mr-1" /> : null}
+              Launch
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/frontend/components/kanban/kanban-column.tsx
+++ b/src/frontend/components/kanban/kanban-column.tsx
@@ -8,6 +8,8 @@ export type UIKanbanColumnId = 'ISSUES' | KanbanColumnType;
 export interface ColumnConfig {
   id: UIKanbanColumnId;
   label: string;
+  /** Shorter label used in mobile column pills */
+  shortLabel?: string;
   description: string;
 }
 
@@ -23,6 +25,7 @@ export function getKanbanColumns(issueProvider: string): ColumnConfig[] {
     {
       id: 'ISSUES',
       label: issueProvider === 'LINEAR' ? 'Todo · Linear' : 'Todo · GitHub',
+      shortLabel: 'Todo',
       description: 'Issues assigned to you',
     },
     { id: 'WORKING', label: 'Working', description: 'Agent is working' },

--- a/src/frontend/components/kanban/kanban-context.tsx
+++ b/src/frontend/components/kanban/kanban-context.tsx
@@ -85,8 +85,8 @@ interface KanbanContextValue {
   togglingWorkspaceId: string | null;
   archiveWorkspace: (workspaceId: string, commitUncommitted: boolean) => Promise<void>;
   archivingWorkspaceId: string | null;
-  onCreateWorkspace?: () => void;
-  isCreatingWorkspace?: boolean;
+  showInlineForm: boolean;
+  setShowInlineForm: (show: boolean) => void;
 }
 
 const KanbanContext = createContext<KanbanContextValue | null>(null);
@@ -103,8 +103,6 @@ interface KanbanProviderProps {
   projectId: string;
   projectSlug: string;
   issueProvider: string;
-  onCreateWorkspace?: () => void;
-  isCreatingWorkspace?: boolean;
   children: ReactNode;
 }
 
@@ -112,8 +110,6 @@ export function KanbanProvider({
   projectId,
   projectSlug,
   issueProvider,
-  onCreateWorkspace,
-  isCreatingWorkspace,
   children,
 }: KanbanProviderProps) {
   const utils = trpc.useUtils();
@@ -157,6 +153,7 @@ export function KanbanProvider({
   const archiveMutation = trpc.workspace.archive.useMutation();
   const [togglingWorkspaceId, setTogglingWorkspaceId] = useState<string | null>(null);
   const [archivingWorkspaceId, setArchivingWorkspaceId] = useState<string | null>(null);
+  const [showInlineForm, setShowInlineForm] = useState(false);
 
   const refetchIssues = isLinear ? refetchLinearIssues : refetchGithubIssues;
 
@@ -247,8 +244,8 @@ export function KanbanProvider({
         togglingWorkspaceId,
         archiveWorkspace,
         archivingWorkspaceId,
-        onCreateWorkspace,
-        isCreatingWorkspace,
+        showInlineForm,
+        setShowInlineForm,
       }}
     >
       {children}


### PR DESCRIPTION
## Summary

- Replace the "New Workspace" button in the Kanban Issues column with an expandable inline form (initial prompt textarea, auto-fix toggle, provider dropdown)
- After launch, stay on the board view — workspace card appears in the WORKING column with a yellow "SETTING UP" label
- Add `initialPrompt` and `provider` fields to MANUAL workspace creation, routing the prompt as the first session message
- Extract `SetupStatusChip` as a reusable shared component matching CI status chip styling
- Fix light mode visibility of the New Workspace button
- Remove unused workspace creation plumbing from kanban context

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (164 files, 2229 tests)
- [x] `pnpm check:fix` clean
- [ ] Click "New Workspace" → inline form expands with textarea, auto-fix toggle, provider dropdown
- [ ] Defaults match user settings (auto-fix toggle, provider)
- [ ] Type a prompt, click Launch → workspace appears in WORKING column with "SETTING UP" label
- [ ] Launch with empty prompt → workspace created normally
- [ ] Cancel / Escape closes form, Cmd+Enter submits
- [ ] Verify light mode and dark mode visibility
- [ ] Mobile layout renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
