### PR TITLE
Remove new-workspace button from workspace detail header

### DIFF
--- a/src/client/routes/projects/workspaces/workspace-detail-container.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-container.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
-import { useCreateWorkspace } from '@/client/hooks/use-create-workspace';
 import { trpc } from '@/client/lib/trpc';
 import { isWorkspaceDoneOrMerged } from '@/client/lib/workspace-archive';
 import { useChatWebSocket } from '@/components/chat';
@@ -302,9 +301,6 @@ export function WorkspaceDetailContainer() {
     selectedProvider,
   });
 
-  const { handleCreate: handleCreateWorkspace, isCreating: isCreatingWorkspace } =
-    useCreateWorkspace(workspace?.projectId, slug);
-
   const handleArchive = useCallback(
     (commitUncommitted: boolean) => {
       archiveWorkspace.mutate({ id: workspaceId, commitUncommitted });
@@ -437,8 +433,6 @@ export function WorkspaceDetailContainer() {
           running={workspaceRunning}
           isCreatingSession={createSession.isPending}
           hasChanges={hasChanges}
-          onCreateWorkspace={handleCreateWorkspace}
-          isCreatingWorkspace={isCreatingWorkspace}
         />
       )}
       <WorkspaceDetailView

--- a/src/client/routes/projects/workspaces/workspace-detail-header.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-header.tsx
@@ -70,7 +70,6 @@ import {
   resolveProviderSelection,
 } from '@/lib/session-provider-selection';
 import { cn } from '@/lib/utils';
-import { NewWorkspaceButton } from './components/new-workspace-button';
 import { encodeGitHubTreeRef } from './github-branch-url';
 import type { useSessionManagement, useWorkspaceData } from './use-workspace-detail';
 import { useWorkspaceProjectNavigation } from './use-workspace-project-navigation';
@@ -763,8 +762,6 @@ interface WorkspaceHeaderProps {
   running: boolean;
   isCreatingSession: boolean;
   hasChanges?: boolean;
-  onCreateWorkspace: () => void;
-  isCreatingWorkspace: boolean;
 }
 
 /**
@@ -783,8 +780,6 @@ export function WorkspaceDetailHeaderSlot({
   running,
   isCreatingSession,
   hasChanges,
-  onCreateWorkspace,
-  isCreatingWorkspace,
 }: WorkspaceHeaderProps) {
   const isMobile = useIsMobile();
   const { slug, projects, handleProjectChange, handleCurrentProjectSelect } =
@@ -848,7 +843,6 @@ export function WorkspaceDetailHeaderSlot({
             !isMobile && 'flex-wrap gap-0.5 md:gap-1'
           )}
         >
-          <NewWorkspaceButton onClick={onCreateWorkspace} isCreating={isCreatingWorkspace} />
           <RunScriptButton workspaceId={workspaceId} />
           {isMobile ? (
             <>


### PR DESCRIPTION
## Summary
- Remove the "New Workspace" button from the workspace detail page header
- Remove the associated `useCreateWorkspace` hook usage and related props (`onCreateWorkspace`, `isCreatingWorkspace`) from the container and header components
- The sidebar already provides workspace creation, making the header button redundant

## Test plan
- [ ] Verify workspace detail page renders without the new-workspace button
- [ ] Verify creating workspaces still works via the sidebar
- [ ] Run `pnpm typecheck` — passes
- [ ] Run `pnpm check:fix` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
