### PR TITLE
Update docs for Linear domain and issue provider behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Structure & Module Organization
 - `src/backend/`: Express + tRPC server, WebSocket handlers, and resource accessors
-- `src/backend/domains/`: Domain modules (session, workspace, github, ratchet, terminal, run-script). The session domain manages ACP agent runtimes, chat services, event translation, and permission handling.
+- `src/backend/domains/`: Domain modules (session, workspace, github, linear, ratchet, terminal, run-script). The session domain manages ACP agent runtimes, chat services, event translation, and permission handling.
 - `src/backend/orchestration/`: Cross-domain coordination layer (bridges, workspace init/archive)
 - `src/backend/services/`: Infrastructure-only services (logger, config, scheduler, port, health, etc.)
 - `src/client/`: React UI (routes/pages, plus client-specific hooks/components/lib; router in `src/client/router.tsx`)
@@ -30,7 +30,7 @@ Path aliases: `@/*` → `src/`, `@prisma-gen/*` → `prisma/generated/`.
 - Prefer existing patterns and directory conventions; keep backend logic in `src/backend/` and UI in `src/client/`.
 
 ## Backend Domain Module Pattern
-- **6 domains:** session, workspace, github, ratchet, terminal, run-script (all in `src/backend/domains/`). The session domain contains subdirectories: acp/ (runtime manager, process handles, event translation, permissions), lifecycle/ (session service, hydrator), chat/ (message handling, event forwarding), data/ (session data readers/helpers), store/ (in-memory state + transcript/state machines), logging/.
+- **7 domains:** session, workspace, github, linear, ratchet, terminal, run-script (all in `src/backend/domains/`). The session domain contains subdirectories: acp/ (runtime manager, process handles, event translation, permissions), lifecycle/ (session service, hydrator), chat/ (message handling, event forwarding), data/ (session data readers/helpers), store/ (in-memory state + transcript/state machines), logging/.
 - Each domain has an `index.ts` barrel file as the sole public API
 - Consumers must import from barrel (`@/backend/domains/session`), never from internal paths
 - Domains never import from sibling domains (enforced by dependency-cruiser `no-cross-domain-imports` rule)
@@ -68,8 +68,9 @@ Path aliases: `@/*` → `src/`, `@prisma-gen/*` → `prisma/generated/`.
 - The app can run commands without manual approval in some modes; review changes carefully before merging.
 
 ## Feature Notes (Keep Docs Current)
