### PR TITLE
Fix #1355: Raise coverage for infra backend modules

### DIFF
--- a/src/backend/resource_accessors/workspace.accessor.test.ts
+++ b/src/backend/resource_accessors/workspace.accessor.test.ts
@@ -1,52 +1,168 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockCreate = vi.fn();
+const mockFindMany = vi.fn();
+const mockFindUnique = vi.fn();
+const mockFindFirst = vi.fn();
+const mockUpdateMany = vi.fn();
+const mockExecuteRaw = vi.fn();
 
 vi.mock('@/backend/db', () => ({
   prisma: {
     workspace: {
       create: (...args: unknown[]) => mockCreate(...args),
+      findMany: (...args: unknown[]) => mockFindMany(...args),
+      findUnique: (...args: unknown[]) => mockFindUnique(...args),
+      findFirst: (...args: unknown[]) => mockFindFirst(...args),
+      updateMany: (...args: unknown[]) => mockUpdateMany(...args),
     },
+    $executeRaw: (...args: unknown[]) => mockExecuteRaw(...args),
   },
 }));
 
 import { workspaceAccessor } from './workspace.accessor';
 
-describe('workspaceAccessor.create', () => {
-  it('passes ratchetEnabled when provided', async () => {
-    mockCreate.mockResolvedValue({ id: 'ws-1' });
+describe('workspaceAccessor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
-    await workspaceAccessor.create({
-      projectId: 'project-1',
-      name: 'Issue workspace',
-      githubIssueNumber: 12,
-      ratchetEnabled: false,
-    });
+  describe('create', () => {
+    it('passes ratchetEnabled when provided', async () => {
+      mockCreate.mockResolvedValue({ id: 'ws-1' });
 
-    expect(mockCreate).toHaveBeenCalledWith({
-      data: expect.objectContaining({
+      await workspaceAccessor.create({
         projectId: 'project-1',
         name: 'Issue workspace',
         githubIssueNumber: 12,
         ratchetEnabled: false,
-      }),
+      });
+
+      expect(mockCreate).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          projectId: 'project-1',
+          name: 'Issue workspace',
+          githubIssueNumber: 12,
+          ratchetEnabled: false,
+        }),
+      });
+    });
+
+    it('keeps ratchetEnabled undefined when not provided', async () => {
+      mockCreate.mockResolvedValue({ id: 'ws-2' });
+
+      await workspaceAccessor.create({
+        projectId: 'project-1',
+        name: 'Manual workspace',
+      });
+
+      expect(mockCreate).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          projectId: 'project-1',
+          name: 'Manual workspace',
+          ratchetEnabled: undefined,
+        }),
+      });
     });
   });
 
