### PR TITLE
Reduce project name font size in Kanban board header

### DIFF
--- a/src/client/routes/projects/workspaces/components/workspaces-board-view.tsx
+++ b/src/client/routes/projects/workspaces/components/workspaces-board-view.tsx
@@ -6,7 +6,8 @@ function BoardHeaderSlot({ projectName }: { projectName: string }) {
   const title = useMemo(
     () => (
       <>
-        Workspaces <span className="font-normal text-muted-foreground">· {projectName}</span>
+        Workspaces{' '}
+        <span className="font-normal text-muted-foreground text-xs">· {projectName}</span>
       </>
     ),
     [projectName]


### PR DESCRIPTION
## Summary
- Reduce the project name font size in the Kanban board header from default to `text-xs` for better visual hierarchy, making the project name feel secondary to the "Workspaces" title

## Test plan
- [ ] Open a project with workspaces and verify the Kanban board header shows the project name in a smaller font size
- [ ] Confirm the "Workspaces" title remains at its original size

🤖 Generated with [Claude Code](https://claude.com/claude-code)
