### PR TITLE
Handle null review submittedAt in ratchet PR checks

### DIFF
--- a/src/backend/domains/github/github-cli.service.test.ts
+++ b/src/backend/domains/github/github-cli.service.test.ts
@@ -609,6 +609,54 @@ describe('GitHubCLIService', () => {
         ]);
       });
 
+      it('should accept reviews with null submittedAt', async () => {
+        const fullPRData = {
+          number: 123,
+          title: 'Test PR',
+          url: 'https://github.com/owner/repo/pull/123',
+          author: { login: 'octocat' },
+          createdAt: '2024-01-01T00:00:00Z',
+          updatedAt: '2024-01-02T00:00:00Z',
+          isDraft: false,
+          state: 'OPEN',
+          reviewDecision: null,
+          statusCheckRollup: null,
+          reviews: [
+            {
+              id: 'review-1',
+              author: { login: 'reviewer' },
+              state: 'PENDING',
+              submittedAt: null,
+            },
+          ],
+          comments: [],
+          labels: [],
+          additions: 10,
+          deletions: 2,
+          changedFiles: 1,
+          headRefName: 'feature-branch',
+          baseRefName: 'main',
+          mergeStateStatus: 'CLEAN',
+        };
+
+        mockExecFile.mockResolvedValue({
+          stdout: JSON.stringify(fullPRData),
+          stderr: '',
+        });
+
+        const result = await githubCLIService.getPRFullDetails('owner/repo', 123);
+
+        expect(result.reviews).toEqual([
+          {
+            id: 'review-1',
+            author: { login: 'reviewer' },
+            state: 'PENDING',
+            submittedAt: null,
+            body: undefined,
+          },
+        ]);
+      });
+
       it('should throw error when full PR details are incomplete', async () => {
         const malformedData = {
           number: 123,

--- a/src/backend/domains/github/github-cli/schemas.ts
+++ b/src/backend/domains/github/github-cli/schemas.ts
@@ -98,7 +98,7 @@ export const fullPRDetailsSchema = z.object({
         id: z.string(),
         author: z.object({ login: z.string() }),
         state: z.string(),
-        submittedAt: z.string(),
+        submittedAt: z.string().nullable(),
         body: z.string().optional(),
       })
       .passthrough()

--- a/src/backend/domains/ratchet/bridges.ts
+++ b/src/backend/domains/ratchet/bridges.ts
@@ -28,7 +28,7 @@ export interface RatchetPRFullDetails {
   state: string;
   number: number;
   reviewDecision: string | null;
-  reviews: Array<{ submittedAt: string; author: { login: string } }>;
+  reviews: Array<{ submittedAt: string | null; author: { login: string } }>;
   comments: Array<{ updatedAt: string; author: { login: string } }>;
   statusCheckRollup: Array<{
     name?: string;

--- a/src/backend/domains/ratchet/ratchet.service.test.ts
+++ b/src/backend/domains/ratchet/ratchet.service.test.ts
@@ -798,7 +798,7 @@ describe('ratchet service (state-change + idle dispatch)', () => {
     const latestActivity = unsafeCoerce<{
       computeLatestReviewActivityAtMs: (
         prDetails: {
-          reviews: Array<{ submittedAt: string; author: { login: string } }>;
+          reviews: Array<{ submittedAt: string | null; author: { login: string } }>;
           comments: Array<{ updatedAt: string; author: { login: string } }>;
         },
         reviewComments: Array<{ updatedAt: string; author: { login: string } }>,
@@ -983,7 +983,7 @@ describe('ratchet service (state-change + idle dispatch)', () => {
 
   describe('computeLatestReviewActivityAtMs edge cases', () => {
     type PRDetails = {
-      reviews: Array<{ submittedAt: string; author: { login: string } }>;
+      reviews: Array<{ submittedAt: string | null; author: { login: string } }>;
       comments: Array<{ updatedAt: string; author: { login: string } }>;
     };
     type ReviewComment = { updatedAt: string; author: { login: string } };
@@ -1032,6 +1032,18 @@ describe('ratchet service (state-change + idle dispatch)', () => {
         null
       );
       expect(result).toBe(new Date('2026-01-01T00:00:00Z').getTime());
+    });
+
+    it('ignores reviews that have null submittedAt', () => {
+      const result = callCompute(
+        {
+          reviews: [{ submittedAt: null, author: { login: 'reviewer' } }],
+          comments: [{ updatedAt: '2026-01-02T00:00:00Z', author: { login: 'commenter' } }],
+        },
+        [],
+        null
+      );
+      expect(result).toBe(new Date('2026-01-02T00:00:00Z').getTime());
     });
 
     it('returns the latest timestamp across all sources', () => {

--- a/src/backend/domains/ratchet/ratchet.service.ts
+++ b/src/backend/domains/ratchet/ratchet.service.ts
@@ -1321,7 +1321,7 @@ class RatchetService extends EventEmitter {
 
   private computeLatestReviewActivityAtMs(
     prDetails: {
-      reviews: Array<{ submittedAt: string; author: { login: string } }>;
+      reviews: Array<{ submittedAt: string | null; author: { login: string } }>;
       comments: Array<{ updatedAt: string; author: { login: string } }>;
     },
     reviewComments: Array<{ updatedAt: string; author: { login: string } }>,
@@ -1343,7 +1343,11 @@ class RatchetService extends EventEmitter {
     ];
 
     const timestamps = entries
-      .filter((entry) => !this.isIgnoredReviewAuthor(entry.authorLogin, authenticatedUsername))
+      .filter(
+        (entry): entry is { authorLogin: string; timestamp: string } =>
+          entry.timestamp !== null &&
+          !this.isIgnoredReviewAuthor(entry.authorLogin, authenticatedUsername)
+      )
       .map((entry) => Date.parse(entry.timestamp))
       .filter((timestamp) => Number.isFinite(timestamp));
 

--- a/src/shared/github-types.ts
+++ b/src/shared/github-types.ts
@@ -34,7 +34,7 @@ export interface GitHubReview {
   id: string;
   author: { login: string };
   state: 'APPROVED' | 'CHANGES_REQUESTED' | 'COMMENTED' | 'PENDING' | 'DISMISSED';
-  submittedAt: string;
+  submittedAt: string | null;
   body?: string;
 }
 


### PR DESCRIPTION
## Summary
Ratchet checks could fail when `gh pr view --json reviews` returns a review with `submittedAt: null` (for pending/unsubmitted reviews). Our schema required a string, so `getPRFullDetails` threw and ratchet processing aborted.

## Changes
- Allow nullable review submission timestamps in GitHub CLI PR details schema.
- Update shared `GitHubReview` and ratchet bridge contracts to use `submittedAt: string | null`.
- Make ratchet review activity timestamp computation ignore `null` `submittedAt` entries.
- Add regression tests for:
  - parsing PR details with `reviews[].submittedAt = null`
  - ratchet latest-review-activity logic skipping null timestamps

## Validation
- `pnpm exec vitest run src/backend/domains/github/github-cli.service.test.ts src/backend/domains/ratchet/ratchet.service.test.ts`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small contract and parsing tweak to accept `submittedAt: null` plus filtering in timestamp aggregation; low risk but affects ratchet dispatch decisions based on review-activity timestamps.
> 
> **Overview**
> Prevents ratchet PR processing from failing when `gh pr view --json reviews` returns pending reviews with `submittedAt: null`.
> 
> Updates the GitHub CLI Zod schema (`fullPRDetailsSchema`), shared `GitHubReview` type, and ratchet GitHub bridge contract to allow `submittedAt: string | null`, and changes ratchet’s `computeLatestReviewActivityAtMs` to ignore null timestamps. Adds regression tests for parsing null `submittedAt` reviews and for skipping them during latest-activity computation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6493c3f8a87cda6c7d2e5295f30307a3728e1def. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->