### PR TITLE
Enable creating workspaces from the sidebar

### DIFF
--- a/src/client/components/app-sidebar.tsx
+++ b/src/client/components/app-sidebar.tsx
@@ -276,7 +276,7 @@ function SidebarInner({
             <SidebarMenu>
               <SidebarMenuItem>
                 <SidebarMenuButton
-                  onClick={onCreateWorkspace}
+                  onClick={() => onCreateWorkspace()}
                   disabled={!canCreateWorkspace || isCreatingWorkspace}
                   className="h-9"
                 >


### PR DESCRIPTION
## Summary
- add a `New Workspace` action to the app sidebar so workspaces can be created directly from sidebar navigation
- reuse the shared `useCreateWorkspace` hook in `AppSidebar` for consistent creation behavior, naming, cache updates, and navigation
- show loading state and disable the action while creating (and when no project is selected)

## Testing
- pnpm typecheck
- pnpm exec biome check src/frontend/components/app-sidebar.tsx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI change that reuses existing workspace-creation logic; main risk is unintended creation/navigation behavior when project context is missing or state is stale.
> 
> **Overview**
> Adds a **`New Workspace`** button at the top of `AppSidebar` that triggers workspace creation directly from the navigation sidebar.
> 
> Wires the sidebar to the shared `useCreateWorkspace` hook (passing existing workspace names to avoid an extra fetch), and disables the action + shows a spinner/text while a workspace is being created or when no project is selected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff0d309822a61f0b3017d5bdeb3b54fbd06278b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->