### PR TITLE
Fix Vite chunk warning for terminal-instance imports

### DIFF
--- a/src/components/project/setup-terminal-modal.tsx
+++ b/src/components/project/setup-terminal-modal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { lazy, Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import { z } from 'zod';
 import {
   Dialog,
@@ -7,8 +7,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { TerminalInstance } from '@/components/workspace/terminal-instance';
 import { buildWebSocketUrl } from '@/lib/websocket-config';
+
+const TerminalInstance = lazy(() =>
+  import('@/components/workspace/terminal-instance').then((m) => ({ default: m.TerminalInstance }))
+);
 
 const SetupTerminalMessageSchema = z.object({
   type: z.string(),
@@ -108,12 +111,14 @@ export function SetupTerminalModal({ open, onClose }: SetupTerminalModalProps) {
         </DialogHeader>
         <div className="flex-1 min-h-0 rounded-md overflow-hidden border bg-[#18181b]">
           {connected && (
-            <TerminalInstance
-              onData={handleData}
-              onResize={handleResize}
-              output={output}
-              isActive={open}
-            />
+            <Suspense fallback={null}>
+              <TerminalInstance
+                onData={handleData}
+                onResize={handleResize}
+                output={output}
+                isActive={open}
+              />
+            </Suspense>
           )}
         </div>
       </DialogContent>

--- a/src/components/workspace/index.ts
+++ b/src/components/workspace/index.ts
@@ -16,7 +16,6 @@ export * from './run-script-button';
 export * from './run-script-port-badge';
 export * from './screenshot-viewer-tab';
 export * from './screenshots-panel';
-export * from './terminal-instance';
 export * from './terminal-panel';
 export * from './terminal-tab-bar';
 export * from './todo-panel-container';


### PR DESCRIPTION
## Summary
This PR removes a Vite build warning caused by mixing dynamic and static imports of `terminal-instance`.

## What changed
- Converted `SetupTerminalModal` to lazily load `TerminalInstance` using `React.lazy` + `Suspense`
- Removed `terminal-instance` from the `src/components/workspace/index.ts` barrel export so it is not pulled in statically
- Kept `TerminalPanel`'s existing lazy import behavior unchanged

## Why
Vite reported that `terminal-instance.tsx` was both dynamically and statically imported, which prevents moving it to a separate chunk. These changes make import behavior consistent so chunk splitting works as intended.

## Validation
- Ran `pnpm build`
- Confirmed the warning is gone and `terminal-instance` is emitted as its own chunk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, build-focused change that only affects module loading/render timing for the terminal UI; minimal runtime logic impact.
> 
> **Overview**
> Updates `SetupTerminalModal` to lazy-load `TerminalInstance` via `React.lazy` and render it under `Suspense`, avoiding a static import.
> 
> Removes the `terminal-instance` re-export from `src/components/workspace/index.ts` so the barrel no longer pulls it into the main bundle, making imports consistently dynamic for chunk splitting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36ca8851322a1441ea26e171181ce6f2a5499e5c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->