### PR TITLE
Remove stale Linear state sync integration note

### DIFF
--- a/src/backend/domains/linear/linear-state-sync.service.ts
+++ b/src/backend/domains/linear/linear-state-sync.service.ts
@@ -4,7 +4,6 @@
  * Transitions Linear issue states in response to workspace lifecycle events.
  * Callers provide the decrypted API key — this service is encryption-unaware.
  *
- * Full integration wiring is implemented in Deliverable 5.
  */
 
 import { createLogger } from '@/backend/services/logger.service';


### PR DESCRIPTION
## Summary
- remove outdated doc comment claiming Linear state sync integration is implemented in a future deliverable
- keep `LinearStateSyncService` header aligned with current behavior, where orchestration wiring already exists

## Testing
- no manual tests run (comment-only change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change in a Linear backend service header; no runtime behavior is affected.
> 
> **Overview**
> Removes an outdated doc comment in `linear-state-sync.service.ts` that referenced future deliverable wiring, aligning the header comment with current integration reality.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9e38d2c7d28a171e4a4db75aba7692720e9a067. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->