### PR TITLE
Keep archiving workspaces hidden across refresh

### DIFF
--- a/src/backend/domains/workspace/query/workspace-query.service.ts
+++ b/src/backend/domains/workspace/query/workspace-query.service.ts
@@ -77,6 +77,9 @@ class WorkspaceQueryService {
         excludeStatuses: [WorkspaceStatus.ARCHIVED],
       }),
     ]);
+    const nonArchivingWorkspaces = workspaces.filter(
+      (workspace) => !workspaceArchiveTrackerService.isArchiving(workspace.id)
+    );
 
     const defaultBranch = project?.defaultBranch ?? 'main';
 
@@ -92,7 +95,7 @@ class WorkspaceQueryService {
       string,
       'plan_approval' | 'user_question' | 'permission_request' | null
     >();
-    for (const workspace of workspaces) {
+    for (const workspace of nonArchivingWorkspaces) {
       const runtimeState = deriveWorkspaceRuntimeState(workspace, (sessionIds) =>
         this.session.isAnySessionWorking(sessionIds)
       );
@@ -114,7 +117,7 @@ class WorkspaceQueryService {
     > = {};
 
     await Promise.all(
-      workspaces.map((workspace) =>
+      nonArchivingWorkspaces.map((workspace) =>
         gitConcurrencyLimit(async () => {
           if (!workspace.worktreePath) {
             gitStatsResults[workspace.id] = null;
@@ -156,7 +159,7 @@ class WorkspaceQueryService {
     }
 
     return {
-      workspaces: workspaces.map((w) => {
+      workspaces: nonArchivingWorkspaces.map((w) => {
         const flowState = flowStateByWorkspace.get(w.id);
         const sessionDates = [
           ...(w.agentSessions?.map((s) => s.updatedAt) ?? []),


### PR DESCRIPTION
## Summary
- make workspace summary queries exclude workspaces currently marked as archiving
- align `getProjectSummaryState` behavior with `listWithKanbanState` so archiving workspaces do not reappear after refresh
- add a regression test covering the project summary archiving filter path

## Problem
When archiving a workspace, it was hidden immediately via optimistic UI state. After a refresh, the sidebar/project summary query could still return that workspace until archiving fully completed, causing inconsistent visibility.

## Fix
`WorkspaceQueryService.getProjectSummaryState` now filters out workspaces tracked by `workspaceArchiveTrackerService.isArchiving(...)` before computing derived sidebar/runtime fields.

## Testing
- `pnpm test src/backend/domains/workspace/query/workspace-query.service.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized filtering change plus a regression test; main impact is potentially hiding a workspace if it’s incorrectly marked as archiving.
> 
> **Overview**
> Ensures project summary/sidebar results stay consistent while a workspace is being archived by filtering out IDs tracked by `workspaceArchiveTrackerService.isArchiving(...)` in `WorkspaceQueryService.getProjectSummaryState`.
> 
> Adds a regression test verifying an archiving workspace is excluded from `getProjectSummaryState` results.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c65b529ef8fee457b80d8b1b65ff1633eabf7d8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->