### PR TITLE
Remove unsafe coercions in snapshot runtime paths

### DIFF
--- a/src/backend/orchestration/snapshot-reconciliation.orchestrator.ts
+++ b/src/backend/orchestration/snapshot-reconciliation.orchestrator.ts
@@ -82,7 +82,21 @@ interface DriftEntry {
 // Drift detection (pure function, exported for testing)
 // ---------------------------------------------------------------------------
 
-const DRIFT_FIELD_GROUPS: { group: string; fields: string[] }[] = [
+type DriftComparableField =
+  | 'status'
+  | 'name'
+  | 'branchName'
+  | 'prState'
+  | 'prCiStatus'
+  | 'prNumber'
+  | 'ratchetEnabled'
+  | 'ratchetState'
+  | 'runScriptStatus'
+  | 'isWorking'
+  | 'pendingRequestType'
+  | 'sessionSummaries';
+
+const DRIFT_FIELD_GROUPS: { group: string; fields: DriftComparableField[] }[] = [
   { group: 'workspace', fields: ['status', 'name', 'branchName'] },
   { group: 'pr', fields: ['prState', 'prCiStatus', 'prNumber'] },
   { group: 'ratchet', fields: ['ratchetEnabled', 'ratchetState'] },
@@ -102,11 +116,11 @@ export function detectDrift(
 
   for (const { group, fields } of DRIFT_FIELD_GROUPS) {
     for (const field of fields) {
-      const authValue = (authoritative as Record<string, unknown>)[field];
+      const authValue = authoritative[field];
       if (authValue === undefined) {
         continue;
       }
-      const snapValue = (existing as unknown as Record<string, unknown>)[field];
+      const snapValue = existing[field];
       if (!isDeepStrictEqual(authValue, snapValue)) {
         drifts.push({
           field,

--- a/src/client/lib/snapshot-to-sidebar.ts
+++ b/src/client/lib/snapshot-to-sidebar.ts
@@ -150,7 +150,7 @@ export type SnapshotServerMessage = z.infer<typeof SnapshotServerMessageSchema>;
  */
 export function mapSnapshotEntryToServerWorkspace(
   entry: WorkspaceSnapshotEntry,
-  existing?: Record<string, unknown>
+  existing?: Partial<Pick<ServerWorkspace, 'githubIssueNumber' | 'linearIssueId'>>
 ): ServerWorkspace {
   return {
     id: entry.workspaceId,

--- a/src/lib/diff/syntax-highlight.ts
+++ b/src/lib/diff/syntax-highlight.ts
@@ -36,6 +36,17 @@ interface HastRoot {
 
 type HastNode = HastText | HastElement;
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object';
+}
+
+function isHastRoot(value: unknown): value is HastRoot {
+  if (!isRecord(value)) {
+    return false;
+  }
+  return value.type === 'root' && Array.isArray(value.children);
+}
+
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
@@ -207,7 +218,11 @@ function tokenizeAndMapLines(
   }
 
   const content = fileLines.map((l) => l.content).join('\n');
-  const root = refractor.highlight(content, language) as unknown as HastRoot;
+  const highlighted = refractor.highlight(content, language);
+  if (!isHastRoot(highlighted)) {
+    return;
+  }
+  const root = highlighted;
   const tokenLines = splitHastByLine(root, stylesheet);
 
   for (let i = 0; i < fileLines.length; i++) {


### PR DESCRIPTION
## Summary
This PR removes unsafe type coercion from runtime snapshot/reconciliation paths and replaces them with typed access patterns and guards.

### What changed
- Replaced dynamic `Record`-based field writes in the workspace snapshot store with typed field-key mappings and keyed assignment.
- Replaced drift detection `as unknown` indexing with a typed drift field union.
- Removed `null as unknown as NodeJS.Timeout` from the event coalescer by making timers nullable and guarding `clearTimeout`.
- Tightened snapshot sidebar cache typing in the client hook to eliminate `as unknown` assignments.
- Narrowed `mapSnapshotEntryToServerWorkspace` preserved-cache input type to the exact optional fields that are carried forward.
- Replaced refractor output `as unknown as HastRoot` with a runtime type guard before token splitting.

## Why
These areas are part of data reconciliation/serialization and are high impact for correctness. Removing unsafe coercions here restores compile-time guarantees and reduces the chance of runtime shape mismatches being silently accepted.

## Validation
- `pnpm typecheck`
- `pnpm test src/backend/orchestration/snapshot-reconciliation.orchestrator.test.ts src/backend/orchestration/event-collector.orchestrator.test.ts src/backend/services/workspace-snapshot-store.service.test.ts src/client/hooks/use-project-snapshot-sync.test.ts src/lib/diff/syntax-highlight.test.ts src/client/lib/snapshot-to-sidebar.test.ts`

## Notes
- This PR intentionally targets runtime paths first. Test-only `unsafeCoerce` usage remains and can be addressed in follow-up cleanup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily type-safety refactors, but they touch core snapshot reconciliation/store merge and client cache update paths where subtle typing/guard changes could alter which updates apply or silently skip highlighting.
> 
> **Overview**
> Removes several unsafe `as unknown`/`Record<string, unknown>` coercions across the snapshot pipeline (event coalescing, reconciliation drift detection, store merging, and client cache sync) by introducing typed field unions/mappings and typed cache shapes.
> 
> `EventCoalescer` timers are now nullable with guarded `clearTimeout`, snapshot drift detection uses a `DriftComparableField` union for safe indexed access, and `WorkspaceSnapshotStore` replaces dynamic field writes with typed `SnapshotField` mappings plus a helper assigner. On the client, sidebar cache updates now use a typed `CacheWorkspace`, `mapSnapshotEntryToServerWorkspace` narrows its preserved-cache input to the exact carried-over fields, and diff syntax highlighting adds a runtime `HastRoot` guard before splitting refractor output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf538bf561fdbfc115adfa1ef236a127c30dfc7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->