### PR TITLE
Validate env vars via ConfigEnvSchema and configService

### DIFF
--- a/src/backend/app-context.ts
+++ b/src/backend/app-context.ts
@@ -70,6 +70,9 @@ const defaultRunScriptService = createRunScriptService({
 
 export function createServices(overrides: Partial<AppServices> = {}): AppServices {
   const resolvedAcpRuntimeManager = overrides.acpRuntimeManager ?? acpRuntimeManager;
+  if (typeof resolvedAcpRuntimeManager.setAcpStartupTimeoutMs === 'function') {
+    resolvedAcpRuntimeManager.setAcpStartupTimeoutMs(configService.getAcpStartupTimeoutMs());
+  }
   const resolvedSessionDomainService = overrides.sessionDomainService ?? sessionDomainService;
   const resolvedSessionService =
     overrides.sessionService ??

--- a/src/backend/domains/session/acp/acp-runtime-manager.test.ts
+++ b/src/backend/domains/session/acp/acp-runtime-manager.test.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'node:events';
 import { tmpdir } from 'node:os';
 import { PassThrough } from 'node:stream';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ---- Hoisted mock state (shared between factory and tests) ----
 
@@ -192,19 +192,9 @@ function setupSuccessfulSpawn() {
 
 describe('AcpRuntimeManager', () => {
   let manager: AcpRuntimeManager;
-  let originalAcpStartupTimeout: string | undefined;
 
   beforeEach(() => {
     manager = new AcpRuntimeManager();
-    originalAcpStartupTimeout = process.env.ACP_STARTUP_TIMEOUT_MS;
-  });
-
-  afterEach(() => {
-    if (typeof originalAcpStartupTimeout === 'string') {
-      process.env.ACP_STARTUP_TIMEOUT_MS = originalAcpStartupTimeout;
-      return;
-    }
-    Reflect.deleteProperty(process.env, 'ACP_STARTUP_TIMEOUT_MS');
   });
 
   describe('getOrCreateClient', () => {
@@ -381,7 +371,7 @@ describe('AcpRuntimeManager', () => {
     });
 
     it('times out when ACP initialize handshake never resolves', async () => {
-      process.env.ACP_STARTUP_TIMEOUT_MS = '20';
+      manager.setAcpStartupTimeoutMs(20);
 
       const child = createMockChildProcess();
       mockSpawn.mockReturnValue(child);
@@ -406,7 +396,7 @@ describe('AcpRuntimeManager', () => {
     });
 
     it('times out when ACP session creation never resolves', async () => {
-      process.env.ACP_STARTUP_TIMEOUT_MS = '20';
+      manager.setAcpStartupTimeoutMs(20);
 
       const child = createMockChildProcess();
       mockSpawn.mockReturnValue(child);

--- a/src/backend/domains/session/data/claude-session-history-loader.service.test.ts
+++ b/src/backend/domains/session/data/claude-session-history-loader.service.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { configService } from '@/backend/services/config.service';
 import { claudeSessionHistoryLoaderService } from './claude-session-history-loader.service';
 
 function encodeProjectPath(cwd: string): string {
@@ -40,14 +41,16 @@ describe('claudeSessionHistoryLoaderService', () => {
     tempDir = mkdtempSync(join(tmpdir(), 'ff-claude-history-'));
     originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
     process.env.CLAUDE_CONFIG_DIR = tempDir;
+    configService.reload();
   });
 
   afterEach(() => {
     if (typeof originalClaudeConfigDir === 'string') {
       process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
     } else {
-      process.env.CLAUDE_CONFIG_DIR = undefined;
+      Reflect.deleteProperty(process.env, 'CLAUDE_CONFIG_DIR');
     }
+    configService.reload();
     rmSync(tempDir, { recursive: true, force: true });
   });
 

--- a/src/backend/domains/session/data/claude-session-history-loader.service.ts
+++ b/src/backend/domains/session/data/claude-session-history-loader.service.ts
@@ -1,8 +1,8 @@
 import { access, readdir, stat } from 'node:fs/promises';
-import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { z } from 'zod';
 import { summarizeZodIssues } from '@/backend/domains/session/zod-issue-summary';
+import { configService } from '@/backend/services/config.service';
 import { createLogger } from '@/backend/services/logger.service';
 import type { HistoryMessage, ToolResultContentValue } from '@/shared/acp-protocol';
 import { readNonEmptyJsonlLines } from './session-history-jsonl-reader';
@@ -51,7 +51,7 @@ export type ClaudeSessionHistoryLoadResult =
   | { status: 'error'; reason: 'read_failed'; filePath: string };
 
 function getClaudeConfigDir(): string {
-  return process.env.CLAUDE_CONFIG_DIR ?? join(homedir(), '.claude');
+  return configService.getClaudeConfigDir();
 }
 
 function encodeProjectPath(cwd: string): string {

--- a/src/backend/domains/session/logging/acp-trace-logger.service.ts
+++ b/src/backend/domains/session/logging/acp-trace-logger.service.ts
@@ -36,17 +36,6 @@ interface AcpTraceEntry {
   payload: unknown;
 }
 
-function shouldEnableAcpTraceLogging(): boolean {
-  const raw = process.env.ACP_TRACE_LOGS_ENABLED;
-  if (raw === 'true') {
-    return true;
-  }
-  if (raw === 'false') {
-    return false;
-  }
-  return process.env.NODE_ENV === 'development';
-}
-
 function safeSessionId(sessionId: string): string {
   return sessionId.replace(/[^a-zA-Z0-9-]/g, '_');
 }
@@ -71,9 +60,8 @@ export class AcpTraceLogger {
   private readonly sessionLogs = new Map<string, AcpTraceState>();
 
   constructor() {
-    this.enabled = shouldEnableAcpTraceLogging();
-    this.logDir =
-      process.env.ACP_TRACE_LOGS_PATH ?? join(configService.getDebugLogDir(), 'acp-events');
+    this.enabled = configService.isAcpTraceLoggingEnabled();
+    this.logDir = configService.getAcpTraceLogsPath();
 
     if (this.enabled && !existsSync(this.logDir)) {
       mkdirSync(this.logDir, { recursive: true });

--- a/src/backend/domains/session/logging/session-file-logger.service.test.ts
+++ b/src/backend/domains/session/logging/session-file-logger.service.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // Hoist the mock functions so they're available before the mock is evaluated
 const mockGetWsLogsPath = vi.hoisted(() => vi.fn());
 const mockIsDevelopment = vi.hoisted(() => vi.fn());
+const mockIsWsLogsEnabled = vi.hoisted(() => vi.fn());
 const mockCreateWriteStream = vi.hoisted(() => vi.fn());
 
 // Mock config service before importing the service
@@ -11,6 +12,7 @@ vi.mock('@/backend/services/config.service', () => ({
   configService: {
     getWsLogsPath: mockGetWsLogsPath,
     isDevelopment: mockIsDevelopment,
+    isWsLogsEnabled: mockIsWsLogsEnabled,
   },
 }));
 
@@ -69,6 +71,7 @@ describe('SessionFileLogger', () => {
 
     // Default config mock - enable in tests (dev mode)
     mockIsDevelopment.mockReturnValue(true);
+    mockIsWsLogsEnabled.mockReturnValue(false);
     mockGetWsLogsPath.mockReturnValue(defaultWsLogsPath);
 
     // Create fresh mock stream

--- a/src/backend/domains/session/logging/session-file-logger.service.ts
+++ b/src/backend/domains/session/logging/session-file-logger.service.ts
@@ -134,7 +134,7 @@ export class SessionFileLogger {
 
   constructor() {
     // Default: only enabled in development unless explicitly overridden
-    this.enabled = configService.isDevelopment() || process.env.WS_LOGS_ENABLED === 'true';
+    this.enabled = configService.isDevelopment() || configService.isWsLogsEnabled();
     // Get from config service (which uses WS_LOGS_PATH env var or falls back to .context/ws-logs in cwd)
     // For Electron, this will be in userData directory
     this.logDir = configService.getWsLogsPath();

--- a/src/backend/domains/session/store/file-lock.service.test.ts
+++ b/src/backend/domains/session/store/file-lock.service.test.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { configService } from '@/backend/services/config.service';
 
 // Mock dependencies before importing the service
 const mockFindById = vi.fn();
@@ -785,6 +786,7 @@ describe('FileLockService', () => {
       restoreEnv('pm_id', originalPmId);
       restoreEnv('NODE_APP_INSTANCE', originalNodeAppInstance);
       restoreEnv('WEB_CONCURRENCY', originalWebConcurrency);
+      configService.reload();
     });
 
     it('warns when cluster-like runtime is detected', async () => {
@@ -806,6 +808,7 @@ describe('FileLockService', () => {
       Reflect.deleteProperty(process.env, 'pm_id');
       Reflect.deleteProperty(process.env, 'NODE_APP_INSTANCE');
       process.env.WEB_CONCURRENCY = '1';
+      configService.reload();
 
       mockLoggerWarn.mockClear();
       const service = new FileLockService();

--- a/src/backend/domains/session/store/file-lock.service.ts
+++ b/src/backend/domains/session/store/file-lock.service.ts
@@ -21,6 +21,7 @@ import * as path from 'node:path';
 import { summarizeZodIssues } from '@/backend/domains/session/zod-issue-summary';
 import { writeFileAtomic } from '@/backend/lib/atomic-file';
 import { agentSessionAccessor } from '@/backend/resource_accessors/agent-session.accessor';
+import { configService } from '@/backend/services/config.service';
 import { SERVICE_INTERVAL_MS, SERVICE_TTL_SECONDS } from '@/backend/services/constants';
 import { createLogger } from '@/backend/services/logger.service';
 import type { PersistedLockStore } from '@/shared/schemas/persisted-stores.schema';
@@ -155,11 +156,7 @@ export class FileLockService {
     const pmId = this.readEnvSignal('pm_id');
     const nodeAppInstance = this.readEnvSignal('NODE_APP_INSTANCE');
 
-    const webConcurrencyRaw = process.env.WEB_CONCURRENCY;
-    const webConcurrency =
-      webConcurrencyRaw && Number.isFinite(Number(webConcurrencyRaw))
-        ? Number(webConcurrencyRaw)
-        : undefined;
+    const webConcurrency = configService.getWebConcurrency();
 
     const isLikelyMultiProcess =
       nodeUniqueId !== undefined ||

--- a/src/backend/services/env-schemas.ts
+++ b/src/backend/services/env-schemas.ts
@@ -28,6 +28,16 @@ function parseBoolean(value: unknown): boolean | undefined {
   return undefined;
 }
 
+function parseOneZeroBoolean(value: unknown): boolean | undefined {
+  if (value === '1' || value === 1) {
+    return true;
+  }
+  if (value === '0' || value === 0) {
+    return false;
+  }
+  return undefined;
+}
+
 function toTrimmedString(value: unknown): string | undefined {
   if (typeof value !== 'string') {
     return undefined;
@@ -58,6 +68,16 @@ export const ConfigEnvSchema = z.object({
   DEFAULT_PERMISSIONS: z.preprocess(toLowerString, PermissionModeSchema).catch('yolo'),
   LOG_LEVEL: z.preprocess(toLowerString, LogLevelSchema).catch('info'),
   SERVICE_NAME: z.preprocess(toTrimmedString, z.string().min(1)).catch('factoryfactory'),
+  ACP_STARTUP_TIMEOUT_MS: PositiveIntEnvSchema.catch(30_000),
+  ACP_TRACE_LOGS_ENABLED: z.preprocess(parseBoolean, z.boolean()).optional().catch(undefined),
+  ACP_TRACE_LOGS_PATH: z.preprocess(toTrimmedString, z.string()).optional().catch(undefined),
+  WS_LOGS_ENABLED: z.preprocess(parseBoolean, z.boolean()).catch(false),
+  WEB_CONCURRENCY: z
+    .preprocess(parseInteger, z.number().int().nonnegative())
+    .optional()
+    .catch(undefined),
+  FF_RUN_SCRIPT_PROXY_ENABLED: z.preprocess(parseOneZeroBoolean, z.boolean()).catch(false),
+  CLAUDE_CONFIG_DIR: z.preprocess(toTrimmedString, z.string()).optional().catch(undefined),
   CLAUDE_RATE_LIMIT_PER_MINUTE: PositiveIntEnvSchema.catch(60),
   CLAUDE_RATE_LIMIT_PER_HOUR: PositiveIntEnvSchema.catch(1000),
   RATE_LIMIT_QUEUE_SIZE: PositiveIntEnvSchema.catch(100),

--- a/src/backend/services/run-script-proxy.service.test.ts
+++ b/src/backend/services/run-script-proxy.service.test.ts
@@ -1,5 +1,6 @@
 import type { ChildProcess } from 'node:child_process';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { configService } from './config.service';
 
 const mockStartCloudflaredTunnel = vi.hoisted(() => vi.fn());
 const mockKillProcessWithTimeout = vi.hoisted(() => vi.fn(async () => undefined));
@@ -59,6 +60,7 @@ describe('RunScriptProxyService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.env.FF_RUN_SCRIPT_PROXY_ENABLED = '1';
+    configService.reload();
     mockStartCloudflaredTunnel.mockResolvedValue({
       publicUrl: 'https://abc.trycloudflare.com',
       proc: createChildProcess(),
@@ -67,10 +69,12 @@ describe('RunScriptProxyService', () => {
 
   afterEach(() => {
     process.env.FF_RUN_SCRIPT_PROXY_ENABLED = originalProxyEnv;
+    configService.reload();
   });
 
   it('returns null when proxy feature is disabled', async () => {
     process.env.FF_RUN_SCRIPT_PROXY_ENABLED = '0';
+    configService.reload();
     const service = new RunScriptProxyService();
 
     await expect(service.ensureTunnel('w1', 3000)).resolves.toBeNull();

--- a/src/backend/services/run-script-proxy.service.ts
+++ b/src/backend/services/run-script-proxy.service.ts
@@ -11,6 +11,7 @@ import {
   proxyAuthenticatedWebSocketUpgrade,
   startCloudflaredTunnel,
 } from '@/shared/proxy-utils';
+import { configService } from './config.service';
 import { createLogger } from './logger.service';
 
 const logger = createLogger('run-script-proxy-service');
@@ -150,7 +151,7 @@ export class RunScriptProxyService {
   private cloudflaredUnavailable = false;
 
   private isEnabled(): boolean {
-    return process.env.FF_RUN_SCRIPT_PROXY_ENABLED === '1';
+    return configService.isRunScriptProxyEnabled();
   }
 
   getTunnelUrl(workspaceId: string): string | null {


### PR DESCRIPTION
## Summary
- Added missing environment variables to `ConfigEnvSchema` so they are validated and discoverable at startup.
- Extended `configService` with typed fields/getters for ACP startup timeout, ACP trace logging config, WS logging enablement, `WEB_CONCURRENCY`, run-script proxy enablement, and Claude config directory.
- Replaced direct `process.env` reads in session/runtime services with `configService` lookups for:
  - `ACP_TRACE_LOGS_ENABLED`, `ACP_TRACE_LOGS_PATH`
  - `WS_LOGS_ENABLED`
  - `WEB_CONCURRENCY`
  - `FF_RUN_SCRIPT_PROXY_ENABLED`
  - `CLAUDE_CONFIG_DIR`
- Kept ACP module boundaries intact by wiring `ACP_STARTUP_TIMEOUT_MS` from `configService` in `app-context` into `AcpRuntimeManager` via `setAcpStartupTimeoutMs(...)`.
- Updated affected tests to reload config after env changes or mock new config getters.

## Testing
- `pnpm test src/backend/domains/session/acp/acp-runtime-manager.test.ts src/backend/domains/session/logging/acp-trace-logger.service.test.ts src/backend/domains/session/logging/session-file-logger.service.test.ts src/backend/domains/session/store/file-lock.service.test.ts src/backend/services/run-script-proxy.service.test.ts src/backend/domains/session/data/claude-session-history-loader.service.test.ts`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches startup timeout and logging/feature-flag gating across several runtime services; behavior now depends on config parsing/reload correctness rather than direct env reads.
> 
> **Overview**
> Moves multiple runtime settings from ad-hoc `process.env` reads to validated, typed configuration via `ConfigEnvSchema` and new `configService` getters (ACP startup timeout, ACP trace logging enable/path, WS log enablement, `WEB_CONCURRENCY`, run-script proxy flag, and Claude config dir).
> 
> Updates ACP/session components to consume these getters: `AcpRuntimeManager` now has a configurable startup timeout (wired in `app-context`), trace/file logging use `configService` for enablement/paths, file-lock multi-process detection uses parsed `WEB_CONCURRENCY`, and run-script proxy enablement is gated via config. Tests are adjusted to reload config after env mutations and to mock new getters where needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a26b54ccfe0fab7c79b01441af0093343ff8da2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->