### PR TITLE
Increase backend test coverage and tighten critical gates

### DIFF
--- a/scripts/check-critical-coverage.mjs
+++ b/scripts/check-critical-coverage.mjs
@@ -15,7 +15,7 @@ const summary = JSON.parse(fs.readFileSync(summaryPath, 'utf-8'));
 const groups = [
   {
     name: 'WebSocket Critical Surface',
-    threshold: 60,
+    threshold: 65,
     files: [
       'src/backend/server.ts',
       'src/backend/routers/websocket/chat.handler.ts',
@@ -26,7 +26,7 @@ const groups = [
   },
   {
     name: 'Resource Accessor Critical Surface',
-    threshold: 60,
+    threshold: 65,
     files: [
       'src/backend/resource_accessors/workspace.accessor.ts',
       'src/backend/resource_accessors/project.accessor.ts',
@@ -36,15 +36,61 @@ const groups = [
       'src/backend/resource_accessors/decision-log.accessor.ts',
     ],
   },
+  {
+    name: 'Run Script Critical Surface',
+    threshold: 60,
+    files: [
+      'src/backend/domains/run-script/startup-script.service.ts',
+      'src/backend/domains/run-script/run-script.service.ts',
+      'src/backend/services/run-script-proxy.service.ts',
+    ],
+  },
+  {
+    name: 'Workspace Runtime Surface',
+    threshold: 85,
+    files: [
+      'src/backend/domains/workspace/query/workspace-query.service.ts',
+      'src/backend/domains/workspace/state/kanban-state.ts',
+      'src/backend/domains/session/session-domain.service.ts',
+    ],
+  },
+  {
+    name: 'Workspace TRPC Surface',
+    threshold: 88,
+    files: [
+      'src/backend/trpc/workspace/init.trpc.ts',
+      'src/backend/trpc/workspace/ide.trpc.ts',
+      'src/backend/trpc/workspace/run-script.trpc.ts',
+      'src/backend/trpc/workspace/workspace-helpers.ts',
+      'src/backend/trpc/user-settings.trpc.ts',
+    ],
+  },
 ];
 
 const perFileThresholds = [
   { file: 'src/backend/server.ts', threshold: 50 },
-  { file: 'src/backend/routers/websocket/chat.handler.ts', threshold: 55 },
-  { file: 'src/backend/routers/websocket/terminal.handler.ts', threshold: 55 },
+  { file: 'src/backend/routers/websocket/chat.handler.ts', threshold: 60 },
+  { file: 'src/backend/routers/websocket/terminal.handler.ts', threshold: 60 },
   { file: 'src/backend/resource_accessors/workspace.accessor.ts', threshold: 50 },
-  { file: 'src/backend/resource_accessors/project.accessor.ts', threshold: 70 },
-  { file: 'src/backend/resource_accessors/agent-session.accessor.ts', threshold: 50 },
+  { file: 'src/backend/resource_accessors/project.accessor.ts', threshold: 75 },
+  { file: 'src/backend/resource_accessors/agent-session.accessor.ts', threshold: 70 },
+  { file: 'src/backend/domains/run-script/startup-script.service.ts', threshold: 75 },
+  { file: 'src/backend/domains/run-script/run-script.service.ts', threshold: 50 },
+  { file: 'src/backend/services/run-script-proxy.service.ts', threshold: 70 },
+  { file: 'src/backend/domains/workspace/query/workspace-query.service.ts', threshold: 85 },
+  { file: 'src/backend/domains/workspace/state/kanban-state.ts', threshold: 80 },
+  { file: 'src/backend/domains/session/session-domain.service.ts', threshold: 90 },
+  { file: 'src/backend/trpc/workspace/init.trpc.ts', threshold: 85 },
+  { file: 'src/backend/trpc/workspace/ide.trpc.ts', threshold: 90 },
+  { file: 'src/backend/trpc/workspace/run-script.trpc.ts', threshold: 90 },
+  { file: 'src/backend/trpc/workspace/workspace-helpers.ts', threshold: 85 },
+  { file: 'src/backend/trpc/user-settings.trpc.ts', threshold: 85 },
+  { file: 'src/backend/trpc/linear.trpc.ts', threshold: 90 },
+  { file: 'src/backend/trpc/pr-review.trpc.ts', threshold: 95 },
+  { file: 'src/backend/trpc/decision-log.trpc.ts', threshold: 95 },
+  { file: 'src/backend/services/git-ops.service.ts', threshold: 90 },
+  { file: 'src/backend/services/rate-limiter.service.ts', threshold: 90 },
+  { file: 'src/backend/interceptors/branch-rename.interceptor.ts', threshold: 95 },
 ];
 
 function getEntry(filePath) {

--- a/src/backend/domains/run-script/startup-script.service.test.ts
+++ b/src/backend/domains/run-script/startup-script.service.test.ts
@@ -1,0 +1,211 @@
+import { EventEmitter } from 'node:events';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockSpawn = vi.hoisted(() => vi.fn());
+const mockClearInitOutput = vi.hoisted(() => vi.fn());
+const mockAppendInitOutput = vi.hoisted(() => vi.fn());
+
+vi.mock('node:child_process', () => ({
+  spawn: (...args: unknown[]) => mockSpawn(...args),
+}));
+
+vi.mock('@/backend/resource_accessors/workspace.accessor', () => ({
+  workspaceAccessor: {
+    clearInitOutput: (...args: unknown[]) => mockClearInitOutput(...args),
+    appendInitOutput: (...args: unknown[]) => mockAppendInitOutput(...args),
+  },
+}));
+
+vi.mock('@/backend/services/logger.service', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+import { startupScriptService } from './startup-script.service';
+
+class FakeProc extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  kill = vi.fn();
+}
+
+describe('StartupScriptService', () => {
+  const markReady = vi.fn();
+  const markFailed = vi.fn();
+  const service = startupScriptService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service.configure({
+      workspace: {
+        markReady,
+        markFailed,
+      },
+    });
+    mockClearInitOutput.mockResolvedValue(undefined);
+    mockAppendInitOutput.mockResolvedValue(undefined);
+  });
+
+  it('marks workspace ready immediately when no startup script is configured', async () => {
+    const result = await service.runStartupScript(
+      { id: 'w1', worktreePath: '/tmp/w1' } as never,
+      {
+        startupScriptCommand: null,
+        startupScriptPath: null,
+      } as never
+    );
+
+    expect(result).toEqual({
+      success: true,
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      timedOut: false,
+      durationMs: 0,
+    });
+    expect(markReady).toHaveBeenCalledWith('w1');
+    expect(mockClearInitOutput).not.toHaveBeenCalled();
+  });
+
+  it('throws when workspace has no worktree path', async () => {
+    await expect(
+      service.runStartupScript(
+        { id: 'w1', worktreePath: null } as never,
+        {
+          startupScriptCommand: 'echo test',
+          startupScriptPath: null,
+        } as never
+      )
+    ).rejects.toThrow('Workspace has no worktree path');
+  });
+
+  it('fails with markFailed for invalid startup script path', async () => {
+    const result = await service.runStartupScript(
+      { id: 'w1', worktreePath: '/tmp/w1' } as never,
+      {
+        startupScriptCommand: null,
+        startupScriptPath: '../escape.sh',
+        startupScriptTimeout: 5,
+      } as never
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.stderr).toContain('Script path must be relative');
+    expect(mockClearInitOutput).toHaveBeenCalledWith('w1');
+    expect(markFailed).toHaveBeenCalledWith('w1', expect.stringContaining('Script path must'));
+  });
+
+  it('runs startup command and marks workspace ready on success', async () => {
+    mockSpawn.mockImplementation(() => {
+      const proc = new FakeProc();
+      queueMicrotask(() => {
+        proc.stdout.emit('data', Buffer.from('hello'));
+        proc.stderr.emit('data', Buffer.from('warn'));
+        proc.emit('close', 0);
+      });
+      return proc;
+    });
+
+    const result = await service.runStartupScript(
+      { id: 'w1', worktreePath: '/tmp/w1' } as never,
+      {
+        startupScriptCommand: 'echo hello',
+        startupScriptPath: null,
+        startupScriptTimeout: 5,
+      } as never
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      exitCode: 0,
+      timedOut: false,
+    });
+    expect(result.stdout).toContain('hello');
+    expect(result.stderr).toContain('warn');
+    expect(markReady).toHaveBeenCalledWith('w1');
+    expect(mockAppendInitOutput).toHaveBeenCalledWith('w1', expect.stringContaining('hello'));
+  });
+
+  it('marks workspace failed when spawn emits error', async () => {
+    mockSpawn.mockImplementation(() => {
+      const proc = new FakeProc();
+      queueMicrotask(() => {
+        proc.emit('error', new Error('spawn failed'));
+      });
+      return proc;
+    });
+
+    const result = await service.runStartupScript(
+      { id: 'w1', worktreePath: '/tmp/w1' } as never,
+      {
+        startupScriptCommand: 'echo hello',
+        startupScriptPath: null,
+        startupScriptTimeout: 5,
+      } as never
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.stderr).toContain('spawn failed');
+    expect(markFailed).toHaveBeenCalledWith('w1', expect.stringContaining('spawn failed'));
+  });
+
+  it('validates script paths and script readability', async () => {
+    expect(service.validateScriptPath('scripts/start.sh', '/repo')).toEqual({ valid: true });
+    expect(service.validateScriptPath('../start.sh', '/repo')).toEqual({
+      valid: false,
+      error: 'Script path must be relative to repository root',
+    });
+    expect(service.validateScriptPath('/tmp/start.sh', '/repo')).toEqual({
+      valid: false,
+      error: 'Script path must be relative to repository root',
+    });
+
+    const rootDir = mkdtempSync(join(tmpdir(), 'startup-script-'));
+    const scriptPath = join(rootDir, 'start.sh');
+    writeFileSync(scriptPath, 'echo hi\n');
+
+    await expect(service.validateScriptReadable('start.sh', rootDir)).resolves.toEqual({
+      readable: true,
+    });
+
+    await expect(service.validateScriptReadable('missing.sh', rootDir)).resolves.toEqual({
+      readable: false,
+      error: 'Script not found: missing.sh',
+    });
+
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  it('reports whether startup script is configured', () => {
+    expect(service.hasStartupScript({ startupScriptCommand: 'echo hi' } as never)).toBe(true);
+    expect(service.hasStartupScript({ startupScriptPath: 'scripts/start.sh' } as never)).toBe(true);
+    expect(
+      service.hasStartupScript({ startupScriptCommand: null, startupScriptPath: null } as never)
+    ).toBe(false);
+  });
+
+  it('swallows append-init-output errors in debounced callback flush', async () => {
+    mockAppendInitOutput.mockRejectedValue(new Error('db down'));
+
+    const internals = service as unknown as {
+      createDebouncedOutputCallback: (workspaceId: string) => {
+        callback: (output: string) => void;
+        flush: () => Promise<void>;
+      };
+    };
+
+    const { callback, flush } = internals.createDebouncedOutputCallback('w1');
+    callback('x'.repeat(4100));
+    await flush();
+
+    expect(mockAppendInitOutput).toHaveBeenCalled();
+  });
+});

--- a/src/backend/domains/workspace/query/workspace-query.service.test.ts
+++ b/src/backend/domains/workspace/query/workspace-query.service.test.ts
@@ -4,21 +4,49 @@ import type {
   WorkspacePRSnapshotBridge,
   WorkspaceSessionBridge,
 } from '@/backend/domains/workspace/bridges';
+import { WorkspaceStatus } from '@/shared/core';
 import { workspaceQueryService } from './workspace-query.service';
 
 const mockFindByProjectIdWithSessions = vi.fn();
+const mockFindByProjectId = vi.fn();
+const mockFindById = vi.fn();
+const mockFindByIdWithProject = vi.fn();
+const mockWorkspaceUpdate = vi.fn();
+const mockProjectFindById = vi.fn();
 const mockDeriveWorkspaceRuntimeState = vi.fn();
+const mockReadConfig = vi.fn();
+const mockGetWorkspaceGitStats = vi.fn();
 
 vi.mock('@/backend/resource_accessors/workspace.accessor', () => ({
   workspaceAccessor: {
     findByProjectIdWithSessions: (...args: unknown[]) => mockFindByProjectIdWithSessions(...args),
-    findByProjectId: vi.fn(),
-    findById: vi.fn(),
+    findByProjectId: (...args: unknown[]) => mockFindByProjectId(...args),
+    findById: (...args: unknown[]) => mockFindById(...args),
+    findByIdWithProject: (...args: unknown[]) => mockFindByIdWithProject(...args),
+    update: (...args: unknown[]) => mockWorkspaceUpdate(...args),
+  },
+}));
+
+vi.mock('@/backend/resource_accessors/project.accessor', () => ({
+  projectAccessor: {
+    findById: (...args: unknown[]) => mockProjectFindById(...args),
   },
 }));
 
 vi.mock('@/backend/domains/workspace/state/workspace-runtime-state', () => ({
   deriveWorkspaceRuntimeState: (...args: unknown[]) => mockDeriveWorkspaceRuntimeState(...args),
+}));
+
+vi.mock('@/backend/services/factory-config.service', () => ({
+  FactoryConfigService: {
+    readConfig: (...args: unknown[]) => mockReadConfig(...args),
+  },
+}));
+
+vi.mock('@/backend/services/git-ops.service', () => ({
+  gitOpsService: {
+    getWorkspaceGitStats: (...args: unknown[]) => mockGetWorkspaceGitStats(...args),
+  },
 }));
 
 vi.mock('@/backend/services/logger.service', () => ({
@@ -30,7 +58,7 @@ vi.mock('@/backend/services/logger.service', () => ({
   }),
 }));
 
-describe('WorkspaceQueryService.listWithRuntimeState', () => {
+describe('WorkspaceQueryService', () => {
   const mockIsAnySessionWorking = vi.fn<WorkspaceSessionBridge['isAnySessionWorking']>();
   const mockGetAllPendingRequests = vi.fn<WorkspaceSessionBridge['getAllPendingRequests']>();
   const mockSessionBridge: WorkspaceSessionBridge = {
@@ -38,13 +66,16 @@ describe('WorkspaceQueryService.listWithRuntimeState', () => {
     getAllPendingRequests: mockGetAllPendingRequests,
   };
 
+  const mockGithubCheckHealth = vi.fn();
+  const mockGithubListReviewRequests = vi.fn();
   const mockGithubBridge: WorkspaceGitHubBridge = {
-    checkHealth: vi.fn(),
-    listReviewRequests: vi.fn(),
+    checkHealth: mockGithubCheckHealth,
+    listReviewRequests: mockGithubListReviewRequests,
   };
 
+  const mockRefreshWorkspace = vi.fn();
   const mockPrSnapshotBridge: WorkspacePRSnapshotBridge = {
-    refreshWorkspace: vi.fn(),
+    refreshWorkspace: mockRefreshWorkspace,
   };
 
   beforeEach(() => {
@@ -57,20 +88,11 @@ describe('WorkspaceQueryService.listWithRuntimeState', () => {
     });
   });
 
-  it('returns isWorking and pendingRequestType derived from runtime + pending requests', async () => {
+  it('listWithRuntimeState maps working state and pending request types', async () => {
     mockFindByProjectIdWithSessions.mockResolvedValue([
-      {
-        id: 'ws-1',
-        name: 'Workspace 1',
-      },
-      {
-        id: 'ws-2',
-        name: 'Workspace 2',
-      },
-      {
-        id: 'ws-3',
-        name: 'Workspace 3',
-      },
+      { id: 'ws-1', name: 'Workspace 1' },
+      { id: 'ws-2', name: 'Workspace 2' },
+      { id: 'ws-3', name: 'Workspace 3' },
     ]);
 
     mockDeriveWorkspaceRuntimeState.mockImplementation((workspace: { id: string }) => {
@@ -110,98 +132,257 @@ describe('WorkspaceQueryService.listWithRuntimeState', () => {
     });
   });
 
-  it('keeps user_question mapping for AskUserQuestion', async () => {
+  it('listWithKanbanState filters hidden columns and applies runtime-derived flags', async () => {
     mockFindByProjectIdWithSessions.mockResolvedValue([
       {
-        id: 'ws-1',
-        name: 'Workspace 1',
+        id: 'w1',
+        status: WorkspaceStatus.READY,
+        prState: 'NONE',
+        hasHadSessions: false,
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      },
+      {
+        id: 'w2',
+        status: WorkspaceStatus.READY,
+        prState: 'OPEN',
+        hasHadSessions: true,
+        createdAt: new Date('2026-01-02T00:00:00.000Z'),
       },
     ]);
 
-    mockDeriveWorkspaceRuntimeState.mockReturnValue({ sessionIds: ['s-1'], isWorking: false });
-
-    mockGetAllPendingRequests.mockReturnValue(new Map([['s-1', { toolName: 'AskUserQuestion' }]]));
-
-    const result = await workspaceQueryService.listWithRuntimeState({ projectId: 'proj-1' });
-
-    expect(result[0]).toMatchObject({
-      id: 'ws-1',
-      pendingRequestType: 'user_question',
-    });
-  });
-
-  it('prioritizes AskUserQuestion over generic permissions regardless of session order', async () => {
-    mockFindByProjectIdWithSessions.mockResolvedValue([
-      {
-        id: 'ws-1',
-        name: 'Workspace 1',
-      },
-    ]);
-
-    mockDeriveWorkspaceRuntimeState.mockReturnValue({
-      sessionIds: ['s-permission', 's-question'],
+    mockDeriveWorkspaceRuntimeState.mockImplementation((workspace: { id: string }) => ({
+      sessionIds: [workspace.id],
       isWorking: false,
-    });
+      flowState: {
+        shouldAnimateRatchetButton: workspace.id === 'w2',
+        phase: 'HAS_PR',
+        ciObservation: 'CHECKS_UNKNOWN',
+      },
+    }));
+    mockGetAllPendingRequests.mockReturnValue(new Map([['w2', { toolName: 'AskUserQuestion' }]]));
 
-    mockGetAllPendingRequests.mockReturnValue(
-      new Map([
-        ['s-permission', { toolName: 'SomeOtherPermissionTool' }],
-        ['s-question', { toolName: 'AskUserQuestion' }],
-      ])
-    );
+    const result = await workspaceQueryService.listWithKanbanState({ projectId: 'proj-1' });
 
-    const result = await workspaceQueryService.listWithRuntimeState({ projectId: 'proj-1' });
-
+    expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
-      id: 'ws-1',
+      id: 'w2',
+      kanbanColumn: 'WAITING',
       pendingRequestType: 'user_question',
+      ratchetButtonAnimated: true,
+      flowPhase: 'HAS_PR',
     });
   });
 
-  it('prioritizes ExitPlanMode over all other pending request types', async () => {
+  it('getProjectSummaryState computes git stats and caches review count', async () => {
+    mockProjectFindById.mockResolvedValue({ id: 'p1', defaultBranch: 'main' });
     mockFindByProjectIdWithSessions.mockResolvedValue([
       {
-        id: 'ws-1',
-        name: 'Workspace 1',
+        id: 'w1',
+        name: 'W1',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        worktreePath: '/tmp/w1',
+        branchName: 'feature/w1',
+        prUrl: null,
+        prNumber: null,
+        prState: 'NONE',
+        prCiStatus: null,
+        ratchetEnabled: false,
+        ratchetState: 'IDLE',
+        runScriptStatus: 'IDLE',
+        cachedKanbanColumn: 'WAITING',
+        stateComputedAt: null,
+        agentSessions: [{ updatedAt: new Date('2026-01-03T00:00:00.000Z') }],
+        terminalSessions: [],
+      },
+      {
+        id: 'w2',
+        name: 'W2',
+        createdAt: new Date('2026-01-02T00:00:00.000Z'),
+        worktreePath: null,
+        branchName: null,
+        prUrl: 'https://github.com/o/r/pull/2',
+        prNumber: 2,
+        prState: 'OPEN',
+        prCiStatus: 'PENDING',
+        ratchetEnabled: true,
+        ratchetState: 'REVIEW_PENDING',
+        runScriptStatus: 'RUNNING',
+        cachedKanbanColumn: 'WORKING',
+        stateComputedAt: new Date('2026-01-02T10:00:00.000Z'),
+        agentSessions: [],
+        terminalSessions: [{ updatedAt: new Date('2026-01-04T00:00:00.000Z') }],
       },
     ]);
 
-    mockDeriveWorkspaceRuntimeState.mockReturnValue({
-      sessionIds: ['s-permission', 's-question', 's-plan'],
-      isWorking: false,
-    });
-
-    mockGetAllPendingRequests.mockReturnValue(
-      new Map([
-        ['s-permission', { toolName: 'SomeOtherPermissionTool' }],
-        ['s-question', { toolName: 'AskUserQuestion' }],
-        ['s-plan', { toolName: 'ExitPlanMode' }],
-      ])
-    );
-
-    const result = await workspaceQueryService.listWithRuntimeState({ projectId: 'proj-1' });
-
-    expect(result[0]).toMatchObject({
-      id: 'ws-1',
-      pendingRequestType: 'plan_approval',
-    });
-  });
-
-  it('passes list filters through to accessor', async () => {
-    mockFindByProjectIdWithSessions.mockResolvedValue([]);
+    mockDeriveWorkspaceRuntimeState.mockImplementation((workspace: { id: string }) => ({
+      sessionIds: [workspace.id],
+      isWorking: workspace.id === 'w2',
+      flowState: {
+        shouldAnimateRatchetButton: workspace.id === 'w2',
+        phase: workspace.id === 'w2' ? 'HAS_PR' : 'NO_PR',
+        ciObservation: 'CHECKS_UNKNOWN',
+      },
+    }));
     mockGetAllPendingRequests.mockReturnValue(new Map());
 
-    await workspaceQueryService.listWithRuntimeState({
-      projectId: 'proj-1',
-      status: 'READY',
-      limit: 20,
-      offset: 5,
+    mockGetWorkspaceGitStats.mockResolvedValueOnce({
+      total: 3,
+      additions: 2,
+      deletions: 1,
+      hasUncommitted: true,
     });
 
-    expect(mockFindByProjectIdWithSessions).toHaveBeenCalledWith('proj-1', {
-      status: 'READY',
-      limit: 20,
-      offset: 5,
+    mockGithubCheckHealth.mockResolvedValue({ isInstalled: true, isAuthenticated: true });
+    mockGithubListReviewRequests.mockResolvedValue([
+      { reviewDecision: 'APPROVED' },
+      { reviewDecision: 'CHANGES_REQUESTED' },
+    ]);
+
+    const first = await workspaceQueryService.getProjectSummaryState('p1');
+    expect(first.reviewCount).toBe(1);
+    expect(first.workspaces).toHaveLength(2);
+    expect(first.workspaces[0]).toMatchObject({
+      id: 'w1',
+      isWorking: false,
+      gitStats: expect.objectContaining({ total: 3 }),
     });
+
+    mockGithubListReviewRequests.mockClear();
+    const second = await workspaceQueryService.getProjectSummaryState('p1');
+    expect(second.reviewCount).toBe(1);
+    expect(mockGithubListReviewRequests).not.toHaveBeenCalled();
+  });
+
+  it('refreshFactoryConfigs updates script commands and reports per-workspace errors', async () => {
+    mockFindByProjectId.mockResolvedValue([
+      { id: 'w1', worktreePath: '/tmp/w1' },
+      { id: 'w2', worktreePath: '/tmp/w2' },
+      { id: 'w3', worktreePath: null },
+    ]);
+
+    mockReadConfig
+      .mockResolvedValueOnce({ scripts: { run: 'pnpm dev', cleanup: 'pkill node' } })
+      .mockRejectedValueOnce(new Error('bad config'));
+    mockWorkspaceUpdate.mockResolvedValue(undefined);
+
+    const result = await workspaceQueryService.refreshFactoryConfigs('p1');
+
+    expect(result).toEqual({
+      updatedCount: 1,
+      totalWorkspaces: 3,
+      errors: [{ workspaceId: 'w2', error: 'bad config' }],
+    });
+    expect(mockWorkspaceUpdate).toHaveBeenCalledWith('w1', {
+      runScriptCommand: 'pnpm dev',
+      runScriptCleanupCommand: 'pkill node',
+    });
+  });
+
+  it('getFactoryConfig validates project and handles read errors', async () => {
+    mockProjectFindById.mockResolvedValueOnce(null);
+    await expect(workspaceQueryService.getFactoryConfig('missing')).rejects.toThrow(
+      'Project not found'
+    );
+
+    mockProjectFindById.mockResolvedValueOnce({ id: 'p1', repoPath: '/repo' });
+    mockReadConfig.mockResolvedValueOnce({ scripts: { run: 'pnpm dev' } });
+    await expect(workspaceQueryService.getFactoryConfig('p1')).resolves.toEqual({
+      scripts: { run: 'pnpm dev' },
+    });
+
+    mockProjectFindById.mockResolvedValueOnce({ id: 'p1', repoPath: '/repo' });
+    mockReadConfig.mockRejectedValueOnce(new Error('boom'));
+    await expect(workspaceQueryService.getFactoryConfig('p1')).resolves.toBeNull();
+  });
+
+  it('syncPRStatus and syncAllPRStatuses handle success and failure paths', async () => {
+    mockFindById.mockResolvedValueOnce(null);
+    await expect(workspaceQueryService.syncPRStatus('missing')).rejects.toThrow(
+      'Workspace not found'
+    );
+
+    mockFindById.mockResolvedValueOnce({ id: 'w1', prUrl: null });
+    await expect(workspaceQueryService.syncPRStatus('w1')).resolves.toEqual({
+      success: false,
+      reason: 'no_pr_url',
+    });
+
+    mockFindById.mockResolvedValueOnce({ id: 'w1', prUrl: 'https://github.com/o/r/pull/1' });
+    mockRefreshWorkspace.mockResolvedValueOnce({ success: false });
+    await expect(workspaceQueryService.syncPRStatus('w1')).resolves.toEqual({
+      success: false,
+      reason: 'fetch_failed',
+    });
+
+    mockFindById.mockResolvedValueOnce({ id: 'w1', prUrl: 'https://github.com/o/r/pull/1' });
+    mockRefreshWorkspace.mockResolvedValueOnce({
+      success: true,
+      snapshot: { prNumber: 1, prState: 'OPEN' },
+    });
+    await expect(workspaceQueryService.syncPRStatus('w1')).resolves.toEqual({
+      success: true,
+      prState: 'OPEN',
+    });
+
+    mockFindByProjectIdWithSessions.mockResolvedValueOnce([
+      { id: 'w1', prUrl: null },
+      { id: 'w2', prUrl: null },
+    ]);
+    await expect(workspaceQueryService.syncAllPRStatuses('p1')).resolves.toEqual({
+      synced: 0,
+      failed: 0,
+    });
+
+    mockFindByProjectIdWithSessions.mockResolvedValueOnce([
+      { id: 'w1', prUrl: 'https://github.com/o/r/pull/1' },
+      { id: 'w2', prUrl: 'https://github.com/o/r/pull/2' },
+    ]);
+    mockRefreshWorkspace
+      .mockResolvedValueOnce({ success: true })
+      .mockResolvedValueOnce({ success: false });
+
+    await expect(workspaceQueryService.syncAllPRStatuses('p1')).resolves.toEqual({
+      synced: 1,
+      failed: 1,
+    });
+  });
+
+  it('hasChanges checks workspace metadata and git stats safely', async () => {
+    mockFindByIdWithProject.mockResolvedValueOnce(null);
+    await expect(workspaceQueryService.hasChanges('w1')).resolves.toBe(false);
+
+    mockFindByIdWithProject.mockResolvedValueOnce({
+      id: 'w1',
+      worktreePath: '/tmp/w1',
+      project: { defaultBranch: 'main' },
+    });
+    mockGetWorkspaceGitStats.mockResolvedValueOnce({
+      total: 0,
+      additions: 0,
+      deletions: 0,
+      hasUncommitted: false,
+    });
+    await expect(workspaceQueryService.hasChanges('w1')).resolves.toBe(false);
+
+    mockFindByIdWithProject.mockResolvedValueOnce({
+      id: 'w1',
+      worktreePath: '/tmp/w1',
+      project: { defaultBranch: 'main' },
+    });
+    mockGetWorkspaceGitStats.mockResolvedValueOnce({
+      total: 1,
+      additions: 1,
+      deletions: 0,
+      hasUncommitted: false,
+    });
+    await expect(workspaceQueryService.hasChanges('w1')).resolves.toBe(true);
+
+    mockFindByIdWithProject.mockResolvedValueOnce({
+      id: 'w1',
+      worktreePath: '/tmp/w1',
+      project: { defaultBranch: 'main' },
+    });
+    mockGetWorkspaceGitStats.mockRejectedValueOnce(new Error('git failed'));
+    await expect(workspaceQueryService.hasChanges('w1')).resolves.toBe(false);
   });
 });

--- a/src/backend/interceptors/branch-rename.interceptor.test.ts
+++ b/src/backend/interceptors/branch-rename.interceptor.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockSetBranchName = vi.hoisted(() => vi.fn());
+const mockGitCommand = vi.hoisted(() => vi.fn());
+const mockExtractInputValue = vi.hoisted(() => vi.fn());
+
+vi.mock('@/backend/domains/workspace', () => ({
+  workspaceDataService: {
+    setBranchName: (...args: unknown[]) => mockSetBranchName(...args),
+  },
+}));
+
+vi.mock('@/backend/lib/shell', () => ({
+  gitCommand: (...args: unknown[]) => mockGitCommand(...args),
+}));
+
+vi.mock('@/backend/schemas/tool-inputs.schema', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/backend/schemas/tool-inputs.schema')>();
+  return {
+    ...actual,
+    extractInputValue: (...args: unknown[]) => mockExtractInputValue(...args),
+  };
+});
+
+vi.mock('@/backend/services/logger.service', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+import { branchRenameInterceptor } from './branch-rename.interceptor';
+
+describe('branchRenameInterceptor', () => {
+  const context = {
+    workspaceId: 'w1',
+    workingDir: '/tmp/w1',
+  } as never;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('ignores errored tool events and non-rename commands', async () => {
+    await branchRenameInterceptor.onToolComplete!(
+      {
+        toolName: 'Bash',
+        output: { isError: true },
+      } as never,
+      context
+    );
+
+    mockExtractInputValue.mockReturnValue('git status');
+    await branchRenameInterceptor.onToolComplete!(
+      {
+        toolName: 'Bash',
+        output: { isError: false },
+        input: {},
+      } as never,
+      context
+    );
+
+    expect(mockGitCommand).not.toHaveBeenCalled();
+    expect(mockSetBranchName).not.toHaveBeenCalled();
+  });
+
+  it('updates workspace branch name after git branch -m', async () => {
+    mockExtractInputValue.mockReturnValue('git branch -m better-name');
+    mockGitCommand.mockResolvedValue({ code: 0, stdout: 'new-branch\n', stderr: '' });
+
+    await branchRenameInterceptor.onToolComplete!(
+      {
+        toolName: 'Bash',
+        output: { isError: false },
+        input: {},
+      } as never,
+      context
+    );
+
+    expect(mockGitCommand).toHaveBeenCalledWith(['rev-parse', '--abbrev-ref', 'HEAD'], '/tmp/w1');
+    expect(mockSetBranchName).toHaveBeenCalledWith('w1', 'new-branch');
+  });
+
+  it('skips updates when branch lookup fails or returns empty branch', async () => {
+    mockExtractInputValue.mockReturnValue('git branch -M force-name');
+    mockGitCommand.mockResolvedValueOnce({ code: 1, stdout: '', stderr: 'failed' });
+
+    await branchRenameInterceptor.onToolComplete!(
+      {
+        toolName: 'Bash',
+        output: { isError: false },
+        input: {},
+      } as never,
+      context
+    );
+
+    mockGitCommand.mockResolvedValueOnce({ code: 0, stdout: '   \n', stderr: '' });
+    await branchRenameInterceptor.onToolComplete!(
+      {
+        toolName: 'Bash',
+        output: { isError: false },
+        input: {},
+      } as never,
+      context
+    );
+
+    expect(mockSetBranchName).not.toHaveBeenCalled();
+  });
+});

--- a/src/backend/orchestration/decision-log-query.service.test.ts
+++ b/src/backend/orchestration/decision-log-query.service.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockFindByAgentId = vi.hoisted(() => vi.fn());
+const mockFindRecent = vi.hoisted(() => vi.fn());
+const mockFindById = vi.hoisted(() => vi.fn());
+const mockList = vi.hoisted(() => vi.fn());
+const mockCreateAutomatic = vi.hoisted(() => vi.fn());
+const mockCreateManual = vi.hoisted(() => vi.fn());
+
+vi.mock('@/backend/resource_accessors/decision-log.accessor', () => ({
+  decisionLogAccessor: {
+    findByAgentId: (...args: unknown[]) => mockFindByAgentId(...args),
+    findRecent: (...args: unknown[]) => mockFindRecent(...args),
+    findById: (...args: unknown[]) => mockFindById(...args),
+    list: (...args: unknown[]) => mockList(...args),
+    createAutomatic: (...args: unknown[]) => mockCreateAutomatic(...args),
+    createManual: (...args: unknown[]) => mockCreateManual(...args),
+  },
+}));
+
+import { decisionLogQueryService } from './decision-log-query.service';
+
+describe('decisionLogQueryService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('forwards read operations to the accessor', async () => {
+    mockFindByAgentId.mockResolvedValue([{ id: '1' }]);
+    mockFindRecent.mockResolvedValue([{ id: '2' }]);
+    mockFindById.mockResolvedValue({ id: '3' });
+    mockList.mockResolvedValue([{ id: '4' }]);
+
+    await expect(decisionLogQueryService.findByAgentId('a1', 10)).resolves.toEqual([{ id: '1' }]);
+    await expect(decisionLogQueryService.findRecent(25)).resolves.toEqual([{ id: '2' }]);
+    await expect(decisionLogQueryService.findById('3')).resolves.toEqual({ id: '3' });
+    await expect(decisionLogQueryService.list({ agentId: 'a1', limit: 5 })).resolves.toEqual([
+      { id: '4' },
+    ]);
+  });
+
+  it('forwards write operations to the accessor', async () => {
+    mockCreateAutomatic.mockResolvedValue({ id: 'auto' });
+    mockCreateManual.mockResolvedValue({ id: 'manual' });
+
+    await expect(
+      decisionLogQueryService.createAutomatic('a1', 'Bash', 'result', { ok: true })
+    ).resolves.toEqual({ id: 'auto' });
+
+    await expect(
+      decisionLogQueryService.createManual('a1', 'Title', 'Body', 'ctx')
+    ).resolves.toEqual({ id: 'manual' });
+
+    expect(mockCreateAutomatic).toHaveBeenCalledWith('a1', 'Bash', 'result', { ok: true });
+    expect(mockCreateManual).toHaveBeenCalledWith('a1', 'Title', 'Body', 'ctx');
+  });
+});

--- a/src/backend/prompts/quick-actions.test.ts
+++ b/src/backend/prompts/quick-actions.test.ts
@@ -1,0 +1,85 @@
+import { rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  clearQuickActionCache,
+  getQuickAction,
+  getQuickActionContent,
+  listQuickActions,
+} from './quick-actions';
+
+function writeQuickActionFile(id: string, content: string): string {
+  const filePath = join(process.cwd(), 'prompts', 'quick-actions', `${id}.md`);
+  writeFileSync(filePath, content, 'utf8');
+  return filePath;
+}
+
+describe('quick-actions', () => {
+  const cleanupPaths: string[] = [];
+
+  beforeEach(() => {
+    clearQuickActionCache();
+  });
+
+  afterEach(() => {
+    clearQuickActionCache();
+    for (const filePath of cleanupPaths.splice(0)) {
+      rmSync(filePath, { force: true });
+    }
+  });
+
+  it('loads repository quick actions and resolves content by id', () => {
+    const actions = listQuickActions();
+    expect(actions.length).toBeGreaterThan(0);
+
+    const rename = getQuickAction('rename-branch');
+    expect(rename).toMatchObject({
+      id: 'rename-branch',
+      type: 'agent',
+      name: 'Rename Branch',
+    });
+    expect(getQuickActionContent('rename-branch')).toContain('rename the current branch');
+    expect(getQuickAction('does-not-exist')).toBeNull();
+    expect(getQuickActionContent('does-not-exist')).toBeNull();
+  });
+
+  it('parses script quick actions without content', () => {
+    const id = `script-test-${Date.now()}`;
+    cleanupPaths.push(
+      writeQuickActionFile(
+        id,
+        `---\nname: Script Test\ndescription: runs script\ntype: script\nscript: pnpm test\n---\nignored body`
+      )
+    );
+
+    clearQuickActionCache();
+    const action = getQuickAction(id);
+
+    expect(action).toMatchObject({
+      id,
+      type: 'script',
+      script: 'pnpm test',
+      content: undefined,
+    });
+    expect(getQuickActionContent(id)).toBeNull();
+  });
+
+  it('defaults unknown type to agent', () => {
+    const id = `unknown-type-${Date.now()}`;
+    cleanupPaths.push(
+      writeQuickActionFile(
+        id,
+        `---\nname: Unknown\ntype: robot\ndescription: fallback\n---\nUse fallback content`
+      )
+    );
+
+    clearQuickActionCache();
+    const action = getQuickAction(id);
+
+    expect(action).toMatchObject({
+      id,
+      type: 'agent',
+      content: 'Use fallback content',
+    });
+  });
+});

--- a/src/backend/services/git-ops.service.test.ts
+++ b/src/backend/services/git-ops.service.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGitCommand = vi.hoisted(() => vi.fn());
+const mockGetWorkspaceGitStats = vi.hoisted(() => vi.fn());
+const mockPathExists = vi.hoisted(() => vi.fn());
+const mockRm = vi.hoisted(() => vi.fn());
+
+const mockGitClient = vi.hoisted(() => ({
+  checkWorktreeExists: vi.fn(),
+  deleteWorktree: vi.fn(),
+  isBlankRepository: vi.fn(),
+  branchExists: vi.fn(),
+  createWorktree: vi.fn(),
+  createWorktreeFromExistingBranch: vi.fn(),
+  getWorktreePath: vi.fn(),
+  listWorktreesWithBranches: vi.fn(),
+}));
+
+vi.mock('@/backend/lib/shell', () => ({
+  gitCommand: (...args: unknown[]) => mockGitCommand(...args),
+}));
+
+vi.mock('@/backend/lib/git-helpers', () => ({
+  getWorkspaceGitStats: (...args: unknown[]) => mockGetWorkspaceGitStats(...args),
+}));
+
+vi.mock('@/backend/lib/file-helpers', () => ({
+  pathExists: (...args: unknown[]) => mockPathExists(...args),
+}));
+
+vi.mock('node:fs/promises', () => ({
+  rm: (...args: unknown[]) => mockRm(...args),
+}));
+
+vi.mock('@/backend/clients/git.client', () => ({
+  GitClientFactory: {
+    forProject: () => mockGitClient,
+  },
+}));
+
+import { gitOpsService } from './git-ops.service';
+
+const project = {
+  repoPath: '/repo',
+  worktreeBasePath: '/repo/worktrees',
+};
+
+describe('gitOpsService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('forwards workspace git stats helper', async () => {
+    mockGetWorkspaceGitStats.mockResolvedValue({ total: 3, additions: 2, deletions: 1 });
+
+    await expect(gitOpsService.getWorkspaceGitStats('/repo/w1', 'main')).resolves.toEqual({
+      total: 3,
+      additions: 2,
+      deletions: 1,
+    });
+  });
+
+  it('commitIfNeeded skips invalid repo, validates status, and commits when requested', async () => {
+    mockGitCommand.mockResolvedValueOnce({ code: 1, stdout: '', stderr: 'not a repo' });
+    await expect(gitOpsService.commitIfNeeded('/repo/w1', 'W1', true)).resolves.toBeUndefined();
+
+    mockGitCommand
+      .mockResolvedValueOnce({ code: 0, stdout: '.git', stderr: '' })
+      .mockResolvedValueOnce({ code: 1, stdout: '', stderr: 'status failed' });
+    await expect(gitOpsService.commitIfNeeded('/repo/w1', 'W1', true)).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+    });
+
+    mockGitCommand
+      .mockResolvedValueOnce({ code: 0, stdout: '.git', stderr: '' })
+      .mockResolvedValueOnce({ code: 0, stdout: '', stderr: '' });
+    await expect(gitOpsService.commitIfNeeded('/repo/w1', 'W1', true)).resolves.toBeUndefined();
+
+    mockGitCommand
+      .mockResolvedValueOnce({ code: 0, stdout: '.git', stderr: '' })
+      .mockResolvedValueOnce({ code: 0, stdout: ' M file.ts\n', stderr: '' });
+    await expect(gitOpsService.commitIfNeeded('/repo/w1', 'W1', false)).rejects.toMatchObject({
+      code: 'PRECONDITION_FAILED',
+    });
+
+    mockGitCommand
+      .mockResolvedValueOnce({ code: 0, stdout: '.git', stderr: '' })
+      .mockResolvedValueOnce({ code: 0, stdout: ' M file.ts\n', stderr: '' })
+      .mockResolvedValueOnce({ code: 0, stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ code: 0, stdout: '[main] Archive workspace W1', stderr: '' });
+
+    await expect(gitOpsService.commitIfNeeded('/repo/w1', 'W1', true)).resolves.toBeUndefined();
+    expect(mockGitCommand).toHaveBeenCalledWith(['add', '-A'], '/repo/w1');
+    expect(mockGitCommand).toHaveBeenCalledWith(
+      ['commit', '-m', 'Archive workspace W1', '--no-verify'],
+      '/repo/w1'
+    );
+  });
+
+  it('removeWorktree uses git when registered and fs fallback otherwise', async () => {
+    mockGitClient.checkWorktreeExists.mockResolvedValueOnce(true);
+
+    await gitOpsService.removeWorktree('/repo/worktrees/w1', project);
+    expect(mockGitClient.deleteWorktree).toHaveBeenCalledWith('w1');
+
+    mockGitClient.checkWorktreeExists.mockResolvedValueOnce(false);
+    mockPathExists.mockResolvedValueOnce(true);
+
+    await gitOpsService.removeWorktree('/repo/worktrees/w2', project);
+    expect(mockRm).toHaveBeenCalledWith('/repo/worktrees/w2', { recursive: true, force: true });
+
+    mockGitClient.checkWorktreeExists.mockResolvedValueOnce(false);
+    mockPathExists.mockResolvedValueOnce(false);
+
+    await gitOpsService.removeWorktree('/repo/worktrees/w3', project);
+    expect(mockRm).toHaveBeenCalledTimes(1);
+  });
+
+  it('ensures base branch exists unless repository is blank', async () => {
+    mockGitClient.isBlankRepository.mockResolvedValueOnce(true);
+    await expect(
+      gitOpsService.ensureBaseBranchExists(project, 'main', 'main')
+    ).resolves.toBeUndefined();
+
+    mockGitClient.isBlankRepository.mockResolvedValueOnce(false);
+    mockGitClient.branchExists.mockResolvedValueOnce(true);
+    await expect(
+      gitOpsService.ensureBaseBranchExists(project, 'origin/main', 'main')
+    ).resolves.toBeUndefined();
+
+    mockGitClient.isBlankRepository.mockResolvedValueOnce(false);
+    mockGitClient.branchExists.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    await expect(
+      gitOpsService.ensureBaseBranchExists(project, 'refs/heads/main', 'main')
+    ).resolves.toBeUndefined();
+
+    mockGitClient.isBlankRepository.mockResolvedValueOnce(false);
+    mockGitClient.branchExists.mockResolvedValueOnce(false).mockResolvedValueOnce(false);
+    await expect(
+      gitOpsService.ensureBaseBranchExists(project, 'feature/missing', 'main')
+    ).rejects.toThrow("Branch 'feature/missing' does not exist");
+  });
+
+  it('creates worktrees and checks branch checkout status', async () => {
+    mockGitClient.createWorktree.mockResolvedValueOnce({ branchName: 'feature/w1' });
+    mockGitClient.getWorktreePath.mockReturnValue('/repo/worktrees/w1');
+
+    await expect(
+      gitOpsService.createWorktree(project, 'w1', 'main', {
+        workspaceName: 'W1',
+        branchPrefix: 'pf',
+      })
+    ).resolves.toEqual({
+      worktreePath: '/repo/worktrees/w1',
+      branchName: 'feature/w1',
+    });
+
+    mockGitClient.createWorktreeFromExistingBranch.mockResolvedValueOnce({ branchName: 'main' });
+    mockGitClient.getWorktreePath.mockReturnValue('/repo/worktrees/w2');
+
+    await expect(
+      gitOpsService.createWorktreeFromExistingBranch(project, 'w2', 'origin/main')
+    ).resolves.toEqual({
+      worktreePath: '/repo/worktrees/w2',
+      branchName: 'main',
+    });
+
+    mockGitClient.listWorktreesWithBranches.mockResolvedValueOnce([
+      { path: '/repo', branchName: 'main' },
+      { path: '/repo/worktrees/w1', branchName: 'feature/test' },
+      { path: '/tmp/external', branchName: 'feature/test' },
+    ]);
+    await expect(gitOpsService.isBranchCheckedOut(project, 'origin/feature/test')).resolves.toBe(
+      true
+    );
+
+    mockGitClient.listWorktreesWithBranches.mockResolvedValueOnce([
+      { path: '/repo', branchName: 'main' },
+      { path: '/repo/worktrees/w2', branchName: 'feature/other' },
+    ]);
+    await expect(gitOpsService.isBranchCheckedOut(project, 'feature/test')).resolves.toBe(false);
+  });
+});

--- a/src/backend/services/rate-limiter.service.test.ts
+++ b/src/backend/services/rate-limiter.service.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { rateLimiter } from './rate-limiter.service';
+
+type RateLimiterInternals = {
+  requestTimestamps: number[];
+  requestQueue: unknown[];
+  isShuttingDown: boolean;
+  isProcessingQueue: boolean;
+  cleanupInterval: NodeJS.Timeout | null;
+  queueProcessingTimeout: NodeJS.Timeout | null;
+  queueProcessingResolve: (() => void) | null;
+  queueProcessingPromise: Promise<void> | null;
+  pendingTimeouts: Map<string, NodeJS.Timeout>;
+};
+
+function getInternals(): RateLimiterInternals {
+  return rateLimiter as unknown as RateLimiterInternals;
+}
+
+describe('rateLimiter', () => {
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+
+    await rateLimiter.stop();
+
+    const internals = getInternals();
+    internals.requestTimestamps = [];
+    internals.requestQueue = [];
+    internals.isShuttingDown = false;
+    internals.isProcessingQueue = false;
+    internals.cleanupInterval = null;
+    internals.queueProcessingTimeout = null;
+    internals.queueProcessingResolve = null;
+    internals.queueProcessingPromise = null;
+    internals.pendingTimeouts = new Map();
+
+    rateLimiter.resetUsageStats();
+    rateLimiter.updateConfig({
+      claudeRequestsPerMinute: 1,
+      claudeRequestsPerHour: 2,
+      maxQueueSize: 2,
+      queueTimeoutMs: 120_000,
+    });
+  });
+
+  afterEach(async () => {
+    await rateLimiter.stop();
+    vi.useRealTimers();
+  });
+
+  it('acquires slots immediately when not rate-limited', async () => {
+    await expect(rateLimiter.acquireSlot('agent-1', 'task-1')).resolves.toBeUndefined();
+
+    const stats = rateLimiter.getApiUsageStats();
+    expect(stats).toMatchObject({
+      totalRequests: 1,
+      requestsLastMinute: 1,
+      requestsLastHour: 1,
+      queueDepth: 0,
+      isRateLimited: true,
+    });
+
+    expect(Object.fromEntries(rateLimiter.getUsageByAgent())).toEqual({ 'agent-1': 1 });
+    expect(Object.fromEntries(rateLimiter.getUsageByTopLevelTask())).toEqual({ 'task-1': 1 });
+  });
+
+  it('queues requests while rate-limited and drains when window expires', async () => {
+    await rateLimiter.acquireSlot('agent-1', null);
+
+    let resolved = false;
+    const queued = rateLimiter.acquireSlot('agent-2', null).then(() => {
+      resolved = true;
+    });
+
+    await Promise.resolve();
+    expect(rateLimiter.getApiUsageStats().queueDepth).toBe(1);
+    expect(resolved).toBe(false);
+
+    getInternals().requestTimestamps = [];
+    vi.advanceTimersByTime(1000);
+    await queued;
+
+    expect(resolved).toBe(true);
+    expect(rateLimiter.getApiUsageStats().totalRequests).toBe(2);
+  });
+
+  it('rejects when queue is full', async () => {
+    rateLimiter.updateConfig({
+      claudeRequestsPerMinute: 0,
+      claudeRequestsPerHour: 0,
+      maxQueueSize: 0,
+    });
+
+    await expect(rateLimiter.acquireSlot('agent-3', null)).rejects.toThrow(
+      'Rate limit queue is full'
+    );
+  });
+
+  it('times out queued requests and clears usage statistics', async () => {
+    rateLimiter.updateConfig({ queueTimeoutMs: 100 });
+    await rateLimiter.acquireSlot('agent-1', null);
+
+    const queued = rateLimiter.acquireSlot('agent-2', null);
+    const timeoutAssertion = expect(queued).rejects.toThrow('Rate limit queue timeout');
+    await vi.advanceTimersByTimeAsync(101);
+
+    await timeoutAssertion;
+
+    rateLimiter.resetUsageStats();
+    expect(rateLimiter.getApiUsageStats().totalRequests).toBe(0);
+    expect(rateLimiter.getUsageByAgent().size).toBe(0);
+    expect(rateLimiter.getUsageByTopLevelTask().size).toBe(0);
+  });
+
+  it('rejects queued requests during shutdown and supports start lifecycle', async () => {
+    rateLimiter.start();
+    rateLimiter.start();
+
+    await rateLimiter.acquireSlot('agent-1', null);
+    const queued = rateLimiter.acquireSlot('agent-2', null);
+
+    await rateLimiter.stop();
+    await expect(queued).rejects.toThrow('Rate limiter shutting down');
+
+    rateLimiter.updateConfig({ claudeRequestsPerMinute: 10 });
+    expect(rateLimiter.getConfig().claudeRequestsPerMinute).toBe(10);
+  });
+});

--- a/src/backend/services/run-script-proxy.service.test.ts
+++ b/src/backend/services/run-script-proxy.service.test.ts
@@ -1,5 +1,23 @@
-import { describe, expect, it, vi } from 'vitest';
-import { RunScriptProxyService } from './run-script-proxy.service';
+import type { ChildProcess } from 'node:child_process';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockStartCloudflaredTunnel = vi.hoisted(() => vi.fn());
+const mockKillProcessWithTimeout = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock('@/shared/proxy-utils', () => ({
+  authenticateRequest: vi.fn(() => ({
+    authenticated: false,
+    invalidToken: false,
+    viaToken: false,
+    sanitizedPath: '/',
+  })),
+  createAuthCookie: vi.fn(() => 'cookie=1'),
+  createSessionValue: vi.fn(() => ({ id: 's', signature: 'sig' })),
+  proxyAuthenticatedHttpRequest: vi.fn(),
+  proxyAuthenticatedWebSocketUpgrade: vi.fn(),
+  startCloudflaredTunnel: mockStartCloudflaredTunnel,
+  killProcessWithTimeout: mockKillProcessWithTimeout,
+}));
 
 vi.mock('./logger.service', () => ({
   createLogger: () => ({
@@ -10,6 +28,8 @@ vi.mock('./logger.service', () => ({
   }),
 }));
 
+import { RunScriptProxyService } from './run-script-proxy.service';
+
 type ProxyServiceInternals = {
   cleanupSync: () => void;
   tunnels: Map<
@@ -18,18 +38,101 @@ type ProxyServiceInternals = {
       upstreamPort: number;
       publicUrl: string;
       authenticatedUrl: string;
-      cloudflaredProcess: {
-        pid?: number;
-        exitCode: number | null;
-        kill: (signal: NodeJS.Signals) => void;
-      };
+      cloudflaredProcess: ChildProcess;
       closeAuthProxy: () => Promise<void>;
     }
   >;
+  cloudflaredUnavailable: boolean;
 };
 
-describe('RunScriptProxyService.cleanupSync', () => {
-  it('kills active cloudflared processes and clears tunnel map', () => {
+function createChildProcess(pid = 1234): ChildProcess {
+  return {
+    pid,
+    exitCode: null,
+    kill: vi.fn(),
+  } as unknown as ChildProcess;
+}
+
+describe('RunScriptProxyService', () => {
+  const originalProxyEnv = process.env.FF_RUN_SCRIPT_PROXY_ENABLED;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.FF_RUN_SCRIPT_PROXY_ENABLED = '1';
+    mockStartCloudflaredTunnel.mockResolvedValue({
+      publicUrl: 'https://abc.trycloudflare.com',
+      proc: createChildProcess(),
+    });
+  });
+
+  afterEach(() => {
+    process.env.FF_RUN_SCRIPT_PROXY_ENABLED = originalProxyEnv;
+  });
+
+  it('returns null when proxy feature is disabled', async () => {
+    process.env.FF_RUN_SCRIPT_PROXY_ENABLED = '0';
+    const service = new RunScriptProxyService();
+
+    await expect(service.ensureTunnel('w1', 3000)).resolves.toBeNull();
+    expect(mockStartCloudflaredTunnel).not.toHaveBeenCalled();
+  });
+
+  it('creates and reuses authenticated tunnels per workspace/port', async () => {
+    const service = new RunScriptProxyService();
+
+    const url = await service.ensureTunnel('w1', 3000);
+    expect(url).toMatch(/^https:\/\/abc\.trycloudflare\.com\?token=/);
+    expect(service.getTunnelUrl('w1')).toBe(url);
+
+    const reused = await service.ensureTunnel('w1', 3000);
+    expect(reused).toBe(url);
+    expect(mockStartCloudflaredTunnel).toHaveBeenCalledTimes(1);
+
+    await service.stopTunnel('w1');
+    expect(mockKillProcessWithTimeout).toHaveBeenCalledTimes(1);
+    expect(service.getTunnelUrl('w1')).toBeNull();
+  });
+
+  it('replaces existing tunnel when upstream port changes', async () => {
+    const service = new RunScriptProxyService();
+    const first = await service.ensureTunnel('w1', 3000);
+    expect(first).toBeTruthy();
+
+    const second = await service.ensureTunnel('w1', 4173);
+    expect(second).toMatch(/^https:\/\/abc\.trycloudflare\.com\?token=/);
+    expect(mockKillProcessWithTimeout).toHaveBeenCalledTimes(1);
+    expect(mockStartCloudflaredTunnel).toHaveBeenCalledTimes(2);
+  });
+
+  it('marks cloudflared unavailable on command-not-found errors', async () => {
+    const service = new RunScriptProxyService() as unknown as ProxyServiceInternals;
+    mockStartCloudflaredTunnel.mockRejectedValueOnce(new Error('ENOENT: command not found'));
+
+    await expect(
+      (service as unknown as RunScriptProxyService).ensureTunnel('w1', 3000)
+    ).resolves.toBeNull();
+    expect(service.cloudflaredUnavailable).toBe(true);
+
+    mockStartCloudflaredTunnel.mockClear();
+    await expect(
+      (service as unknown as RunScriptProxyService).ensureTunnel('w2', 3001)
+    ).resolves.toBeNull();
+    expect(mockStartCloudflaredTunnel).not.toHaveBeenCalled();
+  });
+
+  it('cleanup stops all active tunnels', async () => {
+    const service = new RunScriptProxyService();
+    await service.ensureTunnel('w1', 3000);
+    await service.ensureTunnel('w2', 3001);
+
+    await service.cleanup();
+
+    expect(mockKillProcessWithTimeout).toHaveBeenCalledTimes(2);
+    expect(service.getTunnelUrl('w1')).toBeNull();
+    expect(service.getTunnelUrl('w2')).toBeNull();
+  });
+
+  it('cleanupSync kills active cloudflared processes and clears tunnel map', () => {
     const service = new RunScriptProxyService() as unknown as ProxyServiceInternals;
     const cloudflaredKill = vi.fn();
     const closeAuthProxy = vi.fn().mockResolvedValue(undefined);
@@ -42,7 +145,7 @@ describe('RunScriptProxyService.cleanupSync', () => {
         pid: 12_345,
         exitCode: null,
         kill: cloudflaredKill,
-      },
+      } as unknown as ChildProcess,
       closeAuthProxy,
     });
 
@@ -53,7 +156,7 @@ describe('RunScriptProxyService.cleanupSync', () => {
     expect(service.tunnels.size).toBe(0);
   });
 
-  it('does not kill cloudflared when process already exited', () => {
+  it('cleanupSync does not kill already-exited processes', () => {
     const service = new RunScriptProxyService() as unknown as ProxyServiceInternals;
     const cloudflaredKill = vi.fn();
     const closeAuthProxy = vi.fn().mockResolvedValue(undefined);
@@ -66,7 +169,7 @@ describe('RunScriptProxyService.cleanupSync', () => {
         pid: 12_345,
         exitCode: 0,
         kill: cloudflaredKill,
-      },
+      } as unknown as ChildProcess,
       closeAuthProxy,
     });
 

--- a/src/backend/trpc/decision-log.router.test.ts
+++ b/src/backend/trpc/decision-log.router.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockFindByAgentId = vi.hoisted(() => vi.fn());
+const mockFindRecent = vi.hoisted(() => vi.fn());
+const mockFindById = vi.hoisted(() => vi.fn());
+
+vi.mock('@/backend/orchestration/decision-log-query.service', () => ({
+  decisionLogQueryService: {
+    findByAgentId: (...args: unknown[]) => mockFindByAgentId(...args),
+    findRecent: (...args: unknown[]) => mockFindRecent(...args),
+    findById: (...args: unknown[]) => mockFindById(...args),
+  },
+}));
+
+import { decisionLogRouter } from './decision-log.trpc';
+
+function createCaller() {
+  return decisionLogRouter.createCaller({ appContext: {} } as never);
+}
+
+describe('decisionLogRouter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('lists logs by agent and recent logs with defaults', async () => {
+    mockFindByAgentId.mockResolvedValue([{ id: 'd1' }]);
+    mockFindRecent.mockResolvedValue([{ id: 'd2' }]);
+
+    const caller = createCaller();
+    await expect(caller.listByAgent({ agentId: 'a1' })).resolves.toEqual([{ id: 'd1' }]);
+    await expect(caller.listRecent()).resolves.toEqual([{ id: 'd2' }]);
+
+    expect(mockFindByAgentId).toHaveBeenCalledWith('a1', 50);
+    expect(mockFindRecent).toHaveBeenCalledWith(100);
+  });
+
+  it('gets decision log by id and throws when missing', async () => {
+    mockFindById.mockResolvedValueOnce({ id: 'd1', decision: 'ok' });
+    mockFindById.mockResolvedValueOnce(null);
+
+    const caller = createCaller();
+    await expect(caller.getById({ id: 'd1' })).resolves.toEqual({ id: 'd1', decision: 'ok' });
+    await expect(caller.getById({ id: 'missing' })).rejects.toThrow(
+      'Decision log not found: missing'
+    );
+  });
+});

--- a/src/backend/trpc/linear.router.test.ts
+++ b/src/backend/trpc/linear.router.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockFindProjectById = vi.hoisted(() => vi.fn());
+const mockValidateKeyAndListTeams = vi.hoisted(() => vi.fn());
+const mockListMyIssues = vi.hoisted(() => vi.fn());
+const mockGetIssue = vi.hoisted(() => vi.fn());
+const mockDecrypt = vi.hoisted(() => vi.fn());
+
+vi.mock('@/backend/domains/workspace', () => ({
+  projectManagementService: {
+    findById: (...args: unknown[]) => mockFindProjectById(...args),
+  },
+}));
+
+vi.mock('@/backend/domains/linear', () => ({
+  linearClientService: {
+    validateKeyAndListTeams: (...args: unknown[]) => mockValidateKeyAndListTeams(...args),
+    listMyIssues: (...args: unknown[]) => mockListMyIssues(...args),
+    getIssue: (...args: unknown[]) => mockGetIssue(...args),
+  },
+}));
+
+vi.mock('@/backend/services/crypto.service', () => ({
+  cryptoService: {
+    decrypt: (...args: unknown[]) => mockDecrypt(...args),
+  },
+}));
+
+import { linearRouter } from './linear.trpc';
+
+function createCaller() {
+  return linearRouter.createCaller({ appContext: {} } as never);
+}
+
+describe('linearRouter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('validates API key and lists teams', async () => {
+    mockValidateKeyAndListTeams.mockResolvedValue([{ id: 'team-1', name: 'Core' }]);
+    const caller = createCaller();
+
+    await expect(caller.validateKeyAndListTeams({ apiKey: 'lin_api' })).resolves.toEqual([
+      { id: 'team-1', name: 'Core' },
+    ]);
+  });
+
+  it('returns project/config errors for listIssuesForProject', async () => {
+    const caller = createCaller();
+
+    mockFindProjectById.mockResolvedValueOnce(null);
+    await expect(caller.listIssuesForProject({ projectId: 'p1' })).resolves.toEqual({
+      issues: [],
+      error: 'Project not found',
+    });
+
+    mockFindProjectById.mockResolvedValueOnce({ issueTrackerConfig: {} });
+    await expect(caller.listIssuesForProject({ projectId: 'p1' })).resolves.toEqual({
+      issues: [],
+      error: 'Linear not configured for this project',
+    });
+  });
+
+  it('lists issues and handles fetch errors', async () => {
+    mockFindProjectById.mockResolvedValue({
+      issueTrackerConfig: {
+        linear: {
+          apiKey: 'encrypted-key',
+          teamId: 'team-1',
+          teamName: 'Core',
+          viewerName: 'Alice',
+        },
+      },
+    });
+    mockDecrypt.mockReturnValue('lin_api_decrypted');
+
+    mockListMyIssues.mockResolvedValueOnce([{ id: 'FF-1' }]);
+
+    const caller = createCaller();
+    await expect(caller.listIssuesForProject({ projectId: 'p1' })).resolves.toEqual({
+      issues: [{ id: 'FF-1' }],
+      error: null,
+    });
+
+    mockListMyIssues.mockRejectedValueOnce(new Error('linear down'));
+    await expect(caller.listIssuesForProject({ projectId: 'p1' })).resolves.toEqual({
+      issues: [],
+      error: 'linear down',
+    });
+  });
+
+  it('gets issue details and handles errors', async () => {
+    mockFindProjectById.mockResolvedValue({
+      issueTrackerConfig: {
+        linear: {
+          apiKey: 'encrypted-key',
+          teamId: 'team-1',
+          teamName: 'Core',
+          viewerName: 'Alice',
+        },
+      },
+    });
+    mockDecrypt.mockReturnValue('lin_api_decrypted');
+
+    const caller = createCaller();
+
+    mockGetIssue.mockResolvedValueOnce({ id: 'FF-1', title: 'Fix tests' });
+    await expect(caller.getIssue({ projectId: 'p1', issueId: 'FF-1' })).resolves.toEqual({
+      issue: { id: 'FF-1', title: 'Fix tests' },
+      error: null,
+    });
+
+    mockGetIssue.mockRejectedValueOnce(new Error('not reachable'));
+    await expect(caller.getIssue({ projectId: 'p1', issueId: 'FF-2' })).resolves.toEqual({
+      issue: null,
+      error: 'not reachable',
+    });
+  });
+});

--- a/src/backend/trpc/pr-review.router.test.ts
+++ b/src/backend/trpc/pr-review.router.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { prReviewRouter } from './pr-review.trpc';
+
+function createCaller(overrides?: {
+  checkHealth?: () => Promise<{ isInstalled: boolean; isAuthenticated: boolean }>;
+  listReviewRequests?: () => Promise<unknown[]>;
+  approvePR?: (owner: string, repo: string, number: number) => Promise<void>;
+  getPRFullDetails?: (repo: string, number: number) => Promise<unknown>;
+  getPRDiff?: (repo: string, number: number) => Promise<string>;
+  submitReview?: (
+    repo: string,
+    number: number,
+    action: 'approve' | 'request-changes' | 'comment',
+    body?: string
+  ) => Promise<void>;
+}) {
+  return prReviewRouter.createCaller({
+    appContext: {
+      services: {
+        githubCLIService: {
+          checkHealth:
+            overrides?.checkHealth ?? (async () => ({ isInstalled: true, isAuthenticated: true })),
+          listReviewRequests: overrides?.listReviewRequests ?? (async () => []),
+          approvePR: overrides?.approvePR ?? (async () => undefined),
+          getPRFullDetails: overrides?.getPRFullDetails ?? (async () => ({ number: 1 })),
+          getPRDiff: overrides?.getPRDiff ?? (async () => 'diff --git a b'),
+          submitReview: overrides?.submitReview ?? (async () => undefined),
+        },
+      },
+    },
+  } as never);
+}
+
+describe('prReviewRouter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns empty review requests when gh is unhealthy', async () => {
+    const checkHealth = vi.fn(async () => ({ isInstalled: false, isAuthenticated: false }));
+    const listReviewRequests = vi.fn(async () => [{ number: 1 }]);
+    const caller = createCaller({ checkHealth, listReviewRequests });
+
+    await expect(caller.listReviewRequests()).resolves.toEqual({
+      prs: [],
+      health: { isInstalled: false, isAuthenticated: false },
+      error: null,
+    });
+    expect(listReviewRequests).not.toHaveBeenCalled();
+  });
+
+  it('lists review requests and handles fetch errors', async () => {
+    const listReviewRequests = vi.fn(async () => [{ number: 42 }]);
+    const caller = createCaller({ listReviewRequests });
+
+    await expect(caller.listReviewRequests()).resolves.toEqual({
+      prs: [{ number: 42 }],
+      health: { isInstalled: true, isAuthenticated: true },
+      error: null,
+    });
+
+    const failingCaller = createCaller({
+      listReviewRequests: () => {
+        throw new Error('gh failed');
+      },
+    });
+    await expect(failingCaller.listReviewRequests()).resolves.toEqual({
+      prs: [],
+      health: { isInstalled: true, isAuthenticated: true },
+      error: 'gh failed',
+    });
+  });
+
+  it('delegates approve, health, details, diff, and submit review', async () => {
+    const approvePR = vi.fn(async () => undefined);
+    const submitReview = vi.fn(async () => undefined);
+    const caller = createCaller({
+      approvePR,
+      submitReview,
+      getPRFullDetails: async () => ({ number: 12, title: 'Fix CI' }),
+      getPRDiff: async () => 'diff content',
+    });
+
+    await expect(caller.approve({ owner: 'o', repo: 'r', prNumber: 12 })).resolves.toEqual({
+      success: true,
+    });
+    await expect(caller.checkHealth()).resolves.toEqual({
+      isInstalled: true,
+      isAuthenticated: true,
+    });
+    await expect(caller.getPRDetails({ repo: 'o/r', number: 12 })).resolves.toEqual({
+      number: 12,
+      title: 'Fix CI',
+    });
+    await expect(caller.getDiff({ repo: 'o/r', number: 12 })).resolves.toEqual({
+      diff: 'diff content',
+    });
+    await expect(
+      caller.submitReview({
+        repo: 'o/r',
+        number: 12,
+        action: 'request-changes',
+        body: 'needs work',
+      })
+    ).resolves.toEqual({ success: true });
+
+    expect(approvePR).toHaveBeenCalledWith('o', 'r', 12);
+    expect(submitReview).toHaveBeenCalledWith('o/r', 12, 'request-changes', 'needs work');
+  });
+});

--- a/src/backend/trpc/procedures/project-scoped.test.ts
+++ b/src/backend/trpc/procedures/project-scoped.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { router } from '@/backend/trpc/trpc';
+import { projectScopedProcedure } from './project-scoped';
+
+const testRouter = router({
+  readProject: projectScopedProcedure.query(({ ctx }) => ({ projectId: ctx.projectId })),
+});
+
+describe('projectScopedProcedure', () => {
+  it('allows calls when projectId is present', async () => {
+    const caller = testRouter.createCaller({ appContext: {}, projectId: 'p1' } as never);
+    await expect(caller.readProject()).resolves.toEqual({ projectId: 'p1' });
+  });
+
+  it('throws BAD_REQUEST when projectId is missing', async () => {
+    const caller = testRouter.createCaller({ appContext: {} } as never);
+    await expect(caller.readProject()).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+});

--- a/src/backend/trpc/user-settings.router.test.ts
+++ b/src/backend/trpc/user-settings.router.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGet = vi.hoisted(() => vi.fn());
+const mockUpdate = vi.hoisted(() => vi.fn());
+const mockGetWorkspaceOrder = vi.hoisted(() => vi.fn());
+const mockUpdateWorkspaceOrder = vi.hoisted(() => vi.fn());
+const mockExecCommand = vi.hoisted(() => vi.fn());
+
+vi.mock('@/backend/domains/workspace', () => ({
+  userSettingsQueryService: {
+    get: (...args: unknown[]) => mockGet(...args),
+    update: (...args: unknown[]) => mockUpdate(...args),
+    getWorkspaceOrder: (...args: unknown[]) => mockGetWorkspaceOrder(...args),
+    updateWorkspaceOrder: (...args: unknown[]) => mockUpdateWorkspaceOrder(...args),
+  },
+}));
+
+vi.mock('@/backend/lib/shell', () => ({
+  execCommand: (...args: unknown[]) => mockExecCommand(...args),
+}));
+
+import { userSettingsRouter } from './user-settings.trpc';
+
+function createCaller() {
+  return userSettingsRouter.createCaller({ appContext: {} } as never);
+}
+
+describe('userSettingsRouter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('gets and updates settings', async () => {
+    mockGet.mockResolvedValue({ preferredIde: 'cursor', customIdeCommand: null });
+    mockUpdate.mockResolvedValue({ preferredIde: 'vscode', customIdeCommand: null });
+
+    const caller = createCaller();
+    await expect(caller.get()).resolves.toEqual({ preferredIde: 'cursor', customIdeCommand: null });
+    await expect(
+      caller.update({ preferredIde: 'vscode', playSoundOnComplete: true })
+    ).resolves.toEqual({ preferredIde: 'vscode', customIdeCommand: null });
+
+    expect(mockUpdate).toHaveBeenCalledWith({ preferredIde: 'vscode', playSoundOnComplete: true });
+  });
+
+  it('requires command when preferred ide is custom', async () => {
+    const caller = createCaller();
+    await expect(caller.update({ preferredIde: 'custom' })).rejects.toThrow(
+      'Custom IDE command is required when using custom IDE'
+    );
+  });
+
+  it('tests custom command and validates command format', async () => {
+    mockExecCommand.mockResolvedValue({ code: 0, stdout: '', stderr: '' });
+    const caller = createCaller();
+
+    await expect(caller.testCustomCommand({ customCommand: 'echo {workspace}' })).resolves.toEqual({
+      success: true,
+      message: 'Command executed successfully',
+    });
+    expect(mockExecCommand).toHaveBeenCalled();
+
+    await expect(caller.testCustomCommand({ customCommand: 'echo nope' })).rejects.toThrow(
+      'Command must include {workspace} placeholder'
+    );
+
+    await expect(
+      caller.testCustomCommand({ customCommand: 'echo {workspace}; rm -rf /' })
+    ).rejects.toThrow('Command contains invalid shell metacharacters');
+
+    mockExecCommand.mockRejectedValueOnce(new Error('spawn failed'));
+    await expect(caller.testCustomCommand({ customCommand: 'echo {workspace}' })).rejects.toThrow(
+      'Command failed: spawn failed'
+    );
+  });
+
+  it('gets and updates workspace order', async () => {
+    mockGetWorkspaceOrder.mockResolvedValue(['w2', 'w1']);
+    mockUpdateWorkspaceOrder.mockResolvedValue(undefined);
+
+    const caller = createCaller();
+    await expect(caller.getWorkspaceOrder({ projectId: 'p1' })).resolves.toEqual(['w2', 'w1']);
+    await expect(
+      caller.updateWorkspaceOrder({ projectId: 'p1', workspaceIds: ['w1', 'w2'] })
+    ).resolves.toEqual({ success: true });
+
+    expect(mockUpdateWorkspaceOrder).toHaveBeenCalledWith('p1', ['w1', 'w2']);
+  });
+});

--- a/src/backend/trpc/workspace/ide.router.test.ts
+++ b/src/backend/trpc/workspace/ide.router.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockFindById = vi.hoisted(() => vi.fn());
+const mockGetUserSettings = vi.hoisted(() => vi.fn());
+const mockCheckIdeAvailable = vi.hoisted(() => vi.fn());
+const mockOpenPathInIde = vi.hoisted(() => vi.fn());
+
+vi.mock('@/backend/domains/workspace', () => ({
+  workspaceDataService: {
+    findById: (...args: unknown[]) => mockFindById(...args),
+  },
+  userSettingsQueryService: {
+    get: (...args: unknown[]) => mockGetUserSettings(...args),
+  },
+}));
+
+vi.mock('@/backend/lib/ide-helpers', () => ({
+  checkIdeAvailable: (...args: unknown[]) => mockCheckIdeAvailable(...args),
+  openPathInIde: (...args: unknown[]) => mockOpenPathInIde(...args),
+}));
+
+import { workspaceIdeRouter } from './ide.trpc';
+
+function createCaller() {
+  return workspaceIdeRouter.createCaller({ appContext: {} } as never);
+}
+
+describe('workspaceIdeRouter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('lists available ides including custom IDE when configured', async () => {
+    mockGetUserSettings.mockResolvedValue({
+      preferredIde: 'custom',
+      customIdeCommand: 'open {workspace}',
+    });
+    mockCheckIdeAvailable.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+    const caller = createCaller();
+    await expect(caller.getAvailableIdes()).resolves.toEqual({
+      ides: [
+        { id: 'cursor', name: 'Cursor' },
+        { id: 'custom', name: 'Custom IDE' },
+      ],
+      preferredIde: 'custom',
+    });
+  });
+
+  it('opens workspace using preferred ide by default', async () => {
+    mockFindById.mockResolvedValue({ id: 'w1', worktreePath: '/tmp/w1' });
+    mockGetUserSettings.mockResolvedValue({ preferredIde: 'vscode', customIdeCommand: null });
+    mockOpenPathInIde.mockResolvedValue(true);
+
+    const caller = createCaller();
+    await expect(caller.openInIde({ id: 'w1' })).resolves.toEqual({ success: true });
+    expect(mockOpenPathInIde).toHaveBeenCalledWith('vscode', '/tmp/w1', null);
+  });
+
+  it('validates workspace and custom ide config', async () => {
+    const caller = createCaller();
+
+    mockFindById.mockResolvedValue(null);
+    await expect(caller.openInIde({ id: 'missing' })).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+    mockFindById.mockResolvedValue({ id: 'w1', worktreePath: null });
+    await expect(caller.openInIde({ id: 'w1' })).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+
+    mockFindById.mockResolvedValue({ id: 'w1', worktreePath: '/tmp/w1' });
+    mockGetUserSettings.mockResolvedValue({ preferredIde: 'custom', customIdeCommand: null });
+    await expect(caller.openInIde({ id: 'w1', ide: 'custom' })).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+    });
+  });
+
+  it('returns internal error when IDE launch fails', async () => {
+    mockFindById.mockResolvedValue({ id: 'w1', worktreePath: '/tmp/w1' });
+    mockGetUserSettings.mockResolvedValue({ preferredIde: 'cursor', customIdeCommand: null });
+    mockOpenPathInIde.mockResolvedValue(false);
+
+    const caller = createCaller();
+    await expect(caller.openInIde({ id: 'w1', ide: 'cursor' })).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+    });
+  });
+});

--- a/src/backend/trpc/workspace/init.router.test.ts
+++ b/src/backend/trpc/workspace/init.router.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockRunStartupScript = vi.hoisted(() => vi.fn());
+const mockFindByIdWithProject = vi.hoisted(() => vi.fn());
+const mockFindById = vi.hoisted(() => vi.fn());
+const mockResetToNew = vi.hoisted(() => vi.fn());
+const mockStartProvisioning = vi.hoisted(() => vi.fn());
+const mockGetInitMode = vi.hoisted(() => vi.fn());
+const mockSetInitMode = vi.hoisted(() => vi.fn());
+const mockGetWorkspaceInitPolicy = vi.hoisted(() => vi.fn());
+const mockInitializeWorkspaceWorktree = vi.hoisted(() => vi.fn());
+
+vi.mock('@/backend/domains/run-script', () => ({
+  startupScriptService: {
+    runStartupScript: (...args: unknown[]) => mockRunStartupScript(...args),
+  },
+}));
+
+vi.mock('@/backend/domains/workspace', () => ({
+  workspaceDataService: {
+    findByIdWithProject: (...args: unknown[]) => mockFindByIdWithProject(...args),
+    findById: (...args: unknown[]) => mockFindById(...args),
+  },
+  workspaceStateMachine: {
+    resetToNew: (...args: unknown[]) => mockResetToNew(...args),
+    startProvisioning: (...args: unknown[]) => mockStartProvisioning(...args),
+  },
+  worktreeLifecycleService: {
+    getInitMode: (...args: unknown[]) => mockGetInitMode(...args),
+    setInitMode: (...args: unknown[]) => mockSetInitMode(...args),
+  },
+  getWorkspaceInitPolicy: (...args: unknown[]) => mockGetWorkspaceInitPolicy(...args),
+}));
+
+vi.mock('@/backend/orchestration/workspace-init.orchestrator', () => ({
+  initializeWorkspaceWorktree: (...args: unknown[]) => mockInitializeWorkspaceWorktree(...args),
+}));
+
+vi.mock('@/backend/services/logger.service', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+import { workspaceInitRouter } from './init.trpc';
+
+function createCaller() {
+  return workspaceInitRouter.createCaller({ appContext: {} } as never);
+}
+
+describe('workspaceInitRouter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockInitializeWorkspaceWorktree.mockResolvedValue(undefined);
+    mockRunStartupScript.mockResolvedValue({ success: true });
+  });
+
+  it('returns initialization status with policy fields', async () => {
+    mockFindByIdWithProject.mockResolvedValue({
+      id: 'w1',
+      status: 'FAILED',
+      initErrorMessage: 'boom',
+      initOutput: 'out',
+      initStartedAt: new Date('2026-01-01T00:00:00.000Z'),
+      initCompletedAt: null,
+      worktreePath: null,
+      project: { startupScriptCommand: 'pnpm dev', startupScriptPath: null },
+    });
+    mockGetWorkspaceInitPolicy.mockReturnValue({ phase: 'FAILED', banner: 'retry' });
+
+    const caller = createCaller();
+    await expect(caller.getInitStatus({ id: 'w1' })).resolves.toEqual({
+      status: 'FAILED',
+      initErrorMessage: 'boom',
+      initOutput: 'out',
+      initStartedAt: new Date('2026-01-01T00:00:00.000Z'),
+      initCompletedAt: null,
+      phase: 'FAILED',
+      chatBanner: 'retry',
+      hasStartupScript: true,
+      hasWorktreePath: false,
+    });
+  });
+
+  it('retries full initialization when worktree is missing', async () => {
+    mockFindByIdWithProject.mockResolvedValue({
+      id: 'w1',
+      status: 'FAILED',
+      worktreePath: null,
+      branchName: 'feature/x',
+      project: { worktreeBasePath: '/tmp/worktrees' },
+    });
+    mockResetToNew.mockResolvedValue({ id: 'w1', status: 'NEW' });
+    mockGetInitMode.mockResolvedValue(true);
+    mockFindById.mockResolvedValue({ id: 'w1', status: 'NEW' });
+
+    const caller = createCaller();
+    await expect(caller.retryInit({ id: 'w1' })).resolves.toEqual({ id: 'w1', status: 'NEW' });
+
+    expect(mockResetToNew).toHaveBeenCalledWith('w1', 3);
+    expect(mockSetInitMode).toHaveBeenCalledWith('w1', true, '/tmp/worktrees');
+
+    await Promise.resolve();
+    expect(mockInitializeWorkspaceWorktree).toHaveBeenCalledWith('w1', {
+      branchName: 'feature/x',
+      useExistingBranch: true,
+    });
+  });
+
+  it('retries startup script when worktree exists', async () => {
+    const workspace = {
+      id: 'w2',
+      status: 'FAILED',
+      worktreePath: '/tmp/w2',
+      project: { id: 'p1' },
+    };
+    mockFindByIdWithProject.mockResolvedValue(workspace);
+    mockStartProvisioning.mockResolvedValue({ status: 'PROVISIONING' });
+    mockFindById.mockResolvedValue({ id: 'w2', status: 'READY' });
+
+    const caller = createCaller();
+    await expect(caller.retryInit({ id: 'w2' })).resolves.toEqual({ id: 'w2', status: 'READY' });
+
+    expect(mockStartProvisioning).toHaveBeenCalledWith('w2', { maxRetries: 3 });
+    expect(mockRunStartupScript).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'w2', status: 'PROVISIONING' }),
+      workspace.project
+    );
+  });
+
+  it('validates retry preconditions', async () => {
+    const caller = createCaller();
+
+    mockFindByIdWithProject.mockResolvedValue(null);
+    await expect(caller.retryInit({ id: 'missing' })).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+    mockFindByIdWithProject.mockResolvedValue({
+      id: 'w1',
+      status: 'READY',
+      project: { worktreeBasePath: '/tmp' },
+      worktreePath: null,
+    });
+    await expect(caller.retryInit({ id: 'w1' })).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+
+    mockFindByIdWithProject.mockResolvedValue({
+      id: 'w1',
+      status: 'FAILED',
+      project: { worktreeBasePath: '/tmp' },
+      worktreePath: null,
+    });
+    mockResetToNew.mockResolvedValue(null);
+    await expect(caller.retryInit({ id: 'w1' })).rejects.toMatchObject({
+      code: 'TOO_MANY_REQUESTS',
+    });
+  });
+});

