### PR TITLE
Fix ratchet toggle leaking across workspaces

### DIFF
--- a/src/backend/domains/ratchet/index.ts
+++ b/src/backend/domains/ratchet/index.ts
@@ -24,10 +24,11 @@ export type {
   RatchetAction,
   RatchetCheckResult,
   RatchetStateChangedEvent,
+  RatchetToggledEvent,
   WorkspaceRatchetResult,
 } from './ratchet.service';
 // Core ratchet polling and dispatch
-export { RATCHET_STATE_CHANGED, ratchetService } from './ratchet.service';
+export { RATCHET_STATE_CHANGED, RATCHET_TOGGLED, ratchetService } from './ratchet.service';
 
 // Reconciliation (workspace/session cleanup)
 export { reconciliationService } from './reconciliation.service';


### PR DESCRIPTION
## Summary
- add a dedicated ratchet toggle event (`RATCHET_TOGGLED`) emitted by `setWorkspaceRatcheting` so enable/disable changes are observable as first-class domain events
- emit `RATCHET_STATE_CHANGED` when disabling ratchet forces a non-`IDLE` workspace state back to `IDLE`
- wire `RATCHET_TOGGLED` into the snapshot event collector to immediately upsert `ratchetEnabled` and `ratchetState` for the specific workspace only
- export the new event/type from the ratchet domain barrel and extend orchestration + ratchet tests to cover the new behavior

## Why
Workspace toggle mutations were persisted correctly, but snapshot/event propagation did not carry `ratchetEnabled` updates explicitly. Under cache reconciliation and websocket updates, this could make ratchet toggle state appear to leak across workspaces.

## Testing
- `pnpm test src/backend/orchestration/event-collector.orchestrator.test.ts src/backend/domains/ratchet/ratchet.service.test.ts`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cross-domain event wiring and snapshot mutation behavior; mistakes could lead to stale or incorrect workspace state in clients, though the change is localized and covered by new tests.
> 
> **Overview**
> Fixes ratchet enable/disable propagation by introducing a dedicated `RATCHET_TOGGLED` event emitted from `ratchetService.setWorkspaceRatcheting` and exporting it from the ratchet domain.
> 
> Disabling ratchet now also emits `RATCHET_STATE_CHANGED` when it forces a non-`IDLE` workspace back to `IDLE`, and the event collector subscribes to `RATCHET_TOGGLED` to immediately upsert `{ ratchetEnabled, ratchetState }` for the specific workspace. Tests are expanded to cover the new event emissions and the additional event-collector subscription/mapping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e4ab62d1c90f5da824553c2a7cf3388d775ea37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->