### PR TITLE
Allow all hosts in Vite dev server for Cloudflare tunnel access

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
     chunkSizeWarningLimit: 5000,
   },
   server: {
+    allowedHosts: 'all',
     proxy: {
       '/api': {
         target: backendUrl,


### PR DESCRIPTION
## Summary
- Allow Cloudflare tunnel (and other external) hostnames to reach the Vite dev server by setting `server.allowedHosts: 'all'`
- Without this, Vite rejects requests whose `Host` header doesn't match `localhost`, blocking access through tunnels

## Test plan
- [ ] Run `pnpm dev` and access the app through a Cloudflare tunnel URL — should load without a "Blocked request" error
- [ ] Verify local `localhost` access still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
