### PR TITLE
Display project name in Kanban board header

### DIFF
--- a/src/client/routes/projects/workspaces/components/workspaces-board-view.tsx
+++ b/src/client/routes/projects/workspaces/components/workspaces-board-view.tsx
@@ -1,8 +1,18 @@
+import { useMemo } from 'react';
 import { HeaderRightSlot, useAppHeader } from '@/frontend/components/app-header-context';
 import { KanbanBoard, KanbanControls, KanbanProvider } from '@/frontend/components/kanban';
 
-function BoardHeaderSlot() {
-  useAppHeader({ title: 'Workspaces' });
+function BoardHeaderSlot({ projectName }: { projectName: string }) {
+  const title = useMemo(
+    () => (
+      <>
+        Workspaces <span className="font-normal text-muted-foreground">· {projectName}</span>
+      </>
+    ),
+    [projectName]
+  );
+
+  useAppHeader({ title });
 
   return (
     <HeaderRightSlot>
@@ -13,16 +23,18 @@ function BoardHeaderSlot() {
 
 export function WorkspacesBoardView({
   projectId,
+  projectName,
   slug,
   issueProvider,
 }: {
   projectId: string;
+  projectName: string;
   slug: string;
   issueProvider: string;
 }) {
   return (
     <KanbanProvider projectId={projectId} projectSlug={slug} issueProvider={issueProvider}>
-      <BoardHeaderSlot />
+      <BoardHeaderSlot projectName={projectName} />
       <div className="flex flex-col h-full p-3 md:p-6 gap-3 md:gap-4">
         <div className="flex-1 min-h-0">
           <KanbanBoard />

--- a/src/client/routes/projects/workspaces/list.tsx
+++ b/src/client/routes/projects/workspaces/list.tsx
@@ -13,6 +13,11 @@ export default function WorkspacesListPage() {
   }
 
   return (
-    <WorkspacesBoardView projectId={project.id} slug={slug} issueProvider={project.issueProvider} />
+    <WorkspacesBoardView
+      projectId={project.id}
+      projectName={project.name}
+      slug={slug}
+      issueProvider={project.issueProvider}
+    />
   );
 }

--- a/src/frontend/components/app-header-context.tsx
+++ b/src/frontend/components/app-header-context.tsx
@@ -11,8 +11,8 @@ import {
 import { createPortal } from 'react-dom';
 
 interface AppHeaderContextValue {
-  title: string;
-  setTitle: (title: string) => void;
+  title: ReactNode;
+  setTitle: (title: ReactNode) => void;
   /** Portal target element for right-side header content */
   rightSlot: HTMLElement | null;
   setRightSlot: (el: HTMLElement | null) => void;
@@ -24,7 +24,7 @@ interface AppHeaderContextValue {
 const AppHeaderContext = createContext<AppHeaderContextValue | null>(null);
 
 export function AppHeaderProvider({ children }: { children: ReactNode }) {
-  const [title, setTitle] = useState('');
+  const [title, setTitle] = useState<ReactNode>('');
   const [rightSlot, setRightSlot] = useState<HTMLElement | null>(null);
   const [leftExtraSlot, setLeftExtraSlot] = useState<HTMLElement | null>(null);
 
@@ -49,7 +49,7 @@ export function useAppHeaderContext(): AppHeaderContextValue {
  * Returns portal target elements for rightContent and leftExtra
  * so routes can use createPortal to render into the header slots.
  */
-export function useAppHeaderTitle(title: string) {
+export function useAppHeaderTitle(title: ReactNode) {
   const ctx = useAppHeaderContext();
 
   useLayoutEffect(() => {
@@ -97,6 +97,6 @@ export function HeaderLeftExtraSlot({ children }: { children: ReactNode }) {
  * Simple convenience hook that just sets the header title.
  * Use HeaderRightSlot/HeaderLeftExtraSlot components for slot content.
  */
-export function useAppHeader({ title }: { title: string }) {
+export function useAppHeader({ title }: { title: ReactNode }) {
   useAppHeaderTitle(title);
 }


### PR DESCRIPTION
## Summary
- Show project name alongside "Workspaces" in the Kanban board header
- Project name is styled with lighter color and normal font weight for visual distinction
- Improves context awareness when viewing workspaces across different projects

## Changes
- Updated `WorkspacesBoardView` to accept and pass `projectName` prop
- Modified header to display "Workspaces · [Project Name]" with visual hierarchy
- Enhanced `app-header-context` to support ReactNode titles instead of just strings

## Test plan
- [x] Navigate to Kanban board view
- [x] Verify project name appears next to "Workspaces" in header
- [x] Confirm visual styling (project name is lighter and less bold)
- [x] TypeScript checks pass
- [x] No infinite render loops

🤖 Generated with [Claude Code](https://claude.com/claude-code)