### PR TITLE
Move load-session retry cooldown state into SessionStoreRegistry

### DIFF
--- a/src/backend/domains/session/session-domain.service.ts
+++ b/src/backend/domains/session/session-domain.service.ts
@@ -464,6 +464,18 @@ export class SessionDomainService extends EventEmitter {
     return store.historyHydrated === true;
   }
 
+  setHistoryRetryAt(sessionId: string, retryAt: number): void {
+    this.registry.setHistoryRetryAt(sessionId, retryAt);
+  }
+
+  canAttemptHistoryHydration(sessionId: string): boolean {
+    return this.registry.canAttemptHistoryHydration(sessionId);
+  }
+
+  clearHistoryRetryCooldown(sessionId: string): void {
+    this.registry.clearHistoryRetryCooldown(sessionId);
+  }
+
   markHistoryHydrated(
     sessionId: string,
     source: 'jsonl' | 'acp_fallback' | 'none',

--- a/src/backend/domains/session/store/session-store-registry.test.ts
+++ b/src/backend/domains/session/store/session-store-registry.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SessionStoreRegistry } from './session-store-registry';
+
+describe('SessionStoreRegistry history retry cooldowns', () => {
+  let nowMs = Date.parse('2026-02-24T12:00:00.000Z');
+
+  beforeEach(() => {
+    nowMs = Date.parse('2026-02-24T12:00:00.000Z');
+    vi.spyOn(Date, 'now').mockImplementation(() => nowMs);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('blocks retry attempts until retry deadline and then allows them', () => {
+    const registry = new SessionStoreRegistry();
+    registry.setHistoryRetryAt('session-1', nowMs + 30_000);
+
+    expect(registry.canAttemptHistoryHydration('session-1')).toBe(false);
+
+    nowMs += 30_001;
+    expect(registry.canAttemptHistoryHydration('session-1')).toBe(true);
+  });
+
+  it('removes cooldown entries when a session is cleared', () => {
+    const registry = new SessionStoreRegistry();
+    registry.setHistoryRetryAt('session-1', nowMs + 30_000);
+
+    expect(registry.canAttemptHistoryHydration('session-1')).toBe(false);
+
+    registry.clearSession('session-1');
+    expect(registry.canAttemptHistoryHydration('session-1')).toBe(true);
+  });
+
+  it('removes cooldown entries when all sessions are cleared', () => {
+    const registry = new SessionStoreRegistry();
+    registry.setHistoryRetryAt('session-1', nowMs + 30_000);
+    registry.setHistoryRetryAt('session-2', nowMs + 30_000);
+
+    registry.clearAllSessions();
+
+    expect(registry.canAttemptHistoryHydration('session-1')).toBe(true);
+    expect(registry.canAttemptHistoryHydration('session-2')).toBe(true);
+  });
+
+  it('evicts the earliest retry deadline when cooldown tracking reaches capacity', () => {
+    const registry = new SessionStoreRegistry();
+
+    for (let i = 0; i < 1024; i += 1) {
+      registry.setHistoryRetryAt(`session-${i}`, nowMs + i + 1);
+    }
+
+    registry.setHistoryRetryAt('session-overflow', nowMs + 50_000);
+
+    expect(registry.canAttemptHistoryHydration('session-0')).toBe(true);
+    expect(registry.canAttemptHistoryHydration('session-1')).toBe(false);
+    expect(registry.canAttemptHistoryHydration('session-overflow')).toBe(false);
+  });
+});

--- a/src/backend/domains/session/store/session-store-registry.ts
+++ b/src/backend/domains/session/store/session-store-registry.ts
@@ -3,8 +3,11 @@ import type { PendingInteractiveRequest } from '@/shared/pending-request-types';
 import { createInitialSessionRuntimeState } from '@/shared/session-runtime';
 import type { SessionStore } from './session-store.types';
 
+const MAX_TRACKED_HISTORY_RETRY_SESSIONS = 1024;
+
 export class SessionStoreRegistry {
   private readonly stores = new Map<string, SessionStore>();
+  private readonly nextHistoryRetryAtBySession = new Map<string, number>();
 
   getOrCreate(sessionId: string): SessionStore {
     let store = this.stores.get(sessionId);
@@ -25,10 +28,12 @@ export class SessionStoreRegistry {
   }
 
   clearSession(sessionId: string): void {
+    this.nextHistoryRetryAtBySession.delete(sessionId);
     this.stores.delete(sessionId);
   }
 
   clearAllSessions(): void {
+    this.nextHistoryRetryAtBySession.clear();
     this.stores.clear();
   }
 
@@ -48,5 +53,59 @@ export class SessionStoreRegistry {
 
   getQueueSnapshot(sessionId: string): QueuedMessage[] {
     return [...this.getOrCreate(sessionId).queue];
+  }
+
+  setHistoryRetryAt(sessionId: string, retryAt: number): void {
+    const now = Date.now();
+    this.pruneExpiredHistoryRetryEntries(now);
+
+    if (
+      !this.nextHistoryRetryAtBySession.has(sessionId) &&
+      this.nextHistoryRetryAtBySession.size >= MAX_TRACKED_HISTORY_RETRY_SESSIONS
+    ) {
+      this.evictHistoryRetryEntryWithEarliestRetryAt();
+    }
+
+    this.nextHistoryRetryAtBySession.set(sessionId, retryAt);
+  }
+
+  canAttemptHistoryHydration(sessionId: string): boolean {
+    const now = Date.now();
+    this.pruneExpiredHistoryRetryEntries(now);
+
+    const retryAt = this.nextHistoryRetryAtBySession.get(sessionId);
+    if (retryAt === undefined) {
+      return true;
+    }
+
+    return retryAt <= now;
+  }
+
+  clearHistoryRetryCooldown(sessionId: string): void {
+    this.nextHistoryRetryAtBySession.delete(sessionId);
+  }
+
+  private pruneExpiredHistoryRetryEntries(now: number): void {
+    for (const [trackedSessionId, retryAt] of this.nextHistoryRetryAtBySession) {
+      if (retryAt <= now) {
+        this.nextHistoryRetryAtBySession.delete(trackedSessionId);
+      }
+    }
+  }
+
+  private evictHistoryRetryEntryWithEarliestRetryAt(): void {
+    let sessionIdToEvict: string | undefined;
+    let earliestRetryAt = Number.POSITIVE_INFINITY;
+
+    for (const [trackedSessionId, retryAt] of this.nextHistoryRetryAtBySession) {
+      if (retryAt < earliestRetryAt) {
+        earliestRetryAt = retryAt;
+        sessionIdToEvict = trackedSessionId;
+      }
+    }
+
+    if (sessionIdToEvict) {
+      this.nextHistoryRetryAtBySession.delete(sessionIdToEvict);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- move history retry cooldown tracking out of `load-session.handler.ts` module scope and into `SessionStoreRegistry`
- add bounded cooldown state management (`setHistoryRetryAt`, `canAttemptHistoryHydration`, eviction/pruning) with lifecycle cleanup on `clearSession` and `clearAllSessions`
- expose cooldown helpers on `SessionDomainService` and update `load-session` handler + tests to use the domain/store-backed state
- add dedicated `SessionStoreRegistry` tests covering cooldown gating, cleanup behavior, and capacity eviction

## Test Plan
- [x] `pnpm test`
- [x] `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is largely preserved but state ownership changes; risk is limited to potential edge-case differences in retry gating or cleanup affecting history hydration frequency.
> 
> **Overview**
> Moves the JSONL history hydration retry-cooldown state out of `load-session.handler.ts` module scope and into `SessionStoreRegistry`, with `SessionDomainService` now exposing `setHistoryRetryAt`, `canAttemptHistoryHydration`, and `clearHistoryRetryCooldown`.
> 
> Updates `load-session` hydration to use these domain-backed APIs (including clearing cooldown when no `providerSessionId` or on success/not-found paths), and adjusts tests accordingly. Adds focused unit tests for registry cooldown gating, lifecycle cleanup on `clearSession`/`clearAllSessions`, and bounded tracking via earliest-deadline eviction at the 1024-session cap.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 236016495c21657cd0a9dbb49bf98e90a8fa0b01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->