### PR TITLE
Fix new workspace sidebar overflow and remove auto-fix labels

### DIFF
--- a/src/client/components/kanban/inline-workspace-form.tsx
+++ b/src/client/components/kanban/inline-workspace-form.tsx
@@ -210,7 +210,7 @@ export function InlineWorkspaceForm({
           />
         ) : null}
         <div className="flex flex-wrap items-center justify-between gap-2">
-          <div className="flex items-center gap-3">
+          <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
             <div className="flex items-center gap-1.5">
               <RatchetToggleButton
                 enabled={ratchetEnabled}
@@ -219,7 +219,6 @@ export function InlineWorkspaceForm({
                 onToggle={setRatchetEnabled}
                 disabled={isLoadingSettings || isCreating}
               />
-              <span className="text-xs text-muted-foreground max-[420px]:hidden">Auto-fix</span>
             </div>
             <Select
               value={provider}
@@ -251,12 +250,12 @@ export function InlineWorkspaceForm({
               type="button"
               variant="ghost"
               size="sm"
-              className="h-7 px-2 text-xs"
+              className="h-7 w-7 shrink-0 px-0"
+              aria-label="Attach files"
               onClick={() => fileInputRef.current?.click()}
               disabled={isCreating}
             >
-              <Paperclip className="h-3.5 w-3.5 mr-1" />
-              Attach
+              <Paperclip className="h-3.5 w-3.5" />
             </Button>
             <input
               ref={fileInputRef}
@@ -268,7 +267,7 @@ export function InlineWorkspaceForm({
               aria-label="Attach files"
             />
           </div>
-          <div className="flex gap-2 ml-auto">
+          <div className="ml-auto flex shrink-0 gap-2">
             <Button
               variant="ghost"
               size="sm"

--- a/src/client/routes/admin-page.tsx
+++ b/src/client/routes/admin-page.tsx
@@ -593,7 +593,7 @@ function RatchetSettingsSection() {
   const utils = trpc.useUtils();
   const updateSettings = trpc.userSettings.update.useMutation({
     onSuccess: () => {
-      toast.success('Auto-fix settings updated');
+      toast.success('Ratchet settings updated');
       utils.userSettings.get.invalidate();
     },
     onError: (error) => {
@@ -604,11 +604,11 @@ function RatchetSettingsSection() {
   const triggerRatchetCheck = trpc.admin.triggerRatchetCheck.useMutation({
     onSuccess: (result) => {
       toast.success(
-        `Auto-fix check completed: ${result.checked} checked, ${result.stateChanges} state changes, ${result.actionsTriggered} actions triggered`
+        `Ratchet check completed: ${result.checked} checked, ${result.stateChanges} state changes, ${result.actionsTriggered} actions triggered`
       );
     },
     onError: (error) => {
-      toast.error(`Failed to trigger auto-fix check: ${error.message}`);
+      toast.error(`Failed to trigger ratchet check: ${error.message}`);
     },
   });
 
@@ -618,7 +618,7 @@ function RatchetSettingsSection() {
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <RatchetWrenchIcon enabled className="w-5 h-5" iconClassName="w-3.5 h-3.5" />
-            Auto-Fix Pull Requests
+            Ratchet Pull Requests
           </CardTitle>
           <CardDescription>
             Automatically dispatch agents to fix CI failures and address code review comments
@@ -638,7 +638,7 @@ function RatchetSettingsSection() {
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <RatchetWrenchIcon enabled className="w-5 h-5" iconClassName="w-3.5 h-3.5" />
-          Auto-Fix Pull Requests
+          Ratchet Pull Requests
         </CardTitle>
         <CardDescription>
           Automatically dispatch agents to fix CI failures and address code review comments
@@ -660,7 +660,7 @@ function RatchetSettingsSection() {
           <div className="space-y-0.5">
             <Label htmlFor="ratchet-enabled">Default for new workspaces</Label>
             <p className="text-sm text-muted-foreground">
-              Enable auto-fix for workspaces created from GitHub issues
+              Enable Ratchet for workspaces created from GitHub issues
             </p>
           </div>
           <Switch

--- a/src/client/routes/projects/workspaces/workspace-detail-header.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-header.tsx
@@ -353,7 +353,7 @@ function RatchetingToggle({
         ) : (
           <Zap className="h-4 w-4" />
         )}
-        {workspaceRatchetEnabled ? 'Turn off auto-fix' : 'Turn on auto-fix'}
+        {workspaceRatchetEnabled ? 'Turn off Ratchet' : 'Turn on Ratchet'}
       </DropdownMenuItem>
     );
   }

--- a/src/components/workspace/ratchet-toggle-button.tsx
+++ b/src/components/workspace/ratchet-toggle-button.tsx
@@ -16,10 +16,10 @@ interface RatchetToggleButtonProps {
 
 function getTooltip(enabled: boolean, state: RatchetStateLike): string {
   if (!enabled) {
-    return 'Auto-fix is off. Click to enable automatic fixes for CI failures and review comments.';
+    return 'Ratchet is off. Click to enable automatic fixes for CI failures and review comments.';
   }
   const stateLabel = getRatchetStateLabel(state);
-  return `Auto-fix is on (${stateLabel}). Click to disable.`;
+  return `Ratchet is on (${stateLabel}). Click to disable.`;
 }
 
 export function RatchetToggleButton({
@@ -51,7 +51,7 @@ export function RatchetToggleButton({
             onToggle(!enabled);
           }}
           disabled={disabled}
-          aria-label={enabled ? 'Disable auto-fix' : 'Enable auto-fix'}
+          aria-label={enabled ? 'Disable ratchet' : 'Enable ratchet'}
           aria-pressed={enabled}
           className={cn('h-7 w-7 p-0', className)}
         >


### PR DESCRIPTION
## Summary
- fix overflow in the side-panel "New Workspace" inline form by allowing controls to wrap within narrow widths
- make the attachment action compact (icon-only) so it no longer gets pushed outside the container
- remove visible "auto-fix" UI wording in app surfaces and replace with "Ratchet" terminology (admin settings copy, workspace menu text, tooltip, and ARIA labels)

## Testing
- pnpm typecheck
- pnpm check:fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes: flexbox/layout tweaks and copy/ARIA text updates, with no changes to underlying ratcheting behavior or APIs.
> 
> **Overview**
> Fixes overflow in the inline “New Workspace” sidebar form by allowing the control row to wrap and by making the attachment action icon-only to stay within narrow widths.
> 
> Replaces remaining user-facing *Auto-fix* wording with *Ratchet* across the admin settings section, workspace header menu text, and `RatchetToggleButton` tooltip/ARIA labels (plus updated toast messages).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa06f74a9914949a17e2ae54eb804528c95eabb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->