### PR TITLE
Wire ACP context compaction events to chat state

### DIFF
--- a/src/components/chat/reducer/types.ts
+++ b/src/components/chat/reducer/types.ts
@@ -188,7 +188,7 @@ export interface ChatState {
   pendingMessages: Map<string, PendingMessageContent>;
   /** Last rejected message for recovery (allows restoring to input) */
   lastRejectedMessage: RejectedMessageInfo | null;
-  /** Whether context compaction is in progress (placeholder for future SDK support) */
+  /** Whether context compaction is in progress */
   isCompacting: boolean;
   /** Tool progress tracking for long-running tools - Map from tool_use_id to progress info */
   toolProgress: Map<string, ToolProgressInfo>;


### PR DESCRIPTION
## Summary
- Wire ACP `context_compaction` session updates through `AcpEventTranslator`.
- Emit existing chat delta events (`compacting_start` / `compacting_end`) so frontend `isCompacting` state toggles and the compacting indicator can render.
- Add forward-compatible payload parsing for common boolean/string/nested compaction shapes, with warning logs for unknown shapes.
- Add translator tests covering start, end, nested payloads, and unknown payload handling.
- Remove stale placeholder wording on `isCompacting` in chat reducer state types.

## Testing
- `pnpm vitest run src/backend/domains/session/acp/acp-event-translator.test.ts`
- `pnpm exec biome check src/backend/domains/session/acp/acp-event-translator.ts src/backend/domains/session/acp/acp-event-translator.test.ts src/components/chat/reducer/types.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive translation logic with guarded parsing and tests; main risk is misinterpreting unexpected payload shapes and toggling `isCompacting` incorrectly.
> 
> **Overview**
> Wires ACP `context_compaction` `SessionUpdate`s through `AcpEventTranslator`, emitting existing chat delta events (`compacting_start` / `compacting_end`) to drive the frontend `isCompacting` indicator.
> 
> Adds forward-compatible parsing to infer active/inactive compaction from multiple boolean/string fields and optional nested payload objects, and logs a warning + drops the event when the shape is unrecognized. Includes new translator tests for start/end, nested payload handling, and unknown-shape warnings, and removes the stale “placeholder” wording on `ChatState.isCompacting`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8686e08913d46bdb736a44a7fa6b745b5837103. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->