### PR TITLE
Fix #1297: Prevent rate limiter queue race

### DIFF
--- a/src/backend/services/rate-limiter.service.ts
+++ b/src/backend/services/rate-limiter.service.ts
@@ -256,6 +256,7 @@ class RateLimiter {
       const request = this.requestQueue.shift();
       if (request) {
         request.resolve();
+        await Promise.resolve();
       }
     }
 


### PR DESCRIPTION
## Summary
- Fixes a race where queued `acquireSlot` calls could be left in the queue without an active processor.
- Adds a regression test that reproduces immediate re-queueing from a resolved queued request.
- Ensures queue processing yields to microtasks before deciding the queue is drained.

## Changes
- **Rate limiter queue loop**: Added a microtask yield after resolving each queued request in `processQueue` so synchronous `.then()` re-queues are observed before loop exit.
- **Regression test**: Added coverage for the `queueProcessingPromise`/`isProcessingQueue` race when a queued request chains another `acquireSlot` immediately.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable (backend service + automated regression test)

Closes #1297

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to queue-processing scheduling plus a regression test; main risk is subtle timing/behavior change in how quickly queued requests are processed.
> 
> **Overview**
> Fixes a race in `processQueue` where resolving a queued request could synchronously enqueue another `acquireSlot` and still allow the loop to exit, leaving the new request stuck without an active processor.
> 
> Adds a regression test that chains a new `acquireSlot` from a resolved queued request and asserts `queueProcessingPromise`/`isProcessingQueue` stay active and the queue fully drains.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e8dd7b23af03b5ef327538796bc31c6850571f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->