### PR TITLE
Add default permission presets for ratchet and new workspaces

### DIFF
--- a/prisma/migrations/20260220110000_add_user_permission_presets/migration.sql
+++ b/prisma/migrations/20260220110000_add_user_permission_presets/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "UserSettings" ADD COLUMN "defaultWorkspacePermissions" TEXT NOT NULL DEFAULT 'STRICT';
+ALTER TABLE "UserSettings" ADD COLUMN "ratchetPermissions" TEXT NOT NULL DEFAULT 'YOLO';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,12 @@ enum SessionProvider {
   CODEX
 }
 
+enum SessionPermissionPreset {
+  STRICT
+  RELAXED
+  YOLO
+}
+
 enum WorkspaceProviderSelection {
   WORKSPACE_DEFAULT
   CLAUDE
@@ -273,6 +279,8 @@ model UserSettings {
   // Ratchet Settings (unified PR progression)
   ratchetEnabled            Boolean  @default(false)  // Default for new GitHub-issue-created workspaces
   defaultSessionProvider    SessionProvider @default(CLAUDE)
+  defaultWorkspacePermissions SessionPermissionPreset @default(STRICT) // Default execution-mode preset for non-ratchet sessions
+  ratchetPermissions        SessionPermissionPreset @default(YOLO) // Default execution-mode preset for ratchet sessions
 
   createdAt             DateTime @default(now())
   updatedAt             DateTime @updatedAt

--- a/src/backend/domains/ratchet/ratchet.service.test.ts
+++ b/src/backend/domains/ratchet/ratchet.service.test.ts
@@ -102,6 +102,8 @@ describe('ratchet service (state-change + idle dispatch)', () => {
       cachedSlashCommands: null,
       ratchetEnabled: false,
       defaultSessionProvider: 'CLAUDE',
+      defaultWorkspacePermissions: 'STRICT',
+      ratchetPermissions: 'YOLO',
       createdAt: new Date('2026-01-01T00:00:00.000Z'),
       updatedAt: new Date('2026-01-01T00:00:00.000Z'),
     });

--- a/src/backend/domains/session/data/session-provider-resolver.service.test.ts
+++ b/src/backend/domains/session/data/session-provider-resolver.service.test.ts
@@ -73,6 +73,8 @@ describe('sessionProviderResolverService', () => {
       cachedSlashCommands: null,
       ratchetEnabled: false,
       defaultSessionProvider: 'CLAUDE',
+      defaultWorkspacePermissions: 'STRICT',
+      ratchetPermissions: 'YOLO',
       createdAt: new Date('2026-01-01T00:00:00.000Z'),
       updatedAt: new Date('2026-01-01T00:00:00.000Z'),
     });

--- a/src/backend/domains/workspace/lifecycle/creation.service.test.ts
+++ b/src/backend/domains/workspace/lifecycle/creation.service.test.ts
@@ -129,6 +129,8 @@ describe('WorkspaceCreationService', () => {
       cachedSlashCommands: null,
       ratchetEnabled: true,
       defaultSessionProvider: 'CLAUDE',
+      defaultWorkspacePermissions: 'STRICT',
+      ratchetPermissions: 'YOLO',
       createdAt: new Date(),
       updatedAt: new Date(),
     };
@@ -221,6 +223,8 @@ describe('WorkspaceCreationService', () => {
           cachedSlashCommands: null,
           ratchetEnabled: false,
           defaultSessionProvider: 'CLAUDE',
+          defaultWorkspacePermissions: 'STRICT',
+          ratchetPermissions: 'YOLO',
           createdAt: new Date(),
           updatedAt: new Date(),
         };
@@ -493,6 +497,8 @@ describe('WorkspaceCreationService', () => {
           cachedSlashCommands: null,
           ratchetEnabled: true,
           defaultSessionProvider: 'CODEX',
+          defaultWorkspacePermissions: 'STRICT',
+          ratchetPermissions: 'YOLO',
           createdAt: new Date(),
           updatedAt: new Date(),
         });

--- a/src/backend/domains/workspace/query/user-settings-query.service.ts
+++ b/src/backend/domains/workspace/query/user-settings-query.service.ts
@@ -13,6 +13,8 @@ class UserSettingsQueryService {
     notificationSoundPath?: string | null;
     ratchetEnabled?: boolean;
     defaultSessionProvider?: 'CLAUDE' | 'CODEX';
+    defaultWorkspacePermissions?: 'STRICT' | 'RELAXED' | 'YOLO';
+    ratchetPermissions?: 'STRICT' | 'RELAXED' | 'YOLO';
   }): Promise<UserSettings> {
     return userSettingsAccessor.update(data);
   }

--- a/src/backend/orchestration/data-backup.service.test.ts
+++ b/src/backend/orchestration/data-backup.service.test.ts
@@ -183,6 +183,8 @@ const mockUserSettings: UserSettings = {
   cachedSlashCommands: { commands: [] },
   ratchetEnabled: true,
   defaultSessionProvider: SessionProvider.CLAUDE,
+  defaultWorkspacePermissions: 'STRICT',
+  ratchetPermissions: 'YOLO',
   createdAt: new Date('2025-01-01T00:00:00.000Z'),
   updatedAt: new Date('2025-01-01T00:00:00.000Z'),
 };
@@ -302,6 +304,8 @@ function createImportData(overrides?: Partial<ExportData['data']>): ExportData {
         notificationSoundPath: '/path/to/sound.mp3',
         ratchetEnabled: true,
         defaultSessionProvider: SessionProvider.CLAUDE,
+        defaultWorkspacePermissions: 'STRICT',
+        ratchetPermissions: 'YOLO',
       },
       ...overrides,
     },
@@ -336,6 +340,8 @@ describe('DataBackupService', () => {
         expect.objectContaining({
           ratchetEnabled: true,
           defaultSessionProvider: SessionProvider.CLAUDE,
+          defaultWorkspacePermissions: 'STRICT',
+          ratchetPermissions: 'YOLO',
         })
       );
       expect(exportDataSchema.safeParse(result).success).toBe(true);

--- a/src/backend/orchestration/data-backup.service.ts
+++ b/src/backend/orchestration/data-backup.service.ts
@@ -315,6 +315,8 @@ async function importUserSettings(
       // Ratchet settings
       ratchetEnabled: settings.ratchetEnabled,
       defaultSessionProvider: settings.defaultSessionProvider,
+      defaultWorkspacePermissions: settings.defaultWorkspacePermissions,
+      ratchetPermissions: settings.ratchetPermissions,
       // Note: workspaceOrder and cachedSlashCommands are intentionally not imported
       // as they are rebuild-able cache data
     },
@@ -451,6 +453,8 @@ class DataBackupService {
               // Ratchet settings
               ratchetEnabled: userSettings.ratchetEnabled,
               defaultSessionProvider: userSettings.defaultSessionProvider,
+              defaultWorkspacePermissions: userSettings.defaultWorkspacePermissions,
+              ratchetPermissions: userSettings.ratchetPermissions,
               // Note: workspaceOrder and cachedSlashCommands are intentionally excluded
               // as they are rebuild-able cache data (per design doc)
             }

--- a/src/backend/resource_accessors/user-settings.accessor.ts
+++ b/src/backend/resource_accessors/user-settings.accessor.ts
@@ -1,4 +1,9 @@
-import type { Prisma, SessionProvider, UserSettings } from '@prisma-gen/client';
+import type {
+  Prisma,
+  SessionPermissionPreset,
+  SessionProvider,
+  UserSettings,
+} from '@prisma-gen/client';
 import { prisma } from '@/backend/db';
 import { workspaceOrderMapSchema } from '@/shared/schemas/persisted-stores.schema';
 
@@ -11,6 +16,8 @@ interface UpdateUserSettingsInput {
   // Ratchet settings
   ratchetEnabled?: boolean;
   defaultSessionProvider?: SessionProvider;
+  defaultWorkspacePermissions?: SessionPermissionPreset;
+  ratchetPermissions?: SessionPermissionPreset;
 }
 
 // Type for workspace order storage: { [projectId]: workspaceId[] }
@@ -42,6 +49,8 @@ class UserSettingsAccessor {
           customIdeCommand: null,
           playSoundOnComplete: true,
           defaultSessionProvider: 'CLAUDE',
+          defaultWorkspacePermissions: 'STRICT',
+          ratchetPermissions: 'YOLO',
         },
       });
     }
