### PR TITLE
Fix CLI health banner layout on wide screens

### DIFF
--- a/src/frontend/components/cli-health-banner.tsx
+++ b/src/frontend/components/cli-health-banner.tsx
@@ -125,10 +125,10 @@ export function CLIHealthBanner() {
 
   return (
     <div className="border-b border-warning/20 bg-warning/10 px-4 py-3">
-      <div className="mx-auto max-w-7xl">
+      <div>
         <div className="flex items-start justify-between gap-4">
-          <div className="flex items-start gap-3">
-            <AlertTriangle className="mt-0.5 h-5 w-5 flex-shrink-0 text-warning" />
+          <div className="flex items-center gap-3">
+            <AlertTriangle className="h-5 w-5 flex-shrink-0 text-warning" />
             <div className="space-y-2">
               <p className="text-sm font-medium text-warning-foreground dark:text-warning">
                 Some features require additional setup


### PR DESCRIPTION
## Summary
- Remove `max-w-7xl mx-auto` centering so banner text stays left-aligned and buttons stay right-aligned at any screen width
- Vertically center the warning icon with the text content instead of top-aligning it

## Test plan
- [ ] Resize browser to wide screen and verify text stays left, buttons stay right
- [ ] Verify warning icon is vertically centered with the two lines of text

🤖 Generated with [Claude Code](https://claude.com/claude-code)