### PR TITLE
Use project selector as sole workspaces header label

### DIFF
--- a/src/client/routes/projects/workspaces/components/workspaces-board-view.tsx
+++ b/src/client/routes/projects/workspaces/components/workspaces-board-view.tsx
@@ -15,12 +15,11 @@ function BoardHeaderSlot({
   onProjectChange: (value: string) => void;
   projects: Array<{ id: string; slug: string; name: string }> | undefined;
 }) {
-  useAppHeader({ title: 'Workspaces' });
+  useAppHeader({ title: '' });
 
   return (
     <>
       <HeaderLeftExtraSlot>
-        <span className="text-xs text-muted-foreground">·</span>
         <ProjectSelectorDropdown
           selectedProjectSlug={selectedProjectSlug}
           onProjectChange={onProjectChange}


### PR DESCRIPTION
## Summary
- remove the `Workspaces` header title from the workspaces board view
- remove the leading separator dot before the project selector
- keep the project selector as the sole left-side header control for that page

## Testing
- pnpm typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, UI-only header text/layout tweak with no data, auth, or business-logic changes.
> 
> **Overview**
> On the workspaces board view, clears the app header title (was `Workspaces`) so the project selector serves as the sole left-side header label.
> 
> Also removes the leading separator dot before `ProjectSelectorDropdown`, simplifying the header layout while keeping existing kanban controls unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6723ab85b8f3064ec83b915906c415f7253a311. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->