### PR TITLE
Fix Docker image crash from Prisma .ts imports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,13 +50,6 @@ COPY . .
 ENV NODE_ENV=production
 RUN pnpm build
 
-# Prisma 7.x generates .ts imports in client.js (e.g. "./internal/class.ts").
-# TypeScript with moduleResolution:"bundler" doesn't rewrite these to .js,
-# so Node.js can't resolve them. Copy the raw .ts source files into dist/
-# alongside the compiled .js so the imports resolve at runtime.
-RUN cp -r prisma/generated/*.ts dist/prisma/generated/ \
- && cp -r prisma/generated/internal/*.ts dist/prisma/generated/internal/ \
- && cp -r prisma/generated/models/*.ts dist/prisma/generated/models/
 
 # ============================================================================
 # Stage 3: Production runner

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   ],
   "scripts": {
     "dev": "pnpm --filter @factory-factory/core build && node scripts/ensure-native-modules.mjs node && tsx src/cli/index.ts serve --dev",
-    "build": "pnpm --filter @factory-factory/core build && node scripts/check-ambiguous-relative-imports.mjs && rm -rf dist && tsc -p tsconfig.backend.json && tsc-alias -p tsconfig.backend.json --resolve-full-paths && cp -r prompts dist/ && vite build",
+    "build": "pnpm --filter @factory-factory/core build && node scripts/check-ambiguous-relative-imports.mjs && rm -rf dist && tsc -p tsconfig.backend.json && tsc-alias -p tsconfig.backend.json --resolve-full-paths && node scripts/fix-prisma-imports.mjs && cp -r prompts dist/ && vite build",
     "build:storybook": "storybook build",
     "start": "pnpm --filter @factory-factory/core build && node scripts/ensure-native-modules.mjs node && tsx src/cli/index.ts serve",
     "test": "pnpm --filter @factory-factory/core build && node scripts/ensure-native-modules.mjs node && vitest run",

--- a/scripts/fix-prisma-imports.mjs
+++ b/scripts/fix-prisma-imports.mjs
@@ -1,0 +1,47 @@
+/**
+ * Post-build fixup: rewrite .ts import specifiers to .js in compiled Prisma output.
+ *
+ * Prisma 7.x generates TypeScript files with explicit .ts extensions in imports.
+ * tsc with moduleResolution:"bundler" preserves those extensions in the compiled .js,
+ * but Node.js can't load .ts files at runtime. The compiled .js counterparts already
+ * exist, so we just need to point the imports at them.
+ */
+
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const GENERATED_DIR = join("dist", "prisma", "generated");
+
+async function walk(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await walk(full)));
+    } else if (entry.name.endsWith(".js")) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+const files = await walk(GENERATED_DIR);
+let rewritten = 0;
+
+for (const file of files) {
+  const src = await readFile(file, "utf8");
+  // Rewrite  from "….ts"  and  from '….ts'  to use .js extension
+  const fixed = src.replace(
+    /(from\s+['"])([^'"]+)\.ts(['"])/g,
+    "$1$2.js$3",
+  );
+  if (fixed !== src) {
+    await writeFile(file, fixed);
+    rewritten++;
+  }
+}
+
+console.log(
+  `fix-prisma-imports: rewrote .ts → .js in ${rewritten}/${files.length} files`,
+);


### PR DESCRIPTION
## Summary
- Fix Docker image crash caused by Prisma 7.x generating `.ts` import extensions in compiled JS output
- Add `scripts/fix-prisma-imports.mjs` post-build step that rewrites `.ts` → `.js` in Prisma's compiled output
- Remove broken Dockerfile workaround that copied raw `.ts` files into `dist/` (Node 20 can't execute them)

## Test plan
- [x] `pnpm build` succeeds and `dist/prisma/generated/client.js` contains `.js` import specifiers
- [x] `docker compose up --build` starts the container successfully
- [x] `curl http://localhost:3000/health` returns `{"status":"ok"}`
- [ ] CI Docker Build & Push workflow passes on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)
