### PR TITLE
Refactor workspace init startup script flow into pipeline

### DIFF
--- a/src/backend/orchestration/workspace-init-script-pipeline.ts
+++ b/src/backend/orchestration/workspace-init-script-pipeline.ts
@@ -1,0 +1,119 @@
+import { startupScriptService } from '@/backend/domains/run-script';
+import { sessionService } from '@/backend/domains/session';
+import type { FactoryConfigService } from '@/backend/services/factory-config.service';
+import { createLogger } from '@/backend/services/logger.service';
+import type { WorkspaceWithProject } from './types';
+
+const logger = createLogger('workspace-init-script-pipeline');
+
+export type StartupScriptPhase = 'factory_setup' | 'project_startup';
+
+export interface StartupScriptPipelineResult {
+  handled: boolean;
+  phase: StartupScriptPhase | null;
+  success: boolean;
+}
+
+interface StartupScriptPipelineContext {
+  workspaceId: string;
+  workspaceWithProject: WorkspaceWithProject;
+  worktreePath: string;
+  factoryConfig: Awaited<ReturnType<typeof FactoryConfigService.readConfig>>;
+  getWorkspaceInitErrorMessage: () => Promise<string | null | undefined>;
+}
+
+interface StartupScriptPhaseDefinition {
+  phase: StartupScriptPhase;
+  shouldRun: (context: StartupScriptPipelineContext) => boolean;
+  buildProjectConfig: (
+    context: StartupScriptPipelineContext
+  ) => StartupScriptPipelineContext['workspaceWithProject']['project'];
+  logStart: (context: StartupScriptPipelineContext) => void;
+  scriptFailedLogMessage: string;
+  cleanupFailedLogMessage: string;
+}
+
+const scriptPhaseDefinitions: StartupScriptPhaseDefinition[] = [
+  {
+    phase: 'factory_setup',
+    shouldRun: (context) => !!context.factoryConfig?.scripts.setup,
+    buildProjectConfig: (context) => ({
+      ...context.workspaceWithProject.project,
+      startupScriptCommand: context.factoryConfig?.scripts.setup ?? null,
+      startupScriptPath: null,
+    }),
+    logStart: (context) => {
+      logger.info('Running setup script from factory-factory.json', {
+        workspaceId: context.workspaceId,
+      });
+    },
+    scriptFailedLogMessage: 'Setup script from factory-factory.json failed but workspace created',
+    cleanupFailedLogMessage: 'Failed to stop Claude sessions after setup script failure',
+  },
+  {
+    phase: 'project_startup',
+    shouldRun: (context) =>
+      startupScriptService.hasStartupScript(context.workspaceWithProject.project),
+    buildProjectConfig: (context) => context.workspaceWithProject.project,
+    logStart: (context) => {
+      const project = context.workspaceWithProject.project;
+      logger.info('Running startup script for workspace', {
+        workspaceId: context.workspaceId,
+        hasCommand: !!project.startupScriptCommand,
+        hasScriptPath: !!project.startupScriptPath,
+      });
+    },
+    scriptFailedLogMessage: 'Startup script failed but workspace created',
+    cleanupFailedLogMessage: 'Failed to stop Claude sessions after startup script failure',
+  },
+];
+
+async function runScriptPhase(
+  context: StartupScriptPipelineContext,
+  phaseDefinition: StartupScriptPhaseDefinition
+): Promise<StartupScriptPipelineResult | null> {
+  if (!phaseDefinition.shouldRun(context)) {
+    return null;
+  }
+
+  phaseDefinition.logStart(context);
+  const scriptResult = await startupScriptService.runStartupScript(
+    { ...context.workspaceWithProject, worktreePath: context.worktreePath },
+    phaseDefinition.buildProjectConfig(context)
+  );
+
+  if (!scriptResult.success) {
+    const workspaceInitErrorMessage = await context.getWorkspaceInitErrorMessage();
+    logger.warn(phaseDefinition.scriptFailedLogMessage, {
+      workspaceId: context.workspaceId,
+      error: workspaceInitErrorMessage,
+    });
+    try {
+      await sessionService.stopWorkspaceSessions(context.workspaceId);
+    } catch (error) {
+      logger.warn(phaseDefinition.cleanupFailedLogMessage, {
+        workspaceId: context.workspaceId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return {
+    handled: true,
+    phase: phaseDefinition.phase,
+    success: scriptResult.success,
+  };
+}
+
+export async function executeStartupScriptPipeline(
+  context: StartupScriptPipelineContext
+): Promise<StartupScriptPipelineResult> {
+  for (const phaseDefinition of scriptPhaseDefinitions) {
+    const phaseResult = await runScriptPhase(context, phaseDefinition);
+    if (phaseResult) {
+      return phaseResult;
+    }
+  }
+
+  return { handled: false, phase: null, success: true };
+}


### PR DESCRIPTION
## Summary
- extract workspace-init startup script execution into a dedicated orchestration pipeline module
- flatten `initializeWorkspaceWorktree` script handling to a single pipeline step with unchanged behavior
- add regression coverage for the eager session settlement ordering before failure cleanup

## Changes
- **Orchestration pipeline**: Added `workspace-init-script-pipeline.ts` with composable phase execution (`factory_setup`, `project_startup`) and a shared pipeline result type.
- **Workspace init flow**: Replaced duplicated script branches in `workspace-init.orchestrator.ts` with one call to `executeStartupScriptPipeline`, preserving script priority and ready/failure behavior.
- **Race-safety regression test**: Added a deferred-promise test proving `agentSessionPromise` settles before failure cleanup calls `stopWorkspaceSessions`.

## Testing
- [x] `pnpm test src/backend/orchestration/workspace-init.orchestrator.test.ts`
- [x] `pnpm test src/backend/orchestration/workspace-init.orchestrator.test.ts src/backend/domains/workspace/worktree/worktree-init.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors workspace initialization control flow around startup script execution and session cleanup, which could subtly change when/which scripts run or when sessions are stopped if edge cases are missed. Added regression coverage reduces risk but this still touches orchestration and failure paths.
> 
> **Overview**
> Refactors workspace initialization startup-script handling into a new `executeStartupScriptPipeline` with two ordered phases (*factory setup* from `factory-factory.json`, then *project startup*), consolidating the shared logging/cleanup behavior and returning a single `{handled, phase, success}` result.
> 
> `initializeWorkspaceWorktree` now delegates all startup-script decisions to this pipeline (removing the duplicated per-script branches) while preserving script priority and session-stop-on-script-failure behavior.
> 
> Adds a regression test that forces an in-flight eager `startSession()` to resolve before failure cleanup runs, ensuring `stopWorkspaceSessions()` doesn’t race a late session start.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e614dbbec58d971fff53ee625b6ecc6d043fb13. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->