### PR TITLE
Refactor ratchet reconciliation to use workspace-init bridge

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -339,10 +339,7 @@ module.exports = {
         'Orchestration coordinates domains, not the other way around.',
       from: {
         path: '^src/backend/domains/',
-        pathNot:
-          '\\.test\\.ts$|' +
-          // reconciliation needs to re-trigger workspace init for stuck provisioning
-          '^src/backend/domains/ratchet/reconciliation\\.service\\.ts$',
+        pathNot: '\\.test\\.ts$',
       },
       to: { path: '^src/backend/orchestration/' },
     },

--- a/src/backend/domains/ratchet/bridges.ts
+++ b/src/backend/domains/ratchet/bridges.ts
@@ -81,6 +81,10 @@ export interface RatchetPRSnapshotBridge {
 /** Workspace capabilities needed by ratchet domain */
 export interface RatchetWorkspaceBridge {
   markFailed(workspaceId: string, reason: string): Promise<void>;
+  initializeWorktree(
+    workspaceId: string,
+    options?: { branchName?: string; useExistingBranch?: boolean }
+  ): Promise<void>;
 }
 
 /** GitHub capabilities needed by ratchet domain */

--- a/src/backend/domains/ratchet/reconciliation.service.ts
+++ b/src/backend/domains/ratchet/reconciliation.service.ts
@@ -1,4 +1,3 @@
-import { initializeWorkspaceWorktree } from '@/backend/orchestration/workspace-init.orchestrator';
 import { terminalSessionAccessor } from '@/backend/resource_accessors/terminal-session.accessor';
 import { workspaceAccessor } from '@/backend/resource_accessors/workspace.accessor';
 import { SERVICE_INTERVAL_MS } from '@/backend/services/constants';
@@ -93,7 +92,7 @@ class ReconciliationService {
 
   /**
    * Initialize workspaces that need worktrees via the state machine.
-   * Uses initializeWorkspaceWorktree to ensure proper state transitions
+   * Uses workspace bridge initialization to ensure proper state transitions
    * (NEW -> PROVISIONING -> READY/FAILED), factory-factory.json support,
    * and startup script handling.
    *
@@ -123,7 +122,7 @@ class ReconciliationService {
       } else {
         // NEW workspace - initialize normally
         try {
-          await initializeWorkspaceWorktree(workspace.id, {
+          await this.workspace.initializeWorktree(workspace.id, {
             branchName: workspace.branchName ?? undefined,
           });
           logger.info('Initialized workspace via reconciliation', {

--- a/src/backend/orchestration/domain-bridges.orchestrator.test.ts
+++ b/src/backend/orchestration/domain-bridges.orchestrator.test.ts
@@ -58,6 +58,10 @@ vi.mock('@/backend/domains/run-script', () => ({
   startupScriptService: { configure: vi.fn() },
 }));
 
+vi.mock('./workspace-init.orchestrator', () => ({
+  initializeWorkspaceWorktree: vi.fn(),
+}));
+
 // --- Import mocked modules to get references ---
 
 import { githubCLIService, prSnapshotService } from '@/backend/domains/github';
@@ -81,6 +85,7 @@ import {
   workspaceStateMachine,
 } from '@/backend/domains/workspace';
 import { configureDomainBridges } from './domain-bridges.orchestrator';
+import { initializeWorkspaceWorktree } from './workspace-init.orchestrator';
 
 // Helper to extract bridge argument from a mocked configure call.
 function getBridge<T>(mockFn: (arg: T) => void): T {
@@ -208,6 +213,16 @@ describe('configureDomainBridges', () => {
 
       await bridge.workspace.markFailed('ws1', 'broken');
       expect(workspaceStateMachine.markFailed).toHaveBeenCalledWith('ws1', 'broken');
+    });
+
+    it('workspace bridge initializeWorktree delegates to initializeWorkspaceWorktree', async () => {
+      configureDomainBridges();
+      const bridge = getBridge(reconciliationService.configure);
+
+      await bridge.workspace.initializeWorktree('ws1', { branchName: 'feature/test' });
+      expect(initializeWorkspaceWorktree).toHaveBeenCalledWith('ws1', {
+        branchName: 'feature/test',
+      });
     });
   });
 

--- a/src/backend/orchestration/domain-bridges.orchestrator.ts
+++ b/src/backend/orchestration/domain-bridges.orchestrator.ts
@@ -36,6 +36,7 @@ import {
 } from '@/backend/domains/workspace';
 import { workspaceSnapshotStore } from '@/backend/services/workspace-snapshot-store.service';
 import { deriveWorkspaceSidebarStatus } from '@/shared/workspace-sidebar-status';
+import { initializeWorkspaceWorktree } from './workspace-init.orchestrator';
 
 type BridgeServices = {
   chatEventForwarderService: typeof chatEventForwarderService;
@@ -143,6 +144,7 @@ export function configureDomainBridges(services: Partial<BridgeServices> = {}): 
       markFailed: async (id, reason) => {
         await workspaceStateMachine.markFailed(id, reason);
       },
+      initializeWorktree: (id, options) => initializeWorkspaceWorktree(id, options),
     },
   });
 


### PR DESCRIPTION
## Summary
This PR removes a domain-isolation violation in the ratchet domain by replacing a direct orchestration import with an injected bridge callback.

## What Changed
- Added `initializeWorktree(workspaceId, options?)` to `RatchetWorkspaceBridge`.
- Updated `reconciliation.service.ts` to call `this.workspace.initializeWorktree(...)` instead of importing `initializeWorkspaceWorktree` from orchestration.
- Wired the new bridge callback in `configureDomainBridges()` to delegate to `initializeWorkspaceWorktree`.
- Updated ratchet reconciliation tests to mock/use the bridge method.
- Added orchestration bridge wiring test coverage for `initializeWorktree` delegation.
- Removed the dependency-cruiser exception that previously allowed `src/backend/domains/ratchet/reconciliation.service.ts` to import orchestration.

## Why
Domains should not depend on orchestration directly. This change restores the intended architecture boundary and keeps cross-domain coordination in the orchestration layer.

## Validation
- `pnpm test -- src/backend/domains/ratchet/reconciliation.service.test.ts src/backend/orchestration/domain-bridges.orchestrator.test.ts`
- `pnpm deps:check`
- Commit hooks also ran successfully (`biome`, `typecheck`, `deps:check`, `knip`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a refactor of dependency wiring with unchanged functional intent; risk is limited to misconfiguration of the new bridge causing workspace initialization not to run during reconciliation.
> 
> **Overview**
> Ratchet `reconciliation.service` no longer imports `initializeWorkspaceWorktree` from orchestration; it calls a newly injected `RatchetWorkspaceBridge.initializeWorktree()` instead, and orchestration wires that bridge to delegate to `initializeWorkspaceWorktree`.
> 
> The PR tightens dependency rules by removing the previous `.dependency-cruiser.cjs` exception allowing this import, and updates/adds tests to mock and verify the new bridge delegation path in both ratchet reconciliation and `domain-bridges.orchestrator`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a496534e5c26dc309f3319733b4910664862a5c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->