-  it('keeps ratchetEnabled undefined when not provided', async () => {
-    mockCreate.mockResolvedValue({ id: 'ws-2' });
+  it('throws for mutually-exclusive status filters in findByProjectIdWithSessions', () => {
+    expect(() =>
+      workspaceAccessor.findByProjectIdWithSessions('project-1', {
+        status: 'READY',
+        excludeStatuses: ['FAILED'],
+      })
+    ).toThrow('Cannot specify both status and excludeStatuses filters');
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
 
-    await workspaceAccessor.create({
-      projectId: 'project-1',
-      name: 'Manual workspace',
+  it('short-circuits findByIds and findByIdsWithProject for empty id arrays', async () => {
+    await expect(workspaceAccessor.findByIds([])).resolves.toEqual([]);
+    await expect(workspaceAccessor.findByIdsWithProject([])).resolves.toEqual([]);
+
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  it('queries IDs with and without project include', async () => {
+    mockFindMany.mockResolvedValueOnce([{ id: 'ws-1' }]).mockResolvedValueOnce([{ id: 'ws-2' }]);
+
+    await workspaceAccessor.findByIds(['ws-1']);
+    await workspaceAccessor.findByIdsWithProject(['ws-2']);
+
+    expect(mockFindMany).toHaveBeenNthCalledWith(1, {
+      where: { id: { in: ['ws-1'] } },
     });
+    expect(mockFindMany).toHaveBeenNthCalledWith(2, {
+      where: { id: { in: ['ws-2'] } },
+      include: { project: true },
+    });
+  });
 
-    expect(mockCreate).toHaveBeenCalledWith({
-      data: expect.objectContaining({
-        projectId: 'project-1',
-        name: 'Manual workspace',
-        ratchetEnabled: undefined,
-      }),
+  it('marks workspace as having had sessions with guarded updateMany', async () => {
+    mockUpdateMany.mockResolvedValue({ count: 1 });
+
+    await workspaceAccessor.markHasHadSessions('ws-1');
+
+    expect(mockUpdateMany).toHaveBeenCalledWith({
+      where: { id: 'ws-1', hasHadSessions: false },
+      data: { hasHadSessions: true },
+    });
+  });
+
+  it('appends init output and skips existence check when update succeeds', async () => {
+    mockExecuteRaw.mockResolvedValue(1);
+
+    await workspaceAccessor.appendInitOutput('ws-1', 'hello output', 256);
+
+    expect(mockExecuteRaw).toHaveBeenCalledTimes(1);
+    expect(mockFindUnique).not.toHaveBeenCalled();
+  });
+
+  it('checks existence when init output update affects no rows and throws if missing', async () => {
+    mockExecuteRaw.mockResolvedValue(0);
+    mockFindUnique.mockResolvedValue(null);
+
+    await expect(workspaceAccessor.appendInitOutput('missing', 'line')).rejects.toThrow(
+      'Workspace not found: missing'
+    );
+    expect(mockFindUnique).toHaveBeenCalledWith({
+      where: { id: 'missing' },
+      select: { id: true },
+    });
+  });
+
+  it('returns successfully when init output update affects no rows but workspace exists', async () => {
+    mockExecuteRaw.mockResolvedValue(0);
+    mockFindUnique.mockResolvedValue({ id: 'ws-1' });
+
+    await expect(workspaceAccessor.appendInitOutput('ws-1', 'line')).resolves.toBeUndefined();
+  });
+
+  it('finds one ratchet candidate by id with READY and PR filters', async () => {
+    mockFindFirst.mockResolvedValue({ id: 'ws-1', prUrl: 'https://github.com/org/repo/pull/1' });
+
+    await workspaceAccessor.findForRatchetById('ws-1');
+
+    expect(mockFindFirst).toHaveBeenCalledWith({
+      where: {
+        id: 'ws-1',
+        status: 'READY',
+        prUrl: { not: null },
+      },
+      select: {
+        id: true,
+        prUrl: true,
+        prNumber: true,
+        prState: true,
+        prCiStatus: true,
+        defaultSessionProvider: true,
+        ratchetSessionProvider: true,
+        ratchetEnabled: true,
+        ratchetState: true,
+        ratchetActiveSessionId: true,
+        ratchetLastCiRunId: true,
+        prReviewLastCheckedAt: true,
+      },
     });
   });
 });

--- a/src/backend/services/crypto.service.test.ts
+++ b/src/backend/services/crypto.service.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetBaseDir = vi.hoisted(() => vi.fn());
+const mockInfo = vi.hoisted(() => vi.fn());
+const mockExistsSync = vi.hoisted(() => vi.fn());
+const mockMkdirSync = vi.hoisted(() => vi.fn());
+const mockReadFileSync = vi.hoisted(() => vi.fn());
+const mockWriteFileSync = vi.hoisted(() => vi.fn());
+
+vi.mock('./config.service', () => ({
+  configService: {
+    getBaseDir: (...args: unknown[]) => mockGetBaseDir(...args),
+  },
+}));
+
+vi.mock('./logger.service', () => ({
+  createLogger: () => ({
+    info: (...args: unknown[]) => mockInfo(...args),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock('node:fs', () => ({
+  existsSync: (...args: unknown[]) => mockExistsSync(...args),
+  mkdirSync: (...args: unknown[]) => mockMkdirSync(...args),
+  readFileSync: (...args: unknown[]) => mockReadFileSync(...args),
+  writeFileSync: (...args: unknown[]) => mockWriteFileSync(...args),
+}));
+
+import { cryptoService } from './crypto.service';
+
+describe('cryptoService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetBaseDir.mockReturnValue('/tmp/factory-factory-test');
+    (cryptoService as unknown as { encryptionKey: Buffer | null }).encryptionKey = null;
+  });
+
+  it('generates a key when missing and round-trips encrypted values', () => {
+    mockExistsSync.mockImplementation((path: string) => path === '/tmp/factory-factory-test');
+
+    const encrypted = cryptoService.encrypt('super-secret');
+    const decrypted = cryptoService.decrypt(encrypted);
+
+    expect(decrypted).toBe('super-secret');
+    expect(mockMkdirSync).not.toHaveBeenCalled();
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      '/tmp/factory-factory-test/encryption.key',
+      expect.any(Buffer),
+      { mode: 0o600 }
+    );
+    expect(mockInfo).toHaveBeenCalledWith('Generating new encryption key', {
+      path: '/tmp/factory-factory-test/encryption.key',
+    });
+  });
+
+  it('reuses an existing valid key and does not write a new one', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(Buffer.alloc(32, 7));
+
+    const encrypted = cryptoService.encrypt('hello');
+    expect(cryptoService.decrypt(encrypted)).toBe('hello');
+
+    expect(mockReadFileSync).toHaveBeenCalledWith('/tmp/factory-factory-test/encryption.key');
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+  });
+
+  it('throws when existing key has an invalid length', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(Buffer.alloc(31, 1));
+
+    expect(() => cryptoService.encrypt('hello')).toThrow('has invalid length');
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+  });
+
+  it('throws when decrypt input format is invalid', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(Buffer.alloc(32, 9));
+
+    expect(() => cryptoService.decrypt('bad-format')).toThrow(
+      'Invalid encrypted value format: expected iv:authTag:ciphertext'
+    );
+  });
+});

--- a/src/backend/trpc/closed-sessions.router.test.ts
+++ b/src/backend/trpc/closed-sessions.router.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockReadFile = vi.hoisted(() => vi.fn());
+const mockUnlink = vi.hoisted(() => vi.fn());
+const mockSessionDataService = vi.hoisted(() => ({
+  findClosedSessionsByWorkspaceId: vi.fn(),
+  findClosedSessionByIdWithWorkspace: vi.fn(),
+  deleteClosedSession: vi.fn(),
+}));
+
+vi.mock('node:fs/promises', () => ({
+  readFile: (...args: unknown[]) => mockReadFile(...args),
+  unlink: (...args: unknown[]) => mockUnlink(...args),
+}));
+
+vi.mock('@/backend/domains/session', () => ({
+  sessionDataService: mockSessionDataService,
+}));
+
+import { closedSessionsRouter } from './closed-sessions.trpc';
+
+function createCaller() {
+  return closedSessionsRouter.createCaller({ appContext: {} } as never);
+}
+
+describe('closedSessionsRouter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('lists closed sessions with default and explicit limits', async () => {
+    mockSessionDataService.findClosedSessionsByWorkspaceId.mockResolvedValue([]);
+    const caller = createCaller();
+
+    await expect(caller.list({ workspaceId: 'ws-1' })).resolves.toEqual([]);
+    await expect(caller.list({ workspaceId: 'ws-1', limit: 7 })).resolves.toEqual([]);
+
+    expect(mockSessionDataService.findClosedSessionsByWorkspaceId).toHaveBeenNthCalledWith(
+      1,
+      'ws-1',
+      20
+    );
+    expect(mockSessionDataService.findClosedSessionsByWorkspaceId).toHaveBeenNthCalledWith(
+      2,
+      'ws-1',
+      7
+    );
+  });
+
+  it('returns a parsed transcript when the transcript file exists', async () => {
+    const transcript = {
+      messages: [{ role: 'user', content: 'hello' }],
+      sessionSummary: 'Test summary',
+    };
+    mockSessionDataService.findClosedSessionByIdWithWorkspace.mockResolvedValue({
+      id: 'closed-1',
+      transcriptPath: 'transcripts/closed-1.json',
+      workspace: { worktreePath: '/tmp/worktree' },
+    });
+    mockReadFile.mockResolvedValue(JSON.stringify(transcript));
+
+    const caller = createCaller();
+    await expect(caller.getTranscript({ id: 'closed-1' })).resolves.toEqual(transcript);
+
+    expect(mockReadFile).toHaveBeenCalledWith('/tmp/worktree/transcripts/closed-1.json', 'utf-8');
+  });
+
+  it('throws NOT_FOUND when transcript session metadata is missing', async () => {
+    mockSessionDataService.findClosedSessionByIdWithWorkspace.mockResolvedValue(null);
+    const caller = createCaller();
+
+    await expect(caller.getTranscript({ id: 'missing' })).rejects.toThrow(
+      'Closed session not found: missing'
+    );
+  });
+
+  it('throws BAD_REQUEST when workspace has no worktree path', async () => {
+    mockSessionDataService.findClosedSessionByIdWithWorkspace.mockResolvedValue({
+      id: 'closed-1',
+      transcriptPath: 'transcripts/closed-1.json',
+      workspace: { worktreePath: null },
+    });
+    const caller = createCaller();
+
+    await expect(caller.getTranscript({ id: 'closed-1' })).rejects.toThrow(
+      'Workspace has no worktree path'
+    );
+  });
+
+  it('maps ENOENT transcript reads to NOT_FOUND', async () => {
+    mockSessionDataService.findClosedSessionByIdWithWorkspace.mockResolvedValue({
+      id: 'closed-1',
+      transcriptPath: 'transcripts/closed-1.json',
+      workspace: { worktreePath: '/tmp/worktree' },
+    });
+    mockReadFile.mockRejectedValue(
+      Object.assign(new Error('missing file'), {
+        code: 'ENOENT',
+      })
+    );
+    const caller = createCaller();
+
+    await expect(caller.getTranscript({ id: 'closed-1' })).rejects.toThrow(
+      'Transcript file not found'
+    );
+  });
+
+  it('maps non-ENOENT transcript read failures to INTERNAL_SERVER_ERROR', async () => {
+    mockSessionDataService.findClosedSessionByIdWithWorkspace.mockResolvedValue({
+      id: 'closed-1',
+      transcriptPath: 'transcripts/closed-1.json',
+      workspace: { worktreePath: '/tmp/worktree' },
+    });
+    mockReadFile.mockRejectedValue(new Error('permission denied'));
+    const caller = createCaller();
+
+    await expect(caller.getTranscript({ id: 'closed-1' })).rejects.toThrow(
+      'Failed to read transcript file'
+    );
+  });
+
+  it('deletes closed sessions and best-effort deletes transcript files', async () => {
+    mockSessionDataService.findClosedSessionByIdWithWorkspace.mockResolvedValue({
+      id: 'closed-1',
+      transcriptPath: 'transcripts/closed-1.json',
+      workspace: { worktreePath: '/tmp/worktree' },
+    });
+    mockSessionDataService.deleteClosedSession.mockResolvedValue(undefined);
+    mockUnlink.mockResolvedValue(undefined);
+    const caller = createCaller();
+
+    await expect(caller.delete({ id: 'closed-1' })).resolves.toEqual({ success: true });
+    expect(mockSessionDataService.deleteClosedSession).toHaveBeenCalledWith('closed-1');
+    expect(mockUnlink).toHaveBeenCalledWith('/tmp/worktree/transcripts/closed-1.json');
+  });
+
+  it('returns success even when transcript unlink fails', async () => {
+    mockSessionDataService.findClosedSessionByIdWithWorkspace.mockResolvedValue({
+      id: 'closed-1',
+      transcriptPath: 'transcripts/closed-1.json',
+      workspace: { worktreePath: '/tmp/worktree' },
+    });
+    mockSessionDataService.deleteClosedSession.mockResolvedValue(undefined);
+    mockUnlink.mockRejectedValue(new Error('permission denied'));
+    const caller = createCaller();
+
+    await expect(caller.delete({ id: 'closed-1' })).resolves.toEqual({ success: true });
+  });
+
+  it('throws NOT_FOUND when deleting an unknown closed session', async () => {
+    mockSessionDataService.findClosedSessionByIdWithWorkspace.mockResolvedValue(null);
+    const caller = createCaller();
+
+    await expect(caller.delete({ id: 'missing' })).rejects.toThrow(
+      'Closed session not found: missing'
+    );
+    expect(mockSessionDataService.deleteClosedSession).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Add dedicated tests for `closed-sessions.trpc` list/transcript/delete paths, including error translation branches.
- Add unit tests for `crypto.service` key generation/loading, encrypt/decrypt round trips, and invalid input handling.
- Expand `workspace.accessor` tests for conditional query/update behavior and append-output failure handling.
- Raise backend stable coverage across the target infra modules.

## Changes
- **tRPC / Closed Sessions**: Added [`closed-sessions.router.test.ts`] coverage for defaults, transcript parsing, missing session/worktree failures, file-read error mapping, and best-effort delete behavior.
- **Crypto Service**: Added [`crypto.service.test.ts`] coverage for key lifecycle and decrypt format validation, with mocked filesystem/config/logger dependencies.
- **Workspace Accessor**: Expanded [`workspace.accessor.test.ts`] to cover filter validation, empty-ID short circuits, ID lookup variants, guarded updates, appendInitOutput success/failure, and ratchet lookup query shape.
- **Coverage snapshots (`pnpm test:coverage:backend:stable`)**:
  - Before (2026-02-26): overall backend line coverage `75.43%`; `closed-sessions.trpc.ts` `0.00%`; `crypto.service.ts` `17.50%`; `workspace.accessor.ts` `51.85%`.
  - After (2026-02-26): overall backend line coverage `76.02%`; `closed-sessions.trpc.ts` `100.00%`; `crypto.service.ts` `97.50%`; `workspace.accessor.ts` `72.22%`.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Coverage run succeeds (`pnpm test:coverage:backend:stable`)
- [ ] Manual testing: Not needed (test-only backend changes)

Closes #1355

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that add coverage around database/file/crypto edge cases; low runtime risk but may require minor adjustments if mocks diverge from real implementations.
> 
> **Overview**
> Adds new Vitest coverage for `closed-sessions.trpc` (`list`, `getTranscript`, `delete`), including limit defaults, transcript JSON parsing, and error mapping (missing session/worktree, ENOENT vs other read failures, best-effort unlink).
> 
> Introduces `crypto.service` unit tests covering key generation vs reuse, key-length validation, encrypt/decrypt round-trips, and invalid ciphertext format handling. Expands `workspace.accessor` tests to cover filter validation, empty-ID short-circuits, query shapes for ID lookups/ratchet candidate selection, guarded `updateMany` for `hasHadSessions`, and `appendInitOutput` success/fallback existence-check behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a663067ae82a19fc95e484f05c4476acc1dff542. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->