@@ -71,6 +80,8 @@ class UserSettingsAccessor {
         playSoundOnComplete: data.playSoundOnComplete ?? true,
         cachedSlashCommands: data.cachedSlashCommands ?? undefined,
         defaultSessionProvider: data.defaultSessionProvider ?? 'CLAUDE',
+        defaultWorkspacePermissions: data.defaultWorkspacePermissions ?? 'STRICT',
+        ratchetPermissions: data.ratchetPermissions ?? 'YOLO',
       },
     });
   }

--- a/src/backend/trpc/user-settings.trpc.ts
+++ b/src/backend/trpc/user-settings.trpc.ts
@@ -4,7 +4,7 @@
  * Provides operations for managing user settings (IDE preferences, etc).
  */
 
-import { SessionProvider } from '@prisma-gen/client';
+import { SessionPermissionPreset, SessionProvider } from '@prisma-gen/client';
 import { z } from 'zod';
 import { userSettingsQueryService } from '@/backend/domains/workspace';
 import { execCommand } from '@/backend/lib/shell';
@@ -44,6 +44,9 @@ export const userSettingsRouter = router({
         ratchetEnabled: z.boolean().optional(),
         // Session provider defaults
         defaultSessionProvider: z.nativeEnum(SessionProvider).optional(),
+        // Permission preset defaults
+        defaultWorkspacePermissions: z.nativeEnum(SessionPermissionPreset).optional(),
+        ratchetPermissions: z.nativeEnum(SessionPermissionPreset).optional(),
       })
     )
     .mutation(async ({ input }) => {

--- a/src/client/routes/admin-page.tsx
+++ b/src/client/routes/admin-page.tsx
@@ -429,6 +429,7 @@ function ChatProviderDefaultsSection() {
   }
 
   const currentProvider = settings?.defaultSessionProvider ?? 'CLAUDE';
+  const currentWorkspacePermissions = settings?.defaultWorkspacePermissions ?? 'STRICT';
 
   return (
     <Card>
@@ -438,7 +439,7 @@ function ChatProviderDefaultsSection() {
           Default provider used when a workspace defers provider selection
         </CardDescription>
       </CardHeader>
-      <CardContent className="space-y-2">
+      <CardContent className="space-y-3">
         <Label htmlFor="chat-default-provider">Default chat provider</Label>
         <Select
           value={currentProvider}
@@ -458,6 +459,27 @@ function ChatProviderDefaultsSection() {
           </SelectContent>
         </Select>
         <ProviderCliWarning provider={currentProvider} />
+        <div className="space-y-2 pt-1">
+          <Label htmlFor="workspace-permissions">Default permissions for new workspaces</Label>
+          <Select
+            value={currentWorkspacePermissions}
+            onValueChange={(value) => {
+              if (value === 'STRICT' || value === 'RELAXED' || value === 'YOLO') {
+                updateSettings.mutate({ defaultWorkspacePermissions: value });
+              }
+            }}
+            disabled={updateSettings.isPending}
+          >
+            <SelectTrigger id="workspace-permissions">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="STRICT">Strict</SelectItem>
+              <SelectItem value="RELAXED">Relaxed</SelectItem>
+              <SelectItem value="YOLO">YOLO</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
       </CardContent>
     </Card>
   );
@@ -566,6 +588,8 @@ function RatchetSettingsSection() {
     );
   }
 
+  const currentRatchetPermissions = settings?.ratchetPermissions ?? 'YOLO';
+
   return (
     <Card>
       <CardHeader>
@@ -604,6 +628,31 @@ function RatchetSettingsSection() {
             }}
             disabled={updateSettings.isPending}
           />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="ratchet-permissions">Ratchet permission defaults</Label>
+          <Select
+            value={currentRatchetPermissions}
+            onValueChange={(value) => {
+              if (value === 'STRICT' || value === 'RELAXED' || value === 'YOLO') {
+                updateSettings.mutate({ ratchetPermissions: value });
+              }
+            }}
+            disabled={updateSettings.isPending}
+          >
+            <SelectTrigger id="ratchet-permissions">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="STRICT">Strict</SelectItem>
+              <SelectItem value="RELAXED">Relaxed</SelectItem>
+              <SelectItem value="YOLO">YOLO</SelectItem>
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            Controls the default execution mode used when Ratchet starts a fixer session.
+          </p>
         </div>
 
         {/* Manual trigger button */}

--- a/src/shared/schemas/export-data.schema.ts
+++ b/src/shared/schemas/export-data.schema.ts
@@ -36,6 +36,7 @@ const KanbanColumn = z.enum(enumValues(CoreKanbanColumn));
 const RatchetState = z.enum(enumValues(CoreRatchetState));
 const SessionStatus = z.enum(enumValues(CoreSessionStatus));
 const SessionProvider = z.enum(['CLAUDE', 'CODEX']);
+const SessionPermissionPreset = z.enum(['STRICT', 'RELAXED', 'YOLO']);
 const WorkspaceProviderSelection = z.enum(['WORKSPACE_DEFAULT', 'CLAUDE', 'CODEX']);
 
 const exportedProjectSchema = z.object({
@@ -141,6 +142,8 @@ const exportedUserSettingsSchema = z.object({
   notificationSoundPath: z.string().nullable(),
   ratchetEnabled: z.boolean(),
   defaultSessionProvider: SessionProvider,
+  defaultWorkspacePermissions: SessionPermissionPreset.optional().default('STRICT'),
+  ratchetPermissions: SessionPermissionPreset.optional().default('YOLO'),
 });
 
 export const exportDataSchema = z.object({


### PR DESCRIPTION
## Summary
- add persisted user defaults for session permission presets with a new `SessionPermissionPreset` enum (`STRICT`, `RELAXED`, `YOLO`)
- add migration to store both:
  - `defaultWorkspacePermissions` (applies to new non-ratchet workspace sessions)
  - `ratchetPermissions` (applies to ratchet fixer sessions)
- extend user settings backend surface (accessor/query service/tRPC update input) to read and update these defaults
- add Admin UI controls for both defaults in Chat Defaults and Auto-Fix sections
- apply configured permission presets at CODEX session startup by mapping presets to ACP `execution_mode` options and updating session config/capabilities
- keep behavior safe on older DB states by falling back to built-in defaults when user settings cannot be read
- include export/import support for the new user settings fields

## Why
This gives users one place to set default permission behavior for both ratchet and newly created workspace sessions, so they don't need to manually reconfigure execution mode each time.

## Validation
- `pnpm typecheck`
- `pnpm check:fix`
- `pnpm exec vitest run src/backend/domains/session/lifecycle/session.service.test.ts src/backend/orchestration/data-backup.service.test.ts src/backend/domains/workspace/lifecycle/creation.service.test.ts src/backend/domains/session/data/session-provider-resolver.service.test.ts src/backend/domains/ratchet/ratchet.service.test.ts`

## Migration
- `prisma/migrations/20260220110000_add_user_permission_presets/migration.sql`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches DB schema and session-start behavior that changes default execution permissions for new CODEX sessions; mis-mapping or config-option mismatches could lead to unexpectedly permissive or restrictive runs.
> 
> **Overview**
> Adds a new `SessionPermissionPreset` (STRICT/RELAXED/YOLO) and persists two new user settings—`defaultWorkspacePermissions` and `ratchetPermissions`—via a Prisma migration and schema update.
> 
> Wires these defaults through the backend (`userSettings` accessor/query/tRPC) and data backup export/import, and exposes admin-page controls to edit both.
> 
> Updates `SessionService` to automatically map the configured preset to ACP `execution_mode` and apply it when starting/creating *new* CODEX sessions (with safe fallbacks and logging if settings can’t be loaded).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 665f4c9f5a849e49836a6d1a55dc92cc0a5def36. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->