### PR TITLE
Add stop cleanup to pre-push rename interceptor

### DIFF
--- a/src/backend/interceptors/pre-push-rename.interceptor.ts
+++ b/src/backend/interceptors/pre-push-rename.interceptor.ts
@@ -21,6 +21,10 @@ export const prePushRenameInterceptor: ToolInterceptor = {
   name: 'pre-push-rename',
   tools: '*',
 
+  stop(): void {
+    renamedWorkspaces.clear();
+  },
+
   async onToolStart(event: ToolEvent, context: InterceptorContext): Promise<void> {
     let renameCompleted = false;
     try {


### PR DESCRIPTION
## Summary
- add a `stop()` lifecycle hook to `prePushRenameInterceptor`
- clear module-level `renamedWorkspaces` during interceptor shutdown
- align pre-push interceptor lifecycle cleanup with `pre-pr-rename.interceptor.ts`

## Why
`renamedWorkspaces` was never cleared in the pre-push interceptor, which could accumulate workspace IDs across long-running server processes or repeated restart cycles and block expected re-renames after failures.

## Validation
- `pnpm -s typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk lifecycle change that only clears in-memory interceptor state during shutdown; behavior during tool execution is unchanged aside from avoiding stale workspace IDs in long-running processes.
> 
> **Overview**
> Adds a `stop()` lifecycle hook to `prePushRenameInterceptor` that clears the module-level `renamedWorkspaces` set.
> 
> This prevents stale workspace IDs from persisting across server shutdown/restart cycles and keeps pre-push rename state management consistent with the existing pre-PR rename interceptor.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16b26ec565edc7ae3ff48812cda3d32e3200c0e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->