### PR TITLE
Fix Kanban archive cancel navigation and DONE UX

### DIFF
--- a/src/components/workspace/archive-workspace-dialog.tsx
+++ b/src/components/workspace/archive-workspace-dialog.tsx
@@ -47,7 +47,11 @@ export function ArchiveWorkspaceDialog({
 
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
-      <AlertDialogContent>
+      <AlertDialogContent
+        onClick={(event) => {
+          event.stopPropagation();
+        }}
+      >
         <AlertDialogHeader>
           <AlertDialogTitle>Archive Workspace</AlertDialogTitle>
           <AlertDialogDescription>{description}</AlertDialogDescription>
@@ -67,10 +71,19 @@ export function ArchiveWorkspaceDialog({
           </label>
         </div>
         <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogCancel
+            onClick={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              onOpenChange(false);
+            }}
+          >
+            Cancel
+          </AlertDialogCancel>
           <AlertDialogAction
             onClick={(event) => {
               event.preventDefault();
+              event.stopPropagation();
               onConfirm(commitChangesChecked);
               onOpenChange(false);
             }}

--- a/src/frontend/components/kanban/kanban-card.tsx
+++ b/src/frontend/components/kanban/kanban-card.tsx
@@ -94,19 +94,24 @@ function GitContextRow({
 }
 
 function CardArchiveButton({
-  workspaceId,
+  workspace,
   isPending,
   onArchive,
 }: {
-  workspaceId: string;
+  workspace: WorkspaceWithKanban;
   isPending: boolean;
   onArchive: (workspaceId: string, commitUncommitted: boolean) => void;
 }) {
   const [dialogOpen, setDialogOpen] = useState(false);
+  const requiresConfirmation = workspace.kanbanColumn !== 'DONE';
 
   const handleClick = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
+    if (!requiresConfirmation) {
+      onArchive(workspace.id, true);
+      return;
+    }
     setDialogOpen(true);
   };
 
@@ -117,7 +122,7 @@ function CardArchiveButton({
           <Button
             variant="ghost"
             size="icon"
-            className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity hover:bg-destructive/10 hover:text-destructive shrink-0"
+            className="h-6 w-6 hover:bg-destructive/10 hover:text-destructive shrink-0"
             onClick={handleClick}
             disabled={isPending}
           >
@@ -130,12 +135,14 @@ function CardArchiveButton({
         </TooltipTrigger>
         <TooltipContent>Archive workspace</TooltipContent>
       </Tooltip>
-      <ArchiveWorkspaceDialog
-        open={dialogOpen}
-        onOpenChange={setDialogOpen}
-        hasUncommitted={false}
-        onConfirm={(commitUncommitted) => onArchive(workspaceId, commitUncommitted)}
-      />
+      {requiresConfirmation && (
+        <ArchiveWorkspaceDialog
+          open={dialogOpen}
+          onOpenChange={setDialogOpen}
+          hasUncommitted={false}
+          onConfirm={(commitUncommitted) => onArchive(workspace.id, commitUncommitted)}
+        />
+      )}
     </>
   );
 }
@@ -183,7 +190,7 @@ function CardTitleIcons({
       <CardStatusIndicator status={workspace.status} errorMessage={workspace.initErrorMessage} />
       {!isArchived && onArchive && (
         <CardArchiveButton
-          workspaceId={workspace.id}
+          workspace={workspace}
           isPending={isArchivePending}
           onArchive={onArchive}
         />


### PR DESCRIPTION
## Summary
- fix the Kanban archive dialog so canceling no longer bubbles clicks to the underlying card link and redirects into the workspace
- restore one-click archive behavior for workspaces in the `DONE` column (skip confirmation and archive immediately)
- make the archive button always visible on Kanban cards instead of only on hover

## Implementation details
- added click propagation guards inside `ArchiveWorkspaceDialog` content/actions to prevent link navigation side effects
- updated `CardArchiveButton` to branch on `workspace.kanbanColumn !== 'DONE'` for confirmation behavior
- removed hover-only opacity classes from the Kanban archive button

## Validation
- pnpm typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, UI-only event-handling and conditional rendering changes; primary risk is minor UX regressions around archiving/navigation.
> 
> **Overview**
> Fixes Kanban archive interactions so dialog/button clicks don’t bubble to the underlying card `Link` and cause unintended navigation.
> 
> Workspaces in the `DONE` column now archive immediately (skipping the confirmation dialog), and the archive icon button is always visible instead of only on hover.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3aff253c795e43f92ab26343127a92371bfe52d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->