### PR TITLE
Fix #1295: Prevent overlapping scheduler PR sync batches

### DIFF
--- a/src/backend/orchestration/scheduler.service.ts
+++ b/src/backend/orchestration/scheduler.service.ts
@@ -35,7 +35,7 @@ class SchedulerService {
     this.isShuttingDown = false;
 
     this.syncInterval = setInterval(() => {
-      if (this.isShuttingDown) {
+      if (this.isShuttingDown || this.syncInProgress !== null) {
         return;
       }
 


### PR DESCRIPTION
## Summary
- Prevent scheduler PR sync/discovery interval ticks from starting a new batch while one is already in progress.
- Add regression coverage for non-overlapping interval execution and shutdown waiting semantics.
- Align scheduler tick behavior with the existing snapshot reconciliation orchestrator pattern.

## Changes
- **SchedulerService**: Added an in-flight guard in the interval callback (`syncInProgress !== null`) so overlapping batches cannot be scheduled.
- **Scheduler tests**: Added interval regression tests that verify no overlap during long-running work and that `stop()` waits for in-flight sync completion.
- **Scheduler tests**: Switched interval timer advancement to `SERVICE_INTERVAL_MS.schedulerPrSync` to avoid hardcoded timing.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not run (backend scheduler behavior covered by automated tests)

Closes #1295

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the scheduler tick logic to skip starting a new PR sync/discovery batch while a previous one is still running, which affects background job cadence and could delay updates under long-running work. Added tests reduce regression risk but this is still core orchestration behavior.
> 
> **Overview**
> **Prevents overlapping scheduler runs** by adding an in-flight guard (`syncInProgress !== null`) so interval ticks won’t start a new PR sync/discovery batch while the previous batch is still executing.
> 
> **Strengthens regression coverage** with new interval tests that verify non-overlapping behavior and that `stop()` waits for in-flight sync work to finish, and updates the timer advancement to use `SERVICE_INTERVAL_MS.schedulerPrSync` instead of hardcoded durations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8291432e28014bbc010dc67ff2646017eab8b9eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->