### PR TITLE
Fix #1296: persist ACP thought chunks in transcript

### DIFF
--- a/src/backend/domains/session/acp/acp-event-translator.test.ts
+++ b/src/backend/domains/session/acp/acp-event-translator.test.ts
@@ -78,7 +78,7 @@ describe('AcpEventTranslator', () => {
   });
 
   describe('agent_thought_chunk', () => {
-    it('translates text to thinking content_block', () => {
+    it('translates text to assistant thinking content', () => {
       const { translator } = createTranslator();
       const update = {
         sessionUpdate: 'agent_thought_chunk',
@@ -91,14 +91,10 @@ describe('AcpEventTranslator', () => {
       expect(events[0]).toEqual({
         type: 'agent_message',
         data: {
-          type: 'stream_event',
-          event: {
-            type: 'content_block_delta',
-            index: 0,
-            delta: {
-              type: 'thinking_delta',
-              thinking: 'Let me think about this...',
-            },
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'thinking', thinking: 'Let me think about this...' }],
           },
         },
       });

--- a/src/backend/domains/session/acp/acp-event-translator.ts
+++ b/src/backend/domains/session/acp/acp-event-translator.ts
@@ -107,11 +107,10 @@ export class AcpEventTranslator {
       {
         type: 'agent_message',
         data: {
-          type: 'stream_event',
-          event: {
-            type: 'content_block_delta',
-            index: 0,
-            delta: { type: 'thinking_delta', thinking: text },
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'thinking', thinking: text }],
           },
         },
       },


### PR DESCRIPTION
## Summary
- Persist ACP `agent_thought_chunk` updates by translating them into assistant `thinking` content instead of non-persisted stream deltas.
- Accumulate ACP assistant `thinking` chunks at a stable transcript order, matching existing text chunk behavior.
- Add regression coverage to prevent thought-stream persistence regressions.

## Changes
- **ACP translator**: `agent_thought_chunk` now emits `agent_message` with `data.type = assistant` and `content: [{ type: 'thinking' }]`.
- **ACP event processor**: generalized assistant chunk accumulation to support both `text` and `thinking`, including order-stable upsert behavior.
- **Tests**: updated translator test expectations and added a session lifecycle test asserting thinking chunks are accumulated via `upsertClaudeEvent` and not dropped.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Stream ACP thoughts in a live session and verify they remain after refresh/reload

Closes #1296

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how ACP streaming deltas are translated and persisted (including transcript ordering/upserts), which could affect message rendering or ordering if chunk shapes differ from expectations.
> 
> **Overview**
> ACP `agent_thought_chunk` translation is changed to emit an `agent_message` with `data.type = 'assistant'` and `content: [{ type: 'thinking' }]`, replacing the prior non-persisted stream delta shape.
> 
> The ACP event processor’s streaming accumulator is generalized from text-only to *text or thinking* chunks, maintaining a stable `order` via `upsertClaudeEvent` and resetting accumulation for non-simple assistant payloads.
> 
> Tests update translator expectations and add a lifecycle regression test asserting thinking chunks are accumulated at a single persisted transcript order (no `appendClaudeEvent` per chunk).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3d3033d4c59e32546d314e037f66605d38d1d39. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->