### PR TITLE
Remove legacy sidecar fallback from init mode lookup

### DIFF
--- a/src/backend/domains/workspace/lifecycle/creation.service.test.ts
+++ b/src/backend/domains/workspace/lifecycle/creation.service.test.ts
@@ -287,7 +287,7 @@ describe('WorkspaceCreationService', () => {
         );
         expect(
           worktreeLifecycleServiceModule.worktreeLifecycleService.setInitMode
-        ).toHaveBeenCalledWith('ws-123', true, '/path/to/worktrees');
+        ).toHaveBeenCalledWith('ws-123', true);
       });
 
       it('should use branch name as workspace name when name not provided', async () => {

--- a/src/backend/domains/workspace/lifecycle/creation.service.ts
+++ b/src/backend/domains/workspace/lifecycle/creation.service.ts
@@ -111,11 +111,7 @@ export class WorkspaceCreationService {
 
     // Set initialization mode if resuming existing branch
     if (initMode) {
-      await worktreeLifecycleService.setInitMode(
-        workspace.id,
-        initMode.useExistingBranch,
-        initMode.worktreeBasePath
-      );
+      await worktreeLifecycleService.setInitMode(workspace.id, initMode.useExistingBranch);
     }
 
     // Provision default session if enabled
@@ -151,7 +147,6 @@ export class WorkspaceCreationService {
     };
     initMode?: {
       useExistingBranch: boolean;
-      worktreeBasePath?: string;
     };
   }> {
     switch (source.type) {
@@ -205,7 +200,6 @@ export class WorkspaceCreationService {
           },
           initMode: {
             useExistingBranch: true,
-            worktreeBasePath: project.worktreeBasePath,
           },
         };
       }

--- a/src/backend/domains/workspace/worktree/worktree-lifecycle.service.ts
+++ b/src/backend/domains/workspace/worktree/worktree-lifecycle.service.ts
@@ -1,67 +1,7 @@
-import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import { writeFileAtomic } from '@/backend/lib/atomic-file';
 import { pathExists } from '@/backend/lib/file-helpers';
-import { FileLockMutex } from '@/backend/lib/file-lock-mutex';
 import { workspaceAccessor } from '@/backend/resource_accessors/workspace.accessor';
 import { gitOpsService } from '@/backend/services/git-ops.service';
-import { createLogger } from '@/backend/services/logger.service';
-import { resumeModesSchema } from '@/shared/schemas/persisted-stores.schema';
-
-const logger = createLogger('worktree-lifecycle');
-const RESUME_MODE_FILENAME = '.ff-resume-modes.json';
-const RESUME_MODE_LOCK_FILENAME = '.ff-resume-modes.json.lock';
-
-const LOCK_ACQUIRE_TIMEOUT_MS = 5000;
-const LOCK_RETRY_DELAY_MS = 50;
-const LOCK_MAX_RETRY_DELAY_MS = 500;
-const LOCK_MAX_STALE_RETRIES = 3;
-const LOCK_STALE_THRESHOLD_MS = LOCK_ACQUIRE_TIMEOUT_MS * 5;
-const resumeModeFileLock = new FileLockMutex({
-  acquireTimeoutMs: LOCK_ACQUIRE_TIMEOUT_MS,
-  postTimeoutWaitMs: 0,
-  initialRetryDelayMs: LOCK_RETRY_DELAY_MS,
-  maxRetryDelayMs: LOCK_MAX_RETRY_DELAY_MS,
-  maxStaleRetries: LOCK_MAX_STALE_RETRIES,
-  staleThresholdMs: LOCK_STALE_THRESHOLD_MS,
-});
-
-async function readResumeModes(worktreeBasePath: string): Promise<Record<string, boolean>> {
-  const filePath = path.join(worktreeBasePath, RESUME_MODE_FILENAME);
-  try {
-    const content = await fs.readFile(filePath, 'utf-8');
-    try {
-      const parsed = JSON.parse(content);
-      const validated = resumeModesSchema.parse(parsed);
-      return validated;
-    } catch (error) {
-      logger.warn('Failed to parse resume modes file; falling back to empty', {
-        filePath,
-        worktreeBasePath,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return {};
-    }
-  } catch (error) {
-    const code = (error as NodeJS.ErrnoException | undefined)?.code;
-    if (code && code !== 'ENOENT') {
-      logger.warn('Failed to read resume modes file; falling back to empty', {
-        filePath,
-        worktreeBasePath,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
-    return {};
-  }
-}
-
-async function writeResumeModes(
-  worktreeBasePath: string,
-  modes: Record<string, boolean>
-): Promise<void> {
-  const targetPath = path.join(worktreeBasePath, RESUME_MODE_FILENAME);
-  await writeFileAtomic(targetPath, JSON.stringify(modes), { encoding: 'utf-8' });
-}
 
 export class WorktreePathSafetyError extends Error {
   constructor(message: string) {
@@ -102,75 +42,13 @@ function getProjectOrThrow(workspace: WorkspaceWithProject) {
 class WorktreeLifecycleService {
   // DOM-04: Instance fields replace module-level globals
   private readonly initModes = new Map<string, boolean>();
-  private readonly resumeModeLocks = new Map<string, Promise<void>>();
 
-  private async withResumeModeLock<T>(
-    worktreeBasePath: string,
-    handler: () => Promise<T>
-  ): Promise<T> {
-    // First acquire in-process lock (for same-process coordination)
-    const previous = this.resumeModeLocks.get(worktreeBasePath) ?? Promise.resolve();
-    let release: (() => void) | undefined;
-    const next = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    const lock = previous.then(() => next);
-    this.resumeModeLocks.set(worktreeBasePath, lock);
-    await previous;
-
-    // Then acquire cross-process file lock
-    const lockPath = path.join(worktreeBasePath, RESUME_MODE_LOCK_FILENAME);
-    let releaseLock: (() => Promise<void>) | undefined;
-
-    try {
-      // Ensure directory exists before creating lock file
-      await fs.mkdir(worktreeBasePath, { recursive: true });
-      releaseLock = await resumeModeFileLock.acquire(lockPath);
-      return await handler();
-    } finally {
-      // Release file lock first
-      if (releaseLock) {
-        await releaseLock().catch((error) => {
-          logger.warn('Error releasing file lock', {
-            lockPath,
-            error: error instanceof Error ? error.message : String(error),
-          });
-        });
-      }
-
-      // Then release in-process lock
-      release?.();
-      if (this.resumeModeLocks.get(worktreeBasePath) === lock) {
-        this.resumeModeLocks.delete(worktreeBasePath);
-      }
-    }
-  }
-
-  private async updateResumeModes(
-    worktreeBasePath: string,
-    handler: (modes: Record<string, boolean>) => void
-  ): Promise<void> {
-    await this.withResumeModeLock(worktreeBasePath, async () => {
-      const modes = await readResumeModes(worktreeBasePath);
-      handler(modes);
-      await writeResumeModes(worktreeBasePath, modes);
-    });
-  }
-
-  async setInitMode(
-    workspaceId: string,
-    useExistingBranch: boolean | undefined,
-    worktreeBasePath?: string
-  ): Promise<void> {
+  setInitMode(workspaceId: string, useExistingBranch: boolean | undefined): Promise<void> {
     if (useExistingBranch === undefined) {
-      return;
+      return Promise.resolve();
     }
     this.initModes.set(workspaceId, useExistingBranch);
-    if (worktreeBasePath) {
-      await this.updateResumeModes(worktreeBasePath, (modes) => {
-        modes[workspaceId] = useExistingBranch;
-      });
-    }
+    return Promise.resolve();
   }
 
   async getInitMode(workspaceId: string): Promise<boolean | undefined> {
@@ -188,16 +66,9 @@ class WorktreeLifecycleService {
     return undefined;
   }
 
-  async clearInitMode(workspaceId: string, worktreeBasePath?: string): Promise<void> {
+  clearInitMode(workspaceId: string): Promise<void> {
     this.initModes.delete(workspaceId);
-    if (!worktreeBasePath) {
-      return;
-    }
-    await this.updateResumeModes(worktreeBasePath, (modes) => {
-      if (workspaceId in modes) {
-        delete modes[workspaceId];
-      }
-    });
+    return Promise.resolve();
   }
 
   async cleanupWorkspaceWorktree(

--- a/src/backend/orchestration/workspace-init.orchestrator.test.ts
+++ b/src/backend/orchestration/workspace-init.orchestrator.test.ts
@@ -244,7 +244,7 @@ describe('initializeWorkspaceWorktree', () => {
 
       await initializeWorkspaceWorktree(WORKSPACE_ID);
 
-      expect(worktreeLifecycleService.clearInitMode).toHaveBeenCalledWith(WORKSPACE_ID, '/base');
+      expect(worktreeLifecycleService.clearInitMode).toHaveBeenCalledWith(WORKSPACE_ID);
     });
   });
 
@@ -830,7 +830,7 @@ describe('initializeWorkspaceWorktree', () => {
       await initializeWorkspaceWorktree(WORKSPACE_ID);
 
       // worktreeCreated is true, so clearInitMode should still be called via finally
-      expect(worktreeLifecycleService.clearInitMode).toHaveBeenCalledWith(WORKSPACE_ID, '/base');
+      expect(worktreeLifecycleService.clearInitMode).toHaveBeenCalledWith(WORKSPACE_ID);
     });
 
     it('marks workspace failed when workspace update throws', async () => {

--- a/src/backend/orchestration/workspace-init.orchestrator.ts
+++ b/src/backend/orchestration/workspace-init.orchestrator.ts
@@ -866,7 +866,7 @@ export async function initializeWorkspaceWorktree(
     await handleWorkspaceInitFailure(workspaceId, error as Error);
   } finally {
     if (worktreeCreated) {
-      await worktreeLifecycleService.clearInitMode(workspaceId, project?.worktreeBasePath);
+      await worktreeLifecycleService.clearInitMode(workspaceId);
     }
   }
 }

--- a/src/backend/trpc/workspace/init.router.test.ts
+++ b/src/backend/trpc/workspace/init.router.test.ts
@@ -101,7 +101,7 @@ describe('workspaceInitRouter', () => {
     await expect(caller.retryInit({ id: 'w1' })).resolves.toEqual({ id: 'w1', status: 'NEW' });
 
     expect(mockResetToNew).toHaveBeenCalledWith('w1', 3);
-    expect(mockSetInitMode).toHaveBeenCalledWith('w1', true, '/tmp/worktrees');
+    expect(mockSetInitMode).toHaveBeenCalledWith('w1', true);
 
     await Promise.resolve();
     expect(mockInitializeWorkspaceWorktree).toHaveBeenCalledWith('w1', {

--- a/src/backend/trpc/workspace/init.trpc.ts
+++ b/src/backend/trpc/workspace/init.trpc.ts
@@ -79,11 +79,7 @@ export const workspaceInitRouter = router({
         const resumeMode =
           input.useExistingBranch ?? (await worktreeLifecycleService.getInitMode(workspace.id));
         if (resumeMode !== undefined) {
-          await worktreeLifecycleService.setInitMode(
-            workspace.id,
-            resumeMode,
-            workspace.project.worktreeBasePath
-          );
+          await worktreeLifecycleService.setInitMode(workspace.id, resumeMode);
         }
         // Run full initialization (creates worktree + runs startup script)
         initializeWorkspaceWorktree(workspace.id, {

--- a/src/shared/schemas/persisted-stores.schema.ts
+++ b/src/shared/schemas/persisted-stores.schema.ts
@@ -2,20 +2,11 @@
  * Zod schemas for validating persisted JSON stores (local files/localStorage).
  *
  * These schemas protect against malformed or corrupted data from:
- * - Resume modes map (Record<string, boolean>)
  * - Advisory lock persistence format
  * - Resume workspace ID list (string[])
  */
 
 import { z } from 'zod';
-
-/**
- * Schema for resume modes JSON file (.ff-resume-modes.json)
- * Maps workspace IDs to resume mode flags
- */
-export const resumeModesSchema = z.record(z.string(), z.boolean());
-
-export type ResumeModes = z.infer<typeof resumeModesSchema>;
 
 /**
  * Schema for a single persisted lock entry


### PR DESCRIPTION
## Summary
- remove the legacy `.ff-resume-modes.json` fallback from `worktreeLifecycleService.getInitMode`
- make `getInitMode` read init mode only from in-memory cache and the workspace `creationSource` field in the database
- update init-mode call sites in workspace initialization orchestration and retry-init tRPC flow to the new `getInitMode(workspaceId)` signature

## Why
`getInitMode` previously had a three-step lookup (cache -> DB -> sidecar file). The sidecar fallback kept a legacy compatibility path permanently active and could trigger filesystem reads on every lookup. This change removes that legacy read path and keeps DB state as the canonical source.

## Validation
- `pnpm test src/backend/domains/workspace/worktree/worktree-lifecycle.service.test.ts`
- `pnpm test src/backend/trpc/workspace/init.router.test.ts`
- `pnpm test src/backend/orchestration/workspace-init.orchestrator.test.ts`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes workspace initialization/resume behavior by removing the filesystem sidecar fallback and altering `getInitMode`/`setInitMode` signatures; older workspaces that relied on `.ff-resume-modes.json` may no longer resume via that path.
> 
> **Overview**
> Simplifies worktree init-mode handling by **removing the legacy `.ff-resume-modes.json` sidecar read/write path** and associated locking/validation, leaving init mode sourced only from an in-memory map and the workspace `creationSource` in the database.
> 
> Updates all callers (workspace creation, init orchestrator, and `retryInit` tRPC flow) to the new `worktreeLifecycleService.getInitMode(workspaceId)` / `setInitMode(workspaceId, mode)` / `clearInitMode(workspaceId)` signatures, and deletes the now-unused `resumeModesSchema` from `persisted-stores.schema` with tests adjusted accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48627621dd81d1e31f30f869a91d6cf39e474862. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->