### PR TITLE
Create reusable WorkspacesBackLink component (#1178)

### DIFF
--- a/src/client/routes/admin-page.tsx
+++ b/src/client/routes/admin-page.tsx
@@ -1,5 +1,4 @@
 import {
-  ArrowLeft,
   CheckCircle2,
   Download,
   ExternalLink,
@@ -27,7 +26,7 @@ import {
 } from '@/components/ui/select';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Switch } from '@/components/ui/switch';
-import { RatchetWrenchIcon } from '@/components/workspace';
+import { RatchetWrenchIcon, WorkspacesBackLink } from '@/components/workspace';
 import { DevServerSetupPanel } from '@/components/workspace/dev-server-setup-panel';
 import { HeaderLeftExtraSlot, useAppHeader } from '@/frontend/components/app-header-context';
 import { Loading } from '@/frontend/components/loading';
@@ -818,13 +817,7 @@ export default function AdminDashboardPage() {
     <div className="h-full overflow-y-auto">
       {projectSlug && (
         <HeaderLeftExtraSlot>
-          <Button variant="ghost" size="sm" className="shrink-0 text-muted-foreground" asChild>
-            <Link to={`/projects/${projectSlug}/workspaces`}>
-              <ArrowLeft className="h-3.5 w-3.5" />
-              <span className="hidden sm:inline">Back to Workspaces</span>
-              <span className="sm:hidden">Workspaces</span>
-            </Link>
-          </Button>
+          <WorkspacesBackLink projectSlug={projectSlug} />
         </HeaderLeftExtraSlot>
       )}
       <div className="space-y-6 p-3 md:p-6">

--- a/src/client/routes/projects/workspaces/workspace-detail-header.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-header.tsx
@@ -1,7 +1,6 @@
 import {
   AppWindow,
   Archive,
-  ArrowLeft,
   CheckCircle2,
   CircleDot,
   Github,
@@ -14,7 +13,7 @@ import {
   Zap,
 } from 'lucide-react';
 import { useEffect, useState } from 'react';
-import { Link, useParams } from 'react-router';
+import { useParams } from 'react-router';
 import { CiStatusChip } from '@/components/shared/ci-status-chip';
 import { Button } from '@/components/ui/button';
 import {
@@ -54,6 +53,7 @@ import {
   RunScriptPortBadge,
   useRunScriptLaunch,
   useWorkspacePanel,
+  WorkspacesBackLink,
 } from '@/components/workspace';
 import {
   HeaderLeftExtraSlot,
@@ -849,12 +849,7 @@ export function WorkspaceDetailHeaderSlot({
           <WorkspaceCiStatus workspace={workspace} />
           <RunScriptPortBadge workspaceId={workspaceId} />
         </div>
-        <Button variant="ghost" size="sm" className="shrink-0 text-muted-foreground" asChild>
-          <Link to={`/projects/${slug}/workspaces`}>
-            <ArrowLeft className="h-3.5 w-3.5" />
-            <span className="hidden sm:inline">Workspaces</span>
-          </Link>
-        </Button>
+        <WorkspacesBackLink projectSlug={slug} />
       </HeaderLeftExtraSlot>
       <HeaderRightSlot>
         <div

--- a/src/client/routes/projects/workspaces/workspace-detail-view.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-view.tsx
@@ -112,7 +112,7 @@ export function WorkspaceDetailView({
       <div className="flex flex-col items-center justify-center h-full gap-4">
         <p className="text-destructive">Workspace not found</p>
         <Button variant="outline" onClick={workspaceState.handleBackToWorkspaces}>
-          Back to workspaces
+          Workspaces
         </Button>
       </div>
     );

--- a/src/components/workspace/index.ts
+++ b/src/components/workspace/index.ts
@@ -26,3 +26,4 @@ export * from './use-terminal-websocket';
 export * from './workspace-content-view';
 export * from './workspace-panel-context';
 export * from './workspace-status-badge';
+export * from './workspaces-back-link';

--- a/src/components/workspace/workspaces-back-link.tsx
+++ b/src/components/workspace/workspaces-back-link.tsx
@@ -1,0 +1,22 @@
+import { ArrowLeft } from 'lucide-react';
+import { Link } from 'react-router';
+import { Button } from '@/components/ui/button';
+
+interface WorkspacesBackLinkProps {
+  projectSlug: string;
+}
+
+/**
+ * Reusable component for linking back to the workspaces board.
+ * Displays "Workspaces" with an arrow icon, responsive to screen size.
+ */
+export function WorkspacesBackLink({ projectSlug }: WorkspacesBackLinkProps) {
+  return (
+    <Button variant="ghost" size="sm" className="shrink-0 text-muted-foreground" asChild>
+      <Link to={`/projects/${projectSlug}/workspaces`}>
+        <ArrowLeft className="h-3.5 w-3.5" />
+        <span className="hidden sm:inline">Workspaces</span>
+      </Link>
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary
- Created a reusable `WorkspacesBackLink` component to standardize navigation back to the workspaces board
- Replaced inconsistent link text ("Back to Workspaces", "Back workspaces board") with consistent "Workspaces" label across the app

## Changes
- **New Component**: Created `src/components/workspace/workspaces-back-link.tsx` - A reusable component that renders a back link to the workspaces board with consistent styling and responsive behavior
- **Admin Dashboard**: Replaced custom link implementation with `WorkspacesBackLink` component
- **Workspace Detail Header**: Updated to use `WorkspacesBackLink` component instead of inline implementation
- **Workspace Detail View**: Changed "Back to workspaces" text to just "Workspaces" for consistency

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Manual testing: All workspaces back links now consistently display "Workspaces" (desktop) or just the arrow icon (mobile)

Closes #1178

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
