### PR TITLE
Refactor Codex ACP adapter into retry and negotiation modules

### DIFF
--- a/src/backend/domains/session/acp/codex-app-server-adapter/retry-logic.ts
+++ b/src/backend/domains/session/acp/codex-app-server-adapter/retry-logic.ts
@@ -1,0 +1,77 @@
+import { CodexRequestError } from './codex-rpc-client';
+
+const OVERLOAD_ERROR_CODE = -32_001;
+const DEFAULT_MAX_RETRY_ATTEMPTS = 3;
+
+export const MAX_CLOSE_WATCHER_ATTACH_RETRIES = 50;
+
+type AttachCloseWatcherWithRetryParams = {
+  getClosed: () => Promise<void>;
+  onClose: () => Promise<void>;
+  onAttachRetryLimitReached: (maxAttempts: number) => void;
+  maxAttachRetries?: number;
+};
+
+export function attachCloseWatcherWithRetry(params: AttachCloseWatcherWithRetryParams): void {
+  const maxAttachRetries = params.maxAttachRetries ?? MAX_CLOSE_WATCHER_ATTACH_RETRIES;
+  let attachAttempts = 0;
+
+  const attachCloseWatcher = () => {
+    try {
+      void params
+        .getClosed()
+        .finally(async () => {
+          await params.onClose();
+        })
+        .catch(() => {
+          // Ignore close-watcher errors and still attempt subprocess shutdown.
+        });
+    } catch {
+      attachAttempts += 1;
+      if (attachAttempts >= maxAttachRetries) {
+        params.onAttachRetryLimitReached(maxAttachRetries);
+        return;
+      }
+      const retryTimer = setTimeout(attachCloseWatcher, 0);
+      retryTimer.unref?.();
+    }
+  };
+
+  queueMicrotask(attachCloseWatcher);
+}
+
+type RequestWithOverloadRetryParams<T> = {
+  request: () => Promise<unknown>;
+  parse: (raw: unknown) => T;
+  maxAttempts?: number;
+};
+
+export async function requestWithOverloadRetry<T>(
+  params: RequestWithOverloadRetryParams<T>
+): Promise<T> {
+  const maxAttempts = params.maxAttempts ?? DEFAULT_MAX_RETRY_ATTEMPTS;
+  let attempt = 0;
+  let lastError: unknown;
+
+  while (attempt < maxAttempts) {
+    attempt += 1;
+    try {
+      const raw = await params.request();
+      return params.parse(raw);
+    } catch (error) {
+      lastError = error;
+      if (
+        !(error instanceof CodexRequestError) ||
+        error.code !== OVERLOAD_ERROR_CODE ||
+        attempt >= maxAttempts
+      ) {
+        throw error;
+      }
+
+      const delayMs = Math.round(2 ** attempt * 100 + Math.random() * 120);
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+
+  throw lastError;
+}

--- a/src/backend/domains/session/acp/codex-app-server-adapter/session-negotiation.ts
+++ b/src/backend/domains/session/acp/codex-app-server-adapter/session-negotiation.ts
@@ -1,0 +1,223 @@
+import { dedupeStrings, isNonEmptyString } from './acp-adapter-utils';
+import type {
+  AdapterSession,
+  ApprovalPolicy,
+  CodexClient,
+  CodexModelEntry,
+  CollaborationModeEntry,
+  ReasoningEffort,
+  SandboxMode,
+} from './adapter-state';
+import {
+  collaborationModeListResponseSchema,
+  configRequirementsReadResponseSchema,
+  modelListResponseSchema,
+  threadResumeResponseSchema,
+  threadStartResponseSchema,
+} from './codex-zod';
+import { requestWithOverloadRetry } from './retry-logic';
+import { DEFAULT_APPROVAL_POLICIES, DEFAULT_SANDBOX_MODES } from './session-config-resolver';
+
+type SessionDefaults = AdapterSession['defaults'];
+
+export type NegotiatedSession = {
+  sessionId: string;
+  threadId: string;
+  cwd: string;
+  defaults: SessionDefaults;
+};
+
+type SessionDefaultResolvers = {
+  resolveDefaultModel: () => string;
+  resolveSessionModel: (model: unknown, fallbackModel: string) => string;
+  resolveSandboxPolicy: (sandbox: unknown, cwd: string) => Record<string, unknown>;
+  resolveReasoningEffortForModel: (
+    modelId: string,
+    candidateReasoningEffort: unknown
+  ) => ReasoningEffort | null;
+  resolveDefaultCollaborationMode: () => string;
+};
+
+export function toSessionId(threadId: string): string {
+  return `sess_${threadId}`;
+}
+
+export function toThreadId(sessionId: string): string {
+  return sessionId.startsWith('sess_') ? sessionId.slice('sess_'.length) : sessionId;
+}
+
+export function requireApprovalPolicy(
+  approvalPolicy: unknown,
+  source: 'thread/start' | 'thread/resume'
+): ApprovalPolicy {
+  if (!isNonEmptyString(approvalPolicy)) {
+    throw new Error(`Codex ${source} response did not include approvalPolicy`);
+  }
+  return approvalPolicy;
+}
+
+export async function negotiateNewSession(
+  params: {
+    codex: CodexClient;
+    cwd: string;
+  } & SessionDefaultResolvers
+): Promise<NegotiatedSession> {
+  const defaultModel = params.resolveDefaultModel();
+  const responseRaw = await params.codex.request('thread/start', {
+    cwd: params.cwd,
+    model: defaultModel,
+  });
+
+  const response = threadStartResponseSchema.parse(responseRaw);
+  const model = params.resolveSessionModel(response.model, defaultModel);
+
+  return {
+    sessionId: toSessionId(response.thread.id),
+    threadId: response.thread.id,
+    cwd: params.cwd,
+    defaults: {
+      model,
+      approvalPolicy: requireApprovalPolicy(response.approvalPolicy, 'thread/start'),
+      sandboxPolicy: params.resolveSandboxPolicy(response.sandbox, params.cwd),
+      reasoningEffort: params.resolveReasoningEffortForModel(model, response.reasoningEffort),
+      collaborationMode: params.resolveDefaultCollaborationMode(),
+    },
+  };
+}
+
+export async function negotiateSessionResume(
+  params: {
+    codex: CodexClient;
+    sessionId: string;
+    cwd: string;
+  } & SessionDefaultResolvers
+): Promise<NegotiatedSession> {
+  const responseRaw = await params.codex.request('thread/resume', {
+    threadId: toThreadId(params.sessionId),
+    cwd: params.cwd,
+  });
+
+  const response = threadResumeResponseSchema.parse(responseRaw);
+  const defaultModel = params.resolveDefaultModel();
+  const model = params.resolveSessionModel(response.model, defaultModel);
+
+  return {
+    sessionId: params.sessionId,
+    threadId: response.thread.id,
+    cwd: params.cwd,
+    defaults: {
+      model,
+      approvalPolicy: requireApprovalPolicy(response.approvalPolicy, 'thread/resume'),
+      sandboxPolicy: params.resolveSandboxPolicy(response.sandbox, params.cwd),
+      reasoningEffort: params.resolveReasoningEffortForModel(model, response.reasoningEffort),
+      collaborationMode: params.resolveDefaultCollaborationMode(),
+    },
+  };
+}
+
+export async function loadConfigRequirements(params: { codex: CodexClient }): Promise<{
+  allowedApprovalPolicies: ApprovalPolicy[];
+  allowedSandboxModes: SandboxMode[];
+}> {
+  const raw = await params.codex.request('configRequirements/read', undefined);
+  const parsed = configRequirementsReadResponseSchema.parse(raw);
+  const requirements = parsed.requirements;
+  const allowedApprovalPolicies = dedupeStrings(
+    (requirements?.allowedApprovalPolicies ?? []).filter(isNonEmptyString)
+  );
+  const allowedSandboxModes = dedupeStrings(
+    (requirements?.allowedSandboxModes ?? []).filter(
+      (mode): mode is SandboxMode =>
+        mode === 'read-only' || mode === 'workspace-write' || mode === 'danger-full-access'
+    )
+  );
+  const hasExplicitApprovalPolicies = Array.isArray(requirements?.allowedApprovalPolicies);
+  const hasExplicitSandboxModes = Array.isArray(requirements?.allowedSandboxModes);
+
+  return {
+    allowedApprovalPolicies:
+      allowedApprovalPolicies.length > 0
+        ? allowedApprovalPolicies
+        : hasExplicitApprovalPolicies
+          ? []
+          : DEFAULT_APPROVAL_POLICIES,
+    allowedSandboxModes:
+      allowedSandboxModes.length > 0
+        ? allowedSandboxModes
+        : hasExplicitSandboxModes
+          ? []
+          : DEFAULT_SANDBOX_MODES,
+  };
+}
+
+export async function loadCollaborationModes(params: {
+  codex: CodexClient;
+}): Promise<CollaborationModeEntry[]> {
+  const entries: CollaborationModeEntry[] = [];
+  let cursor: string | null = null;
+
+  for (;;) {
+    const response = await requestWithOverloadRetry({
+      request: () => params.codex.request('collaborationMode/list', cursor ? { cursor } : {}),
+      parse: (raw) => collaborationModeListResponseSchema.parse(raw),
+    });
+    entries.push(
+      ...response.data.flatMap((entry) =>
+        isNonEmptyString(entry.mode)
+          ? [
+              {
+                mode: entry.mode,
+                name: entry.name,
+                model: entry.model ?? null,
+                reasoningEffort: entry.reasoning_effort ?? null,
+                developerInstructions: entry.developer_instructions ?? null,
+              },
+            ]
+          : []
+      )
+    );
+
+    cursor = response.nextCursor ?? null;
+    if (!cursor) {
+      break;
+    }
+  }
+
+  if (entries.length === 0) {
+    throw new Error('Codex collaborationMode/list returned no modes');
+  }
+  return entries;
+}
+
+export async function loadModelCatalog(params: { codex: CodexClient }): Promise<CodexModelEntry[]> {
+  const models: CodexModelEntry[] = [];
+  let cursor: string | null = null;
+
+  for (;;) {
+    const response = await requestWithOverloadRetry({
+      request: () => params.codex.request('model/list', cursor ? { cursor } : {}),
+      parse: (raw) => modelListResponseSchema.parse(raw),
+    });
+    models.push(
+      ...response.data.map((model) => ({
+        id: model.id,
+        displayName: model.displayName,
+        description: model.description,
+        defaultReasoningEffort: model.defaultReasoningEffort,
+        supportedReasoningEfforts: (model.supportedReasoningEfforts ?? [])
+          .filter((entry) => isNonEmptyString(entry.reasoningEffort))
+          .map((entry) => ({
+            reasoningEffort: entry.reasoningEffort,
+            description: entry.description,
+          })),
+        inputModalities: model.inputModalities ?? [],
+        isDefault: model.isDefault ?? false,
+      }))
+    );
+
+    cursor = response.nextCursor ?? null;
+    if (!cursor) {
+      return models;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- extract Codex adapter retry concerns into `retry-logic.ts`
- extract session negotiation and initialization loading concerns into `session-negotiation.ts`
- keep all new modules inside `src/backend/domains/session/acp/codex-app-server-adapter/` to preserve the self-contained dependency boundary
- simplify `codex-app-server-acp-adapter.ts` by delegating close-watcher retry, startup loading, and new/load session negotiation

## Key Changes
- added `attachCloseWatcherWithRetry` and `requestWithOverloadRetry` helpers
- moved `loadConfigRequirements`, `loadCollaborationModes`, and `loadModelCatalog` into the negotiation module
- moved `toSessionId` / `toThreadId` and new/load session response shaping into negotiation helpers
- preserved existing behavior and call patterns for constructor close-watcher and initialization/session startup flows

## Validation
- `pnpm test src/backend/domains/session/acp/codex-app-server-adapter/codex-app-server-acp-adapter.test.ts`
- `pnpm typecheck`
- `pnpm deps:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a refactor, but it rewires session init/start/resume and adds centralized retry logic around Codex RPC calls, so any behavior drift could affect session creation and catalog loading.
> 
> **Overview**
> Refactors the Codex ACP adapter by extracting connection-close watcher retry and overload retry handling into a new `retry-logic.ts`, and moving session/thread ID mapping plus session start/resume “negotiation” into `session-negotiation.ts`.
> 
> Adapter initialization now loads config requirements, collaboration modes, and model catalog via the new negotiation helpers (with shared overload retry for list endpoints), and `newSession`/`loadSession` delegate to `negotiateNewSession`/`negotiateSessionResume` to shape session defaults and IDs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5242790b09cde396bab964ef300ee4830009f897. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->