### PR TITLE
Fix drag-to-resize behavior for app sidebar

### DIFF
--- a/src/client/components/app-sidebar-resize.test.ts
+++ b/src/client/components/app-sidebar-resize.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  clampSidebarWidth,
+  getPersistedSidebarWidth,
+  parseSidebarWidth,
+  persistSidebarWidth,
+} from './app-sidebar-resize';
+
+describe('app-sidebar resize helpers', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('clamps width values to supported range', () => {
+    expect(clampSidebarWidth(100)).toBe(240);
+    expect(clampSidebarWidth(352.2)).toBe(352);
+    expect(clampSidebarWidth(1000)).toBe(640);
+  });
+
+  it('parses persisted values and falls back to default for invalid values', () => {
+    expect(parseSidebarWidth('480')).toBe(480);
+    expect(parseSidebarWidth('999')).toBe(640);
+    expect(parseSidebarWidth('not-a-number')).toBe(352);
+    expect(parseSidebarWidth(null)).toBe(352);
+  });
+
+  it('reads and writes persisted width through localStorage', () => {
+    localStorage.setItem('sidebar_width', '500');
+    expect(getPersistedSidebarWidth()).toBe(500);
+
+    persistSidebarWidth(999);
+    expect(localStorage.getItem('sidebar_width')).toBe('640');
+  });
+});

--- a/src/client/components/app-sidebar-resize.ts
+++ b/src/client/components/app-sidebar-resize.ts
@@ -1,0 +1,58 @@
+const SIDEBAR_WIDTH_STORAGE_KEY = 'sidebar_width';
+
+const SIDEBAR_DEFAULT_WIDTH = 352;
+const SIDEBAR_MIN_WIDTH = 240;
+const SIDEBAR_MAX_WIDTH = 640;
+
+type SidebarWidthStorageReader = Pick<Storage, 'getItem'>;
+type SidebarWidthStorageWriter = Pick<Storage, 'setItem'>;
+
+function getLocalStorageSafe(): Storage | null {
+  try {
+    return globalThis.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function clampSidebarWidth(width: number): number {
+  if (!Number.isFinite(width)) {
+    return SIDEBAR_DEFAULT_WIDTH;
+  }
+  return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, Math.round(width)));
+}
+
+export function parseSidebarWidth(value: string | null): number {
+  if (value == null) {
+    return SIDEBAR_DEFAULT_WIDTH;
+  }
+  const parsed = Number.parseFloat(value);
+  return clampSidebarWidth(parsed);
+}
+
+export function getPersistedSidebarWidth(storage: SidebarWidthStorageReader | null = null): number {
+  const activeStorage = storage ?? getLocalStorageSafe();
+  if (!activeStorage) {
+    return SIDEBAR_DEFAULT_WIDTH;
+  }
+  try {
+    return parseSidebarWidth(activeStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY));
+  } catch {
+    return SIDEBAR_DEFAULT_WIDTH;
+  }
+}
+
+export function persistSidebarWidth(
+  width: number,
+  storage: SidebarWidthStorageWriter | null = null
+): void {
+  const activeStorage = storage ?? getLocalStorageSafe();
+  if (!activeStorage) {
+    return;
+  }
+  try {
+    activeStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(clampSidebarWidth(width)));
+  } catch {
+    // Ignore storage access issues.
+  }
+}


### PR DESCRIPTION
## Summary
- add true drag-to-resize behavior for the desktop app sidebar using pointer events
- replace the fixed desktop width with a dynamic width state that updates live during drag
- clamp sidebar width to a safe range (`240px` to `640px`) and persist user-selected width in `localStorage` (`sidebar_width`)
- ensure resize cleanup is robust on pointer end, pointer cancel, unmount, and sidebar collapse
- add unit tests for sidebar resize width parsing, clamping, and persistence helpers

## Files changed
- `src/client/components/app-sidebar.tsx`
- `src/client/components/app-sidebar-resize.ts`
- `src/client/components/app-sidebar-resize.test.ts`

## Validation
- `pnpm exec vitest run src/client/components/app-sidebar-resize.test.ts`
- `pnpm exec biome check src/client/components/app-sidebar.tsx src/client/components/app-sidebar-resize.ts src/client/components/app-sidebar-resize.test.ts`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes desktop sidebar layout/interaction and adds global pointer event handling + `localStorage` persistence; bugs here could leave the UI in a stuck resizing/cursor state or render the sidebar at an unexpected width.
> 
> **Overview**
> Adds true drag-to-resize for the desktop `AppSidebar` via pointer events, replacing the fixed `w-[22rem]` width with a live `sidebarWidth` state and a resize handle.
> 
> Introduces `app-sidebar-resize.ts` helpers to clamp/parse widths (240–640px) and persist the selected width to `localStorage` (with safe fallbacks), plus unit tests covering clamping, parsing, and persistence. Cleanup logic is added to reliably stop resizing on pointer end/cancel, sidebar collapse, and unmount.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26af4f10a6530e911e008d4c711596e6175b913a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->