### PR TITLE
Fix #1256: synchronize shared enums and add drift guard

### DIFF
--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -5,4 +5,10 @@ describe('@factory-factory/core', () => {
   it('can be imported', () => {
     expect(core).toBeDefined();
   });
+
+  it('exports IssueProvider', () => {
+    expect(core.IssueProvider).toBeDefined();
+    expect(core.IssueProvider.GITHUB).toBe('GITHUB');
+    expect(core.IssueProvider.LINEAR).toBe('LINEAR');
+  });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,7 @@ export {
 // Types & Enums
 export {
   CIStatus,
+  IssueProvider,
   KanbanColumn,
   PRState,
   RatchetState,

--- a/packages/core/src/types/enums.test.ts
+++ b/packages/core/src/types/enums.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   CIStatus,
+  IssueProvider,
   KanbanColumn,
   PRState,
   RatchetState,
@@ -17,6 +18,7 @@ describe('domain enums', () => {
       'PROVISIONING',
       'READY',
       'FAILED',
+      'ARCHIVING',
       'ARCHIVED',
     ]);
   });
@@ -67,7 +69,12 @@ describe('domain enums', () => {
       'MANUAL',
       'RESUME_BRANCH',
       'GITHUB_ISSUE',
+      'LINEAR_ISSUE',
     ]);
+  });
+
+  it('IssueProvider has all expected values', () => {
+    expect(Object.values(IssueProvider)).toEqual(['GITHUB', 'LINEAR']);
   });
 
   it('RunScriptStatus has all expected values', () => {

--- a/packages/core/src/types/enums.ts
+++ b/packages/core/src/types/enums.ts
@@ -3,6 +3,7 @@ export const WorkspaceStatus = {
   PROVISIONING: 'PROVISIONING',
   READY: 'READY',
   FAILED: 'FAILED',
+  ARCHIVING: 'ARCHIVING',
   ARCHIVED: 'ARCHIVED',
 } as const;
 export type WorkspaceStatus = (typeof WorkspaceStatus)[keyof typeof WorkspaceStatus];
@@ -56,9 +57,16 @@ export const WorkspaceCreationSource = {
   MANUAL: 'MANUAL',
   RESUME_BRANCH: 'RESUME_BRANCH',
   GITHUB_ISSUE: 'GITHUB_ISSUE',
+  LINEAR_ISSUE: 'LINEAR_ISSUE',
 } as const;
 export type WorkspaceCreationSource =
   (typeof WorkspaceCreationSource)[keyof typeof WorkspaceCreationSource];
+
+export const IssueProvider = {
+  GITHUB: 'GITHUB',
+  LINEAR: 'LINEAR',
+} as const;
+export type IssueProvider = (typeof IssueProvider)[keyof typeof IssueProvider];
 
 export const RunScriptStatus = {
   IDLE: 'IDLE',

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,5 +1,6 @@
 export {
   CIStatus,
+  IssueProvider,
   KanbanColumn,
   PRState,
   RatchetState,

--- a/src/shared/core/enums.drift.test.ts
+++ b/src/shared/core/enums.drift.test.ts
@@ -1,0 +1,65 @@
+import {
+  CIStatus as PackageCIStatus,
+  IssueProvider as PackageIssueProvider,
+  KanbanColumn as PackageKanbanColumn,
+  PRState as PackagePRState,
+  RatchetState as PackageRatchetState,
+  RunScriptStatus as PackageRunScriptStatus,
+  SessionStatus as PackageSessionStatus,
+  WorkspaceCreationSource as PackageWorkspaceCreationSource,
+  WorkspaceStatus as PackageWorkspaceStatus,
+} from '@factory-factory/core-types/enums';
+import { describe, expect, it } from 'vitest';
+import {
+  CIStatus,
+  IssueProvider,
+  KanbanColumn,
+  PRState,
+  RatchetState,
+  RunScriptStatus,
+  SessionStatus,
+  WorkspaceCreationSource,
+  WorkspaceStatus,
+} from './enums';
+
+type SharedEnums = {
+  WorkspaceStatus: Record<string, string>;
+  SessionStatus: Record<string, string>;
+  PRState: Record<string, string>;
+  CIStatus: Record<string, string>;
+  KanbanColumn: Record<string, string>;
+  RatchetState: Record<string, string>;
+  WorkspaceCreationSource: Record<string, string>;
+  IssueProvider: Record<string, string>;
+  RunScriptStatus: Record<string, string>;
+};
+
+const appEnums: SharedEnums = {
+  WorkspaceStatus,
+  SessionStatus,
+  PRState,
+  CIStatus,
+  KanbanColumn,
+  RatchetState,
+  WorkspaceCreationSource,
+  IssueProvider,
+  RunScriptStatus,
+};
+
+describe('core enum drift guard', () => {
+  it('keeps app shared core enums synchronized with @factory-factory/core', () => {
+    const packageEnums: SharedEnums = {
+      WorkspaceStatus: PackageWorkspaceStatus,
+      SessionStatus: PackageSessionStatus,
+      PRState: PackagePRState,
+      CIStatus: PackageCIStatus,
+      KanbanColumn: PackageKanbanColumn,
+      RatchetState: PackageRatchetState,
+      WorkspaceCreationSource: PackageWorkspaceCreationSource,
+      IssueProvider: PackageIssueProvider,
+      RunScriptStatus: PackageRunScriptStatus,
+    };
+
+    expect(packageEnums).toEqual(appEnums);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,7 +42,8 @@
     ],
     "paths": {
       "@/*": ["./src/*"],
-      "@prisma-gen/*": ["./prisma/generated/*"]
+      "@prisma-gen/*": ["./prisma/generated/*"],
+      "@factory-factory/core-types/*": ["./packages/core/src/types/*"]
     }
   },
   "include": [

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, './src'),
       '@prisma-gen': path.resolve(__dirname, './prisma/generated'),
+      '@factory-factory/core-types': path.resolve(__dirname, './packages/core/src/types'),
     },
   },
 });


### PR DESCRIPTION
## Summary
- Synchronize `@factory-factory/core` enums with app shared core to remove drift.
- Add a root-level drift guard test that compares app enums against package enums.
- Export `IssueProvider` from package entrypoints and extend enum coverage tests.

## Changes
- **`packages/core/src/types/enums.ts`**: Added missing `WorkspaceStatus.ARCHIVING`, `WorkspaceCreationSource.LINEAR_ISSUE`, and new `IssueProvider` enum.
- **`packages/core` exports**: Re-exported `IssueProvider` from `types/index.ts` and package `index.ts`.
- **Enum tests**: Updated package enum tests and index export test for new enum surface.
- **Drift guard CI test**: Added `src/shared/core/enums.drift.test.ts` to assert definition parity between app and package enums.
- **Test resolver wiring**: Added `@factory-factory/core-types/*` alias in `tsconfig.json` and `vitest.config.ts` for static cross-package enum imports in the drift test.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable (enum/type and test-only changes)

Closes #1256

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds/aligns string enums and tests plus TypeScript/Vitest path aliases; primary risk is minor downstream behavior changes if code assumes the previous enum value sets.
> 
> **Overview**
> Synchronizes shared enum surfaces between the app and `packages/core` by adding missing values (`WorkspaceStatus.ARCHIVING`, `WorkspaceCreationSource.LINEAR_ISSUE`) and introducing a new `IssueProvider` enum.
> 
> Updates package exports and tests to cover `IssueProvider`, and adds a new Vitest drift-guard (`src/shared/core/enums.drift.test.ts`) that asserts app shared enums exactly match the `@factory-factory/core` enum definitions. Adds `@factory-factory/core-types` path/alias wiring in `tsconfig.json` and `vitest.config.ts` to support those cross-package imports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e2d8395c5db73e2f4fe8622b5deb5ab185b9039. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->