### PR TITLE
Fix duplicate workspace entries in sidebar sections

### DIFF
--- a/src/client/components/app-sidebar.tsx
+++ b/src/client/components/app-sidebar.tsx
@@ -40,6 +40,7 @@ import { cn } from '@/lib/utils';
 import { Logo } from './logo';
 import { PendingRequestBadge } from './pending-request-badge';
 import { ThemeToggle } from './theme-toggle';
+import { groupWorkspacesForSidebar } from './workspace-sidebar-grouping';
 import { WorkspaceStatusIcon } from './workspace-status-icon';
 
 type NavigationData = ReturnType<typeof useAppNavigationData>;
@@ -410,19 +411,7 @@ export function AppSidebar({ navData }: { navData: NavigationData }) {
 
   // Group workspaces by kanban column, sorted by createdAt descending (newest first)
   const { waiting, working, done } = useMemo(() => {
-    const ws = navData.serverWorkspaces ?? [];
-    const byNewest = (a: ServerWorkspace, b: ServerWorkspace) =>
-      new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
-    return {
-      waiting: ws.filter((w) => w.cachedKanbanColumn === 'WAITING').sort(byNewest),
-      working: ws
-        .filter(
-          (w) =>
-            w.cachedKanbanColumn === 'WORKING' || (w.isWorking && w.cachedKanbanColumn !== 'DONE')
-        )
-        .sort(byNewest),
-      done: ws.filter((w) => w.cachedKanbanColumn === 'DONE').sort(byNewest),
-    };
+    return groupWorkspacesForSidebar(navData.serverWorkspaces ?? []);
   }, [navData.serverWorkspaces]);
 
   const sharedProps = {

--- a/src/client/components/workspace-sidebar-grouping.test.ts
+++ b/src/client/components/workspace-sidebar-grouping.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import type { ServerWorkspace } from './use-workspace-list-state';
+import { groupWorkspacesForSidebar } from './workspace-sidebar-grouping';
+
+function makeWorkspace(
+  overrides: Partial<ServerWorkspace> & { id: string; name: string; createdAt: string }
+): ServerWorkspace {
+  const { id, name, createdAt, ...rest } = overrides;
+  return {
+    id,
+    name,
+    createdAt,
+    isWorking: false,
+    gitStats: null,
+    branchName: null,
+    prUrl: null,
+    prNumber: null,
+    prState: null,
+    prCiStatus: null,
+    cachedKanbanColumn: 'WAITING',
+    ...rest,
+  };
+}
+
+describe('groupWorkspacesForSidebar', () => {
+  it('keeps waiting/working/done groups mutually exclusive', () => {
+    const workspaces = [
+      makeWorkspace({
+        id: 'waiting-and-working',
+        name: 'Waiting and working',
+        createdAt: '2024-02-01T00:00:00Z',
+        cachedKanbanColumn: 'WAITING',
+        isWorking: true,
+      }),
+      makeWorkspace({
+        id: 'done-and-working',
+        name: 'Done and working',
+        createdAt: '2024-02-02T00:00:00Z',
+        cachedKanbanColumn: 'DONE',
+        isWorking: true,
+      }),
+      makeWorkspace({
+        id: 'waiting-only',
+        name: 'Waiting only',
+        createdAt: '2024-02-03T00:00:00Z',
+        cachedKanbanColumn: 'WAITING',
+        isWorking: false,
+      }),
+      makeWorkspace({
+        id: 'working-only',
+        name: 'Working only',
+        createdAt: '2024-02-04T00:00:00Z',
+        cachedKanbanColumn: 'WORKING',
+        isWorking: false,
+      }),
+    ];
+
+    const grouped = groupWorkspacesForSidebar(workspaces);
+
+    expect(grouped.waiting.map((workspace) => workspace.id)).toEqual(['waiting-only']);
+    expect(grouped.working.map((workspace) => workspace.id)).toEqual([
+      'working-only',
+      'waiting-and-working',
+    ]);
+    expect(grouped.done.map((workspace) => workspace.id)).toEqual(['done-and-working']);
+  });
+});

--- a/src/client/components/workspace-sidebar-grouping.ts
+++ b/src/client/components/workspace-sidebar-grouping.ts
@@ -1,0 +1,40 @@
+import type { ServerWorkspace } from './use-workspace-list-state';
+
+export interface SidebarWorkspaceGroups {
+  waiting: ServerWorkspace[];
+  working: ServerWorkspace[];
+  done: ServerWorkspace[];
+}
+
+function getCreatedAtMs(value: string | Date): number {
+  if (value instanceof Date) {
+    return value.getTime();
+  }
+
+  const parsed = new Date(value).getTime();
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function byNewest(a: ServerWorkspace, b: ServerWorkspace): number {
+  return getCreatedAtMs(b.createdAt) - getCreatedAtMs(a.createdAt);
+}
+
+function isInWorkingSection(workspace: ServerWorkspace): boolean {
+  if (workspace.cachedKanbanColumn === 'DONE') {
+    return false;
+  }
+
+  return workspace.cachedKanbanColumn === 'WORKING' || workspace.isWorking;
+}
+
+export function groupWorkspacesForSidebar(workspaces: ServerWorkspace[]): SidebarWorkspaceGroups {
+  return {
+    waiting: workspaces
+      .filter(
+        (workspace) => workspace.cachedKanbanColumn === 'WAITING' && !isInWorkingSection(workspace)
+      )
+      .sort(byNewest),
+    working: workspaces.filter((workspace) => isInWorkingSection(workspace)).sort(byNewest),
+    done: workspaces.filter((workspace) => workspace.cachedKanbanColumn === 'DONE').sort(byNewest),
+  };
+}


### PR DESCRIPTION
## Summary
This fixes a sidebar bug where the same workspace could appear in both **Waiting** and **Working** sections.

## Root Cause
`AppSidebar` grouped sections with overlapping conditions:
- `Waiting`: `cachedKanbanColumn === 'WAITING'`
- `Working`: `cachedKanbanColumn === 'WORKING' || (isWorking && cachedKanbanColumn !== 'DONE')`

If a workspace had `cachedKanbanColumn='WAITING'` and `isWorking=true`, it was rendered in both sections.

## Changes
- Extracted sidebar grouping into `groupWorkspacesForSidebar`.
- Made section membership mutually exclusive:
  - `DONE` stays in Done
  - `WORKING` or `isWorking=true` (excluding DONE) goes to Working
  - `WAITING` goes to Waiting only if not already in Working
- Updated `AppSidebar` to use the shared grouping helper.
- Added a regression test covering overlap scenarios to ensure no duplicate section membership.

## Validation
- `pnpm vitest run src/client/components/workspace-sidebar-grouping.test.ts src/client/components/use-workspace-list-state.test.ts`
- `pnpm biome check src/client/components/app-sidebar.tsx src/client/components/workspace-sidebar-grouping.ts src/client/components/workspace-sidebar-grouping.test.ts`
- Commit hooks also ran successfully (`typecheck`, `depcruise`, `knip`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, UI-only grouping refactor with a regression test; low risk aside from potentially changing sidebar ordering/classification for edge-case workspace states.
> 
> **Overview**
> Fixes a sidebar bug where a workspace could render in both **Waiting** and **Working**.
> 
> Workspace grouping logic is extracted into `groupWorkspacesForSidebar`, making section membership mutually exclusive (excludes `DONE` from Working, and excludes Working items from Waiting) while keeping newest-first sorting. Adds a focused Vitest regression test covering overlapping `cachedKanbanColumn`/`isWorking` cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cf676bed37b46df1c1072b237a1953ec319705d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->