### PR TITLE
Increase pasted-text threshold for attachment conversion

### DIFF
--- a/src/components/chat/chat-input.stories.tsx
+++ b/src/components/chat/chat-input.stories.tsx
@@ -174,7 +174,7 @@ export const InteractivePasteDrop: Story = {
           <p className="font-medium mb-2">Test Instructions:</p>
           <ul className="list-disc list-inside space-y-1">
             <li>Paste an image (Cmd/Ctrl+V after copying an image)</li>
-            <li>Paste large text (10+ lines or 1000+ characters)</li>
+            <li>Paste large text (20+ lines or 2000+ characters)</li>
             <li>Drag and drop an image file</li>
             <li>Drag and drop a text file (.txt, .md, .js, etc.)</li>
           </ul>

--- a/src/components/chat/chat-input/hooks/use-paste-drop-handler.ts
+++ b/src/components/chat/chat-input/hooks/use-paste-drop-handler.ts
@@ -84,7 +84,7 @@ async function handleFileDrop(
  *
  * Paste behavior:
  * - Images: Always convert to attachments
- * - Large text (10+ lines or 1000+ chars): Convert to text attachment
+ * - Large text (20+ lines or 2000+ chars): Convert to text attachment
  * - Small text: Default behavior (insert inline)
  *
  * Drop behavior:

--- a/src/lib/paste-utils.test.ts
+++ b/src/lib/paste-utils.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { getClipboardImages } from './paste-utils';
+import {
+  getClipboardImages,
+  isLargeText,
+  LARGE_TEXT_CHAR_THRESHOLD,
+  LARGE_TEXT_LINE_THRESHOLD,
+} from './paste-utils';
 
 vi.mock('./image-utils', async () => {
   const actual = await vi.importActual<typeof import('./image-utils')>('./image-utils');
@@ -81,5 +86,32 @@ describe('getClipboardImages', () => {
 
     expect(result.attachments).toEqual([]);
     expect(result.errors).toEqual(['Image too large: 6 B (max 5 B)']);
+  });
+});
+
+describe('isLargeText', () => {
+  it('returns false below both thresholds', () => {
+    const text = 'short text';
+    expect(isLargeText(text)).toBe(false);
+  });
+
+  it('returns true at the line threshold', () => {
+    const text = Array.from({ length: LARGE_TEXT_LINE_THRESHOLD }, () => 'line').join('\n');
+    expect(isLargeText(text)).toBe(true);
+  });
+
+  it('returns false just below the line threshold', () => {
+    const text = Array.from({ length: LARGE_TEXT_LINE_THRESHOLD - 1 }, () => 'line').join('\n');
+    expect(isLargeText(text)).toBe(false);
+  });
+
+  it('returns true at the character threshold', () => {
+    const text = 'a'.repeat(LARGE_TEXT_CHAR_THRESHOLD);
+    expect(isLargeText(text)).toBe(true);
+  });
+
+  it('returns false just below the character threshold', () => {
+    const text = 'a'.repeat(LARGE_TEXT_CHAR_THRESHOLD - 1);
+    expect(isLargeText(text)).toBe(false);
   });
 });

--- a/src/lib/paste-utils.ts
+++ b/src/lib/paste-utils.ts
@@ -9,21 +9,21 @@ import {
 
 /**
  * Threshold for considering text as "large" (number of lines).
- * Text with 10+ lines is shown as an attachment to avoid cluttering the input field
+ * Text with 20+ lines is shown as an attachment to avoid cluttering the input field
  * and to give users a clear visual indicator of the content size.
  */
-export const LARGE_TEXT_LINE_THRESHOLD = 10;
+export const LARGE_TEXT_LINE_THRESHOLD = 20;
 
 /**
  * Threshold for considering text as "large" (character count).
- * Text with 1000+ characters is shown as an attachment even if it has few lines,
+ * Text with 2000+ characters is shown as an attachment even if it has few lines,
  * as long single lines can also clutter the input field.
  */
-export const LARGE_TEXT_CHAR_THRESHOLD = 1000;
+export const LARGE_TEXT_CHAR_THRESHOLD = 2000;
 
 /**
  * Check if text is considered "large" and should be shown as an attachment.
- * Text is large if it has 10+ lines OR 1000+ characters.
+ * Text is large if it has 20+ lines OR 2000+ characters.
  */
 export function isLargeText(text: string): boolean {
   const lineCount = text.split('\n').length;


### PR DESCRIPTION
## Summary
- Increase the pasted-text attachment threshold from `10 lines / 1000 chars` to `20 lines / 2000 chars`.
- Keep small and medium paste operations inline longer before converting to a text attachment.
- Update related paste-behavior references in chat input hook comments and Storybook test instructions.
- Add focused unit tests for `isLargeText` at and just below both thresholds.

## Testing
- `pnpm test -- src/lib/paste-utils.test.ts` (passes; this repo command path runs the full Vitest suite)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UX threshold tweak with added unit coverage; minimal risk beyond slightly changing when paste-to-attachment triggers.
> 
> **Overview**
> Increases the “large pasted text” thresholds used to auto-convert clipboard text into a text attachment from **10 lines/1000 chars** to **20 lines/2000 chars**, keeping more medium-sized pastes inline.
> 
> Updates related user-facing guidance (Storybook `InteractivePasteDrop`) and developer documentation comments, and adds unit tests for `isLargeText` at and just below the new thresholds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 784458d388058f9faf8c2972edd7b8216858b02a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->