### PR TITLE
Fix #1179: Prevent Launch button overlap in New Workspace form

### DIFF
--- a/src/frontend/components/kanban/inline-workspace-form.tsx
+++ b/src/frontend/components/kanban/inline-workspace-form.tsx
@@ -107,7 +107,7 @@ export function InlineWorkspaceForm({
           autoFocus
           disabled={isCreating}
         />
-        <div className="flex items-center justify-between gap-2">
+        <div className="flex flex-wrap items-center justify-between gap-2">
           <div className="flex items-center gap-3">
             <div className="flex items-center gap-1.5">
               <RatchetToggleButton
@@ -133,7 +133,7 @@ export function InlineWorkspaceForm({
               </SelectContent>
             </Select>
           </div>
-          <div className="flex gap-2">
+          <div className="flex gap-2 ml-auto">
             <Button
               variant="ghost"
               size="sm"


### PR DESCRIPTION
## Summary
- Fixed button overlap issue in the New Workspace inline form on the Kanban board
- Buttons now wrap to the next line on narrow screens instead of overlapping their container

## Changes
- **InlineWorkspaceForm**: Added `flex-wrap` to button container and `ml-auto` to button group for proper wrapping behavior on narrow screens

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Resize browser window to narrow width and click "New Workspace" on Kanban board - Launch and Cancel buttons should wrap to next line instead of overlapping

Closes #1179

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
