### PR TITLE
Make IDE settings auto-save on change

### DIFF
--- a/src/client/routes/admin-page.tsx
+++ b/src/client/routes/admin-page.tsx
@@ -385,7 +385,7 @@ function IdeSettingsSection() {
               <Button
                 variant="outline"
                 onClick={handleTestCommand}
-                disabled={testCommand.isPending || !settings.customIdeCommand}
+                disabled={testCommand.isPending || !settings?.customIdeCommand}
               >
                 {testCommand.isPending ? 'Testing...' : 'Test'}
               </Button>


### PR DESCRIPTION
## Summary
- Refactor IDE settings in admin page to auto-save on change instead of requiring an explicit Save button
- Selecting an IDE or editing the custom command now immediately persists via mutation
- Remove `useEffect`/local state synchronization pattern in favor of reading directly from server state
- Invalidate `userSettings.get` query on success so the UI stays in sync

## Test plan
- [ ] Open admin page → IDE Settings section
- [ ] Change preferred IDE dropdown — verify it saves immediately (toast appears)
- [ ] Select "Custom" IDE, enter a command — verify it persists without a Save button
- [ ] Clear the custom command and re-enter — verify it updates correctly
- [ ] Test the "Test" button with a custom command
- [ ] Verify no regressions on other admin page sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)
