### PR TITLE
Compact mobile nav sheet and single-row menu header

### DIFF
--- a/src/frontend/components/hamburger-menu.tsx
+++ b/src/frontend/components/hamburger-menu.tsx
@@ -1,4 +1,4 @@
-import { GitPullRequest, Kanban, Menu, Settings } from 'lucide-react';
+import { GitPullRequest, Kanban, Menu, Settings, X } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { Link, useLocation } from 'react-router';
 import { Badge } from '@/components/ui/badge';
@@ -13,7 +13,7 @@ import {
   SheetTitle,
 } from '@/components/ui/sheet';
 import type { useAppNavigationData } from '@/frontend/hooks/use-app-navigation-data';
-import { LogoText } from './logo';
+import { LogoIcon } from './logo';
 import { ProjectSelectorDropdown } from './project-selector';
 import { ThemeToggle } from './theme-toggle';
 import { WorkspaceStatusIcon } from './workspace-status-icon';
@@ -38,10 +38,10 @@ function MenuContent({ navData, onClose }: HamburgerMenuProps & { onClose: () =>
 
   return (
     <div className="flex flex-col h-full gap-1">
-      {/* Logo + Project Selector */}
-      <div className="px-2 py-1">
-        <LogoText className="text-xl" />
-        <div className="mt-1">
+      {/* Compact header row */}
+      <div className="flex items-center gap-2 px-1 pb-1 pr-0.5">
+        <LogoIcon className="h-7 w-7 shrink-0" />
+        <div className="min-w-0 flex-1">
           <ProjectSelectorDropdown
             selectedProjectSlug={navData.selectedProjectSlug}
             onProjectChange={(value) => {
@@ -51,6 +51,11 @@ function MenuContent({ navData, onClose }: HamburgerMenuProps & { onClose: () =>
             projects={navData.projects}
           />
         </div>
+        <SheetClose asChild>
+          <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0" aria-label="Close menu">
+            <X className="h-4 w-4" />
+          </Button>
+        </SheetClose>
       </div>
 
       <Separator />
@@ -169,7 +174,7 @@ export function HamburgerMenu({ navData }: HamburgerMenuProps) {
       </Button>
       <SheetContent
         side="left"
-        className="w-full sm:w-[28rem] sm:max-w-[28rem] p-3 pt-[calc(env(safe-area-inset-top)+0.75rem)] overflow-y-auto [&>button:first-child]:top-[calc(env(safe-area-inset-top)+1.15rem)]"
+        className="w-full sm:w-[24rem] sm:max-w-[24rem] p-3 pt-[calc(env(safe-area-inset-top)+0.75rem)] overflow-y-auto [&>button:first-child]:hidden"
       >
         <SheetHeader className="sr-only">
           <SheetTitle>Navigation Menu</SheetTitle>


### PR DESCRIPTION
## Summary
- reduce the mobile side navigation sheet width from `28rem` to `24rem`
- compact the menu header into a single row with app icon, project selector, and close (`X`) button
- hide the default sheet close control so the new inline close button is the primary close action

## Files Changed
- `src/frontend/components/hamburger-menu.tsx`

## Validation
- `pnpm test -- src/frontend/components/hamburger-menu.test.tsx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely UI/layout changes to the navigation sheet with minimal logic changes and no security or data-handling impact.
> 
> **Overview**
> Updates the hamburger menu sheet to use a compact single-row header with `LogoIcon`, the project selector, and a new inline `X` close button.
> 
> Reduces the left sheet width from `28rem` to `24rem` at `sm` breakpoints and hides the default sheet close control so the new header close button is the primary close action.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36d63995da44086ed149ba99a3d475f060677fee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->