### PR TITLE
Refactor run-script services to instance-based DI

### DIFF
--- a/src/backend/app-context.ts
+++ b/src/backend/app-context.ts
@@ -2,8 +2,8 @@
 import { githubCLIService } from './domains/github';
 import { ratchetService } from './domains/ratchet';
 import {
+  createRunScriptService,
   type RunScriptService,
-  runScriptService,
   runScriptStateMachine,
   startupScriptService,
 } from './domains/run-script';
@@ -64,6 +64,10 @@ export type AppContext = {
   config: AppConfig;
 };
 
+const defaultRunScriptService = createRunScriptService({
+  registerShutdownHandlers: true,
+});
+
 export function createServices(overrides: Partial<AppServices> = {}): AppServices {
   const resolvedAcpRuntimeManager = overrides.acpRuntimeManager ?? acpRuntimeManager;
   const resolvedSessionDomainService = overrides.sessionDomainService ?? sessionDomainService;
@@ -90,7 +94,7 @@ export function createServices(overrides: Partial<AppServices> = {}): AppService
     kanbanStateService,
     ratchetService,
     rateLimiter,
-    runScriptService: runScriptService,
+    runScriptService: overrides.runScriptService ?? defaultRunScriptService,
     runScriptStateMachine,
     schedulerService,
     serverInstanceService,

--- a/src/backend/domains/run-script/index.ts
+++ b/src/backend/domains/run-script/index.ts
@@ -6,7 +6,7 @@
 export type { RunScriptWorkspaceBridge } from './bridges';
 
 // Run script execution
-export { RunScriptService, runScriptService } from './run-script.service';
+export { createRunScriptService, RunScriptService } from './run-script.service';
 
 // State machine
 export {

--- a/src/backend/domains/run-script/run-script-domain-exports.test.ts
+++ b/src/backend/domains/run-script/run-script-domain-exports.test.ts
@@ -1,16 +1,17 @@
 import { describe, expect, it } from 'vitest';
 import {
+  createRunScriptService,
   RunScriptService,
   RunScriptStateMachineError,
-  runScriptService,
   runScriptStateMachine,
   startupScriptService,
 } from './index';
 
 describe('Run script domain barrel exports', () => {
-  it('exports runScriptService singleton', () => {
-    expect(runScriptService).toBeDefined();
-    expect(runScriptService).toBeInstanceOf(RunScriptService);
+  it('exports runScriptService factory', () => {
+    const service = createRunScriptService();
+    expect(service).toBeDefined();
+    expect(service).toBeInstanceOf(RunScriptService);
   });
 
   it('exports RunScriptService class', () => {

--- a/src/backend/domains/run-script/run-script.service.ts
+++ b/src/backend/domains/run-script/run-script.service.ts
@@ -878,7 +878,7 @@ export class RunScriptService {
 
   /**
    * Register process signal handlers for graceful shutdown.
-   * Called once at module load time after singleton creation.
+   * Should be called once for the process-lifetime service instance.
    */
   registerShutdownHandlers(): void {
     if (this.shutdownHandlersRegistered) {
@@ -918,5 +918,12 @@ export class RunScriptService {
   }
 }
 
-export const runScriptService = new RunScriptService();
-runScriptService.registerShutdownHandlers();
+export function createRunScriptService(
+  options: { registerShutdownHandlers?: boolean } = {}
+): RunScriptService {
+  const service = new RunScriptService();
+  if (options.registerShutdownHandlers) {
+    service.registerShutdownHandlers();
+  }
+  return service;
+}

--- a/src/backend/trpc/workspace.trpc.ts
+++ b/src/backend/trpc/workspace.trpc.ts
@@ -252,11 +252,15 @@ export const workspaceRouter = router({
   // Archive a workspace
   archive: publicProcedure
     .input(z.object({ id: z.string(), commitUncommitted: z.boolean().optional() }))
-    .mutation(async ({ input }) => {
+    .mutation(async ({ ctx, input }) => {
       const workspace = await getWorkspaceWithProjectOrThrow(input.id);
-      return archiveWorkspace(workspace, {
-        commitUncommitted: input.commitUncommitted ?? true,
-      });
+      return archiveWorkspace(
+        workspace,
+        {
+          commitUncommitted: input.commitUncommitted ?? true,
+        },
+        ctx.appContext.services
+      );
     }),
 
   // Bulk archive workspaces in a specific kanban column
@@ -289,7 +293,7 @@ export const workspaceRouter = router({
       for (const workspaceWithState of workspacesWithState) {
         try {
           const workspace = await getWorkspaceWithProjectOrThrow(workspaceWithState.id);
-          await archiveWorkspace(workspace, { commitUncommitted });
+          await archiveWorkspace(workspace, { commitUncommitted }, ctx.appContext.services);
           results.push({ id: workspace.id, success: true });
         } catch (error) {
           logger.error('Failed to archive workspace during bulk operation', {


### PR DESCRIPTION
## Summary
This PR removes run-script singleton coupling and completes the instance-based dependency-injection refactor for service usage paths that were still implicitly global.

### What changed
- Replaced the run-script singleton export with a factory (`createRunScriptService`) in the run-script domain.
- Moved default run-script service instantiation + shutdown handler registration into app context service wiring.
- Refactored workspace archive orchestration to accept injected dependencies (`sessionService`, `runScriptService`, `terminalService`, `githubCLIService`) instead of importing service singletons directly.
- Updated workspace TRPC archive/bulkArchive handlers to pass `ctx.appContext.services` into the archive orchestrator.
- Updated run-script barrel export tests and workspace archive orchestrator tests to use the new DI model.

## Why
- Eliminates process-global singleton coupling for run-script service access.
- Improves test isolation and makes service behavior instance-scoped under explicit app wiring.
- Keeps cross-domain orchestration dependencies explicit and easier to mock.

## Validation
- `pnpm test src/backend/orchestration/workspace-archive.orchestrator.test.ts src/backend/domains/run-script/run-script-domain-exports.test.ts src/backend/trpc/workspace.router.test.ts`
- `pnpm typecheck`
- `pnpm check:fix`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches process-lifetime shutdown handling and workspace archive cleanup orchestration, so incorrect wiring could leak processes or break archiving despite limited behavioral changes.
> 
> **Overview**
> Refactors `run-script` from a process-global singleton to an instance-based service created via `createRunScriptService`, with shutdown handler registration moved into `app-context` wiring.
> 
> Updates workspace archival to use explicit dependency injection: `archiveWorkspace` now receives a `services` object (session/run-script/terminal/GitHub) and TRPC `archive`/`bulkArchive` pass `ctx.appContext.services`; tests are adjusted accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1054366d66b9e0d23b29dd472e281f80c926a468. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->