### PR TITLE
Revert "Fix #1296: persist ACP thought chunks in transcript"

### DIFF
--- a/src/backend/domains/session/acp/acp-event-translator.test.ts
+++ b/src/backend/domains/session/acp/acp-event-translator.test.ts
@@ -78,7 +78,7 @@ describe('AcpEventTranslator', () => {
   });
 
   describe('agent_thought_chunk', () => {
-    it('translates text to assistant thinking content', () => {
+    it('translates text to thinking content_block', () => {
       const { translator } = createTranslator();
       const update = {
         sessionUpdate: 'agent_thought_chunk',
@@ -91,10 +91,14 @@ describe('AcpEventTranslator', () => {
       expect(events[0]).toEqual({
         type: 'agent_message',
         data: {
-          type: 'assistant',
-          message: {
-            role: 'assistant',
-            content: [{ type: 'thinking', thinking: 'Let me think about this...' }],
+          type: 'stream_event',
+          event: {
+            type: 'content_block_delta',
+            index: 0,
+            delta: {
+              type: 'thinking_delta',
+              thinking: 'Let me think about this...',
+            },
           },
         },
       });

--- a/src/backend/domains/session/acp/acp-event-translator.ts
+++ b/src/backend/domains/session/acp/acp-event-translator.ts
@@ -107,10 +107,11 @@ export class AcpEventTranslator {
       {
         type: 'agent_message',
         data: {
-          type: 'assistant',
-          message: {
-            role: 'assistant',
-            content: [{ type: 'thinking', thinking: text }],
+          type: 'stream_event',
+          event: {
+            type: 'content_block_delta',
+            index: 0,
+            delta: { type: 'thinking_delta', thinking: text },
           },
         },
       },

--- a/src/backend/domains/session/lifecycle/acp-event-processor.ts
+++ b/src/backend/domains/session/lifecycle/acp-event-processor.ts
@@ -24,14 +24,6 @@ type PendingAcpToolCall = {
   acpLocations?: Array<{ path: string; line?: number | null }>;
 };
 
-type AssistantChunkType = 'text' | 'thinking';
-
-type AcpAssistantStreamState = {
-  order: number;
-  chunkType: AssistantChunkType;
-  accContent: string;
-};
-
 export type AcpEventProcessorDependencies = {
   runtimeManager: AcpRuntimeManager;
   sessionDomainService: SessionDomainService;
@@ -46,8 +38,8 @@ export class AcpEventProcessor {
   private readonly sessionConfigService: SessionConfigService;
   private readonly acpEventTranslator = new AcpEventTranslator(logger);
 
-  /** Per-session assistant chunk accumulation state for ACP streaming. */
-  readonly acpStreamState = new Map<string, AcpAssistantStreamState>();
+  /** Per-session text accumulation state for ACP streaming (reuses order so frontend upserts). */
+  readonly acpStreamState = new Map<string, { textOrder: number; accText: string }>();
   /** Per-session ACP tool calls that have started but not yet been completed by tool_result. */
   readonly pendingAcpToolCalls = new Map<string, Map<string, PendingAcpToolCall>>();
   /**
@@ -207,16 +199,14 @@ export class AcpEventProcessor {
 
     const data = (delta as { data: AgentMessage }).data;
 
-    // Text/thinking chunks: accumulate into single message, reuse same order
+    // Text chunks: accumulate into single message, reuse same order
     // so the frontend upserts rather than inserting a new bubble per chunk.
     if (data.type === 'assistant') {
-      const accumulated = this.accumulateAcpAssistantContent(sid, data);
-      if (accumulated) {
-        return;
-      }
+      this.accumulateAcpText(sid, data);
+      return;
     }
 
-    // Non-accumulated agent_message (tool_use, result, complex assistant payload): reset accumulator
+    // Non-text agent_message (thinking, tool_use, result): reset text accumulator
     this.acpStreamState.delete(sid);
     // Persist to transcript + allocate order in one step
     const order = this.sessionDomainService.appendClaudeEvent(sid, data);
@@ -302,60 +292,30 @@ export class AcpEventProcessor {
   }
 
   /**
-   * Accumulate ACP assistant text/thinking chunks into a single message at a stable order.
+   * Accumulate ACP assistant text chunks into a single message at a stable order.
    */
-  private accumulateAcpAssistantContent(sid: string, data: AgentMessage): boolean {
-    const chunk = this.extractAssistantChunk(data);
-    if (!chunk) {
-      return false;
-    }
-
+  private accumulateAcpText(sid: string, data: AgentMessage): void {
+    const content = data.message?.content;
+    const chunkText =
+      Array.isArray(content) && content[0]?.type === 'text'
+        ? (content[0] as { text: string }).text
+        : '';
     let ss = this.acpStreamState.get(sid);
-    if (!ss || ss.chunkType !== chunk.chunkType) {
-      ss = {
-        order: this.sessionDomainService.allocateOrder(sid),
-        chunkType: chunk.chunkType,
-        accContent: '',
-      };
+    if (!ss) {
+      ss = { textOrder: this.sessionDomainService.allocateOrder(sid), accText: '' };
       this.acpStreamState.set(sid, ss);
     }
-
-    ss.accContent += chunk.content;
+    ss.accText += chunkText;
     const accMsg: AgentMessage = {
       type: 'assistant',
-      message: {
-        role: 'assistant',
-        content:
-          ss.chunkType === 'thinking'
-            ? [{ type: 'thinking', thinking: ss.accContent }]
-            : [{ type: 'text', text: ss.accContent }],
-      },
+      message: { role: 'assistant', content: [{ type: 'text', text: ss.accText }] },
     };
-    this.sessionDomainService.upsertClaudeEvent(sid, accMsg, ss.order);
+    this.sessionDomainService.upsertClaudeEvent(sid, accMsg, ss.textOrder);
     this.sessionDomainService.emitDelta(sid, {
       type: 'agent_message',
       data: accMsg,
-      order: ss.order,
+      order: ss.textOrder,
     } as SessionDeltaEvent & { order: number });
-    return true;
-  }
-
-  private extractAssistantChunk(
-    data: AgentMessage
-  ): { chunkType: AssistantChunkType; content: string } | null {
-    const content = data.message?.content;
-    if (!Array.isArray(content) || content.length !== 1) {
-      return null;
-    }
-
-    const first = content[0];
-    if (first?.type === 'text') {
-      return { chunkType: 'text', content: first.text };
-    }
-    if (first?.type === 'thinking') {
-      return { chunkType: 'thinking', content: first.thinking };
-    }
-    return null;
   }
 
   private trackPendingAcpToolCalls(sid: string, delta: SessionDeltaEvent): void {

--- a/src/backend/domains/session/lifecycle/session.service.test.ts
+++ b/src/backend/domains/session/lifecycle/session.service.test.ts
@@ -92,7 +92,6 @@ function getAcpProcessorState() {
   return (
     sessionService as unknown as {
       acpEventProcessor: {
-        acpStreamState: Map<string, unknown>;
         pendingAcpToolCalls: Map<string, Map<string, unknown>>;
         sessionToWorkspace: Map<string, string>;
         sessionToWorkingDir: Map<string, string>;
@@ -110,7 +109,6 @@ describe('SessionService', () => {
     mockClearRatchetActiveSessionIfMatching.mockReset();
     mockAcpTraceLoggerCloseSession.mockReset();
     const acpProcessor = getAcpProcessorState();
-    acpProcessor.acpStreamState.clear();
     acpProcessor.pendingAcpToolCalls.clear();
     acpProcessor.sessionToWorkspace.clear();
     acpProcessor.sessionToWorkingDir.clear();
@@ -601,81 +599,6 @@ describe('SessionService', () => {
       })
     );
     expect(mockNotifyToolComplete).toHaveBeenCalledTimes(1);
-  });
-
-  it('accumulates assistant thinking chunks into one persisted message order', () => {
-    const acpProcessor = getAcpProcessorState();
-    const allocateOrderSpy = vi.spyOn(sessionDomainService, 'allocateOrder').mockReturnValue(41);
-    const upsertClaudeEventSpy = vi.spyOn(sessionDomainService, 'upsertClaudeEvent');
-    const emitDeltaSpy = vi.spyOn(sessionDomainService, 'emitDelta');
-    const appendClaudeEventSpy = vi.spyOn(sessionDomainService, 'appendClaudeEvent');
-
-    try {
-      acpProcessor.handleAcpDelta('session-1', {
-        type: 'agent_message',
-        data: {
-          type: 'assistant',
-          message: {
-            role: 'assistant',
-            content: [{ type: 'thinking', thinking: 'Plan' }],
-          },
-        },
-      });
-
-      acpProcessor.handleAcpDelta('session-1', {
-        type: 'agent_message',
-        data: {
-          type: 'assistant',
-          message: {
-            role: 'assistant',
-            content: [{ type: 'thinking', thinking: ' next' }],
-          },
-        },
-      });
-
-      expect(allocateOrderSpy).toHaveBeenCalledTimes(1);
-      expect(upsertClaudeEventSpy).toHaveBeenNthCalledWith(
-        1,
-        'session-1',
-        {
-          type: 'assistant',
-          message: {
-            role: 'assistant',
-            content: [{ type: 'thinking', thinking: 'Plan' }],
-          },
-        },
-        41
-      );
-      expect(upsertClaudeEventSpy).toHaveBeenNthCalledWith(
-        2,
-        'session-1',
-        {
-          type: 'assistant',
-          message: {
-            role: 'assistant',
-            content: [{ type: 'thinking', thinking: 'Plan next' }],
-          },
-        },
-        41
-      );
-      expect(emitDeltaSpy).toHaveBeenNthCalledWith(2, 'session-1', {
-        type: 'agent_message',
-        data: {
-          type: 'assistant',
-          message: {
-            role: 'assistant',
-            content: [{ type: 'thinking', thinking: 'Plan next' }],
-          },
-        },
-        order: 41,
-      });
-      expect(appendClaudeEventSpy).not.toHaveBeenCalled();
-    } finally {
-      allocateOrderSpy.mockRestore();
-      upsertClaudeEventSpy.mockRestore();
-      emitDeltaSpy.mockRestore();
-      appendClaudeEventSpy.mockRestore();
-    }
   });
 
   it('creates client from preloaded session without re-querying session row', async () => {


### PR DESCRIPTION
Reverts purplefish-ai/factory-factory#1321

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how ACP thinking events are translated and whether they are persisted, which can affect transcript integrity and frontend rendering/streaming behavior.
> 
> **Overview**
> Stops persisting ACP `agent_thought_chunk` into the assistant transcript: `AcpEventTranslator` now emits a `stream_event` `content_block_delta` with `thinking_delta` instead of an `assistant` message with `thinking` content.
> 
> Simplifies ACP streaming accumulation in `AcpEventProcessor` to **only** coalesce assistant `text` chunks (dropping the prior text/thinking chunk-type state), and updates tests accordingly (removes the thinking-accumulation coverage and adjusts translator expectations).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99281070853fdfd2a424ae8f570ec53d3775147f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->