### PR TITLE
Fix #1299: Preserve UTF-8 output and signal exits in execCommand

### DIFF
--- a/src/backend/lib/shell.test.ts
+++ b/src/backend/lib/shell.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { execCommand } from './shell';
+
+describe('execCommand', () => {
+  it('preserves UTF-8 output when stdout bytes are split across chunks', async () => {
+    const script = `
+      process.stdout.write(Buffer.from([0xf0, 0x9f]));
+      setTimeout(() => {
+        process.stdout.write(Buffer.from([0x9a, 0x80]));
+      }, 10);
+    `;
+
+    const result = await execCommand(process.execPath, ['-e', script]);
+
+    expect(result.stdout).toBe('🚀');
+    expect(result.code).toBe(0);
+  });
+
+  it('preserves UTF-8 output when stderr bytes are split across chunks', async () => {
+    const script = `
+      process.stderr.write(Buffer.from([0xf0, 0x9f]));
+      setTimeout(() => {
+        process.stderr.write(Buffer.from([0x9a, 0x80]));
+      }, 10);
+    `;
+
+    const result = await execCommand(process.execPath, ['-e', script]);
+
+    expect(result.stderr).toBe('🚀');
+    expect(result.code).toBe(0);
+  });
+
+  it('returns non-zero code when process is terminated by signal', async () => {
+    const script = "process.kill(process.pid, 'SIGKILL');";
+
+    const result = await execCommand(process.execPath, ['-e', script]);
+
+    expect(result.code).not.toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes `execCommand` to decode streamed UTF-8 output correctly across chunk boundaries.
- Prevents signal-terminated child processes from being reported as successful exits.
- Adds regression tests covering split multibyte output and signal termination behavior.

## Changes
- **Backend shell library (`src/backend/lib/shell.ts`)**: Switched stdout/stderr chunk decoding from per-chunk `Buffer.toString()` to `StringDecoder('utf8')` and flush on close.
- **Backend shell library (`src/backend/lib/shell.ts`)**: Changed close handling to return `code: -1` when Node reports `code === null` (signal-terminated/unknown non-exit).
- **Tests (`src/backend/lib/shell.test.ts`)**: Added regression tests for split UTF-8 decoding on both stdout and stderr and for signal-terminated process exit status.

## Testing
- [ ] Tests pass (`pnpm test`) — full suite currently fails in unrelated pre-existing tests (`app-sidebar-resize`, `admin-page`, `file-lock-mutex`) in this branch baseline
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable (backend utility change validated by automated tests)
- [x] Targeted regression tests pass (`pnpm exec vitest run src/backend/lib/shell.test.ts`)

Closes #1299

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-scoped change to a shared process-execution helper; main risk is behavior change for callers that previously relied on `code === 0` when a process was killed.
> 
> **Overview**
> Fixes `execCommand` output handling by switching stdout/stderr decoding from per-chunk `Buffer.toString()` to a streaming `StringDecoder('utf8')`, flushing any buffered partial codepoints on process close.
> 
> Adjusts exit reporting so a `null` close `code` (e.g., signal termination) now returns `-1` instead of `0`, preventing killed processes from being treated as successful. Adds Vitest coverage for split multibyte UTF-8 output on both stdout/stderr and for signal-terminated processes returning a non-zero code.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2840d3c695a0d9ce2f861bd7776e770acd13267. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->