### PR TITLE
Move Workspaces back link beside sidebar toggle

### DIFF
--- a/src/client/routes/projects/workspaces/workspace-detail-header.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-header.tsx
@@ -57,6 +57,7 @@ import {
 } from '@/components/workspace';
 import {
   HeaderLeftExtraSlot,
+  HeaderLeftStartSlot,
   HeaderRightSlot,
   useAppHeader,
 } from '@/frontend/components/app-header-context';
@@ -836,6 +837,9 @@ export function WorkspaceDetailHeaderSlot({
 
   return (
     <>
+      <HeaderLeftStartSlot>
+        <WorkspacesBackLink projectSlug={slug} />
+      </HeaderLeftStartSlot>
       <HeaderLeftExtraSlot>
         <div className="hidden md:flex items-center gap-2 min-w-0">
           <WorkspacePrAction
@@ -849,7 +853,6 @@ export function WorkspaceDetailHeaderSlot({
           <WorkspaceCiStatus workspace={workspace} />
           <RunScriptPortBadge workspaceId={workspaceId} />
         </div>
-        <WorkspacesBackLink projectSlug={slug} />
       </HeaderLeftExtraSlot>
       <HeaderRightSlot>
         <div

--- a/src/frontend/components/app-header-context.tsx
+++ b/src/frontend/components/app-header-context.tsx
@@ -16,6 +16,9 @@ interface AppHeaderContextValue {
   /** Portal target element for right-side header content */
   rightSlot: HTMLElement | null;
   setRightSlot: (el: HTMLElement | null) => void;
+  /** Portal target element for left-start header content (right of sidebar toggle) */
+  leftStartSlot: HTMLElement | null;
+  setLeftStartSlot: (el: HTMLElement | null) => void;
   /** Portal target element for left-side extra content (e.g. info chips) */
   leftExtraSlot: HTMLElement | null;
   setLeftExtraSlot: (el: HTMLElement | null) => void;
@@ -26,11 +29,21 @@ const AppHeaderContext = createContext<AppHeaderContextValue | null>(null);
 export function AppHeaderProvider({ children }: { children: ReactNode }) {
   const [title, setTitle] = useState<ReactNode>('');
   const [rightSlot, setRightSlot] = useState<HTMLElement | null>(null);
+  const [leftStartSlot, setLeftStartSlot] = useState<HTMLElement | null>(null);
   const [leftExtraSlot, setLeftExtraSlot] = useState<HTMLElement | null>(null);
 
   const value = useMemo(
-    () => ({ title, setTitle, rightSlot, setRightSlot, leftExtraSlot, setLeftExtraSlot }),
-    [title, rightSlot, leftExtraSlot]
+    () => ({
+      title,
+      setTitle,
+      rightSlot,
+      setRightSlot,
+      leftStartSlot,
+      setLeftStartSlot,
+      leftExtraSlot,
+      setLeftExtraSlot,
+    }),
+    [title, rightSlot, leftStartSlot, leftExtraSlot]
   );
 
   return <AppHeaderContext.Provider value={value}>{children}</AppHeaderContext.Provider>;
@@ -80,6 +93,17 @@ export function HeaderRightSlot({ children }: { children: ReactNode }) {
     return null;
   }
   return createPortal(children, rightSlot);
+}
+
+/**
+ * Portal component that renders children into the header's left-start slot.
+ */
+export function HeaderLeftStartSlot({ children }: { children: ReactNode }) {
+  const { leftStartSlot } = useAppHeaderContext();
+  if (!leftStartSlot) {
+    return null;
+  }
+  return createPortal(children, leftStartSlot);
 }
 
 /**

--- a/src/frontend/components/app-header.tsx
+++ b/src/frontend/components/app-header.tsx
@@ -28,11 +28,12 @@ function SidebarToggleButton() {
 }
 
 export function AppHeader() {
-  const { title, setRightSlot, setLeftExtraSlot } = useAppHeaderContext();
+  const { title, setRightSlot, setLeftStartSlot, setLeftExtraSlot } = useAppHeaderContext();
 
   return (
     <header className="flex shrink-0 flex-wrap items-center gap-x-2 gap-y-1 border-b bg-background px-2 min-h-12 pt-[env(safe-area-inset-top)]">
       <SidebarToggleButton />
+      <div ref={setLeftStartSlot} className="contents" />
       <div className="flex min-w-0 flex-1 items-center gap-2">
         <span className="min-w-0 truncate text-sm font-semibold">{title}</span>
         <div ref={setLeftExtraSlot} className="flex shrink-0 items-center gap-1" />


### PR DESCRIPTION
## Summary
- add a new `HeaderLeftStartSlot` portal target in the app header context for content that should appear immediately after the sidebar toggle
- render the new slot in `AppHeader` directly to the right of the sidebar/open-sidepanel button
- move `WorkspacesBackLink` from `HeaderLeftExtraSlot` to `HeaderLeftStartSlot` in the workspace detail header so the `<- Workspaces` button is positioned next to the sidepanel button

## Validation
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only portal/layout change with limited scope; main risk is minor header layout regressions if other routes assume only the existing left/right slots.
> 
> **Overview**
> Introduces a new `HeaderLeftStartSlot` portal target in the app header so routes can render content directly to the right of the sidebar toggle.
> 
> Updates `AppHeader` to expose this new slot via context, and moves `WorkspacesBackLink` in the workspace detail header from the left-extra area into the new left-start slot to change its on-screen placement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51ef2ddb3ef7850336135034342058012b29486c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->