### PR TITLE
Fix Docker daemon crash in Docker-in-Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,7 @@ RUN apk add --no-cache \
     github-cli \
     docker \
     docker-cli-compose \
+    containerd \
   && ARCH="$(uname -m)" \
   && case "$ARCH" in \
        x86_64)  CF_ARCH="amd64" ;; \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -13,8 +13,9 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 # Start Docker daemon (Docker-in-Docker)
+# Use vfs storage driver to avoid overlay-on-overlay issues in DinD
 echo "Starting Docker daemon..."
-dockerd &>/var/log/dockerd.log &
+dockerd --storage-driver=vfs &>/var/log/dockerd.log &
 DOCKERD_PID=$!
 
 # Wait for Docker daemon to be ready


### PR DESCRIPTION
## Summary
- Add `containerd` Alpine package to Dockerfile — `dockerd` requires it as its container runtime
- Use `--storage-driver=vfs` for `dockerd` to avoid overlay-on-overlay failures in Docker-in-Docker (matches the official `docker:dind` image approach)

## Context
The Docker daemon was crashing on startup with a SIGSEGV nil pointer dereference in `events.(*Events).Close` during `NewDaemon`. The root cause was two-fold:
1. Missing `containerd` dependency
2. Default `overlay2` storage driver failing on the container's existing overlayfs, then panicking during its own cleanup path

## Test plan
- [ ] Deploy updated image and verify `docker info` succeeds inside the container
- [ ] Verify `docker run hello-world` works inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)
