### PR TITLE
Fix Docker publish workflow to trigger on pushes to main

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Docker Build & Push
 
 on:
   push:
-    branches: [adeeshaek/pixel-1]
+    branches: [main]
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
## Summary
- Fix Docker publish workflow trigger: was hardcoded to `adeeshaek/pixel-1` branch, now triggers on pushes to `main`

## Test plan
- [ ] Verify the workflow runs on the next push to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
