### PR TITLE
Fix #1130: Create PR button not showing without refresh; add to kanban cards

### DIFF
--- a/src/client/routes/projects/workspaces/workspace-detail-container.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-container.tsx
@@ -137,7 +137,11 @@ export function WorkspaceDetailContainer() {
 
   const { data: hasChanges } = trpc.workspace.hasChanges.useQuery(
     { workspaceId },
-    { enabled: workspace?.hasHadSessions === true && workspace?.prState === 'NONE' }
+    {
+      enabled:
+        workspace?.hasHadSessions === true &&
+        (workspace?.prState === 'NONE' || workspace?.prState === 'CLOSED'),
+    }
   );
 
   const { workspaceInitStatus, isScriptFailed } = useWorkspaceInitStatus(

--- a/src/frontend/components/kanban/kanban-board.tsx
+++ b/src/frontend/components/kanban/kanban-board.tsx
@@ -62,6 +62,8 @@ export function KanbanBoard() {
     togglingWorkspaceId,
     archiveWorkspace,
     archivingWorkspaceId,
+    createWorkspacePr,
+    creatingPrWorkspaceId,
     showInlineForm,
   } = useKanban();
 
@@ -202,6 +204,8 @@ export function KanbanBoard() {
               togglingWorkspaceId={togglingWorkspaceId}
               onArchive={archiveWorkspace}
               archivingWorkspaceId={archivingWorkspaceId}
+              onCreatePr={createWorkspacePr}
+              creatingPrWorkspaceId={creatingPrWorkspaceId}
             />
           )}
         </div>
@@ -236,6 +240,8 @@ export function KanbanBoard() {
             togglingWorkspaceId={togglingWorkspaceId}
             onArchive={archiveWorkspace}
             archivingWorkspaceId={archivingWorkspaceId}
+            onCreatePr={createWorkspacePr}
+            creatingPrWorkspaceId={creatingPrWorkspaceId}
           />
         );
       })}

--- a/src/frontend/components/kanban/kanban-column.tsx
+++ b/src/frontend/components/kanban/kanban-column.tsx
@@ -42,6 +42,8 @@ interface KanbanColumnProps {
   togglingWorkspaceId?: string | null;
   onArchive?: (workspaceId: string, commitUncommitted: boolean) => void;
   archivingWorkspaceId?: string | null;
+  onCreatePr?: (workspaceId: string) => void;
+  creatingPrWorkspaceId?: string | null;
 }
 
 export function KanbanColumn({
@@ -52,6 +54,8 @@ export function KanbanColumn({
   togglingWorkspaceId,
   onArchive,
   archivingWorkspaceId,
+  onCreatePr,
+  creatingPrWorkspaceId,
 }: KanbanColumnProps) {
   const isEmpty = workspaces.length === 0;
 
@@ -83,6 +87,8 @@ export function KanbanColumn({
                 isTogglePending={togglingWorkspaceId === workspace.id}
                 onArchive={onArchive}
                 isArchivePending={archivingWorkspaceId === workspace.id}
+                onCreatePr={onCreatePr}
+                isCreatingPr={creatingPrWorkspaceId === workspace.id}
               />
             </div>
           ))

--- a/src/frontend/hooks/use-project-snapshot-sync.ts
+++ b/src/frontend/hooks/use-project-snapshot-sync.ts
@@ -117,6 +117,7 @@ function mergeWorkspaceDetailFromSnapshot(
     ratchetState: entry.ratchetState,
     runScriptStatus: entry.runScriptStatus,
     isWorking: entry.isWorking,
+    hasHadSessions: entry.hasHadSessions,
     pendingRequestType: entry.pendingRequestType,
     sessionSummaries: entry.sessionSummaries,
     sidebarStatus: entry.sidebarStatus,

--- a/src/frontend/lib/snapshot-to-kanban.ts
+++ b/src/frontend/lib/snapshot-to-kanban.ts
@@ -41,6 +41,7 @@ export function mapSnapshotEntryToKanbanWorkspace(
     runScriptStatus: entry.runScriptStatus,
     kanbanColumn: entry.kanbanColumn,
     isWorking: entry.isWorking,
+    hasHadSessions: entry.hasHadSessions,
     ratchetButtonAnimated: entry.ratchetButtonAnimated,
     flowPhase: entry.flowPhase,
     pendingRequestType: entry.pendingRequestType,


### PR DESCRIPTION
## Summary

- Fix Create PR button not appearing on workspace page without a manual refresh
- Enable the `hasChanges` query when `prState` is `CLOSED` (not just `NONE`) to match button visibility logic
- Add Create PR button to kanban task cards when a workspace has had sessions and no open PR exists

## Changes

- **`use-project-snapshot-sync.ts`**: Include `hasHadSessions` in the workspace detail cache merge from WebSocket snapshots. Previously the snapshot merge omitted this field, so the `hasChanges` query was never enabled on first load (it requires `hasHadSessions === true`).
- **`workspace-detail-container.tsx`**: Also enable the `hasChanges` query when `prState === 'CLOSED'` to match the Create PR button's visibility condition.
- **`snapshot-to-kanban.ts`**: Include `hasHadSessions` in the kanban workspace mapping so it's available on kanban cards.
- **`kanban-context.tsx`**: Add `createWorkspacePr` function that creates a new session with the PR creation prompt and navigates to the workspace detail view.
- **`kanban-column.tsx`**: Thread `onCreatePr` and `creatingPrWorkspaceId` props down to kanban cards.
- **`kanban-board.tsx`**: Pass `createWorkspacePr` and `creatingPrWorkspaceId` from context to column components.
- **`kanban-card.tsx`**: Add Create PR button to card body when `hasHadSessions && !isWorking && (prState === 'NONE' || prState === 'CLOSED')`.

## Testing

- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Open a workspace that has had sessions and no PR — the Create PR button should now appear immediately without requiring a page refresh. On the Kanban board, cards with sessions but no PR should show a Create PR button.

Closes #1130

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
