### PR TITLE
Add CLOUD_MODE flag for Docker tunnel control

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -168,3 +168,13 @@ FEATURE_ERROR_TRACKING=false
 # =============================================================================
 
 # TMUX_SOCKET_PATH=/tmp/factoryfactory-tmux
+
+# =============================================================================
+# Docker Cloud Mode Configuration
+# =============================================================================
+
+# Cloud deployment mode for Docker containers
+# - cloudflare: Start cloudflared tunnel for public HTTPS access (default)
+# - native: Direct port access, no tunnel (use with reverse proxy/load balancer)
+# - none: Direct port access, no tunnel (same as native)
+# CLOUD_MODE=cloudflare

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - BACKEND_PORT=3000
       - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:3000}
       - LOG_LEVEL=${LOG_LEVEL:-info}
-      - ENABLE_TUNNEL=${ENABLE_TUNNEL:-true}
+      - CLOUD_MODE=${CLOUD_MODE:-cloudflare}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
       interval: 30s


### PR DESCRIPTION
## Summary
- Replace boolean `ENABLE_TUNNEL` env var with a `CLOUD_MODE` enum (`cloudflare`, `native`, `none`) for clearer Docker tunnel control
- `cloudflare` (default): starts a cloudflared tunnel after FF boots — same as previous behavior
- `native` / `none`: skips tunnel setup, server accessible directly on the exposed port
- Documents the new option in `.env.example`

## Test plan
- [x] `CLOUD_MODE=cloudflare docker compose up --build` — tunnel starts as before
- [x] `CLOUD_MODE=native docker compose up --build` — no tunnel, server on port 3000
- [x] Invalid `CLOUD_MODE` value — warning logged, no tunnel started

🤖 Generated with [Claude Code](https://claude.com/claude-code)
