### PR TITLE
Fix #1264: reset board sidebar on return from settings

### DIFF
--- a/src/client/hooks/use-sidebar-default-open.test.ts
+++ b/src/client/hooks/use-sidebar-default-open.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import {
+  clearTransientOverrideOnCategoryChange,
+  getRouteCategoryForPath,
+} from './use-sidebar-default-open';
+
+describe('getRouteCategoryForPath', () => {
+  it('classifies workspace detail paths', () => {
+    expect(getRouteCategoryForPath('/projects/alpha/workspaces/ws-1')).toBe('workspace_detail');
+  });
+
+  it('classifies board paths with and without trailing slash', () => {
+    expect(getRouteCategoryForPath('/projects/alpha/workspaces')).toBe('board');
+    expect(getRouteCategoryForPath('/projects/alpha/workspaces/')).toBe('board');
+  });
+
+  it('classifies settings and reviews as default routes', () => {
+    expect(getRouteCategoryForPath('/admin')).toBe('default');
+    expect(getRouteCategoryForPath('/reviews')).toBe('default');
+  });
+});
+
+describe('clearTransientOverrideOnCategoryChange', () => {
+  it('clears board override when leaving board routes', () => {
+    const overrides = { board: true, workspace_detail: true };
+    expect(clearTransientOverrideOnCategoryChange(overrides, 'board', 'default')).toEqual({
+      workspace_detail: true,
+    });
+  });
+
+  it('keeps overrides when staying on board', () => {
+    const overrides = { board: true };
+    expect(clearTransientOverrideOnCategoryChange(overrides, 'board', 'board')).toEqual({
+      board: true,
+    });
+  });
+
+  it('keeps overrides when leaving non-transient routes', () => {
+    const overrides = { default: false };
+    expect(
+      clearTransientOverrideOnCategoryChange(overrides, 'default', 'workspace_detail')
+    ).toEqual({
+      default: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Fix sidebar behavior so returning to Workspaces from Settings collapses the sidebar as expected
- Keep existing behavior where sidebar does not auto-collapse for Workspace Detail, Reviews, or Settings routes
- Add focused tests for route categorization and transient board override reset behavior

## Changes
- **Sidebar route state hook**: Updated `useRouteSidebarState` to keep board overrides transient in-memory and clear them when leaving the board route category.
- **Hook test coverage**: Added `use-sidebar-default-open.test.ts` for route classification and transient override clearing.

## Testing
- [x] Tests pass (`pnpm test`) *(except one existing unrelated failure: `src/backend/domains/session/acp/codex-cli-import-resolution.integration.test.ts` expects a crash that does not reproduce in this environment)*
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Open `/admin`, click the `Workspaces` back link, and verify the workspace board opens with sidebar collapsed while `/admin`, `/reviews`, and workspace detail do not auto-collapse.

Closes #1264

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
