### PR TITLE
Fix #1292: prevent GitHub clone path traversal

### DIFF
--- a/src/backend/services/git-clone.service.test.ts
+++ b/src/backend/services/git-clone.service.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockPathExists = vi.fn();
+const mockGitCommand = vi.fn();
+
+vi.mock('@/backend/lib/file-helpers', () => ({
+  pathExists: (...args: unknown[]) => mockPathExists(...args),
+}));
+
+vi.mock('@/backend/lib/shell', () => ({
+  execCommand: vi.fn(),
+  gitCommand: (...args: unknown[]) => mockGitCommand(...args),
+}));
+
+vi.mock('./logger.service', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+import { gitCloneService, parseGithubUrl } from './git-clone.service';
+
+describe('parseGithubUrl', () => {
+  it('parses a valid GitHub URL', () => {
+    expect(parseGithubUrl('https://github.com/purplefish-ai/factory-factory')).toEqual({
+      owner: 'purplefish-ai',
+      repo: 'factory-factory',
+    });
+  });
+
+  it('parses a valid GitHub URL with .git suffix', () => {
+    expect(parseGithubUrl('https://github.com/purplefish-ai/factory-factory.git')).toEqual({
+      owner: 'purplefish-ai',
+      repo: 'factory-factory',
+    });
+  });
+
+  it('rejects traversal owner path segment', () => {
+    expect(parseGithubUrl('https://github.com/../src')).toBeNull();
+  });
+
+  it('rejects traversal repo path segment', () => {
+    expect(parseGithubUrl('https://github.com/purplefish-ai/..')).toBeNull();
+  });
+
+  it('rejects dot-only segments', () => {
+    expect(parseGithubUrl('https://github.com/./repo')).toBeNull();
+    expect(parseGithubUrl('https://github.com/owner/.')).toBeNull();
+  });
+
+  it('rejects invalid characters in owner/repo segments', () => {
+    expect(parseGithubUrl('https://github.com/owner name/repo')).toBeNull();
+    expect(parseGithubUrl('https://github.com/owner/repo name')).toBeNull();
+  });
+});
+
+describe('GitCloneService.checkExistingClone', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns not_exists when clone directory does not exist', async () => {
+    mockPathExists.mockResolvedValue(false);
+
+    await expect(gitCloneService.checkExistingClone('/tmp/repos/owner/repo')).resolves.toBe(
+      'not_exists'
+    );
+    expect(mockGitCommand).not.toHaveBeenCalled();
+  });
+
+  it('returns not_repo when directory exists but is not a git repository', async () => {
+    mockPathExists.mockResolvedValue(true);
+    mockGitCommand.mockResolvedValueOnce({
+      code: 128,
+      stdout: '',
+      stderr: 'fatal: not a git repo',
+    });
+
+    await expect(gitCloneService.checkExistingClone('/tmp/repos/owner/repo')).resolves.toBe(
+      'not_repo'
+    );
+  });
+
+  it('returns valid_repo only when clone path is repository root', async () => {
+    mockPathExists.mockResolvedValue(true);
+    mockGitCommand
+      .mockResolvedValueOnce({ code: 0, stdout: '.git\n', stderr: '' })
+      .mockResolvedValueOnce({ code: 0, stdout: '\n', stderr: '' });
+
+    await expect(gitCloneService.checkExistingClone('/tmp/repos/owner/repo')).resolves.toBe(
+      'valid_repo'
+    );
+    expect(mockGitCommand).toHaveBeenNthCalledWith(
+      1,
+      ['rev-parse', '--git-dir'],
+      '/tmp/repos/owner/repo'
+    );
+    expect(mockGitCommand).toHaveBeenNthCalledWith(
+      2,
+      ['rev-parse', '--show-cdup'],
+      '/tmp/repos/owner/repo'
+    );
+  });
+
+  it('returns not_repo when clone path is nested inside another repository', async () => {
+    mockPathExists.mockResolvedValue(true);
+    mockGitCommand
+      .mockResolvedValueOnce({ code: 0, stdout: '.git\n', stderr: '' })
+      .mockResolvedValueOnce({ code: 0, stdout: '../\n', stderr: '' });
+
+    await expect(gitCloneService.checkExistingClone('/tmp/source-tree/src')).resolves.toBe(
+      'not_repo'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Block unsafe GitHub owner/repo path segments in backend URL parsing.
- Ensure existing clone detection only treats repository roots as valid clones.
- Add regression tests covering traversal and nested-repository bypass cases.

## Changes
- **Git clone URL parsing**: Added strict path-segment validation in `parseGithubUrl` to reject traversal/dot segments and invalid characters before path construction.
- **Existing clone validation**: Updated `checkExistingClone` to require both a valid git repo and `--show-cdup` empty output (repo root only), preventing subdirectory acceptance.
- **Tests**: Added `git-clone.service.test.ts` with parse + clone-status security coverage.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not run (backend service covered via automated tests)

Closes #1292

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens validation around filesystem paths and git repository detection; low code churn but security-sensitive and could reject previously accepted GitHub URLs or treat some existing directories as non-repos.
> 
> **Overview**
> **Prevents path-traversal and nested-repo bypasses in GitHub cloning.** `parseGithubUrl` now validates `owner`/`repo` path segments against a strict allowlist to reject `.`/`..` and other unsafe or malformed names before building clone paths.
> 
> `checkExistingClone` now only returns `valid_repo` when the target directory is a *git repo root* by additionally requiring `git rev-parse --show-cdup` to be empty, avoiding treating subdirectories inside another repository as valid clones.
> 
> Adds `git-clone.service.test.ts` with regression coverage for traversal/invalid URL segments and for repo-root vs nested-repo detection in `checkExistingClone`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e907a4da82b3835262cb7b0d83be644c2db0788a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->