### PR TITLE
Fix #1253: unify stateComputedAt semantics in snapshot sync

### DIFF
--- a/src/backend/domains/workspace/query/workspace-query.service.ts
+++ b/src/backend/domains/workspace/query/workspace-query.service.ts
@@ -202,6 +202,7 @@ class WorkspaceQueryService {
           ciObservation: flowState?.ciObservation ?? 'CHECKS_UNKNOWN',
           runScriptStatus: w.runScriptStatus,
           cachedKanbanColumn: kanbanColumn,
+          // DB timestamp for last cached kanban-state recompute/change.
           stateComputedAt: w.stateComputedAt?.toISOString() ?? null,
           pendingRequestType: pendingRequestByWorkspace.get(w.id) ?? null,
         };

--- a/src/client/components/use-workspace-list-state.ts
+++ b/src/client/components/use-workspace-list-state.ts
@@ -34,7 +34,13 @@ export interface ServerWorkspace {
   ciObservation?: string | null;
   runScriptStatus?: RunScriptStatus | null;
   cachedKanbanColumn?: string | null;
+  /**
+   * Timestamp (from DB) when cached kanban state was last recomputed due to a
+   * column change. This is not the snapshot transport timestamp.
+   */
   stateComputedAt?: string | null;
+  /** Timestamp for the latest snapshot message applied in client cache. */
+  snapshotComputedAt?: string | null;
   sidebarStatus?: WorkspaceSidebarStatus;
   pendingRequestType?: 'plan_approval' | 'user_question' | 'permission_request' | null;
   githubIssueNumber?: number | null;

--- a/src/client/hooks/use-project-snapshot-sync.ts
+++ b/src/client/hooks/use-project-snapshot-sync.ts
@@ -39,6 +39,9 @@ type WorkspaceDetailCache = Record<string, unknown> | undefined;
 type PendingRequestType = 'plan_approval' | 'user_question' | 'permission_request' | null;
 type TrpcUtils = ReturnType<typeof trpc.useUtils>;
 
+// NOTE: `stateComputedAt` is DB-backed kanban-state timing and is preserved by
+// snapshot mappers; snapshot transport recency uses `snapshotComputedAt`.
+
 // =============================================================================
 // Kanban cache update helpers (extracted to keep handleMessage under complexity limit)
 // =============================================================================

--- a/src/client/lib/snapshot-to-kanban.test.ts
+++ b/src/client/lib/snapshot-to-kanban.test.ts
@@ -84,6 +84,7 @@ describe('mapSnapshotEntryToKanbanWorkspace', () => {
     expect(result.ratchetButtonAnimated).toBe(false);
     expect(result.flowPhase).toBe('CI_WAIT');
     expect(result.pendingRequestType).toBe('plan_approval');
+    expect(result.snapshotComputedAt).toBe(entry.computedAt);
     expect(result.sessionSummaries).toEqual([]);
   });
 
@@ -99,12 +100,14 @@ describe('mapSnapshotEntryToKanbanWorkspace', () => {
       description: 'A workspace for testing',
       initErrorMessage: 'Some init error',
       githubIssueNumber: 99,
+      stateComputedAt: '2026-01-12T00:00:00Z',
     };
     const result = mapSnapshotEntryToKanbanWorkspace(entry, existing);
 
     expect(result.description).toBe('A workspace for testing');
     expect(result.initErrorMessage).toBe('Some init error');
     expect(result.githubIssueNumber).toBe(99);
+    expect(result.stateComputedAt).toBe('2026-01-12T00:00:00Z');
   });
 
   it('defaults missing-from-snapshot fields to null when no existing entry', () => {
@@ -114,6 +117,7 @@ describe('mapSnapshotEntryToKanbanWorkspace', () => {
     expect(result.description).toBeNull();
     expect(result.initErrorMessage).toBeNull();
     expect(result.githubIssueNumber).toBeNull();
+    expect(result.stateComputedAt).toBeNull();
   });
 
   it('defaults missing-from-snapshot fields to null when existing entry lacks them', () => {
@@ -124,6 +128,7 @@ describe('mapSnapshotEntryToKanbanWorkspace', () => {
     expect(result.description).toBeNull();
     expect(result.initErrorMessage).toBeNull();
     expect(result.githubIssueNumber).toBeNull();
+    expect(result.stateComputedAt).toBeNull();
   });
 
   it('always sets isArchived to false', () => {

--- a/src/client/lib/snapshot-to-kanban.ts
+++ b/src/client/lib/snapshot-to-kanban.ts
@@ -19,7 +19,8 @@ import type { WorkspaceSnapshotEntry } from '@/client/lib/snapshot-to-sidebar';
 /**
  * Maps a WorkspaceSnapshotEntry to the kanban workspace shape used by the
  * `listWithKanbanState` React Query cache. Merges fields not present in
- * the snapshot from the existing cache entry (or defaults to null).
+ * the snapshot from the existing cache entry (or defaults to null), including
+ * preserving DB-backed `stateComputedAt` semantics.
  */
 export function mapSnapshotEntryToKanbanWorkspace(
   entry: WorkspaceSnapshotEntry,
@@ -46,10 +47,12 @@ export function mapSnapshotEntryToKanbanWorkspace(
     flowPhase: entry.flowPhase,
     pendingRequestType: entry.pendingRequestType,
     isArchived: false,
+    snapshotComputedAt: entry.computedAt,
 
     // Fields NOT in snapshot — merge from existing cache entry or default to null
     description: existing?.description ?? null,
     initErrorMessage: existing?.initErrorMessage ?? null,
     githubIssueNumber: existing?.githubIssueNumber ?? null,
+    stateComputedAt: existing?.stateComputedAt ?? null,
   };
 }

--- a/src/client/lib/snapshot-to-sidebar.test.ts
+++ b/src/client/lib/snapshot-to-sidebar.test.ts
@@ -67,10 +67,25 @@ describe('mapSnapshotEntryToServerWorkspace', () => {
     expect(result.cachedKanbanColumn).toBe('DONE');
   });
 
-  it('maps computedAt to stateComputedAt', () => {
+  it('maps computedAt to snapshotComputedAt', () => {
     const entry = makeEntry({ computedAt: '2026-02-01T12:00:00Z' });
     const result = mapSnapshotEntryToServerWorkspace(entry);
-    expect(result.stateComputedAt).toBe('2026-02-01T12:00:00Z');
+    expect(result.snapshotComputedAt).toBe('2026-02-01T12:00:00Z');
+  });
+
+  it('preserves existing stateComputedAt when applying snapshot data', () => {
+    const entry = makeEntry({ computedAt: '2026-02-01T12:00:00Z' });
+    const result = mapSnapshotEntryToServerWorkspace(entry, {
+      stateComputedAt: '2026-01-20T00:00:00Z',
+    });
+
+    expect(result.stateComputedAt).toBe('2026-01-20T00:00:00Z');
+  });
+
+  it('defaults stateComputedAt to null when existing cache is missing', () => {
+    const entry = makeEntry({ computedAt: '2026-02-01T12:00:00Z' });
+    const result = mapSnapshotEntryToServerWorkspace(entry);
+    expect(result.stateComputedAt).toBeNull();
   });
 
   it('passes through common fields unchanged', () => {


### PR DESCRIPTION
## Summary
- Standardizes `stateComputedAt` semantics as the DB-backed kanban-state recompute/change timestamp.
- Stops snapshot WebSocket mapping from overwriting `stateComputedAt` with snapshot-store `computedAt`.
- Adds `snapshotComputedAt` for snapshot transport recency and preserves existing `stateComputedAt` during cache upserts.

## Changes
- **Sidebar snapshot mapping**: Updated `mapSnapshotEntryToServerWorkspace` to preserve existing `stateComputedAt`, map snapshot recency to `snapshotComputedAt`, and document the semantic split.
- **Kanban snapshot mapping**: Preserves existing `stateComputedAt` and includes `snapshotComputedAt` to avoid dropping/overloading timestamp intent on snapshot updates.
- **Type/docs updates**: Extended `ServerWorkspace` with `snapshotComputedAt` and added semantic comments clarifying intended meanings.
- **Tests**: Added/updated tests for sidebar and kanban mappers plus snapshot sync cache-upsert behavior for both full and delta snapshot messages.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Verify sidebar/kanban state timestamps remain stable across initial load + live snapshot updates

Closes #1253

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how WebSocket snapshot updates map timestamps into React Query caches, which could affect sidebar/kanban ordering or freshness indicators if any UI relied on the old `computedAt`→`stateComputedAt` behavior. Scope is limited to client cache mapping/sync logic and is covered by new tests.
> 
> **Overview**
> **Separates timestamp semantics in snapshot sync.** Snapshot WebSocket updates no longer overwrite `stateComputedAt` (now consistently treated as the DB-backed kanban-state recompute/change timestamp), and instead record snapshot recency in a new `snapshotComputedAt` field.
> 
> This updates both sidebar (`mapSnapshotEntryToServerWorkspace`) and kanban (`mapSnapshotEntryToKanbanWorkspace`) snapshot mappers to preserve existing `stateComputedAt` during cache merges/upserts, adds the new field to the shared `ServerWorkspace` type, and expands snapshot-sync tests to assert the new preservation/assignment behavior for `snapshot_full` and `snapshot_changed` messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45f4f997416291f240988401d12e7163f95d6946. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->