### PR TITLE
Preserve ACP creation lock bookkeeping during stopClient

### DIFF
--- a/src/backend/domains/session/acp/acp-runtime-manager.ts
+++ b/src/backend/domains/session/acp/acp-runtime-manager.ts
@@ -903,15 +903,11 @@ export class AcpRuntimeManager {
   async stopClient(sessionId: string): Promise<void> {
     if (this.stoppingInProgress.has(sessionId)) {
       logger.debug('ACP session stop already in progress', { sessionId });
-      this.creationLocks.delete(sessionId);
-      this.lockRefCounts.delete(sessionId);
       return;
     }
 
     const handle = this.sessions.get(sessionId);
     if (!handle) {
-      this.creationLocks.delete(sessionId);
-      this.lockRefCounts.delete(sessionId);
       return;
     }
 
@@ -960,8 +956,6 @@ export class AcpRuntimeManager {
       if (current === handle) {
         this.sessions.delete(sessionId);
       }
-      this.creationLocks.delete(sessionId);
-      this.lockRefCounts.delete(sessionId);
     }
   }
 


### PR DESCRIPTION
## Summary
- Preserve `creationLocks` and `lockRefCounts` bookkeeping while `stopClient()` is in progress so queued `getOrCreateClient()` calls remain serialized behind the same per-session queue.
- Avoid clearing lock bookkeeping in `stopClient()` early-return or finalizer paths, preventing concurrent lock queues for the same session.
- Keep regression coverage that asserts lock bookkeeping is retained during an in-progress stop path.

## Testing
- `pnpm build`
- `pnpm check:fix`
- `pnpm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that tighten assertions around `stopClient` behavior; low risk aside from potentially exposing existing race conditions in CI if assumptions are wrong.
> 
> **Overview**
> Adds regression coverage in `acp-runtime-manager.test.ts` for `stopClient` edge cases involving internal creation-lock bookkeeping.
> 
> The new assertions verify that when a stop is already in progress—or when a stale process exits during an in-flight restart—`creationLocks`/`lockRefCounts` for the session are not inadvertently cleared mid-operation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 743622460436c5587edadee07033261edf43d149. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
