### PR TITLE
Propagate stopAllClients timeout through SessionService

### DIFF
--- a/src/backend/domains/session/lifecycle/session.service.test.ts
+++ b/src/backend/domains/session/lifecycle/session.service.test.ts
@@ -1420,6 +1420,7 @@ describe('SessionService', () => {
     await sessionService.stopAllClients(4321);
 
     expect(acpRuntimeManager.stopAllClients).toHaveBeenCalledTimes(1);
+    expect(acpRuntimeManager.stopAllClients).toHaveBeenCalledWith(4321);
   });
 
   it('propagates ACP shutdown failure', async () => {
@@ -1428,5 +1429,6 @@ describe('SessionService', () => {
     );
 
     await expect(sessionService.stopAllClients()).rejects.toThrow('acp shutdown failed');
+    expect(acpRuntimeManager.stopAllClients).toHaveBeenCalledWith(5000);
   });
 });

--- a/src/backend/domains/session/lifecycle/session.service.ts
+++ b/src/backend/domains/session/lifecycle/session.service.ts
@@ -1018,12 +1018,12 @@ export class SessionService {
 
   /**
    * Stop all active clients during shutdown.
-   * @param _timeoutMs - Timeout (unused, kept for API compatibility)
+   * @param timeoutMs - Maximum wait time for each client shutdown attempt
    */
-  async stopAllClients(_timeoutMs = 5000): Promise<void> {
+  async stopAllClients(timeoutMs = 5000): Promise<void> {
     this.clearAllScheduledPromptTurnCompletions();
     try {
-      await this.runtimeManager.stopAllClients();
+      await this.runtimeManager.stopAllClients(timeoutMs);
     } catch (error) {
       logger.error('Failed to stop ACP clients during shutdown', {
         error: error instanceof Error ? error.message : String(error),


### PR DESCRIPTION
## Summary
- Fix dead-code behavior in `SessionService.stopAllClients(timeoutMs)` by forwarding `timeoutMs` to `runtimeManager.stopAllClients(timeoutMs)`.
- Rename the method parameter from `_timeoutMs` to `timeoutMs` and update the method doc comment to reflect active timeout behavior.
- Strengthen lifecycle tests to verify both explicit timeout forwarding (`4321`) and default timeout forwarding (`5000`).

## Why
- Shutdown code in `src/backend/server.ts` passes `SHUTDOWN_TIMEOUT_MS` into `sessionService.stopAllClients(...)`, but the value was previously ignored.
- This change ensures caller-provided timeout control is honored during session client shutdown.

## Testing
- `pnpm test src/backend/domains/session/lifecycle/session.service.test.ts`
- Commit hooks also ran: typecheck, dependency-cruiser, and knip.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small behavioral fix limited to shutdown client stopping; main risk is altering shutdown timing/cleanup behavior if callers relied on the previous ignored timeout.
> 
> **Overview**
> **Shutdown timeout is now honored** when stopping ACP clients. `SessionService.stopAllClients(timeoutMs)` now forwards `timeoutMs` to `runtimeManager.stopAllClients(timeoutMs)` (instead of ignoring it), updates the parameter/doc comment accordingly, and tightens lifecycle tests to assert both explicit and default (`5000`) timeout propagation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a8de49da274dc187f3bd7b96a3e0de646d6e375. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->