### PR TITLE
Make side nav project selector full width

### DIFF
--- a/src/frontend/components/project-selector.tsx
+++ b/src/frontend/components/project-selector.tsx
@@ -17,7 +17,7 @@ export function ProjectSelectorDropdown({
 }) {
   return (
     <Select value={selectedProjectSlug} onValueChange={onProjectChange}>
-      <SelectTrigger id="project-select" className="w-fit max-w-full px-4 gap-3">
+      <SelectTrigger id="project-select" className="w-full max-w-full gap-3 px-4">
         <SelectValue placeholder="Select a project" />
       </SelectTrigger>
       <SelectContent>


### PR DESCRIPTION
## Summary
- update `ProjectSelectorDropdown` to use a full-width select trigger in the side navigation
- replace the `w-fit` trigger width override with `w-full` so the project selector spans the sidebar width

## Testing
- pnpm test src/frontend/components/hamburger-menu.test.tsx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure UI styling change to a select trigger with minimal behavioral impact; low chance of regressions beyond layout.
> 
> **Overview**
> Adjusts `ProjectSelectorDropdown` styling so the `SelectTrigger` uses `w-full` rather than `w-fit`, making the project selector span the sidebar width while keeping the existing max-width, padding, and spacing behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff639444845fcc3bc90ebe2ffae0764d6c970fa3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->