### PR TITLE
Remove BACKEND_PORT marker from normal startup logs

### DIFF
--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -309,7 +309,7 @@ export function createServer(requestedPort?: number, appContext?: AppContext): S
             port: actualPort,
             environment: configService.getEnvironment(),
           });
-          if (process.env.FF_RUN_SCRIPT_PROXY_ENABLED === '1') {
+          if (configService.isRunScriptProxyEnabled()) {
             process.stdout.write(`BACKEND_PORT:${actualPort}\n`);
           }
 


### PR DESCRIPTION
## Summary
- stop emitting the `BACKEND_PORT:<port>` stdout marker during normal backend startup
- keep emitting the marker only when `FF_RUN_SCRIPT_PROXY_ENABLED=1` (proxy mode)

## Why
`pnpm start` was showing a raw `BACKEND_PORT:3000` line in startup logs. That marker is only needed for proxy startup detection and should not appear in regular server output.

## Changes
- update backend startup in `src/backend/server.ts` to guard the marker behind:
  - `process.env.FF_RUN_SCRIPT_PROXY_ENABLED === '1'`

## Validation
- started backend in normal mode: marker was not printed
- started backend with `FF_RUN_SCRIPT_PROXY_ENABLED=1`: marker still printed (proxy flow preserved)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes startup logging/STDOUT behavior, and only affects the `BACKEND_PORT:<port>` marker emission when not running in proxy mode.
> 
> **Overview**
> Stops emitting the `BACKEND_PORT:<port>` stdout marker during normal backend startup.
> 
> The marker is now written only when `configService.isRunScriptProxyEnabled()` is true, preserving proxy-mode startup detection while keeping regular logs clean.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ba9d5bd2220c07804d391ec59f409303b646103. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->