### PR TITLE
Fix #1190: CLI health banner colors in light mode

### DIFF
--- a/src/client/globals.css
+++ b/src/client/globals.css
@@ -37,8 +37,8 @@
   --ring: oklch(0.62 0.17 55);
   --success: oklch(0.627 0.194 145.8);
   --success-foreground: oklch(0.98 0 0);
-  --warning: oklch(0.62 0.17 55);
-  --warning-foreground: oklch(0.98 0 0);
+  --warning: oklch(0.55 0.18 55);
+  --warning-foreground: oklch(0.3 0.05 55);
   --info: oklch(0.623 0.214 259.1);
   --info-foreground: oklch(0.98 0 0);
   --chart-1: oklch(0.62 0.17 55);


### PR DESCRIPTION
## Summary
- Fixed CLI health banner color scheme in light mode for better readability and contrast

## Changes
- **Light mode warning colors**: Darkened the warning color from `oklch(0.62 0.17 55)` to `oklch(0.55 0.18 55)` and changed warning foreground from near-white `oklch(0.98 0 0)` to dark text `oklch(0.3 0.05 55)`
- This ensures the banner text is clearly visible on light backgrounds while maintaining the amber warning aesthetic

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: View the CLI health banner in light mode to verify improved contrast and readability

Closes #1190

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