-- **Auto-Fix (Ratchet):** Automatically watches pull requests and dispatches agents to fix issues (1-minute check cadence). When a PR has failing CI or review comments, creates a fixer session to address them. PR states: `IDLE` / `CI_RUNNING` / `CI_FAILED` / `REVIEW_PENDING` / `READY` / `MERGED`. Workspace-level toggle controls whether auto-fix is active. Admin setting controls default for new workspaces created from GitHub issues.
-- **GitHub integration:** Uses local `gh` auth; issue fetch supports workspace issue picker (`listIssuesForWorkspace`) and Kanban intake column (`listIssuesForProject`, assigned to `@me`). Starting from an issue should create a linked workspace (`githubIssueNumber`, `githubIssueUrl`).
-- **Kanban model:** UI has `ISSUES` + DB columns `WORKING`, `WAITING`, `DONE`. Column state is derived, not manually set; READY workspaces with no prior sessions are intentionally hidden, and archived workspaces preserve cached pre-archive column.
+- **Auto-Fix (Ratchet):** Automatically watches pull requests and dispatches agents to fix issues (1-minute check cadence). When a PR has failing CI or review comments, creates a fixer session to address them. PR states: `IDLE` / `CI_RUNNING` / `CI_FAILED` / `REVIEW_PENDING` / `READY` / `MERGED`. Workspace-level toggle controls whether auto-fix is active. Admin setting controls the default ratchet state for new workspaces.
+- **GitHub integration:** Uses local `gh` auth; issue fetch supports workspace issue picker (`listIssuesForWorkspace`) and Kanban intake (`listIssuesForProject`, assigned to `@me`). Starting from an issue creates a linked workspace (`githubIssueNumber`, `githubIssueUrl`).
+- **Linear integration:** Per-project issue provider can be set to Linear with encrypted API key + team selection. Kanban intake uses Linear issues assigned to the configured viewer. Starting from an issue creates a linked workspace (`linearIssueId`, `linearIssueIdentifier`, `linearIssueUrl`) and workspace lifecycle events best-effort sync issue state in Linear.
+- **Kanban model:** UI has a provider-driven intake column (`GitHub Issues` or `Linear Issues`) plus DB columns `WORKING`, `WAITING`, `DONE`. Column state is derived, not manually set; READY workspaces with no prior sessions are intentionally hidden, and archived workspaces preserve cached pre-archive column.
 - **Quick actions:** Workspace quick actions are markdown-driven from `prompts/quick-actions/` (frontmatter metadata + prompt body). Agent quick actions create follow-up sessions and auto-send prompt content when session is ready.
 - **ACP Runtime:** All agent sessions use the Agent Client Protocol (ACP) via `@agentclientprotocol/sdk`. CLAUDE sessions spawn `claude-code-acp`; CODEX sessions spawn Factory Factory's internal `codex-app-server-acp` adapter, both over stdio JSON-RPC. Session init/load is fail-fast and requires provider `configOptions` with model/mode categories. Permission requests present multi-option selection (`allow_once`, `allow_always`, `deny_once`, `deny_always`) and are bridged through ACP permission response handlers.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 - [Feature Highlights](#feature-highlights)
   - [Ratchet (Automatic PR Progression)](#-ratchet-automatic-pr-progression)
   - [GitHub Integration](#-github-integration)
+  - [Linear Integration](#-linear-integration)
   - [Kanban Board](#-kanban-board)
   - [Quick Actions](#-quick-actions)
 - [Development](#development)
@@ -50,6 +51,7 @@
 - GitHub CLI (`gh`) - authenticated
 - Claude Code (for Claude provider) - authenticated via `claude login`
 - ChatGPT/Codex account (for Codex provider)
+- Linear API key (optional, only if using Linear issue intake)
 
 ### Option 1: Run with npx (Recommended)
 
@@ -123,13 +125,15 @@ npx factory-factory@latest serve [options]
 
 Options:
   -p, --port <port>           Frontend port (default: 3000)
-  --backend-port <port>       Backend port (default: 3001)
+  --backend-port <port>       Backend port in --dev mode (default: 3001)
   -d, --database-path <path>  SQLite database path (default: ~/factory-factory/data.db)
   --host <host>               Host to bind to (default: localhost)
   --dev                       Development mode with hot reloading
   --no-open                   Don't open browser automatically
   -v, --verbose               Enable verbose logging
 ```
+
+In production mode (`ff serve` without `--dev`), Factory Factory serves frontend and API on a single port.
 
 ```bash
 # Start a public Cloudflare tunnel (starts server + tunnel)
@@ -187,6 +191,7 @@ ff proxy --private
 3. **Create your first workspace:**
    - Open the web UI (automatically opens at http://localhost:3000)
    - Configure your project with a local git repository
+   - Optional: in Admin, choose an issue provider per project (GitHub Issues or Linear Issues)
    - Click "New Workspace" to create your first isolated worktree
    - Start chatting with your selected ACP provider (CLAUDE or CODEX)
 
@@ -238,8 +243,8 @@ Project (repository configuration)
 - **ACP runtime:** Each session runs through ACP (`@agentclientprotocol/sdk`) and negotiates provider capabilities (models/modes/config options) at runtime
 - **Persistent sessions:** Resume and review previous conversations
 - **Terminal access:** Full PTY terminal per workspace
-- **GitHub integration:** Import issues, track PR state, automatic PR progression via Ratchet
-- **Kanban board:** Visual project management with GitHub issue intake
+- **Issue tracking integration:** Use GitHub or Linear as the per-project issue provider
+- **Kanban board:** Visual project management with provider-specific issue intake
 
 ## Feature Highlights
 
@@ -262,11 +267,21 @@ Seamless integration with GitHub via the authenticated `gh` CLI.
 - **Linked workspaces:** Issues are automatically linked to their workspaces (prevents duplicates)
 - **Kanban intake:** GitHub Issues column shows issues assigned to `@me` for easy triage
 
+### 📐 Linear Integration
+
+Configure Linear as the issue provider per project in Admin settings.
+
+- **Per-project provider:** Choose GitHub Issues or Linear Issues per project
+- **Secure API key storage:** Linear API keys are encrypted at rest in project issue tracker config
+- **Team-scoped intake:** Kanban intake uses your assigned Linear issues for the configured team
+- **Linked workspaces:** Starting from a Linear issue stores `linearIssueId`, `linearIssueIdentifier`, and `linearIssueUrl`
+- **State sync:** Linear issues are best-effort transitioned when work starts and when PRs merge
+
 ### 📋 Kanban Board
 
 Real-time visual project management with automatic column placement.
 
-- **Smart columns:** GitHub Issues → Working → Waiting → Done
+- **Smart columns:** Issues intake (GitHub Issues or Linear Issues) → Working → Waiting → Done
 - **Auto-categorization:**
   - **Working:** Provisioning, new, failed, or actively running sessions
   - **Waiting:** Idle workspaces that have completed at least one session
@@ -297,6 +312,7 @@ This design enables seamless parallel workflows, but you should understand:
 - ✅ Only use with repositories you trust
 - ✅ Review changes carefully before merging PRs
 - ✅ Keep your GitHub authentication secure
+- ✅ Keep Linear API keys scoped and rotated if using Linear integration
 - ✅ Monitor Ratchet auto-fix behavior in Admin settings
 - ✅ Consider running in a VM or container for untrusted code
 
@@ -339,8 +355,9 @@ claude --version        # Verify installation
 # Run migrations manually
 ff db:migrate
 
-# Reset database (⚠️ destroys all data)
-ff db:reset
+# Optional reset (⚠️ destroys all local data; creates a backup first)
+mv ~/factory-factory/data.db ~/factory-factory/data.db.bak
+ff db:migrate
 
 # View database in Prisma Studio
 ff db:studio
@@ -356,7 +373,7 @@ ff serve --verbose
 
 Or specify custom ports:
 ```bash
-ff serve --port 8080 --backend-port 8081
+ff serve --dev --port 8080 --backend-port 8081
 ```
 
 ### Common Issues


### PR DESCRIPTION
## Summary
- update `AGENTS.md` domain documentation to include the `linear` domain and reflect the current 7-domain backend layout
- refresh `AGENTS.md` feature notes to document provider-based issue intake (GitHub + Linear), linked workspace metadata, and Linear lifecycle sync behavior
- update `README.md` to match current behavior: add a Linear integration section, clarify `--backend-port` usage in `--dev`, and remove invalid `ff db:reset` guidance in favor of supported manual reset steps

## Validation
- `pnpm test`
- pre-commit checks triggered by hooks:
  - `pnpm typecheck`
  - `pnpm deps:check`
  - `pnpm knip`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates clarifying issue provider behavior and CLI/db instructions; no runtime code paths change.
> 
> **Overview**
> Updates docs to reflect **Linear as a first-class issue provider** alongside GitHub, including the new `linear` backend domain and provider-driven Kanban intake/linked workspace metadata, plus best-effort Linear lifecycle state sync.
> 
> Refreshes `README.md` usage guidance by adding a Linear integration section, clarifying that `--backend-port` applies to `--dev` mode and that production serves UI+API on one port, and replacing the unsupported `ff db:reset` instructions with manual backup-and-migrate reset steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d4aad8bfa4daafcbc2c739864f6d59d7f5af67f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->