### PR TITLE
Fix Docker image crash from bare Prisma imports

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Docker Build & Push
 
 on:
   push:
-    branches: [main, adeeshaek/docker-build-fails-16-616-executing]
+    branches: [main, adeeshaek/docker-build-fails-16-616-executing, adeeshaek/image-seems-failing-default-2026-02]
 
 env:
   REGISTRY: ghcr.io

--- a/scripts/fix-prisma-imports.mjs
+++ b/scripts/fix-prisma-imports.mjs
@@ -1,14 +1,18 @@
 /**
- * Post-build fixup: rewrite .ts import specifiers to .js in compiled Prisma output.
+ * Post-build fixup: ensure all relative imports in compiled Prisma output
+ * use .js extensions for Node.js ESM compatibility.
  *
- * Prisma 7.x generates TypeScript files with explicit .ts extensions in imports.
- * tsc with moduleResolution:"bundler" preserves those extensions in the compiled .js,
- * but Node.js can't load .ts files at runtime. The compiled .js counterparts already
- * exist, so we just need to point the imports at them.
+ * Handles two cases:
+ * 1. Prisma generates explicit .ts extensions (Prisma 7.4.0 and earlier):
+ *    tsc with moduleResolution:"bundler" preserves .ts extensions → rewrite to .js
+ * 2. Prisma generates bare relative imports (Prisma 7.4.1+):
+ *    tsc-alias --resolve-full-paths should add .js, but as a fallback,
+ *    explicitly add .js to any bare relative imports that are missing an extension.
  */
 
 import { readdir, readFile, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { existsSync } from "node:fs";
+import { join, dirname, resolve } from "node:path";
 
 const GENERATED_DIR = join("dist", "prisma", "generated");
 
@@ -31,11 +35,37 @@ let rewritten = 0;
 
 for (const file of files) {
   const src = await readFile(file, "utf8");
-  // Rewrite  from "….ts"  and  from '….ts'  to use .js extension
-  const fixed = src.replace(
+  const dir = dirname(file);
+
+  // Step 1: rewrite explicit .ts extensions to .js
+  let fixed = src.replace(
     /(from\s+['"])([^'"]+)\.ts(['"])/g,
     "$1$2.js$3",
   );
+
+  // Step 2: add .js to bare relative imports that have no extension
+  // Matches: from "./foo" or from "../foo" (no extension after last segment)
+  fixed = fixed.replace(
+    /(from\s+['"])(\.\.?\/[^'"]+?)(['"])/g,
+    (match, prefix, importPath, suffix) => {
+      // Skip if already has an extension
+      if (/\.[a-z]+$/i.test(importPath)) {
+        return match;
+      }
+      // Check if the .js file actually exists in dist
+      const candidate = resolve(dir, importPath + ".js");
+      if (existsSync(candidate)) {
+        return `${prefix}${importPath}.js${suffix}`;
+      }
+      // Try index.js
+      const indexCandidate = resolve(dir, importPath, "index.js");
+      if (existsSync(indexCandidate)) {
+        return `${prefix}${importPath}/index.js${suffix}`;
+      }
+      return match;
+    },
+  );
+
   if (fixed !== src) {
     await writeFile(file, fixed);
     rewritten++;
@@ -43,5 +73,5 @@ for (const file of files) {
 }
 
 console.log(
-  `fix-prisma-imports: rewrote .ts → .js in ${rewritten}/${files.length} files`,
+  `fix-prisma-imports: fixed imports in ${rewritten}/${files.length} files`,
 );


### PR DESCRIPTION
## Summary
- Harden `fix-prisma-imports.mjs` to handle **both** Prisma 7.4.0 (explicit `.ts` extensions) and 7.4.1+ (bare relative imports) by adding a fallback that appends `.js` to extensionless relative imports in compiled Prisma output
- Add branch trigger to Docker publish workflow for testing

## Test plan
- [x] Verified locally: bare imports (Prisma 7.4.1) get `.js` added by the script
- [x] Verified locally: full build pipeline (`tsc` → `tsc-alias` → `fix-prisma-imports`) produces correct `.js` imports
- [x] `pnpm typecheck`, `pnpm check:fix` pass
- [ ] Docker image builds and starts successfully on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
