### PR TITLE
Revert workspace scripts to pnpm install/dev

### DIFF
--- a/factory-factory.json
+++ b/factory-factory.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "setup": "docker compose build",
-    "run": "docker compose up --watch"
+    "setup": "pnpm install",
+    "run": "pnpm dev"
   }
 }


### PR DESCRIPTION
## Summary
- Revert `factory-factory.json` workspace scripts from `docker compose build`/`docker compose up --watch` back to `pnpm install`/`pnpm dev`
- Docker-in-Docker cannot run on Cloud Run due to missing privileged mode and cgroup access, causing `dockerd` to crash with SIGSEGV during initialization

## Test plan
- [ ] Verify workspace setup runs `pnpm install` successfully
- [ ] Verify workspace run executes `pnpm dev` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)
