### PR TITLE
Fix #1304: prevent history hydration transcript clobber

### DIFF
--- a/src/backend/domains/session/chat/chat-message-handlers/handlers/load-session.handler.ts
+++ b/src/backend/domains/session/chat/chat-message-handlers/handlers/load-session.handler.ts
@@ -114,6 +114,16 @@ async function hydrateProviderHistoryIfNeeded(
 
   if (loadResult.status === 'loaded') {
     sessionDomainService.clearHistoryRetryCooldown(sessionId);
+    if (sessionDomainService.isHistoryHydrated(sessionId)) {
+      return;
+    }
+
+    const refreshedTranscriptCount = sessionDomainService.getTranscriptSnapshot(sessionId).length;
+    if (refreshedTranscriptCount > 0) {
+      sessionDomainService.markHistoryHydrated(sessionId, 'none');
+      return;
+    }
+
     const transcript = buildTranscriptFromHistory(loadResult.history);
     sessionDomainService.replaceTranscript(sessionId, transcript, { historySource: 'jsonl' });
     logger.debug('Hydrated provider transcript from JSONL history', {


### PR DESCRIPTION
## Summary
- Prevent `load_session` history hydration from overwriting transcript messages that arrive while JSONL history is loading.
- Add a regression test that reproduces the async race and verifies transcript clobbering no longer occurs.

## Changes
- **Session load hydration**: Re-check `isHistoryHydrated` and transcript contents after async provider history load resolves; skip `replaceTranscript` if hydration already happened or transcript became non-empty.
- **Regression coverage**: Added a deferred-load test in `load-session.handler.test.ts` to simulate a message arriving during in-flight history I/O.

## Testing
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Targeted regression tests pass (`pnpm test src/backend/domains/session/chat/chat-message-handlers/handlers/load-session.handler.test.ts`)
- [ ] Full test suite pass (`pnpm test`) *(currently failing on unrelated existing localStorage issues in `src/client/routes/admin-page.test.tsx` and `src/client/components/app-sidebar-resize.test.ts`)*
- [ ] Manual testing: Not run

Closes #1304

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts session history hydration logic in a user-facing chat path; if the new guard misfires it could skip or change when transcripts are hydrated from JSONL.
> 
> **Overview**
> Prevents a race in `load_session` where provider JSONL history hydration could overwrite messages that arrive while history I/O is in flight.
> 
> After a successful history load, the handler now re-checks `isHistoryHydrated` and the current transcript snapshot and skips `replaceTranscript` (marking hydration as `none` if the transcript is no longer empty). A new regression test simulates the deferred load and verifies the transcript is not clobbered.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 250c2dc2f79c9a1fa5c05dc88ba9ebf3bdd3ca47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->