### PR TITLE
Fix #1109: color-coded top borders for Kanban columns

### DIFF
--- a/src/frontend/components/kanban/kanban-board.tsx
+++ b/src/frontend/components/kanban/kanban-board.tsx
@@ -10,7 +10,12 @@ import { InlineWorkspaceForm } from './inline-workspace-form';
 import { IssueCard } from './issue-card';
 import { IssueDetailsSheet } from './issue-details-sheet';
 import type { WorkspaceWithKanban } from './kanban-card';
-import { type ColumnConfig, getKanbanColumns, KanbanColumn } from './kanban-column';
+import {
+  type ColumnConfig,
+  getColumnAccentClass,
+  getKanbanColumns,
+  KanbanColumn,
+} from './kanban-column';
 import { type KanbanIssue, useKanban } from './kanban-context';
 
 export function KanbanControls() {
@@ -274,7 +279,12 @@ function IssuesColumn({ column, issues, projectId }: IssuesColumnProps) {
     <>
       <div className="flex flex-col w-full md:flex-1 md:min-w-[280px] md:max-w-[440px] md:h-full">
         {/* Column Header — hidden on mobile where pills handle this */}
-        <div className="hidden md:flex items-center justify-between px-2 py-3 bg-muted/30 rounded-t-lg">
+        <div
+          className={cn(
+            'hidden md:flex items-center justify-between px-2 py-3 bg-muted/30 rounded-t-lg',
+            getColumnAccentClass(column.id)
+          )}
+        >
           <div className="flex items-center gap-2">
             <h3 className="font-semibold text-sm">{column.label}</h3>
             <Badge variant="secondary" className="h-5 min-w-5 justify-center text-xs">

--- a/src/frontend/components/kanban/kanban-column.tsx
+++ b/src/frontend/components/kanban/kanban-column.tsx
@@ -1,4 +1,5 @@
 import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
 import type { KanbanColumn as KanbanColumnType } from '@/shared/core';
 import { KanbanCard, type WorkspaceWithKanban } from './kanban-card';
 
@@ -34,6 +35,22 @@ export function getKanbanColumns(issueProvider: string): ColumnConfig[] {
   ];
 }
 
+/** Returns a top-border accent class for each column to aid visual distinction */
+export function getColumnAccentClass(columnId: UIKanbanColumnId): string {
+  switch (columnId) {
+    case 'ISSUES':
+      return 'border-t-2 border-t-info';
+    case 'WORKING':
+      return 'border-t-2 border-t-brand';
+    case 'WAITING':
+      return 'border-t-2 border-t-warning';
+    case 'DONE':
+      return 'border-t-2 border-t-success';
+    default:
+      return '';
+  }
+}
+
 interface KanbanColumnProps {
   column: ColumnConfig;
   workspaces: WorkspaceWithKanban[];
@@ -58,7 +75,12 @@ export function KanbanColumn({
   return (
     <div className="flex flex-col w-full md:flex-1 md:min-w-[280px] md:max-w-[440px] md:h-full">
       {/* Column Header — hidden on mobile where pills handle this */}
-      <div className="hidden md:flex items-center justify-between px-2 py-3 bg-muted/30 rounded-t-lg">
+      <div
+        className={cn(
+          'hidden md:flex items-center justify-between px-2 py-3 bg-muted/30 rounded-t-lg',
+          getColumnAccentClass(column.id)
+        )}
+      >
         <div className="flex items-center gap-2">
           <h3 className="font-semibold text-sm">{column.label}</h3>
           <Badge variant="secondary" className="h-5 min-w-5 justify-center text-xs">


### PR DESCRIPTION
## Summary
- Add color-coded top borders to each Kanban board column to make them visually distinct in both dark and light mode
- Each column now has a unique 2px accent border color mapped to a semantic design token

## Changes
- **`kanban-column.tsx`**: Added `getColumnAccentClass()` helper that returns a column-specific `border-t-2` Tailwind class; applied it to the `KanbanColumn` header element
- **`kanban-board.tsx`**: Applied the same `getColumnAccentClass()` to the `IssuesColumn` header so all four columns are consistently styled

Column color mapping:
| Column | Color | Token |
|--------|-------|-------|
| Todo / Issues | Blue | `info` |
| Working | Yellow | `brand` |
| Waiting | Amber | `warning` |
| Done | Green | `success` |

Colors use semantic CSS custom properties so they automatically adapt to both dark and light mode themes.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (pre-commit hook ran `typecheck` + `deps:check` + `knip`)
- [x] Lint/format clean (`pnpm check:fix`)
- [ ] Manual testing: Visit the Workspaces Board view — each column header should display a distinct colored top border

Closes #1109

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
