### PR TITLE
Extract workspace flow state types into shared module

### DIFF
--- a/src/backend/domains/workspace/state/flow-state.ts
+++ b/src/backend/domains/workspace/state/flow-state.ts
@@ -1,14 +1,9 @@
 import { CIStatus, PRState, RatchetState } from '@/shared/core';
+import type { WorkspaceCiObservation, WorkspaceFlowPhase } from '@/shared/workspace-flow-state';
 
 const CI_UNKNOWN_GRACE_MS = 90_000;
 
-export type WorkspaceFlowPhase =
-  | 'NO_PR'
-  | 'CI_WAIT'
-  | 'RATCHET_VERIFY'
-  | 'RATCHET_FIXING'
-  | 'READY'
-  | 'MERGED';
+export type { WorkspaceCiObservation, WorkspaceFlowPhase } from '@/shared/workspace-flow-state';
 
 export interface WorkspaceFlowStateInput {
   prUrl: string | null;
@@ -23,14 +18,6 @@ export type WorkspaceFlowStateSource = Pick<
   WorkspaceFlowStateInput,
   'prUrl' | 'prState' | 'prCiStatus' | 'prUpdatedAt' | 'ratchetEnabled' | 'ratchetState'
 >;
-
-export type WorkspaceCiObservation =
-  | 'NOT_FETCHED'
-  | 'NO_CHECKS'
-  | 'CHECKS_PENDING'
-  | 'CHECKS_FAILED'
-  | 'CHECKS_PASSED'
-  | 'CHECKS_UNKNOWN';
 
 export interface WorkspaceFlowState {
   phase: WorkspaceFlowPhase;

--- a/src/backend/services/workspace-snapshot-store.service.ts
+++ b/src/backend/services/workspace-snapshot-store.service.ts
@@ -22,6 +22,8 @@ import type {
   RunScriptStatus,
   WorkspaceStatus,
 } from '@/shared/core';
+import type { SessionSummary } from '@/shared/session-runtime';
+import type { WorkspaceCiObservation, WorkspaceFlowPhase } from '@/shared/workspace-flow-state';
 import type { WorkspaceSidebarStatus } from '@/shared/workspace-sidebar-status';
 import { createLogger } from './logger.service';
 
@@ -41,32 +43,6 @@ export type SnapshotFieldGroup =
   | 'ratchet'
   | 'runScript'
   | 'reconciliation';
-
-/**
- * Flow phase derived from PR + ratchet state.
- * Duplicated from workspace domain to maintain ARCH-02 compliance (no domain imports).
- */
-export type WorkspaceFlowPhase =
-  | 'NO_PR'
-  | 'CI_WAIT'
-  | 'RATCHET_VERIFY'
-  | 'RATCHET_FIXING'
-  | 'READY'
-  | 'MERGED';
-
-/**
- * CI observation state derived from PR CI status.
- * Duplicated from workspace domain to maintain ARCH-02 compliance (no domain imports).
- */
-export type WorkspaceCiObservation =
-  | 'NOT_FETCHED'
-  | 'NO_CHECKS'
-  | 'CHECKS_PENDING'
-  | 'CHECKS_FAILED'
-  | 'CHECKS_PASSED'
-  | 'CHECKS_UNKNOWN';
-
-import type { SessionSummary } from '@/shared/session-runtime';
 export type WorkspaceSessionSummary = SessionSummary;
 
 /**

--- a/src/shared/workspace-flow-state.ts
+++ b/src/shared/workspace-flow-state.ts
@@ -1,0 +1,15 @@
+export type WorkspaceFlowPhase =
+  | 'NO_PR'
+  | 'CI_WAIT'
+  | 'RATCHET_VERIFY'
+  | 'RATCHET_FIXING'
+  | 'READY'
+  | 'MERGED';
+
+export type WorkspaceCiObservation =
+  | 'NOT_FETCHED'
+  | 'NO_CHECKS'
+  | 'CHECKS_PENDING'
+  | 'CHECKS_FAILED'
+  | 'CHECKS_PASSED'
+  | 'CHECKS_UNKNOWN';


### PR DESCRIPTION
## Summary
- extract `WorkspaceFlowPhase` and `WorkspaceCiObservation` into `src/shared/workspace-flow-state.ts`
- update `src/backend/domains/workspace/state/flow-state.ts` to import and re-export these shared types
- update `src/backend/services/workspace-snapshot-store.service.ts` to import the shared types and remove duplicate local definitions
- keep `ARCH-02` layering intact (`services` still does not import from `@/backend/domains/*`) while eliminating type-drift risk

## Validation
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only refactor that centralizes union definitions without changing runtime logic; risk is limited to potential TS import/export or build path issues.
> 
> **Overview**
> Extracts `WorkspaceFlowPhase` and `WorkspaceCiObservation` into new shared module `src/shared/workspace-flow-state.ts` to avoid type drift.
> 
> Updates workspace flow derivation (`flow-state.ts`) to import and re-export these types, and updates `workspace-snapshot-store.service.ts` to consume the shared types while removing its local duplicate definitions (preserving ARCH-02 layering by importing from `@/shared/*`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit acb77d032921d1277e24ee4895c186875e6ff0d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->