### PR TITLE
Fix setup script failure due to node-pty native compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,8 @@ ARG PNPM_VERSION
 WORKDIR /app
 
 # Runtime system dependencies + cloudflared for tunnel + GitHub CLI
+# python3, make, g++ are needed so workspace `pnpm install` can compile
+# native modules (node-pty has no Linux prebuilds)
 RUN apk add --no-cache \
     git \
     bash \
@@ -67,6 +69,9 @@ RUN apk add --no-cache \
     lsof \
     libc6-compat \
     libstdc++ \
+    python3 \
+    make \
+    g++ \
     github-cli \
   && ARCH="$(uname -m)" \
   && case "$ARCH" in \


### PR DESCRIPTION
## Summary
- The `factory-factory.json` setup script (`pnpm i && pnpm db:generate`) fails in the Docker runner container because `node-pty@1.1.0` doesn't ship Linux prebuilds (only darwin/win32)
- When `pnpm install` runs, node-pty's install script falls back to `node-gyp rebuild`, which requires `python3`, `make`, and `g++`
- These build tools were already in the Dockerfile's deps stage (for image builds) but missing from the runner stage where workspace setup scripts execute
- Added `python3`, `make`, `g++` to the runner stage's `apk add` command

## Test plan
- [ ] Rebuild the Docker image and verify `pnpm install` succeeds in a workspace
- [ ] Verify `node-pty` compiles successfully with the added build tools
- [ ] Verify `pnpm dev` works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)
