### PR TITLE
Fix new workspace Kanban card button wrapping

### DIFF
--- a/src/client/components/kanban/inline-workspace-form.tsx
+++ b/src/client/components/kanban/inline-workspace-form.tsx
@@ -209,8 +209,8 @@ export function InlineWorkspaceForm({
             }
           />
         ) : null}
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+        <div className="space-y-2">
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
             <div className="flex items-center gap-1.5">
               <RatchetToggleButton
                 enabled={ratchetEnabled}
@@ -267,11 +267,11 @@ export function InlineWorkspaceForm({
               aria-label="Attach files"
             />
           </div>
-          <div className="ml-auto flex shrink-0 gap-2">
+          <div className="flex justify-end gap-2">
             <Button
               variant="ghost"
               size="sm"
-              className="h-7 text-xs"
+              className="h-7 text-xs whitespace-nowrap"
               onClick={onCancel}
               disabled={isCreating}
             >
@@ -279,7 +279,7 @@ export function InlineWorkspaceForm({
             </Button>
             <Button
               size="sm"
-              className="h-7 text-xs"
+              className="h-7 text-xs whitespace-nowrap"
               onClick={handleLaunch}
               disabled={
                 isCreating ||


### PR DESCRIPTION
## Summary
- tidy the inline new workspace card footer layout in Kanban to avoid awkward wrapping
- separate control inputs (ratchet toggle, provider/mode selects, attachments) from primary actions into two rows
- keep `Cancel` and `Launch` labels on one line using `whitespace-nowrap`

## Why
The previous mixed wrapping in a single flex row caused action buttons to wrap in visually awkward ways when space was constrained.

## Testing
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tailwind/CSS-only layout changes to a single component; no business logic, data, or security behavior is modified.
> 
> **Overview**
> Improves the Kanban inline “new workspace” card footer layout by splitting controls (ratchet/provider/mode/attachments) and primary actions into separate rows to prevent awkward wrapping in constrained widths.
> 
> Adds `whitespace-nowrap` to the `Cancel` and `Launch` buttons and tweaks flex/container classes so actions stay right-aligned and remain on one line.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 487f51bdc303b9d4fa228ed7dd2cd0483c399be7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->