### PR TITLE
Remove import-time AppContext creation from CORS middleware

### DIFF
--- a/src/backend/middleware/cors.middleware.ts
+++ b/src/backend/middleware/cors.middleware.ts
@@ -1,5 +1,5 @@
 import type { NextFunction, Request, Response } from 'express';
-import { type AppContext, createAppContext } from '@/backend/app-context';
+import type { AppContext } from '@/backend/app-context';
 
 /**
  * CORS middleware.
@@ -29,5 +29,3 @@ export function createCorsMiddleware(appContext: AppContext) {
     next();
   };
 }
-
-export const corsMiddleware = createCorsMiddleware(createAppContext());

--- a/src/backend/middleware/index.ts
+++ b/src/backend/middleware/index.ts
@@ -1,4 +1,4 @@
-export { corsMiddleware, createCorsMiddleware } from './cors.middleware';
+export { createCorsMiddleware } from './cors.middleware';
 export {
   createRequestLoggerMiddleware,
   requestLoggerMiddleware,


### PR DESCRIPTION
## Summary
- remove the eager `corsMiddleware` singleton export that instantiated middleware with `createAppContext()` at module load time
- keep `createCorsMiddleware(appContext)` as the only CORS middleware entrypoint
- update the middleware barrel export to stop re-exporting the eager singleton

## Why
Importing `corsMiddleware` previously triggered `createAppContext()` during module evaluation. That created a second app context and re-read configuration/environment data, and in tests could initialize a second Prisma client.

This change removes that import-time side effect so app context creation remains explicit and controlled by callers.

## Validation
- `pnpm exec vitest run src/backend/middleware/middleware.test.ts`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes how CORS middleware is instantiated/exports; main risk is any downstream code still importing `corsMiddleware` will break at compile time.
> 
> **Overview**
> Removes the eager `corsMiddleware` export that called `createAppContext()` at module import time, eliminating side effects like duplicate context/DB client initialization.
> 
> `cors.middleware.ts` now only exposes `createCorsMiddleware(appContext)`, and the middleware barrel (`middleware/index.ts`) stops re-exporting the removed singleton.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90100bf0c5eb914babc3dc08a6be89880405c138. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->