### PR TITLE
Ensure ratchet agents always request re-review after fixes

### DIFF
--- a/prompts/ratchet/dispatch.md
+++ b/prompts/ratchet/dispatch.md
@@ -29,7 +29,7 @@ Required Sequence:
 5. Push only when you made actionable CI or review fixes (not merge-only updates).
 6. Comment briefly on addressed review comments and resolve them. IMPORTANT: When responding to a comment, explicitly @ mention the person who made the comment (e.g., "@username - fixed as suggested").
 7. Request re-review from reviewers whose comments you addressed using `gh pr edit {{PR_NUMBER}} --add-reviewer <login>`.
-8. If you addressed any review comments and pushed changes, post a single PR comment tagging each reviewer whose comments you addressed asking them to re-review. Use `gh pr comment {{PR_NUMBER}} --body "@reviewer1 @reviewer2 please re-review"`. Include all addressed reviewers in one comment.
+8. CRITICAL: If you made ANY code changes in response to review comments (regardless of whether you already commented on them in a previous session), you MUST post a PR comment tagging the reviewers to request re-review. Use `gh pr comment {{PR_NUMBER}} --body "@reviewer1 @reviewer2 please re-review"`. This is MANDATORY even if you previously commented on the review - the act of pushing new changes requires a new re-review request. Include all addressed reviewers in one comment.
 
 Completion Criteria:
 - Branch includes latest `main`.
@@ -37,4 +37,4 @@ Completion Criteria:
 - CI and local verification are healthy, or best effort is documented in session output.
 - Addressed review comments are replied to and resolved.
 - Re-review has been requested from reviewers whose comments were addressed.
-- If review comments were addressed, a PR comment has been posted tagging reviewers to re-review.
+- MANDATORY: If you made code changes addressing review comments, a PR comment MUST be posted tagging ALL reviewers whose comments triggered these changes, asking them to re-review. This is required even if you previously responded to their comments - new code changes always require a new re-review request.

--- a/prompts/workflows/pr-review-fix.md
+++ b/prompts/workflows/pr-review-fix.md
@@ -35,10 +35,11 @@ git add -A && git commit -m "Address review comments" && git push
 \`\`\`
 
 ### 5. Request Re-review
-Post a comment mentioning the reviewers. Use `gh pr list --head $(git branch --show-current)` to find the PR number if not already known:
+CRITICAL: You MUST post a comment mentioning ALL reviewers whose comments you addressed, asking them to re-review. This is MANDATORY whenever you make code changes in response to review comments, even if you've already responded to their comments in previous sessions. Use `gh pr list --head $(git branch --show-current)` to find the PR number if not already known:
 \`\`\`bash
 gh pr comment $(gh pr list --head $(git branch --show-current) --json number --jq '.[0].number') --body "@reviewer1 @reviewer2 I've addressed the review comments. Please re-review when you have a chance."
 \`\`\`
+Do NOT skip this step based on whether you've previously commented. New code changes always require a new re-review request.
 
 ## Guidelines
 

--- a/src/backend/prompts/ratchet-dispatch.ts
+++ b/src/backend/prompts/ratchet-dispatch.ts
@@ -28,7 +28,7 @@ Execute autonomously in this order:
 5. Push only when you made actionable CI or review fixes (not merge-only updates).
 6. Comment briefly on addressed review comments and resolve them.
 7. Request re-review from reviewers whose comments you addressed using \`gh pr edit {{PR_NUMBER}} --add-reviewer <login>\`.
-8. If you addressed any review comments and pushed changes, post a single PR comment tagging each reviewer whose comments you addressed asking them to re-review. Use \`gh pr comment {{PR_NUMBER}} --body "@reviewer1 @reviewer2 please re-review"\`.
+8. CRITICAL: If you made ANY code changes in response to review comments (regardless of whether you already commented on them in a previous session), you MUST post a PR comment tagging the reviewers to request re-review. Use \`gh pr comment {{PR_NUMBER}} --body "@reviewer1 @reviewer2 please re-review"\`. This is MANDATORY even if you previously commented - new code changes always require a new re-review request.
 
 If review feedback is non-actionable, explain why in session output and exit without code changes.
 Do not push merge-only updates. If you only merged main and did not fix CI or review feedback, stop without pushing.


### PR DESCRIPTION
## Summary

Fixed an issue where ratchet agents would skip requesting re-review if they had already commented on review feedback in a previous session. Agents now always post a PR comment tagging reviewers whenever they push code changes in response to review comments, regardless of prior comment history.

## Changes

- Mark re-review request step as **CRITICAL** and **MANDATORY** in ratchet dispatch prompt
- Explicitly clarify that new code changes always require a new re-review request, even if the agent previously commented
- Updated both `prompts/ratchet/dispatch.md` and `prompts/workflows/pr-review-fix.md` with stronger language
- Updated fallback template in `src/backend/prompts/ratchet-dispatch.ts` for consistency

## Test plan

- [ ] Trigger a ratchet session with review comments
- [ ] Verify agent requests re-review after pushing fixes
- [ ] Trigger another ratchet session with the same review comments
- [ ] Verify agent still requests re-review even though it already commented previously

🤖 Generated with [Claude Code](https://claude.com/claude-code)