### PR TITLE
Validate setup-terminal WebSocket messages with Zod

### DIFF
--- a/src/backend/routers/websocket/setup-terminal.handler.test.ts
+++ b/src/backend/routers/websocket/setup-terminal.handler.test.ts
@@ -1,0 +1,64 @@
+import { EventEmitter } from 'node:events';
+import type { IncomingMessage } from 'node:http';
+import type { Duplex } from 'node:stream';
+import { describe, expect, it, vi } from 'vitest';
+import type { WebSocket, WebSocketServer } from 'ws';
+import type { AppContext } from '@/backend/app-context';
+import { WS_READY_STATE } from '@/backend/constants/websocket';
+import { createSetupTerminalUpgradeHandler } from './setup-terminal.handler';
+
+class MockWebSocket extends EventEmitter {
+  readyState = WS_READY_STATE.OPEN;
+  send = vi.fn();
+}
+
+function createLogger() {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+describe('createSetupTerminalUpgradeHandler', () => {
+  it('rejects messages that fail schema validation', () => {
+    const logger = createLogger();
+    const appContext = {
+      services: {
+        createLogger: vi.fn(() => logger),
+      },
+    } as unknown as AppContext;
+
+    const handler = createSetupTerminalUpgradeHandler(appContext);
+    const ws = new MockWebSocket();
+    const wss = {
+      handleUpgrade: vi.fn(
+        (
+          _request: IncomingMessage,
+          _socket: Duplex,
+          _head: Buffer,
+          callback: (socket: WebSocket) => void
+        ) => callback(ws as unknown as WebSocket)
+      ),
+    } as unknown as WebSocketServer;
+    const request = {} as IncomingMessage;
+    const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
+    const wsAliveMap = new WeakMap<WebSocket, boolean>();
+
+    handler(
+      request,
+      socket,
+      Buffer.alloc(0),
+      new URL('http://localhost/setup-terminal'),
+      wss,
+      wsAliveMap
+    );
+
+    ws.emit('message', JSON.stringify({ type: 'resize', cols: '120', rows: 40 }));
+
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: 'error', message: 'Invalid message format' })
+    );
+  });
+});

--- a/src/backend/schemas/websocket/index.ts
+++ b/src/backend/schemas/websocket/index.ts
@@ -19,6 +19,11 @@ export {
 } from '@/shared/websocket';
 
 export {
+  type SetupTerminalMessageInput,
+  SetupTerminalMessageSchema,
+} from './setup-terminal-message.schema';
+
+export {
   type TerminalMessageInput,
   TerminalMessageSchema,
 } from './terminal-message.schema';

--- a/src/backend/schemas/websocket/setup-terminal-message.schema.ts
+++ b/src/backend/schemas/websocket/setup-terminal-message.schema.ts
@@ -1,0 +1,28 @@
+/**
+ * Zod schemas for validating incoming setup-terminal WebSocket messages.
+ * These messages power the lightweight pre-workspace terminal.
+ */
+
+import { z } from 'zod';
+
+export const SetupTerminalMessageSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('create'),
+    cols: z.number().int().positive().optional(),
+    rows: z.number().int().positive().optional(),
+  }),
+  z.object({
+    type: z.literal('input'),
+    data: z.string(),
+  }),
+  z.object({
+    type: z.literal('resize'),
+    cols: z.number().int().positive(),
+    rows: z.number().int().positive(),
+  }),
+  z.object({
+    type: z.literal('ping'),
+  }),
+]);
+
+export type SetupTerminalMessageInput = z.infer<typeof SetupTerminalMessageSchema>;


### PR DESCRIPTION
## Summary
- add a dedicated `SetupTerminalMessageSchema` as a discriminated union for `create`, `input`, `resize`, and `ping`
- replace unchecked `raw as SetupTerminalMessage` casting in the setup-terminal WebSocket handler with `safeParse` and structured invalid-message handling
- add a regression test that verifies malformed setup-terminal messages are rejected with `Invalid message format`

## Test Plan
- [x] `pnpm test src/backend/routers/websocket/chat.handler.test.ts src/backend/routers/websocket/terminal.handler.test.ts src/backend/routers/websocket/setup-terminal.handler.test.ts`
- [x] `pnpm typecheck`
