### PR TITLE
Fix Workspaces sidebar button staying active on detail views

### DIFF
--- a/src/client/components/app-sidebar.tsx
+++ b/src/client/components/app-sidebar.tsx
@@ -324,7 +324,7 @@ function SidebarInner({
           <SidebarMenuItem>
             <SidebarMenuButton
               asChild
-              isActive={pathname?.startsWith(`/projects/${navData.selectedProjectSlug}/workspaces`)}
+              isActive={pathname === `/projects/${navData.selectedProjectSlug}/workspaces`}
             >
               <Link to={`/projects/${navData.selectedProjectSlug}/workspaces`} onClick={onNavigate}>
                 <Kanban className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- Use exact pathname match (`===`) instead of `startsWith` for the Workspaces sidebar menu button's `isActive` check
- Previously, navigating to a workspace detail view (e.g., `/projects/foo/workspaces/some-id`) kept the Workspaces button highlighted because the path still started with the workspaces route
- Now the button is only active on the workspaces list page itself

## Test plan
- [ ] Navigate to the Workspaces list page — button should be highlighted
- [ ] Navigate to a workspace detail view — Workspaces button should no longer be highlighted
- [ ] Navigate to other sidebar sections — verify no regressions in active state

🤖 Generated with [Claude Code](https://claude.com/claude-code)