### PR TITLE
Add pnpm proxy script for private tunnel startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "build": "pnpm --filter @factory-factory/core build && node scripts/check-ambiguous-relative-imports.mjs && rm -rf dist && tsc -p tsconfig.backend.json && tsc-alias -p tsconfig.backend.json --resolve-full-paths && node scripts/fix-prisma-imports.mjs && cp -r prompts dist/ && vite build",
     "build:storybook": "storybook build",
     "start": "pnpm --filter @factory-factory/core build && node scripts/ensure-native-modules.mjs node && tsx src/cli/index.ts serve",
+    "proxy": "pnpm --filter @factory-factory/core build && node scripts/ensure-native-modules.mjs node && tsx src/cli/index.ts proxy --private",
     "test": "pnpm --filter @factory-factory/core build && node scripts/ensure-native-modules.mjs node && vitest run",
     "test:watch": "pnpm --filter @factory-factory/core build && node scripts/ensure-native-modules.mjs node && vitest",
     "test:coverage": "pnpm --filter @factory-factory/core build && node scripts/ensure-native-modules.mjs node && vitest run --coverage",


### PR DESCRIPTION
## Summary
- add a new `proxy` script in `package.json`
- mirror the existing `start` script setup (core build + native module check)
- run the CLI `proxy` command with `--private` so `pnpm proxy` starts with a private proxy by default

## Changes
- `package.json`
  - added `proxy` script that invokes `tsx src/cli/index.ts proxy --private`

## Validation
- pre-commit hooks passed during commit: `biome check --write`, `pnpm typecheck`, `pnpm deps:check`, `pnpm knip --include files,dependencies,unlisted`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 673c8a2bd393c571dc2be724c07db2efbc226ca4. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->