### PR TITLE
Enforce Codex schema drift checks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Codex CLI
-        run: npm install -g @openai/codex
+        run: npm install -g @openai/codex@0.101.0
 
       - name: Generate Prisma client
         run: pnpm db:generate


### PR DESCRIPTION
## Summary
- install Codex CLI (`@openai/codex`) in the main CI `checks` job
- run `pnpm check:codex-schema` in CI so Codex app-server schema drift fails the build automatically
- remove reliance on manual local drift checks to catch adapter incompatibility early

## Verification
- `pnpm typecheck` (ran via pre-commit hook)
- `pnpm deps:check` (ran via pre-commit hook)
- `pnpm knip --include files,dependencies,unlisted` (ran via pre-commit hook)
- `pnpm check:codex-schema` (fails with current drift: snapshot expects `codex-cli 0.101.0`, local CLI is `codex-cli 0.105.0`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that adds an extra CI validation step; main risk is increased CI flakiness/failures if the pinned Codex version or drift check is brittle.
> 
> **Overview**
> Adds a new CI gate in `.github/workflows/ci.yml` to **install a pinned `@openai/codex@0.101.0` CLI** during the `checks` job.
> 
> Runs `pnpm check:codex-schema` as part of CI so **Codex app-server schema drift fails the build automatically**, catching adapter/CLI incompatibilities earlier.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b2c054466b956f4ac6fbd28fecbe8bb8acd1f6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->