### PR TITLE
Move quick actions from header to workspace session bar

### DIFF
--- a/src/client/routes/projects/workspaces/workspace-detail-container.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-container.tsx
@@ -467,6 +467,7 @@ export function WorkspaceDetailContainer() {
           handleSelectSession,
           handleNewChat,
           handleCloseChatSession,
+          handleQuickAction,
           maxSessions,
           hasWorktreePath: !!workspace?.worktreePath,
           selectedProvider,

--- a/src/client/routes/projects/workspaces/workspace-detail-header.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-header.tsx
@@ -30,11 +30,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
-  DropdownMenuPortal,
   DropdownMenuSeparator,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Label } from '@/components/ui/label';
@@ -47,7 +43,6 @@ import {
 } from '@/components/ui/select';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import {
-  QuickActionsMenu,
   RatchetToggleButton,
   RunScriptButton,
   RunScriptPortBadge,
@@ -659,56 +654,6 @@ function ArchiveActionButton({
   );
 }
 
-function WorkspaceQuickActionsSubmenu({
-  handleQuickAction,
-  disabled,
-}: {
-  handleQuickAction: ReturnType<typeof useSessionManagement>['handleQuickAction'];
-  disabled: boolean;
-}) {
-  const { data: quickActions, isLoading } = trpc.session.listQuickActions.useQuery();
-  const agentActions = quickActions?.filter((action) => action.type === 'agent') ?? [];
-
-  if (isLoading) {
-    return (
-      <DropdownMenuItem disabled>
-        <Loader2 className="h-4 w-4 animate-spin" />
-        Loading quick actions...
-      </DropdownMenuItem>
-    );
-  }
-
-  if (agentActions.length === 0) {
-    return null;
-  }
-
-  return (
-    <DropdownMenuSub>
-      <DropdownMenuSubTrigger disabled={disabled}>
-        <Zap className="h-4 w-4" />
-        Quick actions
-      </DropdownMenuSubTrigger>
-      <DropdownMenuPortal>
-        <DropdownMenuSubContent className="w-56">
-          {agentActions.map((action) => (
-            <DropdownMenuItem
-              key={action.id}
-              onSelect={() => {
-                if (action.content) {
-                  handleQuickAction(action.name, action.content);
-                }
-              }}
-              disabled={disabled || !action.content}
-            >
-              {action.name}
-            </DropdownMenuItem>
-          ))}
-        </DropdownMenuSubContent>
-      </DropdownMenuPortal>
-    </DropdownMenuSub>
-  );
-}
-
 function WorkspaceHeaderOverflowMenu({
   workspace,
   workspaceId,
@@ -717,8 +662,6 @@ function WorkspaceHeaderOverflowMenu({
   openInIde,
   archivePending,
   onArchiveRequest,
-  handleQuickAction,
-  isCreatingSession,
 }: {
   workspace: NonNullable<ReturnType<typeof useWorkspaceData>['workspace']>;
   workspaceId: string;
@@ -727,8 +670,6 @@ function WorkspaceHeaderOverflowMenu({
   openInIde: ReturnType<typeof useSessionManagement>['openInIde'];
   archivePending: boolean;
   onArchiveRequest: () => void;
-  handleQuickAction: ReturnType<typeof useSessionManagement>['handleQuickAction'];
-  isCreatingSession: boolean;
 }) {
   const [providerSettingsOpen, setProviderSettingsOpen] = useState(false);
 
@@ -776,10 +717,6 @@ function WorkspaceHeaderOverflowMenu({
             renderAsMenuItem
           />
           <OpenDevAppAction workspaceId={workspaceId} renderAsMenuItem />
-          <WorkspaceQuickActionsSubmenu
-            handleQuickAction={handleQuickAction}
-            disabled={isCreatingSession}
-          />
           <DropdownMenuSeparator />
           <ArchiveActionButton
             workspace={workspace}
@@ -871,8 +808,6 @@ export function WorkspaceDetailHeaderSlot({
                 openInIde={openInIde}
                 archivePending={archivePending}
                 onArchiveRequest={onArchiveRequest}
-                handleQuickAction={handleQuickAction}
-                isCreatingSession={isCreatingSession}
               />
             </>
           ) : (
@@ -880,14 +815,6 @@ export function WorkspaceDetailHeaderSlot({
               <WorkspaceProviderSettings workspace={workspace} workspaceId={workspaceId} />
               <RatchetingToggle workspace={workspace} workspaceId={workspaceId} />
               <WorkspaceBranchLink workspace={workspace} />
-              <QuickActionsMenu
-                onExecuteAgent={(action) => {
-                  if (action.content) {
-                    handleQuickAction(action.name, action.content);
-                  }
-                }}
-                disabled={isCreatingSession}
-              />
               <OpenInIdeAction
                 workspaceId={workspaceId}
                 hasWorktreePath={Boolean(workspace.worktreePath)}

--- a/src/client/routes/projects/workspaces/workspace-detail-view.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-view.tsx
@@ -47,6 +47,7 @@ interface SessionTabsProps {
   handleSelectSession: ReturnType<typeof useSessionManagement>['handleSelectSession'];
   handleNewChat: ReturnType<typeof useSessionManagement>['handleNewChat'];
   handleCloseChatSession: ReturnType<typeof useSessionManagement>['handleCloseSession'];
+  handleQuickAction: ReturnType<typeof useSessionManagement>['handleQuickAction'];
   maxSessions: ReturnType<typeof useWorkspaceData>['maxSessions'];
   hasWorktreePath: boolean;
   selectedProvider: SessionProviderValue;
@@ -130,6 +131,7 @@ export function WorkspaceDetailView({
         onSelectSession={sessionTabs.handleSelectSession}
         onCreateSession={sessionTabs.handleNewChat}
         onCloseSession={sessionTabs.handleCloseChatSession}
+        onQuickAction={sessionTabs.handleQuickAction}
         maxSessions={sessionTabs.maxSessions}
         hasWorktreePath={sessionTabs.hasWorktreePath}
         selectedProvider={sessionTabs.selectedProvider}

--- a/src/components/workspace/main-view-tab-bar.tsx
+++ b/src/components/workspace/main-view-tab-bar.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/lib/session-provider-selection';
 import { cn } from '@/lib/utils';
 import type { SessionStatus as DbSessionStatus } from '@/shared/core';
-
+import { QuickActionsMenu } from './quick-actions-menu';
 import { RatchetWrenchIcon } from './ratchet-wrench-icon';
 import {
   deriveSessionTabRuntime,
@@ -186,6 +186,7 @@ interface MainViewTabBarProps {
   onSelectSession?: (sessionId: string) => void;
   onCreateSession?: () => void;
   onCloseSession?: (sessionId: string) => void;
+  onQuickAction?: (name: string, prompt: string) => void;
   disabled?: boolean;
   /** Maximum sessions allowed per workspace */
   maxSessions?: number;
@@ -201,6 +202,7 @@ export function MainViewTabBar({
   onSelectSession,
   onCreateSession,
   onCloseSession,
+  onQuickAction,
   disabled,
   maxSessions,
   selectedProvider,
@@ -291,6 +293,19 @@ export function MainViewTabBar({
                 : `New ${providerTriggerLabel} session`}
             </TooltipContent>
           </Tooltip>
+        </div>
+      )}
+
+      {onQuickAction && (
+        <div className="ml-0.5 shrink-0">
+          <QuickActionsMenu
+            onExecuteAgent={(action) => {
+              if (action.content) {
+                onQuickAction(action.name, action.content);
+              }
+            }}
+            disabled={isButtonDisabled}
+          />
         </div>
       )}
 

--- a/src/components/workspace/workspace-content-view.tsx
+++ b/src/components/workspace/workspace-content-view.tsx
@@ -24,6 +24,7 @@ interface WorkspaceContentViewProps {
   onSelectSession: (sessionId: string) => void;
   onCreateSession: () => void;
   onCloseSession: (sessionId: string) => void;
+  onQuickAction?: (name: string, prompt: string) => void;
   children: ReactNode;
   /** Maximum sessions allowed per workspace */
   maxSessions?: number;
@@ -54,6 +55,7 @@ export function WorkspaceContentView({
   onSelectSession,
   onCreateSession,
   onCloseSession,
+  onQuickAction,
   children,
   maxSessions,
   hasWorktreePath,
@@ -74,6 +76,7 @@ export function WorkspaceContentView({
           onSelectSession={onSelectSession}
           onCreateSession={onCreateSession}
           onCloseSession={onCloseSession}
+          onQuickAction={onQuickAction}
           disabled={isCreatingSession || isDeletingSession || !hasWorktreePath}
           maxSessions={maxSessions}
           selectedProvider={selectedProvider}


### PR DESCRIPTION
## Summary
- move the workspace quick actions bolt from the top navigation into the workspace session bar (`MainViewTabBar`)
- thread `handleQuickAction` through workspace detail view/content props so quick actions continue to create new sessions
- remove quick actions from the desktop header actions and the mobile overflow menu to avoid duplicate entry points

## Testing
- pnpm typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI/prop-wiring change that reuses existing `handleQuickAction` behavior; low risk aside from potential missing handler wiring or disabled-state regressions.
> 
> **Overview**
> Moves the workspace **Quick Actions** entry point from the top header/overflow menus into the session tab bar (`MainViewTabBar`).
> 
> Threads `handleQuickAction` through `WorkspaceDetailView`/`WorkspaceContentView` into the tab bar via a new `onQuickAction` prop so executing a quick action still creates a new session, and removes the now-duplicated quick-actions UI from `workspace-detail-header`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc5891858e7efbe36d5395cdd6468fb25b3b62ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->