### PR TITLE
Fix #1126: rename 'Board' link to 'Workspaces Board' on workspace view

### DIFF
--- a/src/client/routes/projects/workspaces/workspace-detail-header.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-header.tsx
@@ -811,7 +811,7 @@ export function WorkspaceDetailHeaderSlot({
         <Button variant="ghost" size="sm" className="shrink-0 text-muted-foreground" asChild>
           <Link to={`/projects/${slug}/workspaces`}>
             <ArrowLeft className="h-3.5 w-3.5" />
-            <span className="hidden sm:inline">Board</span>
+            <span className="hidden sm:inline">Workspaces Board</span>
           </Link>
         </Button>
         <div className="hidden md:flex items-center gap-2 min-w-0">


### PR DESCRIPTION
## Summary
- Rename the "Board" back-link label on the Workspace View to "Workspaces Board" for consistency with the board page title

## Changes
- **workspace-detail-header.tsx**: Updated the back-link text from "Board" to "Workspaces Board"

## Testing
- [x] Types pass (`pnpm typecheck`)
- [x] Lint passes (`pnpm check:fix`)
- [ ] Manual testing: Navigate to a workspace detail view and verify the back link in the header reads "Workspaces Board"

Closes #1126

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
