### PR TITLE
Remove redundant Workspaces tab from sidebar

### DIFF
--- a/src/client/components/app-sidebar.tsx
+++ b/src/client/components/app-sidebar.tsx
@@ -1,13 +1,4 @@
-import {
-  CircleDot,
-  GitBranch,
-  GitPullRequest,
-  Kanban,
-  Loader2,
-  Plus,
-  Settings,
-  X,
-} from 'lucide-react';
+import { CircleDot, GitBranch, GitPullRequest, Loader2, Plus, Settings, X } from 'lucide-react';
 import { useEffect, useMemo, useRef } from 'react';
 import { Link, useLocation } from 'react-router';
 import type { ServerWorkspace } from '@/client/components/use-workspace-list-state';
@@ -321,17 +312,6 @@ function SidebarInner({
 
       <SidebarFooter>
         <SidebarMenu>
-          <SidebarMenuItem>
-            <SidebarMenuButton
-              asChild
-              isActive={pathname === `/projects/${navData.selectedProjectSlug}/workspaces`}
-            >
-              <Link to={`/projects/${navData.selectedProjectSlug}/workspaces`} onClick={onNavigate}>
-                <Kanban className="h-4 w-4" />
-                <span>Workspaces</span>
-              </Link>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
           <SidebarMenuItem>
             <SidebarMenuButton
               asChild


### PR DESCRIPTION
## Summary
- remove the redundant `Workspaces` footer tab from the app sidebar
- keep the existing workspace sections (Waiting, Working, Todo, Done) unchanged
- clean up the unused `Kanban` icon import in `app-sidebar.tsx`

## Why
The dedicated `Workspaces` footer tab duplicates navigation that is already represented by the workspace list and board flow in the sidebar.

## Testing
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small navigation/UI-only change removing a sidebar entry and an unused icon import; no data flow or business logic changes.
> 
> **Overview**
> Removes the redundant **Workspaces** footer navigation entry from `AppSidebar`, leaving the existing workspace column sections (Waiting/Working/Todo/Done) as the only workspace navigation.
> 
> Cleans up the now-unused `Kanban` icon import and flattens the `lucide-react` import list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 412e8e25f72a269f94d54aa2c7d0fb18606c8a5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->