### PR TITLE
Install GitHub CLI in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ FROM node:${NODE_VERSION}-alpine AS runner
 ARG PNPM_VERSION
 WORKDIR /app
 
-# Runtime system dependencies + cloudflared for tunnel
+# Runtime system dependencies + cloudflared for tunnel + GitHub CLI
 RUN apk add --no-cache \
     git \
     bash \
@@ -67,6 +67,7 @@ RUN apk add --no-cache \
     lsof \
     libc6-compat \
     libstdc++ \
+    github-cli \
   && ARCH="$(uname -m)" \
   && case "$ARCH" in \
        x86_64)  CF_ARCH="amd64" ;; \


### PR DESCRIPTION
## Summary
- Add `github-cli` package to the Docker production runner stage

This enables the `gh` command to be available in containerized deployments, allowing GitHub integration features (issue fetching, PR management) to work properly in cloud environments.

## Changes
- Updated `Dockerfile` to install `github-cli` via apk in the runner stage

🤖 Generated with [Claude Code](https://claude.com/claude-code)