### PR TITLE
Separate settings into General and Project sections

### DIFF
--- a/src/client/components/app-sidebar.tsx
+++ b/src/client/components/app-sidebar.tsx
@@ -359,7 +359,7 @@ function SidebarInner({
               >
                 <Link to="/admin" onClick={onNavigate}>
                   <Settings className="h-4 w-4" />
-                  <span>Admin Dashboard</span>
+                  <span>Settings</span>
                 </Link>
               </SidebarMenuButton>
               <ThemeToggle />

--- a/src/client/routes/admin/IssueTrackingSection.tsx
+++ b/src/client/routes/admin/IssueTrackingSection.tsx
@@ -154,7 +154,7 @@ function LinearConfigFields({
   );
 }
 
-function ProjectIssueTrackingCard({
+export function ProjectIssueTrackingCard({
   projectId,
   projectName,
   currentProvider,

--- a/src/client/routes/admin/index.ts
+++ b/src/client/routes/admin/index.ts
@@ -1,5 +1,5 @@
 export { type ApiUsageData, ApiUsageSection, type ApiUsageSectionProps } from './ApiUsageSection';
-export { IssueTrackingSection } from './IssueTrackingSection';
+export { IssueTrackingSection, ProjectIssueTrackingCard } from './IssueTrackingSection';
 export {
   type ProcessesData,
   ProcessesSection,


### PR DESCRIPTION
## Summary
- Splits the flat settings page into two labeled sections: **General Settings** and **Project Settings**
- Project Settings (Factory Configuration, Issue Tracking) now show a single project at a time via a dropdown, defaulted to the current project
- Renames sidebar link from "Admin Dashboard" to "Settings"

## Screenshots
<img width="1728" height="885" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/d48229e1-f8cd-4068-8fcb-cc2c4df593c9" />
<img width="1460" height="666" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/c639b41c-7c20-436a-af00-5add9d40b487" />
