### PR TITLE
Fix side panel resize handle drag behavior

### DIFF
--- a/src/components/ui/resizable.handle.test.tsx
+++ b/src/components/ui/resizable.handle.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+
+import { createElement, type ReactNode } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let capturedSeparatorClassName: string | undefined;
+
+vi.mock('react-resizable-panels', () => ({
+  Group: (props: { children?: ReactNode }) => createElement('div', null, props.children),
+  Panel: (props: { children?: ReactNode }) => createElement('div', null, props.children),
+  Separator: (props: { className?: string; children?: ReactNode }) => {
+    capturedSeparatorClassName = props.className;
+    return createElement('div', null, props.children);
+  },
+}));
+
+vi.mock('lucide-react', () => ({
+  GripVertical: () => createElement('svg'),
+}));
+
+import { ResizableHandle } from './resizable';
+
+Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
+  configurable: true,
+  writable: true,
+  value: true,
+});
+
+function renderInDom(render: (root: Root) => void): () => void {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  render(root);
+  return () => {
+    root.unmount();
+    container.remove();
+  };
+}
+
+beforeEach(() => {
+  capturedSeparatorClassName = undefined;
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('ResizableHandle hit target classes', () => {
+  it('includes pseudo-element content class for horizontal group handles', () => {
+    const cleanup = renderInDom((root) => {
+      flushSync(() => {
+        root.render(createElement(ResizableHandle));
+      });
+    });
+
+    expect(capturedSeparatorClassName).toContain("after:content-['']");
+    expect(capturedSeparatorClassName).toContain('cursor-col-resize');
+    cleanup();
+  });
+
+  it('includes row-resize cursor for vertical group handles', () => {
+    const cleanup = renderInDom((root) => {
+      flushSync(() => {
+        root.render(createElement(ResizableHandle, { direction: 'vertical' }));
+      });
+    });
+
+    expect(capturedSeparatorClassName).toContain("after:content-['']");
+    expect(capturedSeparatorClassName).toContain('cursor-row-resize');
+    cleanup();
+  });
+});

--- a/src/components/ui/resizable.tsx
+++ b/src/components/ui/resizable.tsx
@@ -113,9 +113,9 @@ const ResizableHandle = ({ withHandle, className, direction, ...props }: Resizab
         // Orientation-specific styles
         isHorizontalHandle
           ? // Horizontal handle (for vertical panel groups)
-            'h-1 w-full after:absolute after:inset-x-0 after:top-1/2 after:h-4 after:-translate-y-1/2'
+            "h-1 w-full cursor-row-resize after:content-[''] after:absolute after:inset-x-0 after:top-1/2 after:h-4 after:-translate-y-1/2"
           : // Vertical handle (for horizontal panel groups) - default
-            'w-px after:absolute after:inset-y-0 after:left-1/2 after:w-4 after:-translate-x-1/2',
+            "w-px cursor-col-resize after:content-[''] after:absolute after:inset-y-0 after:left-1/2 after:w-4 after:-translate-x-1/2",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- fix the resizable side panel handle hit target so drag-resize works reliably again
- add explicit resize cursors on both handle orientations for clearer affordance
- add a regression test for `ResizableHandle` to ensure the pseudo-element hit-area class remains present

## Root cause
The handle expanded drag target relied on `::after` utilities but did not set pseudo-element content, so the enlarged hit area could collapse to the 1px separator line.

## Testing
- `pnpm test src/components/ui/resizable.persistence.test.tsx src/components/ui/resizable.handle.test.tsx`
- `pnpm exec biome check src/components/ui/resizable.tsx src/components/ui/resizable.handle.test.tsx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-class change plus a targeted regression test; low risk aside from potentially affecting handle styling/interaction in edge cases.
> 
> **Overview**
> Fixes `ResizableHandle` drag reliability by ensuring the expanded `::after` hit-area is actually rendered via `after:content-['']` for both orientations, and adds explicit `cursor-col-resize`/`cursor-row-resize` cursors.
> 
> Adds a new Vitest `jsdom` regression test (`resizable.handle.test.tsx`) that mocks `react-resizable-panels` to assert these critical classes are present for horizontal and vertical handles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac371cc2015287ea122bcd2f22caaa98d47d5c2b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->