### PR TITLE
Ratchet: log workspace check timeouts as warnings

### DIFF
--- a/src/backend/domains/ratchet/ratchet.service.ts
+++ b/src/backend/domains/ratchet/ratchet.service.ts
@@ -257,9 +257,10 @@ class RatchetService extends EventEmitter {
       return await this.withWorkspaceCheckTimeout(workspace, checkPromise);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
-      logger.error('Ratchet workspace check failed', error as Error, {
+      logger.warn('Ratchet workspace check failed', {
         workspaceId: workspace.id,
         prUrl: workspace.prUrl,
+        error: errorMessage,
       });
       return {
         workspaceId: workspace.id,


### PR DESCRIPTION
## Summary
- downgrade ratchet workspace check failure logging from `error` to `warn`
- keep the existing workspace check result behavior unchanged (`action.type = "ERROR"` still returned on failure)
- include the error message in structured log context so timeout details remain visible without error-level noise

## Why
Workspace check timeouts are expected transient failures and should not be surfaced as server errors.

## Validation
- `pnpm test -- src/backend/domains/ratchet/ratchet.service.test.ts`
- pre-commit hooks also ran successfully (`typecheck`, dependency-cruiser, knip)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change that preserves existing error handling/results; minimal functional impact beyond alerting/observability level changes.
> 
> **Overview**
> Downgrades logging for ratchet workspace check failures (including timeouts) from `error` to `warn` and logs the error message as structured context (`error`).
> 
> Workspace check behavior is unchanged: failures still return a `WorkspaceRatchetResult` with `action.type = 'ERROR'` and the same ratchet state preserved.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f78294d1c2c88c5ed45e4ade28c619c80822a60f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->