### PR TITLE
Fix narrow-mobile overflow in inline workspace form

### DIFF
--- a/src/frontend/components/kanban/inline-workspace-form.tsx
+++ b/src/frontend/components/kanban/inline-workspace-form.tsx
@@ -117,7 +117,7 @@ export function InlineWorkspaceForm({
                 onToggle={setRatchetEnabled}
                 disabled={isLoadingSettings || isCreating}
               />
-              <span className="text-xs text-muted-foreground">Auto-fix</span>
+              <span className="text-xs text-muted-foreground max-[420px]:hidden">Auto-fix</span>
             </div>
             <Select
               value={provider}


### PR DESCRIPTION
## Summary
- prevent inline workspace form actions from overflowing on very narrow mobile screens
- hide the `Auto-fix` text label below `420px` width while keeping the ratchet toggle icon visible and interactive
- preserve existing launch/cancel behavior and control layout for larger breakpoints

## Testing
- pnpm typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class change affecting only responsive UI display; no logic, data, or API behavior changes.
> 
> **Overview**
> Prevents action-row overflow in the kanban `InlineWorkspaceForm` on very narrow mobile screens by hiding the `Auto-fix` label below `420px` while keeping the toggle visible.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56db6ec16ce0b6f65867e32f5e98b24e3af26c3d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->