### PR TITLE
Fix #1158: Update ratcheting icon to use filled/unfilled wrench

### DIFF
--- a/src/client/globals.css
+++ b/src/client/globals.css
@@ -225,14 +225,9 @@
   }
 }
 
-.ratchet-toggle[data-ratchet-state='idle'],
-.ratchet-toggle[data-ratchet-state='processing'] {
-  border: 1px dashed color-mix(in oklab, var(--brand) 70%, var(--foreground) 30%);
-}
-
 .ratchet-toggle[data-ratchet-state='processing'] {
   position: relative;
-  border-color: transparent;
+  border: 1px solid transparent;
   background: var(--background);
 }
 

--- a/src/components/workspace/ratchet-wrench-icon.tsx
+++ b/src/components/workspace/ratchet-wrench-icon.tsx
@@ -29,6 +29,7 @@ export function RatchetWrenchIcon({
           enabled ? 'text-foreground' : 'text-muted-foreground',
           iconClassName
         )}
+        fill={enabled ? 'currentColor' : 'none'}
       />
     </span>
   );


### PR DESCRIPTION
## Summary
- Removed yellow dotted border from ratcheting icon in idle state
- Changed wrench icon to be filled when enabled, unfilled when disabled
- Maintained animated border for processing state

## Changes
- **RatchetWrenchIcon component**: Added `fill` prop to Wrench icon - filled when enabled, unfilled when disabled
- **CSS**: Removed dotted border styling for idle state, kept only processing state border for animation

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: View Storybook stories for RatchetToggleButton to see filled/unfilled states

Closes #1158

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
