### PR TITLE
Make ACP context_compaction handling type-safe

### DIFF
--- a/src/backend/domains/session/acp/acp-event-translator.test.ts
+++ b/src/backend/domains/session/acp/acp-event-translator.test.ts
@@ -17,6 +17,8 @@ function createTranslator() {
   return { translator, logger };
 }
 
+type TranslatorSessionUpdate = Parameters<AcpEventTranslator['translateSessionUpdate']>[0];
+
 describe('AcpEventTranslator', () => {
   describe('agent_message_chunk', () => {
     it('translates text content to agent_message delta', () => {
@@ -506,10 +508,10 @@ describe('AcpEventTranslator', () => {
   describe('context_compaction', () => {
     it('emits compacting_start for active state strings', () => {
       const { translator } = createTranslator();
-      const update = {
+      const update: TranslatorSessionUpdate = {
         sessionUpdate: 'context_compaction',
         state: 'started',
-      } as unknown as SessionUpdate;
+      };
 
       const events = translator.translateSessionUpdate(update);
 
@@ -518,10 +520,10 @@ describe('AcpEventTranslator', () => {
 
     it('emits compacting_end for inactive boolean state', () => {
       const { translator } = createTranslator();
-      const update = {
+      const update: TranslatorSessionUpdate = {
         sessionUpdate: 'context_compaction',
         compacting: false,
-      } as unknown as SessionUpdate;
+      };
 
       const events = translator.translateSessionUpdate(update);
 
@@ -530,10 +532,10 @@ describe('AcpEventTranslator', () => {
 
     it('supports nested payloads', () => {
       const { translator } = createTranslator();
-      const update = {
+      const update: TranslatorSessionUpdate = {
         sessionUpdate: 'context_compaction',
         payload: { status: 'in_progress' },
-      } as unknown as SessionUpdate;
+      };
 
       const events = translator.translateSessionUpdate(update);
 
@@ -542,10 +544,10 @@ describe('AcpEventTranslator', () => {
 
     it('returns empty array and logs warning for unknown payload shape', () => {
       const { translator, logger } = createTranslator();
-      const update = {
+      const update: TranslatorSessionUpdate = {
         sessionUpdate: 'context_compaction',
         payload: { unknown: 'value' },
-      } as unknown as SessionUpdate;
+      };
 
       const events = translator.translateSessionUpdate(update);
 


### PR DESCRIPTION
## Summary
- add a typed compatibility shim for ACP `context_compaction` events (`SessionUpdate | ContextCompactionUpdate`) in `AcpEventTranslator`
- remove the pre-switch `unknown` coercion and handle `context_compaction` directly in the main switch statement
- update context compaction translator tests to use the translator input type instead of `unknown as SessionUpdate`
- preserve current runtime behavior while improving type safety until the ACP SDK adds `context_compaction` to its `SessionUpdate` union

## Validation
- `pnpm test src/backend/domains/session/acp/acp-event-translator.test.ts`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to TypeScript typing/dispatch cleanup and test updates, with no intended runtime behavior changes beyond safer logging for malformed updates.
> 
> **Overview**
> Adds a typed compatibility shim so `AcpEventTranslator.translateSessionUpdate` can accept ACP `context_compaction` updates without `unknown` casts, and handles `context_compaction` directly in the main `switch`.
> 
> Updates `context_compaction` tests to use the translator’s input type, and adds a small helper (`readSessionUpdateType`) to keep unknown-type warning logs safe when `sessionUpdate` isn’t a string.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dca7540277b9f7977509dba264d76b743395cfbe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->