### PR TITLE
Set GitHub URL as default tab for new project creation

### DIFF
--- a/src/client/routes/projects/new.tsx
+++ b/src/client/routes/projects/new.tsx
@@ -28,7 +28,7 @@ export default function NewProjectPage() {
   useAppHeader({ title: 'New Project' });
 
   const navigate = useNavigate();
-  const [source, setSource] = useState<ProjectSource>('local');
+  const [source, setSource] = useState<ProjectSource>('github');
 
   // Local path state
   const [repoPath, setRepoPath] = useState('');


### PR DESCRIPTION
## Summary
Changes the default project source from "Local Path" to "GitHub URL" in the new project page.

## Changes
- Updated the initial state of `source` from `'local'` to `'github'` in `src/client/routes/projects/new.tsx`

## Test plan
- [x] Navigate to `/projects/new`
- [x] Verify that the "GitHub URL" tab is selected by default
- [x] Verify that users can still switch to "Local Path" tab if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)