### PR TITLE
Fix #1127: circular JSON error when clicking New Workspace button

### DIFF
--- a/src/client/routes/projects/workspaces/components/new-workspace-button.tsx
+++ b/src/client/routes/projects/workspaces/components/new-workspace-button.tsx
@@ -19,7 +19,7 @@ export function NewWorkspaceButton({
         size="icon"
         variant="ghost"
         className="h-9 w-9"
-        onClick={onClick}
+        onClick={() => onClick()}
         disabled={isCreating}
       >
         {isCreating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
@@ -28,7 +28,7 @@ export function NewWorkspaceButton({
   }
 
   return (
-    <Button size="sm" variant="ghost" onClick={onClick} disabled={isCreating}>
+    <Button size="sm" variant="ghost" onClick={() => onClick()} disabled={isCreating}>
       {isCreating ? (
         <Loader2 className="h-4 w-4 mr-1 animate-spin" />
       ) : (


### PR DESCRIPTION
## Summary
- Fixes "Converting circular structure to JSON" error when clicking "New Workspace" from the workspace detail header
- The bug was caused by React's `MouseEvent<HTMLButtonElement>` being passed through as the `nameOverride` argument to `handleCreate`, which tRPC then tried to serialize

## Changes
- **`new-workspace-button.tsx`**: Wrap both `onClick={onClick}` calls with arrow functions (`onClick={() => onClick()}`) so the mouse event is discarded before reaching the workspace creation handler

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Lint/format pass (`pnpm check:fix`)
- [ ] Manual testing: Click "New Workspace" button from the workspace detail header — workspace should be created without error

Closes #1127

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
