### PR TITLE
Remove redundant Workspaces back button from workspace detail

### DIFF
--- a/src/client/routes/projects/workspaces/workspace-detail-header.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-header.tsx
@@ -60,7 +60,6 @@ import {
   RunScriptPortBadge,
   useRunScriptLaunch,
   useWorkspacePanel,
-  WorkspacesBackLink,
 } from '@/components/workspace';
 import { useIsMobile } from '@/hooks/use-mobile';
 import {
@@ -836,7 +835,6 @@ export function WorkspaceDetailHeaderSlot({
           triggerId="workspace-detail-project-select"
           projectButtonClassName="h-7 w-auto max-w-[10rem] gap-1 border-0 bg-transparent px-1 text-xs font-normal text-muted-foreground shadow-none focus:ring-0 sm:max-w-[18rem] sm:text-sm"
         />
-        <WorkspacesBackLink projectSlug={slug} />
       </HeaderLeftStartSlot>
       <HeaderLeftExtraSlot>
         <div className="hidden md:flex items-center gap-2 min-w-0">


### PR DESCRIPTION
## Summary
- remove the `WorkspacesBackLink` from the workspace detail header start slot
- keep project-name navigation as the primary path back to the workspaces/kanban view
- remove the now-unused `WorkspacesBackLink` import from `workspace-detail-header.tsx`

## Testing
- `pnpm test`
- pre-commit checks ran during commit, including `pnpm typecheck`, dependency-cruiser, and knip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that removes a redundant navigation control; main risk is minor UX regression if users relied on the explicit back link.
> 
> **Overview**
> Removes the redundant `WorkspacesBackLink` from the workspace detail header, leaving the project selector as the primary navigation back to the workspaces view.
> 
> Also drops the now-unused `WorkspacesBackLink` import from `workspace-detail-header.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8dccedac65fe8eb4583c2def7ecfdbece54e7a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->