### PR TITLE
Inject sessionService into chat handlers to enforce import boundary

### DIFF
--- a/src/backend/domains/session/chat/chat-message-handlers.service.ts
+++ b/src/backend/domains/session/chat/chat-message-handlers.service.ts
@@ -105,6 +105,7 @@ class ChatMessageHandlerService {
   }
 
   private handlerRegistry = createChatMessageHandlerRegistry({
+    sessionService,
     getClientCreator: () => this.clientCreator,
     tryDispatchNextMessage: this.tryDispatchNextMessage.bind(this),
     setManualDispatchResume: this.setManualDispatchResume.bind(this),

--- a/src/backend/domains/session/chat/chat-message-handlers/handlers/permission-response.handler.ts
+++ b/src/backend/domains/session/chat/chat-message-handlers/handlers/permission-response.handler.ts
@@ -1,13 +1,19 @@
 import { DEBUG_CHAT_WS } from '@/backend/domains/session/chat/chat-message-handlers/constants';
-import type { ChatMessageHandler } from '@/backend/domains/session/chat/chat-message-handlers/types';
-import { sessionService } from '@/backend/domains/session/lifecycle/session.service';
+import type {
+  ChatMessageHandler,
+  ChatMessageHandlerSessionService,
+} from '@/backend/domains/session/chat/chat-message-handlers/types';
 import { createLogger } from '@/backend/services/logger.service';
 import type { PermissionResponseMessage } from '@/shared/websocket';
 import { clearPendingInteractiveRequest, sendWebSocketError } from './utils';
 
 const logger = createLogger('chat-message-handlers');
 
-export function createPermissionResponseHandler(): ChatMessageHandler<PermissionResponseMessage> {
+export function createPermissionResponseHandler(deps: {
+  sessionService: ChatMessageHandlerSessionService;
+}): ChatMessageHandler<PermissionResponseMessage> {
+  const { sessionService } = deps;
+
   return ({ ws, sessionId, message }) => {
     const { requestId, optionId, answers } = message;
 

--- a/src/backend/domains/session/chat/chat-message-handlers/handlers/session-import-boundary.test.ts
+++ b/src/backend/domains/session/chat/chat-message-handlers/handlers/session-import-boundary.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, test } from 'vitest';
+
+const handlersDir = __dirname;
+
+const HANDLERS = [
+  'user-input.handler.ts',
+  'set-model.handler.ts',
+  'permission-response.handler.ts',
+] as const;
+
+describe('session handler import boundary', () => {
+  test.each(HANDLERS)('%s does not import directly from session domain internals', (fileName) => {
+    const source = readFileSync(join(handlersDir, fileName), 'utf8');
+
+    expect(source).not.toContain("from '@/backend/domains/session'");
+    expect(source).not.toContain("from '@/backend/domains/session/lifecycle/session.service'");
+    expect(source).not.toContain("from '@/backend/domains/session/session-domain.service'");
+  });
+});

--- a/src/backend/domains/session/chat/chat-message-handlers/handlers/set-model.handler.test.ts
+++ b/src/backend/domains/session/chat/chat-message-handlers/handlers/set-model.handler.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ChatMessageHandlerSessionService } from '@/backend/domains/session/chat/chat-message-handlers/types';
 
 const mocks = vi.hoisted(() => ({
   setSessionModel: vi.fn(),
@@ -6,17 +7,20 @@ const mocks = vi.hoisted(() => ({
   getChatBarCapabilities: vi.fn(),
 }));
 
-vi.mock('@/backend/domains/session/lifecycle/session.service', () => ({
-  sessionService: {
-    setSessionModel: mocks.setSessionModel,
-    setSessionReasoningEffort: mocks.setSessionReasoningEffort,
-    getChatBarCapabilities: mocks.getChatBarCapabilities,
-  },
-}));
-
 import { createSetModelHandler } from './set-model.handler';
 
 describe('createSetModelHandler', () => {
+  const deps: { sessionService: ChatMessageHandlerSessionService } = {
+    sessionService: {
+      isSessionRunning: vi.fn(),
+      sendSessionMessage: vi.fn(),
+      respondToAcpPermission: vi.fn(),
+      setSessionModel: mocks.setSessionModel,
+      setSessionReasoningEffort: mocks.setSessionReasoningEffort,
+      getChatBarCapabilities: mocks.getChatBarCapabilities,
+    },
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.setSessionModel.mockResolvedValue(undefined);
@@ -35,7 +39,7 @@ describe('createSetModelHandler', () => {
   });
 
   it('applies model and reasoning effort when provided', async () => {
-    const handler = createSetModelHandler();
+    const handler = createSetModelHandler(deps);
     const ws = {
       send: vi.fn(),
     };
@@ -73,7 +77,7 @@ describe('createSetModelHandler', () => {
   });
 
   it('does not update reasoning effort when field is omitted', async () => {
-    const handler = createSetModelHandler();
+    const handler = createSetModelHandler(deps);
     const ws = {
       send: vi.fn(),
     };
@@ -95,7 +99,7 @@ describe('createSetModelHandler', () => {
   });
 
   it('sends websocket error when model update fails', async () => {
-    const handler = createSetModelHandler();
+    const handler = createSetModelHandler(deps);
     const ws = {
       send: vi.fn(),
     };

--- a/src/backend/domains/session/chat/chat-message-handlers/handlers/set-model.handler.ts
+++ b/src/backend/domains/session/chat/chat-message-handlers/handlers/set-model.handler.ts
@@ -1,13 +1,19 @@
 import { DEBUG_CHAT_WS } from '@/backend/domains/session/chat/chat-message-handlers/constants';
-import type { ChatMessageHandler } from '@/backend/domains/session/chat/chat-message-handlers/types';
-import { sessionService } from '@/backend/domains/session/lifecycle/session.service';
+import type {
+  ChatMessageHandler,
+  ChatMessageHandlerSessionService,
+} from '@/backend/domains/session/chat/chat-message-handlers/types';
 import { createLogger } from '@/backend/services/logger.service';
 import type { SetModelMessage } from '@/shared/websocket';
 import { sendWebSocketError } from './utils';
 
 const logger = createLogger('chat-message-handlers');
 
-export function createSetModelHandler(): ChatMessageHandler<SetModelMessage> {
+export function createSetModelHandler(deps: {
+  sessionService: ChatMessageHandlerSessionService;
+}): ChatMessageHandler<SetModelMessage> {
+  const { sessionService } = deps;
+
   return async ({ ws, sessionId, message }) => {
     try {
       await sessionService.setSessionModel(sessionId, message.model);

--- a/src/backend/domains/session/chat/chat-message-handlers/handlers/user-input.handler.ts
+++ b/src/backend/domains/session/chat/chat-message-handlers/handlers/user-input.handler.ts
@@ -1,12 +1,18 @@
-import type { ChatMessageHandler } from '@/backend/domains/session/chat/chat-message-handlers/types';
-import { sessionService } from '@/backend/domains/session/lifecycle/session.service';
+import type {
+  ChatMessageHandler,
+  ChatMessageHandlerSessionService,
+} from '@/backend/domains/session/chat/chat-message-handlers/types';
 import { createLogger } from '@/backend/services/logger.service';
 import type { AgentContentItem } from '@/shared/acp-protocol';
 import type { UserInputMessage } from '@/shared/websocket';
 
 const logger = createLogger('chat-message-handlers');
 
-export function createUserInputHandler(): ChatMessageHandler<UserInputMessage> {
+export function createUserInputHandler(deps: {
+  sessionService: ChatMessageHandlerSessionService;
+}): ChatMessageHandler<UserInputMessage> {
+  const { sessionService } = deps;
+
   return ({ ws, sessionId, message }) => {
     const rawContent = message.content || message.text;
     if (!rawContent) {

--- a/src/backend/domains/session/chat/chat-message-handlers/registry.ts
+++ b/src/backend/domains/session/chat/chat-message-handlers/registry.ts
@@ -23,16 +23,22 @@ export type ChatMessageHandlerRegistry = {
 export function createChatMessageHandlerRegistry(
   deps: HandlerRegistryDependencies
 ): ChatMessageHandlerRegistry {
+  if (!deps.sessionService) {
+    throw new Error('sessionService dependency is required for chat message handlers');
+  }
+
+  const sessionDeps = { sessionService: deps.sessionService };
+
   return {
     start: createStartHandler(deps),
-    user_input: createUserInputHandler(),
+    user_input: createUserInputHandler(sessionDeps),
     queue_message: createQueueMessageHandler(deps),
     remove_queued_message: createRemoveQueuedMessageHandler(),
     resume_queued_messages: createResumeQueuedMessagesHandler(deps),
     stop: createStopHandler(deps),
     load_session: createLoadSessionHandler(deps),
-    permission_response: createPermissionResponseHandler(),
-    set_model: createSetModelHandler(),
+    permission_response: createPermissionResponseHandler(sessionDeps),
+    set_model: createSetModelHandler(sessionDeps),
     set_thinking_budget: createSetThinkingBudgetHandler(),
     set_config_option: createSetConfigOptionHandler(),
   };

--- a/src/backend/domains/session/chat/chat-message-handlers/types.ts
+++ b/src/backend/domains/session/chat/chat-message-handlers/types.ts
@@ -1,5 +1,20 @@
 import type { WebSocket } from 'ws';
+import type { AgentContentItem } from '@/shared/acp-protocol';
 import type { ChatMessageInput } from '@/shared/websocket';
+
+export interface ChatMessageHandlerSessionService {
+  isSessionRunning: (sessionId: string) => boolean;
+  sendSessionMessage: (sessionId: string, content: string | AgentContentItem[]) => Promise<void>;
+  respondToAcpPermission: (
+    sessionId: string,
+    requestId: string,
+    optionId: string,
+    answers?: Record<string, string[]>
+  ) => boolean;
+  setSessionModel: (sessionId: string, model?: string) => Promise<void>;
+  setSessionReasoningEffort: (sessionId: string, reasoningEffort: string | null) => void;
+  getChatBarCapabilities: (sessionId: string) => Promise<unknown>;
+}
 
 export interface ClientCreator {
   getOrCreate(
@@ -25,6 +40,7 @@ export type ChatMessageHandler<T extends ChatMessageInput = ChatMessageInput> = 
 ) => Promise<void> | void;
 
 export interface HandlerRegistryDependencies {
+  sessionService?: ChatMessageHandlerSessionService;
   getClientCreator: () => ClientCreator | null;
   tryDispatchNextMessage: (sessionId: string) => Promise<void>;
   setManualDispatchResume: (sessionId: string, resumed: boolean) => void;


### PR DESCRIPTION
## Summary
- Replace direct session-domain imports in chat handlers (`user_input`, `set_model`, `permission_response`) with injected `sessionService` dependencies.
- Wire `sessionService` through the chat handler registry and add a runtime guard to ensure the dependency is present.
- Add a regression test that enforces the handler import boundary so these files do not import session domain internals directly.
- Update `set-model` handler tests to use dependency injection instead of module-level service mocks.

## Why
- The previous barrel-import attempt introduced a circular dependency in `depcruise`.
- This change preserves encapsulation for the targeted handlers while avoiding circular imports.

## Test Plan
- [x] `pnpm test`
- [x] `pnpm typecheck`
- [x] `pnpm deps:check`
- [x] `pnpm test src/backend/domains/session/chat/chat-message-handlers/handlers/session-import-boundary.test.ts src/backend/domains/session/chat/chat-message-handlers/handlers/set-model.handler.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily dependency-injection and test changes with a small wiring/bootstrapping risk if `sessionService` is not provided (now fails fast via a guard).
> 
> **Overview**
> Refactors the `user_input`, `set_model`, and `permission_response` chat handlers to stop importing session-domain internals directly, and instead accept a `sessionService` dependency via the handler factory.
> 
> Threads `sessionService` from `ChatMessageHandlerService` through `createChatMessageHandlerRegistry`, adds a runtime guard that the dependency is provided, and introduces a Vitest regression test to enforce the import boundary. Updates the `set-model` handler tests to use injected deps rather than module-level mocks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06a65f82eb20e7c8e73b5b3606c212074060b897. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->