### PR TITLE
Add background to new workspace button in Kanban issues column

### DIFF
--- a/src/client/components/kanban/kanban-board.tsx
+++ b/src/client/components/kanban/kanban-board.tsx
@@ -356,7 +356,7 @@ function IssuesColumn({ column, issues, projectId }: IssuesColumnProps) {
             <button
               type="button"
               onClick={() => setShowInlineForm(true)}
-              className="shrink-0 flex items-center gap-2 rounded-lg border border-dashed border-primary/40 px-3 py-5 text-sm text-primary hover:border-primary/70 hover:text-primary transition-colors cursor-pointer"
+              className="shrink-0 flex items-center gap-2 rounded-lg border border-dashed border-primary/40 bg-card px-3 py-5 text-sm text-primary hover:border-primary/70 hover:text-primary transition-colors cursor-pointer"
             >
               <Plus className="h-4 w-4" />
               New Workspace


### PR DESCRIPTION
## Summary
- Adds `bg-card` background color to the "New Workspace" button in the Kanban board's issues column, giving it a solid card background instead of being transparent

## Test plan
- [ ] Verify the "New Workspace" button in the Kanban issues column has a visible card background
- [ ] Confirm hover styles still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)