### PR TITLE
Use a single kanban category source in sidebar

### DIFF
--- a/src/client/components/workspace-sidebar-grouping.test.ts
+++ b/src/client/components/workspace-sidebar-grouping.test.ts
@@ -23,7 +23,7 @@ function makeWorkspace(
 }
 
 describe('groupWorkspacesForSidebar', () => {
-  it('keeps waiting/working/done groups mutually exclusive', () => {
+  it('groups strictly by cachedKanbanColumn', () => {
     const workspaces = [
       makeWorkspace({
         id: 'waiting-and-working',
@@ -57,11 +57,11 @@ describe('groupWorkspacesForSidebar', () => {
 
     const grouped = groupWorkspacesForSidebar(workspaces);
 
-    expect(grouped.waiting.map((workspace) => workspace.id)).toEqual(['waiting-only']);
-    expect(grouped.working.map((workspace) => workspace.id)).toEqual([
-      'working-only',
+    expect(grouped.waiting.map((workspace) => workspace.id)).toEqual([
+      'waiting-only',
       'waiting-and-working',
     ]);
+    expect(grouped.working.map((workspace) => workspace.id)).toEqual(['working-only']);
     expect(grouped.done.map((workspace) => workspace.id)).toEqual(['done-and-working']);
   });
 });

--- a/src/client/components/workspace-sidebar-grouping.ts
+++ b/src/client/components/workspace-sidebar-grouping.ts
@@ -19,22 +19,14 @@ function byNewest(a: ServerWorkspace, b: ServerWorkspace): number {
   return getCreatedAtMs(b.createdAt) - getCreatedAtMs(a.createdAt);
 }
 
-function isInWorkingSection(workspace: ServerWorkspace): boolean {
-  if (workspace.cachedKanbanColumn === 'DONE') {
-    return false;
-  }
-
-  return workspace.cachedKanbanColumn === 'WORKING' || workspace.isWorking;
-}
-
 export function groupWorkspacesForSidebar(workspaces: ServerWorkspace[]): SidebarWorkspaceGroups {
   return {
     waiting: workspaces
-      .filter(
-        (workspace) => workspace.cachedKanbanColumn === 'WAITING' && !isInWorkingSection(workspace)
-      )
+      .filter((workspace) => workspace.cachedKanbanColumn === 'WAITING')
       .sort(byNewest),
-    working: workspaces.filter((workspace) => isInWorkingSection(workspace)).sort(byNewest),
+    working: workspaces
+      .filter((workspace) => workspace.cachedKanbanColumn === 'WORKING')
+      .sort(byNewest),
     done: workspaces.filter((workspace) => workspace.cachedKanbanColumn === 'DONE').sort(byNewest),
   };
 }


### PR DESCRIPTION
## Summary
- make sidebar workspace grouping use only `cachedKanbanColumn` as the category source
- remove sidebar-specific fallback logic that inferred `Working` from `isWorking`
- update the sidebar grouping test to enforce strict column-based grouping behavior

## Why
The Kanban board already reads a single derived category field (`kanbanColumn`).
This change aligns the sidebar with the same single-writer principle so both views render consistent workspace states.

## Testing
- `pnpm biome check src/client/components/workspace-sidebar-grouping.ts src/client/components/workspace-sidebar-grouping.test.ts`
- `pnpm test src/client/components/workspace-sidebar-grouping.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to sidebar categorization logic plus a test update; risk is limited to potential UX differences if `cachedKanbanColumn` is stale.
> 
> **Overview**
> Sidebar workspace grouping is simplified to **use only** `cachedKanbanColumn` when assigning workspaces to `waiting`/`working`/`done`, removing the prior sidebar-only inference that treated `isWorking` as `WORKING`.
> 
> Tests are updated to assert strict column-based grouping (e.g., a workspace with `cachedKanbanColumn: WAITING` stays in *Waiting* even if `isWorking: true`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7bf25c8a9cc039c4857af92eb91f2848c9bcb3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->