### PR TITLE
Fix interceptor interval leaks with explicit lifecycle hooks

### DIFF
--- a/src/backend/interceptors/index.ts
+++ b/src/backend/interceptors/index.ts
@@ -23,5 +23,19 @@ export function registerInterceptors(): void {
   interceptorRegistry.register(prDetectionInterceptor);
 }
 
+/**
+ * Start all interceptor lifecycle hooks.
+ */
+export async function startInterceptors(): Promise<void> {
+  await interceptorRegistry.start();
+}
+
+/**
+ * Stop all interceptor lifecycle hooks.
+ */
+export async function stopInterceptors(): Promise<void> {
+  await interceptorRegistry.stop();
+}
+
 export { interceptorRegistry } from './registry';
 export type { InterceptorContext, ToolEvent, ToolInterceptor } from './types';

--- a/src/backend/interceptors/pre-pr-rename.interceptor.test.ts
+++ b/src/backend/interceptors/pre-pr-rename.interceptor.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { InterceptorContext, ToolEvent } from './types';
 
 const mockFindById = vi.fn();
@@ -51,8 +51,13 @@ function createEvent(overrides: Partial<ToolEvent>): ToolEvent {
 }
 
 describe('prePrRenameInterceptor', () => {
+  afterEach(() => {
+    prePrRenameInterceptor.stop?.();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
+    prePrRenameInterceptor.start?.();
     mockFindById.mockResolvedValue({
       id: 'workspace-1',
       name: 'Fix authentication bug',

--- a/src/backend/interceptors/pre-pr-rename.interceptor.ts
+++ b/src/backend/interceptors/pre-pr-rename.interceptor.ts
@@ -163,6 +163,17 @@ export const prePrRenameInterceptor: ToolInterceptor = {
   name: 'pre-pr-rename',
   tools: '*',
 
+  start(): void {
+    // Ensure no stale state leaks across server restarts.
+    renamedWorkspaces.clear();
+    remoteCleanupCandidates.clear();
+  },
+
+  stop(): void {
+    renamedWorkspaces.clear();
+    remoteCleanupCandidates.clear();
+  },
+
   async onToolStart(event: ToolEvent, context: InterceptorContext): Promise<void> {
     let renameCompleted = false;
     try {

--- a/src/backend/interceptors/types.ts
+++ b/src/backend/interceptors/types.ts
@@ -41,6 +41,12 @@ export interface ToolInterceptor {
   /** Tools to intercept: array of tool names or '*' for all tools */
   readonly tools: string[] | '*';
 
+  /** Optional lifecycle hook called during server startup */
+  start?(): void | Promise<void>;
+
+  /** Optional lifecycle hook called during server shutdown */
+  stop?(): void | Promise<void>;
+
   /** Called when a tool starts (before execution) */
   onToolStart?(event: ToolEvent, context: InterceptorContext): Promise<void>;
 

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -23,7 +23,7 @@ import { WebSocketServer } from 'ws';
 import { type AppContext, createAppContext } from './app-context';
 import { prisma } from './db';
 import { reconciliationService } from './domains/ratchet';
-import { registerInterceptors } from './interceptors';
+import { registerInterceptors, startInterceptors, stopInterceptors } from './interceptors';
 import {
   createCorsMiddleware,
   createRequestLoggerMiddleware,
@@ -266,6 +266,7 @@ export function createServer(requestedPort?: number, appContext?: AppContext): S
     logger.info('Starting graceful cleanup');
 
     clearInterval(heartbeatInterval);
+    await stopInterceptors();
 
     // Close WebSocket server
     wss.close();
@@ -330,6 +331,7 @@ export function createServer(requestedPort?: number, appContext?: AppContext): S
 
           sessionFileLogger.cleanupOldLogs();
           acpTraceLogger.cleanupOldLogs();
+          await startInterceptors();
           reconciliationService.startPeriodicCleanup();
           rateLimiter.start();
           schedulerService.start();

--- a/src/backend/server.upgrade.test.ts
+++ b/src/backend/server.upgrade.test.ts
@@ -51,6 +51,8 @@ vi.mock('@/backend/domains/ratchet', async (importOriginal) => {
 
 vi.mock('@/backend/interceptors', () => ({
   registerInterceptors: vi.fn(),
+  startInterceptors: vi.fn(async () => undefined),
+  stopInterceptors: vi.fn(async () => undefined),
 }));
 
 vi.mock('@/backend/trpc/index', () => ({


### PR DESCRIPTION
## Summary
- add optional `start()` / `stop()` lifecycle hooks to `ToolInterceptor`
- extend `InterceptorRegistry` with lifecycle orchestration and duplicate registration guard
- expose `startInterceptors()` / `stopInterceptors()` from the interceptor module
- refactor `conversation-rename.interceptor` to remove module-load `setInterval`, start timer during interceptor startup, and clear it during shutdown
- add lifecycle cleanup in `pre-pr-rename.interceptor` for in-memory state (`renamedWorkspaces`, `remoteCleanupCandidates`)
- wire interceptor lifecycle into server startup and graceful shutdown

## Why
Two interceptors were creating background timers/state at module load time without shutdown cleanup. This caused leaked intervals, unclean shutdown behavior, and test-level `setInterval` stubbing workarounds.

## Testing
- `pnpm test src/backend/interceptors/conversation-rename.interceptor.test.ts src/backend/interceptors/pre-pr-rename.interceptor.test.ts src/backend/server.upgrade.test.ts`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches server startup/shutdown sequencing and interceptor registration/lifecycle, so mis-ordering could leave interceptors inactive or leaking, but changes are contained and guarded (idempotent start/stop, error logging).
> 
> **Overview**
> Adds optional `start()`/`stop()` lifecycle hooks to `ToolInterceptor` and extends `InterceptorRegistry` to orchestrate these hooks (including a duplicate-registration guard and auto-start for interceptors registered after startup).
> 
> Refactors `conversationRenameInterceptor` to create/clear its cleanup `setInterval` only during lifecycle hooks (and to clear in-memory session state on stop), adds state-reset lifecycle hooks to `prePrRenameInterceptor`, and wires `startInterceptors()`/`stopInterceptors()` into `server.ts` startup and graceful shutdown. Tests are updated to assert lifecycle behavior and remove interval stubbing workarounds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08adbe70e865959c67d14824c54e05837ad0788b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->