### PR TITLE
Compact Kanban workspace cards

### DIFF
--- a/src/frontend/components/kanban/kanban-card.tsx
+++ b/src/frontend/components/kanban/kanban-card.tsx
@@ -239,7 +239,7 @@ export function KanbanCard({
   const showSetup = workspace.status === 'NEW' || workspace.status === 'PROVISIONING';
   const showCi = sidebarStatus.ciState !== 'NONE';
   const showBranch = Boolean(workspace.branchName);
-  const showPendingRequest = Boolean(workspace.pendingRequestType);
+  const showPendingRequest = workspace.pendingRequestType;
   const hasMetadata = showSetup || showCi || showBranch || showPR || showPendingRequest;
 
   return (
@@ -293,9 +293,7 @@ export function KanbanCard({
             )}
             {showPendingRequest && (
               <div className="flex items-center gap-2">
-                {workspace.pendingRequestType ? (
-                  <PendingRequestBadge type={workspace.pendingRequestType} />
-                ) : null}
+                <PendingRequestBadge type={showPendingRequest} />
               </div>
             )}
           </CardContent>


### PR DESCRIPTION
## Summary
- remove fixed `min-h-5` placeholder rows from `KanbanCard`
- render metadata rows only when the corresponding data exists (setup, CI, branch, PR, pending request)
- skip rendering `CardContent` entirely when there is no metadata to show
- preserve existing card controls and status behavior (ratchet toggle, archive action, chips)

## Problem
Kanban workspace cards always rendered five fixed-height rows, even when most rows were empty. This created excessive vertical whitespace and made cards much taller than todo/git cards.

## Testing
- `pnpm exec biome check src/frontend/components/kanban/kanban-card.tsx`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only conditional rendering changes with minimal logic changes and no security or data handling impact.
> 
> **Overview**
> Compacts `KanbanCard` rendering by removing the fixed-height placeholder rows and only showing metadata rows (setup status, CI, branch, PR, pending request) when corresponding data exists.
> 
> If no metadata is available, the card now skips rendering `CardContent` entirely, reducing whitespace while preserving existing header controls (ratchet toggle, archive) and status badge behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 974b6f2069318cdb45c377f4f85427ee4f471af8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->