### PR TITLE
Enforce provider CLI readiness and add in-app upgrades

### DIFF
--- a/src/backend/domains/session/data/session-provider-resolver.service.ts
+++ b/src/backend/domains/session/data/session-provider-resolver.service.ts
@@ -4,6 +4,16 @@ import { userSettingsAccessor } from '@/backend/resource_accessors/user-settings
 import { workspaceAccessor } from '@/backend/resource_accessors/workspace.accessor';
 
 class SessionProviderResolverService {
+  async resolveProviderForWorkspaceCreation(
+    explicitProvider?: SessionProvider
+  ): Promise<SessionProvider> {
+    if (explicitProvider) {
+      return explicitProvider;
+    }
+
+    return await userSettingsAccessor.getDefaultSessionProvider();
+  }
+
   async resolveSessionProvider(params: {
     workspaceId: string;
     explicitProvider?: SessionProvider;

--- a/src/backend/lib/provider-cli-availability.test.ts
+++ b/src/backend/lib/provider-cli-availability.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getProviderBlockingIssue,
+  getProviderUnavailableMessage,
+} from './provider-cli-availability';
+
+describe('provider-cli-availability', () => {
+  it('returns null when provider requirements are met', () => {
+    const health = {
+      claude: { isInstalled: true },
+      codex: { isInstalled: true, isAuthenticated: true },
+      github: { isInstalled: true, isAuthenticated: true },
+      allHealthy: true,
+    };
+
+    expect(getProviderBlockingIssue('CLAUDE', health)).toBeNull();
+    expect(getProviderBlockingIssue('CODEX', health)).toBeNull();
+  });
+
+  it('reports missing claude install', () => {
+    const health = {
+      claude: { isInstalled: false, error: 'Claude CLI is not installed.' },
+      codex: { isInstalled: true, isAuthenticated: true },
+      github: { isInstalled: true, isAuthenticated: true },
+      allHealthy: false,
+    };
+
+    expect(getProviderBlockingIssue('CLAUDE', health)).toContain('not installed');
+    expect(getProviderUnavailableMessage('CLAUDE', health)).toContain(
+      'Claude provider is unavailable'
+    );
+  });
+
+  it('reports codex auth as blocking', () => {
+    const health = {
+      claude: { isInstalled: true },
+      codex: {
+        isInstalled: true,
+        isAuthenticated: false,
+        error: 'Codex CLI is not authenticated.',
+      },
+      github: { isInstalled: true, isAuthenticated: true },
+      allHealthy: true,
+    };
+
+    expect(getProviderBlockingIssue('CODEX', health)).toContain('not authenticated');
+    expect(getProviderUnavailableMessage('CODEX', health)).toContain(
+      'Codex provider is unavailable'
+    );
+  });
+});

--- a/src/backend/lib/provider-cli-availability.ts
+++ b/src/backend/lib/provider-cli-availability.ts
@@ -1,0 +1,50 @@
+import type { SessionProvider } from '@prisma-gen/client';
+
+export interface ProviderCliHealthStatus {
+  claude: {
+    isInstalled: boolean;
+    error?: string;
+  };
+  codex: {
+    isInstalled: boolean;
+    isAuthenticated?: boolean;
+    error?: string;
+  };
+}
+
+function getProviderLabel(provider: SessionProvider): string {
+  return provider === 'CODEX' ? 'Codex' : 'Claude';
+}
+
+export function getProviderBlockingIssue(
+  provider: SessionProvider,
+  health: ProviderCliHealthStatus
+): string | null {
+  if (provider === 'CLAUDE') {
+    if (!health.claude.isInstalled) {
+      return health.claude.error ?? 'Claude CLI is not installed.';
+    }
+    return null;
+  }
+
+  if (!health.codex.isInstalled) {
+    return health.codex.error ?? 'Codex CLI is not installed.';
+  }
+  if (health.codex.isAuthenticated === false) {
+    return health.codex.error ?? 'Codex CLI is not authenticated.';
+  }
+
+  return null;
+}
+
+export function getProviderUnavailableMessage(
+  provider: SessionProvider,
+  health: ProviderCliHealthStatus
+): string | null {
+  const issue = getProviderBlockingIssue(provider, health);
+  if (!issue) {
+    return null;
+  }
+
+  return `${getProviderLabel(provider)} provider is unavailable: ${issue}`;
+}

--- a/src/backend/services/constants.ts
+++ b/src/backend/services/constants.ts
@@ -11,6 +11,8 @@ export const SERVICE_TIMEOUT_MS = Object.freeze({
   claudeCliVersionCheck: 5000,
   codexCliVersionCheck: 5000,
   codexCliAuthCheck: 5000,
+  cliLatestVersionCheck: 3000,
+  cliUpgrade: 120_000,
   startupScriptForceKillGrace: 5000,
   portLsof: 2000,
   ratchetWorkspaceCheck: 90_000,

--- a/src/backend/trpc/admin.router.test.ts
+++ b/src/backend/trpc/admin.router.test.ts
@@ -86,6 +86,20 @@ function createCaller() {
             forceRefresh,
             allHealthy: true,
           })),
+          upgradeProviderCLI: vi.fn(async (provider: 'CLAUDE' | 'CODEX') => ({
+            provider,
+            packageName: provider === 'CLAUDE' ? '@anthropic-ai/claude-code' : '@openai/codex',
+            command: `npm install -g ${
+              provider === 'CLAUDE' ? '@anthropic-ai/claude-code' : '@openai/codex'
+            }`,
+            output: 'ok',
+            health: {
+              claude: { isInstalled: true },
+              codex: { isInstalled: true, isAuthenticated: true },
+              github: { isInstalled: true, isAuthenticated: true },
+              allHealthy: true,
+            },
+          })),
         },
         terminalService: {
           getAllTerminals: vi.fn(() => []),
@@ -195,6 +209,13 @@ describe('adminRouter', () => {
       forceRefresh: true,
       allHealthy: true,
     });
+    await expect(caller.upgradeProviderCLI({ provider: 'CODEX' })).resolves.toEqual(
+      expect.objectContaining({
+        provider: 'CODEX',
+        packageName: '@openai/codex',
+        message: 'Codex CLI upgraded successfully.',
+      })
+    );
 
     await expect(
       caller.exportDecisionLogs({

--- a/src/backend/trpc/workspace.trpc.ts
+++ b/src/backend/trpc/workspace.trpc.ts
@@ -1,13 +1,15 @@
 import { SessionProvider, WorkspaceProviderSelection } from '@prisma-gen/client';
+import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 import { ratchetService } from '@/backend/domains/ratchet';
-import { sessionService } from '@/backend/domains/session';
+import { sessionProviderResolverService, sessionService } from '@/backend/domains/session';
 import {
   deriveWorkspaceFlowStateFromWorkspace,
   WorkspaceCreationService,
   workspaceDataService,
   workspaceQueryService,
 } from '@/backend/domains/workspace';
+import { getProviderUnavailableMessage } from '@/backend/lib/provider-cli-availability';
 import {
   buildWorkspaceSessionSummaries,
   hasWorkingSessionSummary,
@@ -150,6 +152,23 @@ export const workspaceRouter = router({
   create: publicProcedure.input(workspaceCreationSourceSchema).mutation(async ({ ctx, input }) => {
     const logger = getLogger(ctx);
     const { configService } = ctx.appContext.services;
+    const maxSessionsPerWorkspace = configService.getMaxSessionsPerWorkspace();
+
+    // Workspace creation provisions a default session when session capacity is enabled.
+    // Block creation if the effective provider cannot be used on this machine.
+    if (maxSessionsPerWorkspace > 0) {
+      const explicitProvider = input.type === 'MANUAL' ? input.provider : undefined;
+      const provider =
+        await sessionProviderResolverService.resolveProviderForWorkspaceCreation(explicitProvider);
+      const cliHealth = await ctx.appContext.services.cliHealthService.checkHealth();
+      const providerUnavailableMessage = getProviderUnavailableMessage(provider, cliHealth);
+      if (providerUnavailableMessage) {
+        throw new TRPCError({
+          code: 'PRECONDITION_FAILED',
+          message: `Cannot create workspace: ${providerUnavailableMessage}`,
+        });
+      }
+    }
 
     // Use the canonical workspace creation service
     const workspaceCreationService = new WorkspaceCreationService({

--- a/src/client/routes/projects/workspaces/use-workspace-detail.ts
+++ b/src/client/routes/projects/workspaces/use-workspace-detail.ts
@@ -159,6 +159,9 @@ export function useSessionManagement({
       // With staleTime: 0, invalidate will trigger an immediate refetch
       utils.session.listSessions.invalidate({ workspaceId });
     },
+    onError: (error) => {
+      toast.error(error.message || 'Failed to create session');
+    },
   });
   const startSession = trpc.session.startSession.useMutation();
 

--- a/src/frontend/components/cli-health-banner.tsx
+++ b/src/frontend/components/cli-health-banner.tsx
@@ -1,7 +1,75 @@
 import { AlertTriangle, ExternalLink, RefreshCw, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { trpc } from '@/frontend/lib/trpc';
+
+interface HealthIssue {
+  title: string;
+  description: string;
+  link?: string;
+  linkLabel?: string;
+  upgradeProvider?: 'CLAUDE' | 'CODEX';
+}
+
+interface CliHealthForBanner {
+  claude: { isInstalled: boolean; isOutdated?: boolean; version?: string; latestVersion?: string };
+  codex: {
+    isInstalled: boolean;
+    isAuthenticated?: boolean;
+    isOutdated?: boolean;
+    version?: string;
+    latestVersion?: string;
+  };
+  github: { isInstalled: boolean; isAuthenticated: boolean };
+}
+
+function collectIssues(health: CliHealthForBanner): HealthIssue[] {
+  const issues: HealthIssue[] = [];
+
+  if (!health.claude.isInstalled) {
+    issues.push({
+      title: 'Claude CLI not installed',
+      description: 'Install the Claude CLI to enable AI-powered coding sessions.',
+      link: 'https://claude.ai/download',
+      linkLabel: 'Install',
+    });
+  } else if (health.claude.isOutdated) {
+    issues.push({
+      title: 'Claude CLI out of date',
+      description: `Installed ${health.claude.version ?? 'unknown'}; latest is ${health.claude.latestVersion ?? 'latest'}.`,
+      link: 'https://claude.ai/download',
+      linkLabel: 'Upgrade',
+      upgradeProvider: 'CLAUDE',
+    });
+  }
+
+  if (!health.github.isInstalled) {
+    issues.push({
+      title: 'GitHub CLI not installed',
+      description: 'Install the GitHub CLI (gh) to enable PR management features.',
+      link: 'https://cli.github.com/',
+      linkLabel: 'Install',
+    });
+  } else if (!health.github.isAuthenticated) {
+    issues.push({
+      title: 'GitHub CLI not authenticated',
+      description: 'Run "gh auth login" in your terminal to authenticate with GitHub.',
+    });
+  }
+
+  if (health.codex.isInstalled && health.codex.isAuthenticated && health.codex.isOutdated) {
+    issues.push({
+      title: 'Codex CLI out of date',
+      description: `Installed ${health.codex.version ?? 'unknown'}; latest is ${health.codex.latestVersion ?? 'latest'}.`,
+      link: 'https://developers.openai.com/codex/app-server/',
+      linkLabel: 'Upgrade',
+      upgradeProvider: 'CODEX',
+    });
+  }
+
+  return issues;
+}
 
 /**
  * Banner that displays warnings when CLI dependencies are not properly installed.
@@ -9,6 +77,17 @@ import { trpc } from '@/frontend/lib/trpc';
  */
 export function CLIHealthBanner() {
   const [dismissed, setDismissed] = useState(false);
+  const utils = trpc.useUtils();
+  const upgradeProviderCli = trpc.admin.upgradeProviderCLI.useMutation({
+    onSuccess: (result) => {
+      toast.success(result.message);
+      utils.admin.checkCLIHealth.setData({ forceRefresh: false }, result.health);
+      void refetch();
+    },
+    onError: (error) => {
+      toast.error(error.message);
+    },
+  });
 
   const {
     data: health,
@@ -25,41 +104,20 @@ export function CLIHealthBanner() {
     }
   );
 
-  // Reset dismissed state when health status changes to show new issues
-  const allHealthy = health?.allHealthy;
+  const issueCount = health ? collectIssues(health).length : 0;
+
+  // Reset dismissed state when health issues appear (or change).
   useEffect(() => {
-    if (allHealthy === false) {
-      // Only reset if there are issues
+    if (issueCount > 0) {
       setDismissed(false);
     }
-  }, [allHealthy]);
+  }, [issueCount]);
 
-  if (isLoading || dismissed || !health || health.allHealthy) {
+  if (isLoading || dismissed || !health) {
     return null;
   }
 
-  const issues: Array<{ title: string; description: string; link?: string }> = [];
-
-  if (!health.claude.isInstalled) {
-    issues.push({
-      title: 'Claude CLI not installed',
-      description: 'Install the Claude CLI to enable AI-powered coding sessions.',
-      link: 'https://claude.ai/download',
-    });
-  }
-
-  if (!health.github.isInstalled) {
-    issues.push({
-      title: 'GitHub CLI not installed',
-      description: 'Install the GitHub CLI (gh) to enable PR management features.',
-      link: 'https://cli.github.com/',
-    });
-  } else if (!health.github.isAuthenticated) {
-    issues.push({
-      title: 'GitHub CLI not authenticated',
-      description: 'Run "gh auth login" in your terminal to authenticate with GitHub.',
-    });
-  }
+  const issues = collectIssues(health);
 
   if (issues.length === 0) {
     return null;
@@ -86,9 +144,24 @@ export function CLIHealthBanner() {
                         rel="noopener noreferrer"
                         className="ml-1.5 inline-flex items-center gap-1 text-warning underline hover:text-warning/80"
                       >
-                        Install
+                        {issue.linkLabel ?? 'Install'}
                         <ExternalLink className="h-3 w-3" />
                       </a>
+                    )}
+                    {issue.upgradeProvider && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="ml-2 h-6 border-warning/40 px-2 text-xs text-warning hover:bg-warning/10"
+                        onClick={() =>
+                          upgradeProviderCli.mutate({
+                            provider: issue.upgradeProvider as 'CLAUDE' | 'CODEX',
+                          })
+                        }
+                        disabled={upgradeProviderCli.isPending}
+                      >
+                        {upgradeProviderCli.isPending ? 'Upgrading...' : 'Upgrade now'}
+                      </Button>
                     )}
                   </li>
                 ))}
@@ -100,7 +173,7 @@ export function CLIHealthBanner() {
               variant="ghost"
               size="sm"
               onClick={() => refetch()}
-              disabled={isRefetching}
+              disabled={isRefetching || upgradeProviderCli.isPending}
               className="h-8 text-warning hover:bg-warning/20"
             >
               <RefreshCw className={`mr-1.5 h-3.5 w-3.5 ${isRefetching ? 'animate-spin' : ''}`} />


### PR DESCRIPTION
## Summary
- enforce provider CLI readiness before session creation and before workspace creation when default session provisioning is enabled
- add provider availability helper logic and route checks to return clear `PRECONDITION_FAILED` errors when Claude/Codex is missing or unauthenticated
- extend CLI health checks to include latest-version detection for Claude and Codex via npm registry
- add in-app CLI upgrade support via new `admin.upgradeProviderCLI` mutation that runs global npm upgrades and refreshes health
- update provider warning UI and global CLI health banner to show outdated warnings and offer Upgrade actions
- surface session creation failures to users with toast notifications in workspace detail flows

## Implementation Details
- backend:
  - added `getProviderUnavailableMessage` helper in `src/backend/lib/provider-cli-availability.ts`
  - added `sessionProviderResolverService.resolveProviderForWorkspaceCreation(...)` and used it from workspace creation path
  - added `upgradeProviderCLI` to `CLIHealthService` and exposed it through tRPC admin router
  - added new timeout constants for latest version checks and CLI upgrade commands
- frontend:
  - `ProviderCliWarning` now supports outdated state and inline upgrade action
  - `CLIHealthBanner` now includes outdated issues and "Upgrade now" actions

## Validation
- `pnpm typecheck`
- `pnpm test src/backend/trpc/admin.router.test.ts src/backend/trpc/session.router.test.ts src/backend/trpc/workspace.router.test.ts src/backend/lib/provider-cli-availability.test.ts src/backend/orchestration/cli-health.service.test.ts`
- pre-commit checks passed (Biome, depcruise, knip)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 9b02f074e4504886c890961ea9811ab8eec82e66. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->