### PR TITLE
Use HTTP/2 protocol for cloudflared tunnel

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -41,7 +41,7 @@ if [ "${ENABLE_TUNNEL:-true}" = "true" ]; then
   echo "Starting Cloudflare tunnel..."
 
   TUNNEL_LOG=$(mktemp)
-  cloudflared tunnel --url "http://localhost:${PORT}" > "$TUNNEL_LOG" 2>&1 &
+  cloudflared tunnel --protocol http2 --url "http://localhost:${PORT}" > "$TUNNEL_LOG" 2>&1 &
   TUNNEL_PID=$!
 
   # Wait for the tunnel URL to appear in cloudflared output


### PR DESCRIPTION
## Summary
- Force `cloudflared` to use `--protocol http2` (TCP) instead of the default QUIC (UDP), ensuring the tunnel works on servers that block UDP connections

## Test plan
- [ ] Deploy Docker image to a server that blocks UDP and verify the Cloudflare tunnel establishes successfully
- [ ] Verify tunnel URL is still detected and written to `/app/tunnel-info/url`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
