### PR TITLE
Fix New Workspace button color for light/dark mode

### DIFF
--- a/src/frontend/components/kanban/kanban-board.tsx
+++ b/src/frontend/components/kanban/kanban-board.tsx
@@ -340,7 +340,7 @@ function IssuesColumn({ column, issues, projectId }: IssuesColumnProps) {
             <button
               type="button"
               onClick={() => setShowInlineForm(true)}
-              className="shrink-0 flex items-center gap-2 rounded-lg border border-dashed border-primary/40 px-3 py-5 text-sm text-primary hover:border-primary/70 hover:text-primary transition-colors cursor-pointer"
+              className="shrink-0 flex items-center gap-2 rounded-lg border border-dashed border-foreground/40 px-3 py-5 text-sm text-foreground hover:border-foreground/70 hover:text-foreground transition-colors cursor-pointer"
             >
               <Plus className="h-4 w-4" />
               New Workspace


### PR DESCRIPTION
## Summary
- Fix "New Workspace" button on the kanban board to use `foreground` color token instead of `primary`, so it renders black in light mode and white in dark mode.

## Test plan
- [ ] Verify the "New Workspace" button text and border are black in light mode
- [ ] Verify the "New Workspace" button text and border are white in dark mode
- [ ] Verify hover states still work correctly in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
