### PR TITLE
Make Archive All feel instantaneous in Kanban

### DIFF
--- a/src/frontend/components/kanban/kanban-context.tsx
+++ b/src/frontend/components/kanban/kanban-context.tsx
@@ -208,11 +208,12 @@ export function KanbanProvider({
     const workspacesToArchive = (workspaces ?? []).filter(
       (workspace) => workspace.kanbanColumn === kanbanColumn
     );
+    const workspaceIdsToArchive = workspacesToArchive.map((workspace) => workspace.id);
 
     setArchivingWorkspaceIds((prev) => {
       const next = new Set(prev);
-      for (const workspace of workspacesToArchive) {
-        next.add(workspace.id);
+      for (const workspaceId of workspaceIdsToArchive) {
+        next.add(workspaceId);
       }
       return next;
     });
@@ -241,16 +242,16 @@ export function KanbanProvider({
     } finally {
       setArchivingWorkspaceIds((prev) => {
         const next = new Set(prev);
-        for (const workspace of workspacesToArchive) {
-          next.delete(workspace.id);
+        for (const workspaceId of workspaceIdsToArchive) {
+          next.delete(workspaceId);
         }
         return next;
       });
 
       setArchivingWorkspaceIssueLinks((prev) => {
         const next = new Map(prev);
-        for (const workspace of workspacesToArchive) {
-          next.delete(workspace.id);
+        for (const workspaceId of workspaceIdsToArchive) {
+          next.delete(workspaceId);
         }
         return next;
       });


### PR DESCRIPTION
## Summary
- make Kanban `Archive All` behave like single-workspace archive by applying optimistic UI removal immediately
- mark all workspaces in the targeted column as archiving before the bulk mutation resolves
- keep issue filtering in sync during optimistic state by tracking issue links for those archiving workspaces
- invalidate project summary state and refetch workspaces after bulk archive completes

## Why
Bulk archive previously waited for the server round-trip before cards disappeared, which felt slower than the per-card archive action. This change makes the interaction feel instantaneous while preserving eventual consistency.

## Validation
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds optimistic UI state for bulk-archiving Kanban columns, which can cause temporary UI inconsistencies if the mutation fails or the workspace list is stale; otherwise the change is localized to the Kanban context state management.
> 
> **Overview**
> Makes Kanban bulk archive behave like single-card archive by **optimistically marking all workspaces in the target column as archiving** and filtering them out immediately.
> 
> Tracks the archived workspaces’ issue links during the optimistic window to keep issue filtering consistent, then **refetches workspaces and invalidates** `workspace.getProjectSummaryState` after the mutation completes and finally clears the optimistic state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45de1af68e6bfa235dfa644552a8e6c2b849702b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->