### PR TITLE
Fix #1131: remove progress dot from task card in workspace view

### DIFF
--- a/src/frontend/components/kanban/kanban-card.tsx
+++ b/src/frontend/components/kanban/kanban-card.tsx
@@ -36,18 +36,12 @@ interface KanbanCardProps {
 }
 
 function CardStatusIndicator({
-  isWorking,
   status,
   errorMessage,
 }: {
-  isWorking: boolean;
   status: WorkspaceStatus;
   errorMessage: string | null;
 }) {
-  if (isWorking) {
-    return <span className="h-2 w-2 rounded-full bg-brand animate-pulse shrink-0" />;
-  }
-
   // NEW/PROVISIONING are shown as a label in the card body instead
   if (status === 'NEW' || status === 'PROVISIONING') {
     return null;
@@ -186,11 +180,7 @@ function CardTitleIcons({
           <TooltipContent>Dev server running</TooltipContent>
         </Tooltip>
       )}
-      <CardStatusIndicator
-        isWorking={workspace.isWorking}
-        status={workspace.status}
-        errorMessage={workspace.initErrorMessage}
-      />
+      <CardStatusIndicator status={workspace.status} errorMessage={workspace.initErrorMessage} />
       {!isArchived && onArchive && (
         <CardArchiveButton
           workspaceId={workspace.id}


### PR DESCRIPTION
## Summary
- Removes the animated progress dot from the Task Card in the Workspace (Kanban) view
- The dot was shown when a workspace had an active agent session (`isWorking: true`), but the card already indicates activity via its `border-brand/50 bg-brand/5` styling, making the dot redundant

## Changes
- **`src/frontend/components/kanban/kanban-card.tsx`**: Removed the `isWorking` early-return branch from `CardStatusIndicator` that rendered an animated pulsing dot. The function now always renders `WorkspaceStatusBadge` (except for NEW/PROVISIONING states which are shown in the card body instead).

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Manual testing: When a workspace is in working state, the card shows the brand-colored border/background but no longer displays the extra pulsing dot in the header

Closes #1131

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
