### PR TITLE
Simplify workspaces and settings UI labels

### DIFF
--- a/src/client/routes/admin-page.tsx
+++ b/src/client/routes/admin-page.tsx
@@ -732,7 +732,7 @@ function ServerLogsSection() {
 }
 
 export default function AdminDashboardPage() {
-  useAppHeader({ title: 'Admin Dashboard' });
+  useAppHeader({ title: 'Settings' });
 
   const {
     data: stats,
@@ -762,7 +762,7 @@ export default function AdminDashboardPage() {
 
   // Show full loading only when stats are loading (first load)
   if (isLoadingStats) {
-    return <Loading message="Loading admin dashboard..." />;
+    return <Loading message="Loading settings..." />;
   }
 
   return (
@@ -772,8 +772,8 @@ export default function AdminDashboardPage() {
           <Button variant="ghost" size="sm" className="shrink-0 text-muted-foreground" asChild>
             <Link to={`/projects/${projectSlug}/workspaces`}>
               <ArrowLeft className="h-3.5 w-3.5" />
-              <span className="hidden sm:inline">Back to Workspaces Board</span>
-              <span className="sm:hidden">Board</span>
+              <span className="hidden sm:inline">Back to Workspaces</span>
+              <span className="sm:hidden">Workspaces</span>
             </Link>
           </Button>
         </HeaderLeftExtraSlot>

--- a/src/client/routes/logs.tsx
+++ b/src/client/routes/logs.tsx
@@ -269,7 +269,7 @@ export default function LogsPage() {
           <Link to="/admin">
             <Button variant="ghost" size="sm">
               <ArrowLeft className="w-4 h-4 mr-1" />
-              Admin Dashboard
+              Settings
             </Button>
           </Link>
         </PageHeader>

--- a/src/client/routes/projects/workspaces/components/workspaces-board-view.tsx
+++ b/src/client/routes/projects/workspaces/components/workspaces-board-view.tsx
@@ -2,7 +2,7 @@ import { HeaderRightSlot, useAppHeader } from '@/frontend/components/app-header-
 import { KanbanBoard, KanbanControls, KanbanProvider } from '@/frontend/components/kanban';
 
 function BoardHeaderSlot() {
-  useAppHeader({ title: 'Workspaces Board' });
+  useAppHeader({ title: 'Workspaces' });
 
   return (
     <HeaderRightSlot>

--- a/src/client/routes/projects/workspaces/workspace-detail-header.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-header.tsx
@@ -840,7 +840,7 @@ export function WorkspaceDetailHeaderSlot({
         <Button variant="ghost" size="sm" className="shrink-0 text-muted-foreground" asChild>
           <Link to={`/projects/${slug}/workspaces`}>
             <ArrowLeft className="h-3.5 w-3.5" />
-            <span className="hidden sm:inline">Workspaces Board</span>
+            <span className="hidden sm:inline">Workspaces</span>
           </Link>
         </Button>
         <div className="hidden md:flex items-center gap-2 min-w-0">

--- a/src/frontend/components/hamburger-menu.tsx
+++ b/src/frontend/components/hamburger-menu.tsx
@@ -104,7 +104,7 @@ function MenuContent({ navData, onClose }: HamburgerMenuProps & { onClose: () =>
               }`}
             >
               <Kanban className="h-4 w-4" />
-              <span>Workspaces Board</span>
+              <span>Workspaces</span>
             </Link>
           </SheetClose>
           <SheetClose asChild>
@@ -139,7 +139,7 @@ function MenuContent({ navData, onClose }: HamburgerMenuProps & { onClose: () =>
                 }`}
               >
                 <Settings className="h-4 w-4" />
-                <span>Admin Dashboard</span>
+                <span>Settings</span>
               </Link>
             </SheetClose>
             <ThemeToggle />


### PR DESCRIPTION
## Summary
This PR updates user-facing navigation labels to use simpler wording:

- Rename `Workspaces Board` to `Workspaces`
- Rename `Admin Dashboard` to `Settings`
- Update related back button and loading text for consistency

## Files Updated
- `src/client/routes/projects/workspaces/components/workspaces-board-view.tsx`
- `src/client/routes/projects/workspaces/workspace-detail-header.tsx`
- `src/frontend/components/hamburger-menu.tsx`
- `src/client/routes/admin-page.tsx`
- `src/client/routes/logs.tsx`

## Validation
- Pre-commit checks ran successfully (Biome, typecheck, dependency cruise, knip)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: UI-only text/label changes that don’t affect routing, permissions, or data flow.
> 
> **Overview**
> Simplifies user-facing navigation text by renaming **“Admin Dashboard” → “Settings”** and **“Workspaces Board” → “Workspaces”** across the header, hamburger menu, and logs page.
> 
> Updates related back-button labels and loading messages to match the new naming.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 002de06ea7d6e244422a314577ebc7d0f58c8214. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->