### PR TITLE
Make project name click navigate directly to kanban

### DIFF
--- a/src/client/components/project-selector.tsx
+++ b/src/client/components/project-selector.tsx
@@ -8,6 +8,7 @@ export function ProjectSelectorDropdown({
   onProjectChange,
   projects,
   triggerClassName,
+  projectButtonClassName,
   triggerId = 'project-select',
   onCurrentProjectSelect,
 }: {
@@ -15,6 +16,7 @@ export function ProjectSelectorDropdown({
   onProjectChange: (value: string) => void;
   projects: Array<{ id: string; slug: string; name: string }> | undefined;
   triggerClassName?: string;
+  projectButtonClassName?: string;
   triggerId?: string;
   onCurrentProjectSelect?: () => void;
 }) {
@@ -48,7 +50,7 @@ export function ProjectSelectorDropdown({
           onCurrentProjectSelect
             ? 'cursor-pointer hover:text-foreground focus-visible:text-foreground'
             : 'cursor-default',
-          triggerClassName
+          projectButtonClassName
         )}
         aria-label={`Open ${selectedProjectName} kanban`}
       >
@@ -58,7 +60,10 @@ export function ProjectSelectorDropdown({
         <SelectTrigger
           id={triggerId}
           aria-label="Open project menu"
-          className="h-7 w-7 shrink-0 border-0 bg-transparent px-1 text-muted-foreground shadow-none focus:ring-0"
+          className={cn(
+            'h-7 w-7 shrink-0 border-0 bg-transparent px-1 text-muted-foreground shadow-none focus:ring-0',
+            triggerClassName
+          )}
         >
           <span className="sr-only">Open project menu</span>
         </SelectTrigger>

--- a/src/client/routes/projects/workspaces/components/workspaces-board-view.tsx
+++ b/src/client/routes/projects/workspaces/components/workspaces-board-view.tsx
@@ -28,7 +28,7 @@ function BoardHeaderSlot({
           onCurrentProjectSelect={onCurrentProjectSelect}
           projects={projects}
           triggerId="header-project-select"
-          triggerClassName="h-7 w-auto max-w-[10rem] gap-1 border-0 bg-transparent px-1 text-xs font-normal text-muted-foreground shadow-none focus:ring-0 sm:max-w-[18rem] sm:text-sm"
+          projectButtonClassName="h-7 w-auto max-w-[10rem] gap-1 border-0 bg-transparent px-1 text-xs font-normal text-muted-foreground shadow-none focus:ring-0 sm:max-w-[18rem] sm:text-sm"
         />
       </HeaderLeftStartSlot>
       <HeaderRightSlot>

--- a/src/client/routes/projects/workspaces/workspace-detail-header.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-header.tsx
@@ -819,7 +819,7 @@ export function WorkspaceDetailHeaderSlot({
           onCurrentProjectSelect={handleCurrentProjectSelect}
           projects={projects}
           triggerId="workspace-detail-project-select"
-          triggerClassName="h-7 w-auto max-w-[10rem] gap-1 border-0 bg-transparent px-1 text-xs font-normal text-muted-foreground shadow-none focus:ring-0 sm:max-w-[18rem] sm:text-sm"
+          projectButtonClassName="h-7 w-auto max-w-[10rem] gap-1 border-0 bg-transparent px-1 text-xs font-normal text-muted-foreground shadow-none focus:ring-0 sm:max-w-[18rem] sm:text-sm"
         />
       </HeaderLeftStartSlot>
       <HeaderLeftExtraSlot>


### PR DESCRIPTION
## Summary
- split the project selector in the top header into two interactions:
  - clicking the project name now immediately navigates to that project's kanban/workspaces page
  - clicking the chevron opens the project dropdown menu
- keep existing dropdown options and routing behavior (`switch project`, `+ Create project`, and `Manage projects...`)
- preserve accessibility labels for both controls (name button and menu trigger)

## Why
This makes common navigation faster by making "go to current project's kanban" a single click instead of requiring opening and selecting from the dropdown.

## Testing
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that refactors the header project selector into separate click targets; main risk is minor UX/accessibility regressions in selection and focus behavior.
> 
> **Overview**
> Splits `ProjectSelectorDropdown` into two interactions: the project name is now a standalone button that calls `onCurrentProjectSelect`, while a separate icon-sized `SelectTrigger` opens the project menu.
> 
> Updates usages in the workspaces board header and workspace detail header to pass styling via the new `projectButtonClassName` prop, and adds distinct `aria-label`s for the name button and menu trigger while keeping existing menu options (switch project, create, manage).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6c6025a5b105e0aa62bd17d4deff748ace8a646. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->