--- a/src/backend/trpc/workspace/run-script.router.test.ts
+++ b/src/backend/trpc/workspace/run-script.router.test.ts
@@ -1,0 +1,141 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockFindByIdWithProject = vi.hoisted(() => vi.fn());
+const mockSetRunScriptCommands = vi.hoisted(() => vi.fn());
+
+vi.mock('@/backend/domains/workspace', () => ({
+  workspaceDataService: {
+    findByIdWithProject: (...args: unknown[]) => mockFindByIdWithProject(...args),
+    setRunScriptCommands: (...args: unknown[]) => mockSetRunScriptCommands(...args),
+  },
+}));
+
+import { workspaceRunScriptRouter } from './run-script.trpc';
+
+function createCaller(runScriptService?: {
+  startRunScript?: (workspaceId: string) => Promise<{
+    success: boolean;
+    error?: string;
+    port?: number;
+    pid?: number;
+    proxyUrl?: string | null;
+  }>;
+  stopRunScript?: (workspaceId: string) => Promise<{ success: boolean; error?: string }>;
+  getRunScriptStatus?: (workspaceId: string) => Promise<unknown>;
+}) {
+  return workspaceRunScriptRouter.createCaller({
+    appContext: {
+      services: {
+        runScriptService: {
+          startRunScript: runScriptService?.startRunScript ?? (async () => ({ success: true })),
+          stopRunScript: runScriptService?.stopRunScript ?? (async () => ({ success: true })),
+          getRunScriptStatus:
+            runScriptService?.getRunScriptStatus ??
+            (async () => ({ status: 'IDLE', workspaceId: 'default' })),
+        },
+      },
+    },
+  } as never);
+}
+
+describe('workspaceRunScriptRouter', () => {
+  let workspaceDir: string;
+  let repoDir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    workspaceDir = mkdtempSync(join(tmpdir(), 'ff-ws-'));
+    repoDir = mkdtempSync(join(tmpdir(), 'ff-repo-'));
+  });
+
+  afterEach(() => {
+    rmSync(workspaceDir, { recursive: true, force: true });
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  it('creates factory config and mirrors it into project repo', async () => {
+    mockFindByIdWithProject.mockResolvedValue({
+      id: 'w1',
+      worktreePath: workspaceDir,
+      project: { repoPath: repoDir },
+    });
+
+    const caller = createCaller();
+    await expect(
+      caller.createFactoryConfig({
+        workspaceId: 'w1',
+        config: {
+          scripts: {
+            run: 'pnpm dev',
+            cleanup: 'pkill node',
+          },
+        },
+      })
+    ).resolves.toEqual({ success: true });
+
+    const workspaceConfig = readFileSync(join(workspaceDir, 'factory-factory.json'), 'utf8');
+    const repoConfig = readFileSync(join(repoDir, 'factory-factory.json'), 'utf8');
+    expect(workspaceConfig).toContain('pnpm dev');
+    expect(repoConfig).toContain('pnpm dev');
+    expect(mockSetRunScriptCommands).toHaveBeenCalledWith('w1', 'pnpm dev', 'pkill node');
+  });
+
+  it('validates workspace preconditions for config creation', async () => {
+    const caller = createCaller();
+
+    mockFindByIdWithProject.mockResolvedValue(null);
+    await expect(
+      caller.createFactoryConfig({ workspaceId: 'missing', config: { scripts: {} } })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+    mockFindByIdWithProject.mockResolvedValue({ id: 'w1', worktreePath: null, project: null });
+    await expect(
+      caller.createFactoryConfig({ workspaceId: 'w1', config: { scripts: {} } })
+    ).rejects.toMatchObject({ code: 'PRECONDITION_FAILED' });
+  });
+
+  it('delegates start/stop/status to runScriptService', async () => {
+    const startRunScript = vi.fn(async () => ({
+      success: true,
+      port: 3000,
+      pid: 12_345,
+      proxyUrl: 'https://proxy.example',
+    }));
+    const stopRunScript = vi.fn(async () => ({ success: true }));
+    const getRunScriptStatus = vi.fn(async () => ({ status: 'RUNNING' }));
+
+    const caller = createCaller({ startRunScript, stopRunScript, getRunScriptStatus });
+
+    await expect(caller.startRunScript({ workspaceId: 'w1' })).resolves.toEqual({
+      success: true,
+      port: 3000,
+      pid: 12_345,
+      proxyUrl: 'https://proxy.example',
+    });
+    await expect(caller.stopRunScript({ workspaceId: 'w1' })).resolves.toEqual({ success: true });
+    await expect(caller.getRunScriptStatus({ workspaceId: 'w1' })).resolves.toEqual({
+      status: 'RUNNING',
+    });
+
+    expect(startRunScript).toHaveBeenCalledWith('w1');
+    expect(stopRunScript).toHaveBeenCalledWith('w1');
+    expect(getRunScriptStatus).toHaveBeenCalledWith('w1');
+  });
+
+  it('returns trpc error when start/stop run script fails', async () => {
+    const caller = createCaller({
+      startRunScript: async () => ({ success: false, error: 'start failed' }),
+      stopRunScript: async () => ({ success: false, error: 'stop failed' }),
+    });
+
+    await expect(caller.startRunScript({ workspaceId: 'w1' })).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+    });
+    await expect(caller.stopRunScript({ workspaceId: 'w1' })).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+    });
+  });
+});

