### PR TITLE
Add Python development tools to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,8 +89,10 @@ RUN apk add --no-cache \
   && curl -fsSL "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-${CF_ARCH}" \
        -o /usr/local/bin/cloudflared \
   && chmod +x /usr/local/bin/cloudflared \
-  && curl -LsSf https://astral.sh/uv/install.sh | sh \
-  && mv /root/.cargo/bin/uv /usr/local/bin/uv \
+  && UV_VERSION="0.10.6" \
+  && curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" -o /tmp/uv-install.sh \
+  && UV_UNMANAGED_INSTALL="/usr/local/bin" sh /tmp/uv-install.sh \
+  && rm /tmp/uv-install.sh \
   && pip3 install --no-cache-dir pipx \
   && python3 -m pipx ensurepath
 


### PR DESCRIPTION
## Summary
Add Python development tools (uv, pip, pipx, virtualenv) to the Factory Factory Docker image to enable agents to work on Python projects in their workspaces.

## Changes
- Install `py3-pip` and `py3-virtualenv` via apk
- Install `uv` from Astral's official installer (https://astral.sh/uv)
- Install `pipx` via pip for isolated CLI tool installation
- Update PATH to include `/root/.local/bin` for pipx-installed tools
- Add documentation comment explaining Python tools availability

## Motivation
Factory Factory agents should be able to work on any type of codebase, including Python projects. This change ensures that agents have access to modern Python package management tools when working in their workspace directories.

## Tools Added
- **uv**: Modern, fast Python package manager
- **pip**: Standard Python package installer
- **pipx**: Tool for installing Python CLI applications in isolated environments
- **virtualenv**: Virtual environment creation tool

## Testing
- All pre-commit hooks passed (typecheck, deps:check, knip)
- Docker image builds successfully with new tools
- Python tools are available in PATH for agent workspaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)