### PR TITLE
Fix admin refresh workspaces button overflow on mobile

### DIFF
--- a/src/client/routes/admin-page.tsx
+++ b/src/client/routes/admin-page.tsx
@@ -128,9 +128,9 @@ function ProjectFactoryConfigCard({
         error={saveConfig.error}
       />
       <div className="border-b bg-muted/50 px-4 py-3">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <h3 className="font-semibold text-sm">{projectName}</h3>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
+            <h3 className="min-w-0 truncate font-semibold text-sm">{projectName}</h3>
             {factoryConfig ? (
               <Badge variant="default" className="bg-green-600 hover:bg-green-700">
                 <CheckCircle2 className="w-3 h-3 mr-1" />
@@ -156,7 +156,7 @@ function ProjectFactoryConfigCard({
             size="sm"
             onClick={handleRefresh}
             disabled={refreshConfigs.isPending}
-            className="gap-2"
+            className="w-full gap-2 sm:w-auto"
           >
             <RefreshCw className={`w-4 h-4 ${refreshConfigs.isPending ? 'animate-spin' : ''}`} />
             Refresh Workspaces


### PR DESCRIPTION
## Summary
Fixes a mobile layout issue on the Admin page where the **Refresh Workspaces** button overflowed its container in the project factory config card.

## Changes
- Updated the card header row to be responsive:
  - Mobile: stack content vertically (`flex-col`)
  - Small+ screens: keep horizontal layout (`sm:flex-row`)
- Allowed the left content area to wrap/truncate safely on narrow widths (`min-w-0`, `flex-wrap`, truncated project name).
- Made the refresh button full-width on mobile and auto-width on larger screens (`w-full sm:w-auto`).

## Validation
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely CSS/className layout tweaks to a single UI header with no logic, API, or data-handling changes.
> 
> **Overview**
> Fixes a mobile layout issue in the Admin page’s factory config card header where the **Refresh Workspaces** button could overflow.
> 
> The header is made responsive by stacking content on small screens (`flex-col`) while keeping a row layout on `sm+`, adding safe wrapping/truncation for the project name (`min-w-0`, `truncate`), and making the refresh button full-width on mobile (`w-full sm:w-auto`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87ccc3091c060d0d18a7d7e3a83c2cb3382ea141. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->