--- a/src/backend/trpc/workspace/workspace-helpers.test.ts
+++ b/src/backend/trpc/workspace/workspace-helpers.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockFindById = vi.hoisted(() => vi.fn());
+const mockFindByIdWithProject = vi.hoisted(() => vi.fn());
+
+vi.mock('@/backend/domains/workspace', () => ({
+  workspaceDataService: {
+    findById: (...args: unknown[]) => mockFindById(...args),
+    findByIdWithProject: (...args: unknown[]) => mockFindByIdWithProject(...args),
+  },
+}));
+
+import {
+  getWorkspaceOrThrow,
+  getWorkspaceWithProjectAndWorktreeOrThrow,
+  getWorkspaceWithProjectOrThrow,
+  getWorkspaceWithWorktree,
+  getWorkspaceWithWorktreeOrThrow,
+} from './workspace-helpers';
+
+describe('workspace helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns workspace when found', async () => {
+    mockFindById.mockResolvedValue({ id: 'w1', worktreePath: '/tmp/w1' });
+
+    await expect(getWorkspaceOrThrow('w1')).resolves.toMatchObject({ id: 'w1' });
+    await expect(getWorkspaceWithWorktree('w1')).resolves.toEqual({
+      workspace: expect.objectContaining({ id: 'w1' }),
+      worktreePath: '/tmp/w1',
+    });
+  });
+
+  it('throws NOT_FOUND when workspace is missing', async () => {
+    mockFindById.mockResolvedValue(null);
+    mockFindByIdWithProject.mockResolvedValue(null);
+
+    await expect(getWorkspaceOrThrow('missing')).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    await expect(getWorkspaceWithProjectOrThrow('missing')).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+    await expect(getWorkspaceWithProjectAndWorktreeOrThrow('missing')).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it('returns null for missing worktree and throws for required worktree', async () => {
+    mockFindById.mockResolvedValue({ id: 'w1', worktreePath: null });
+
+    await expect(getWorkspaceWithWorktree('w1')).resolves.toBeNull();
+    await expect(getWorkspaceWithWorktreeOrThrow('w1')).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+    });
+  });
+
+  it('returns workspace with project and worktree when valid', async () => {
+    mockFindByIdWithProject.mockResolvedValue({
+      id: 'w2',
+      worktreePath: '/tmp/w2',
+      project: { id: 'p1' },
+    });
+
+    await expect(getWorkspaceWithProjectOrThrow('w2')).resolves.toMatchObject({ id: 'w2' });
+    await expect(getWorkspaceWithProjectAndWorktreeOrThrow('w2')).resolves.toEqual({
+      workspace: expect.objectContaining({ id: 'w2' }),
+      worktreePath: '/tmp/w2',
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,7 +11,17 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'json', 'json-summary', 'html'],
       include: ['src/backend/**/*.ts'],
-      exclude: ['src/backend/**/*.test.ts', 'src/backend/index.ts', 'src/backend/testing/**'],
+      exclude: [
+        'src/backend/**/*.test.ts',
+        'src/backend/index.ts',
+        'src/backend/testing/**',
+        // Keep coverage focused on behavior-bearing modules.
+        'src/backend/**/index.ts',
+        'src/backend/**/types.ts',
+        'src/backend/**/*.types.ts',
+        'src/backend/**/bridges.ts',
+        'src/backend/**/constants.ts',
+      ],
       // Thresholds disabled for now since unit tests use mocks
       // Enable as integration tests are added and coverage grows
     },


### PR DESCRIPTION
## Summary
- Add comprehensive backend tests for previously untested routers/helpers/interceptors/prompts:
  - workspace init/ide/run-script routers and workspace helper utilities
  - user-settings, linear, pr-review, decision-log, and project-scoped procedures
  - quick-actions prompt loader
  - branch-rename interceptor
  - decision-log query orchestration service
- Add new high-impact service tests for:
  - startup script execution lifecycle
  - rate limiter queueing/timeouts/shutdown
  - git ops worktree/branch/commit paths
- Expand existing tests for:
  - workspace query service flows
  - kanban state service logic
  - session domain state transitions and queue/pending-request behavior
  - run-script proxy tunnel lifecycle
- Tighten coverage policy:
  - focus coverage scoring on behavior-bearing modules (exclude index/types/bridges/constants in `vitest.config.ts`)
  - extend `check-critical-coverage` with new critical groups and stricter thresholds for run-script/workspace/trpc surfaces

## Coverage Impact
- Backend stable coverage improved from **68.39%** to **75.51%** line coverage.
- Critical coverage checks now enforce additional surfaces and stricter per-file thresholds, including:
  - run-script startup/proxy/service files
  - workspace runtime/query/kanban and workspace TRPC endpoints
  - new router/interceptor/service files introduced in this change

## Validation
- `pnpm exec vitest run src/backend`
- `pnpm test:coverage:backend:stable`
- `pnpm check:coverage:critical`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily adds/expands unit tests, but also tightens CI coverage enforcement (new critical surfaces and higher per-file thresholds), which can cause unexpected pipeline failures if coverage regresses.
> 
> **Overview**
> **Expands backend unit tests across critical services and TRPC routers**, including startup script execution, rate limiting, git ops, run-script proxy tunneling, session runtime/queue behavior, workspace query + kanban state, quick-action prompt loading, and the branch-rename interceptor.
> 
> **Tightens coverage policy and gates** by excluding non-behavior modules from Vitest coverage (`index`/`types`/`bridges`/`constants`) and strengthening `scripts/check-critical-coverage.mjs` with new critical groups (run-script + workspace runtime/TRPC) plus higher per-group/per-file thresholds for key backend entrypoints.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b51a427edb4a56ca1f226885367f336de94b9ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->