### PR TITLE
Add empty state for no active workspaces in side panel (#1137)

### DIFF
--- a/src/frontend/components/hamburger-menu.tsx
+++ b/src/frontend/components/hamburger-menu.tsx
@@ -61,11 +61,11 @@ function MenuContent({ navData, onClose }: HamburgerMenuProps & { onClose: () =>
       <Separator />
 
       {/* Active Workspaces */}
-      {activeWorkspaces.length > 0 && (
-        <div>
-          <p className="px-2 pt-3 pb-1.5 text-xs font-medium text-muted-foreground">
-            Active Workspaces
-          </p>
+      <div>
+        <p className="px-2 pt-3 pb-1.5 text-xs font-medium text-muted-foreground">
+          Active Workspaces
+        </p>
+        {activeWorkspaces.length > 0 ? (
           <div className="flex flex-col gap-0.5">
             {activeWorkspaces.map((workspace) => (
               <SheetClose key={workspace.id} asChild>
@@ -83,8 +83,12 @@ function MenuContent({ navData, onClose }: HamburgerMenuProps & { onClose: () =>
               </SheetClose>
             ))}
           </div>
-        </div>
-      )}
+        ) : (
+          <div className="flex items-center justify-center h-[60px] text-muted-foreground text-sm">
+            No active workspaces
+          </div>
+        )}
+      </div>
 
       {/* Bottom section: Reviews, Admin */}
       <div className="mt-auto flex flex-col gap-1">


### PR DESCRIPTION
## Summary
- Adds an empty state message when there are no active workspaces in the side panel
- Follows the existing empty state pattern used in kanban columns
- Improves UX by providing clear feedback instead of hiding the section

## Changes
- **Hamburger Menu**: Modified the "Active Workspaces" section to always display the header and show "No active workspaces" message when the list is empty, using centered layout with muted foreground color matching kanban column empty states

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Open the side panel when no workspaces are in WORKING or WAITING state to verify the empty state message appears

Closes #1137

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
