### PR TITLE
Fix #1298: Harden run-script proxy malformed URL handling

### DIFF
--- a/src/shared/proxy-utils.test.ts
+++ b/src/shared/proxy-utils.test.ts
@@ -1,0 +1,30 @@
+import type { IncomingMessage } from 'node:http';
+import { describe, expect, it } from 'vitest';
+import { authenticateRequest, sanitizePathWithoutToken } from './proxy-utils';
+
+describe('proxy-utils', () => {
+  it('falls back to root path when sanitizing malformed URLs', () => {
+    expect(sanitizePathWithoutToken('/\\')).toBe('/');
+  });
+
+  it('treats malformed auth URLs as unauthenticated instead of throwing', () => {
+    const request = {
+      url: '/\\',
+      headers: {},
+    } as IncomingMessage;
+
+    const result = authenticateRequest({
+      req: request,
+      cookieSecret: Buffer.from('secret'),
+      authToken: 'expected-token',
+      sessionCookieName: 'session',
+    });
+
+    expect(result).toEqual({
+      authenticated: false,
+      viaToken: false,
+      invalidToken: false,
+      sanitizedPath: '/',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Prevent malformed run-script proxy request paths from crashing the backend process.
- Make shared proxy URL auth parsing non-throwing on invalid request URLs.
- Add regression tests for malformed HTTP and WebSocket upgrade requests.

## Changes
- **Shared proxy auth utilities**: Added safe URL parsing helpers in `src/shared/proxy-utils.ts` so malformed paths now return unauthenticated results instead of throwing.
- **Run script proxy service**: Wrapped `authenticateRequest` calls in HTTP and upgrade handlers with defensive `try/catch` and return `400 Bad Request` when parsing/auth throws.
- **Tests**: Added `src/shared/proxy-utils.test.ts` for malformed URL behavior and extended `src/backend/services/run-script-proxy.service.test.ts` with HTTP/upgrade malformed-path regression coverage.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Send malformed requests (e.g. `GET /\\ HTTP/1.1`) to an active run-script auth proxy and confirm 400/401 responses without backend crash.

Closes #1298

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared auth/URL parsing and the run-script auth proxy request handling; while mostly defensive, it could change how some edge-case request paths are interpreted or rejected (now `400`/unauthenticated instead of crashing).
> 
> **Overview**
> Hardens the run-script proxy so malformed request paths can’t crash the backend: unexpected errors during auth/URL parsing are now handled and responded to as **`400 Bad Request`** for both normal HTTP requests and WebSocket upgrades.
> 
> Makes shared proxy URL parsing (`authenticateRequest`, `sanitizePathWithoutToken`) **non-throwing** by safely parsing request URLs and falling back to `/` + unauthenticated when the URL is invalid.
> 
> Adds regression coverage with a new `proxy-utils.test.ts` and new run-script proxy tests that send raw malformed HTTP/upgrade requests and assert a `400` response.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebee4376ba196b24ee54ab3b3e76c1457a2400bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->