### PR TITLE
Fix #1354: increase websocket handler coverage

### DIFF
--- a/src/backend/routers/websocket/post-run-logs.handler.test.ts
+++ b/src/backend/routers/websocket/post-run-logs.handler.test.ts
@@ -1,0 +1,195 @@
+import { EventEmitter } from 'node:events';
+import type { IncomingMessage } from 'node:http';
+import type { Duplex } from 'node:stream';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WebSocket, WebSocketServer } from 'ws';
+import type { AppContext } from '@/backend/app-context';
+import { WS_READY_STATE } from '@/backend/constants/websocket';
+import { createPostRunLogsUpgradeHandler, postRunLogsConnections } from './post-run-logs.handler';
+
+class MockWebSocket extends EventEmitter {
+  readyState: number = WS_READY_STATE.OPEN;
+  send = vi.fn();
+}
+
+function createLogger() {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+function createWssFromQueue(queue: MockWebSocket[]) {
+  return {
+    handleUpgrade: vi.fn(
+      (
+        _request: IncomingMessage,
+        _socket: Duplex,
+        _head: Buffer,
+        callback: (socket: WebSocket) => void
+      ) => {
+        const ws = queue.shift();
+        if (!ws) {
+          throw new Error('No mock websocket available');
+        }
+        callback(ws as unknown as WebSocket);
+      }
+    ),
+  } as unknown as WebSocketServer;
+}
+
+describe('createPostRunLogsUpgradeHandler', () => {
+  beforeEach(() => {
+    postRunLogsConnections.clear();
+    vi.clearAllMocks();
+  });
+
+  it('rejects upgrades when workspaceId is missing', () => {
+    const logger = createLogger();
+    const runScriptService = {
+      getPostRunOutputBuffer: vi.fn(() => ''),
+      subscribeToPostRunOutput: vi.fn(),
+    };
+    const appContext = {
+      services: {
+        createLogger: vi.fn(() => logger),
+        runScriptService,
+      },
+    } as unknown as AppContext;
+
+    const handler = createPostRunLogsUpgradeHandler(appContext);
+    const request = {} as IncomingMessage;
+    const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
+    const wss = { handleUpgrade: vi.fn() } as unknown as WebSocketServer;
+
+    handler(
+      request,
+      socket,
+      Buffer.alloc(0),
+      new URL('http://localhost/post-run-logs'),
+      wss,
+      new WeakMap<WebSocket, boolean>()
+    );
+
+    expect(logger.warn).toHaveBeenCalledWith('Post-run logs WebSocket missing workspaceId');
+    expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('400 Bad Request'));
+    expect(socket.destroy).toHaveBeenCalledTimes(1);
+    expect(wss.handleUpgrade).not.toHaveBeenCalled();
+  });
+
+  it('streams buffered/live output and cleans up subscription on close', () => {
+    const workspaceId = 'workspace-1';
+    const logger = createLogger();
+    const unsubscribe = vi.fn();
+    let outputCallback: ((data: string) => void) | undefined;
+    const runScriptService = {
+      getPostRunOutputBuffer: vi.fn(() => 'buffered post-run logs\n'),
+      subscribeToPostRunOutput: vi.fn((_id: string, callback: (data: string) => void) => {
+        outputCallback = callback;
+        return unsubscribe;
+      }),
+    };
+    const appContext = {
+      services: {
+        createLogger: vi.fn(() => logger),
+        runScriptService,
+      },
+    } as unknown as AppContext;
+
+    const ws = new MockWebSocket();
+    const handler = createPostRunLogsUpgradeHandler(appContext);
+    const request = {} as IncomingMessage;
+    const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
+    const wss = createWssFromQueue([ws]);
+    const wsAliveMap = new WeakMap<WebSocket, boolean>();
+
+    handler(
+      request,
+      socket,
+      Buffer.alloc(0),
+      new URL(`http://localhost/post-run-logs?workspaceId=${workspaceId}`),
+      wss,
+      wsAliveMap
+    );
+
+    expect(runScriptService.getPostRunOutputBuffer).toHaveBeenCalledWith(workspaceId);
+    expect(runScriptService.subscribeToPostRunOutput).toHaveBeenCalledWith(
+      workspaceId,
+      expect.any(Function)
+    );
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: 'output', data: 'buffered post-run logs\n' })
+    );
+    expect(postRunLogsConnections.get(workspaceId)?.has(ws as unknown as WebSocket)).toBe(true);
+
+    if (!outputCallback) {
+      throw new Error('Expected output callback to be registered');
+    }
+
+    outputCallback('live output');
+    expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: 'output', data: 'live output' }));
+
+    const sendsBeforeClosed = ws.send.mock.calls.length;
+    ws.readyState = WS_READY_STATE.CLOSED;
+    outputCallback('ignored output');
+    expect(ws.send).toHaveBeenCalledTimes(sendsBeforeClosed);
+
+    ws.emit('error', new Error('post-run socket failed'));
+    expect(logger.error).toHaveBeenCalledWith(
+      'Post-run logs WebSocket error',
+      expect.objectContaining({ message: 'post-run socket failed' })
+    );
+
+    ws.emit('close');
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+    expect(postRunLogsConnections.has(workspaceId)).toBe(false);
+  });
+
+  it('tracks multiple connections and only deletes workspace entry after the last close', () => {
+    const workspaceId = 'workspace-2';
+    const logger = createLogger();
+    const unsubscribeFirst = vi.fn();
+    const unsubscribeSecond = vi.fn();
+    let subscribeCount = 0;
+    const runScriptService = {
+      getPostRunOutputBuffer: vi.fn(() => ''),
+      subscribeToPostRunOutput: vi.fn(() => {
+        subscribeCount += 1;
+        return subscribeCount === 1 ? unsubscribeFirst : unsubscribeSecond;
+      }),
+    };
+    const appContext = {
+      services: {
+        createLogger: vi.fn(() => logger),
+        runScriptService,
+      },
+    } as unknown as AppContext;
+
+    const ws1 = new MockWebSocket();
+    const ws2 = new MockWebSocket();
+    const handler = createPostRunLogsUpgradeHandler(appContext);
+    const request = {} as IncomingMessage;
+    const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
+    const wss = createWssFromQueue([ws1, ws2]);
+    const wsAliveMap = new WeakMap<WebSocket, boolean>();
+    const url = new URL(`http://localhost/post-run-logs?workspaceId=${workspaceId}`);
+
+    handler(request, socket, Buffer.alloc(0), url, wss, wsAliveMap);
+    handler(request, socket, Buffer.alloc(0), url, wss, wsAliveMap);
+
+    expect(runScriptService.getPostRunOutputBuffer).toHaveBeenCalledTimes(2);
+    expect(ws1.send).not.toHaveBeenCalled();
+    expect(ws2.send).not.toHaveBeenCalled();
+    expect(postRunLogsConnections.get(workspaceId)?.size).toBe(2);
+
+    ws1.emit('close');
+    expect(unsubscribeFirst).toHaveBeenCalledTimes(1);
+    expect(postRunLogsConnections.get(workspaceId)?.size).toBe(1);
+
+    ws2.emit('close');
+    expect(unsubscribeSecond).toHaveBeenCalledTimes(1);
+    expect(postRunLogsConnections.has(workspaceId)).toBe(false);
+  });
+});

--- a/src/backend/routers/websocket/setup-terminal.handler.test.ts
+++ b/src/backend/routers/websocket/setup-terminal.handler.test.ts
@@ -1,14 +1,34 @@
 import { EventEmitter } from 'node:events';
 import type { IncomingMessage } from 'node:http';
 import type { Duplex } from 'node:stream';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { WebSocket, WebSocketServer } from 'ws';
 import type { AppContext } from '@/backend/app-context';
 import { WS_READY_STATE } from '@/backend/constants/websocket';
+
+const mockPtyWrite = vi.fn();
+const mockPtyResize = vi.fn();
+const mockPtyKill = vi.fn();
+const mockPtySpawn = vi.fn();
+
+let onDataCallback: ((data: string) => void) | null = null;
+let onExitCallback: ((event: { exitCode: number }) => void) | null = null;
+
+vi.mock('node:module', () => ({
+  createRequire: () => (id: string) => {
+    if (id === 'node-pty') {
+      return {
+        spawn: mockPtySpawn,
+      };
+    }
+    throw new Error(`Unexpected require: ${id}`);
+  },
+}));
+
 import { createSetupTerminalUpgradeHandler } from './setup-terminal.handler';
 
 class MockWebSocket extends EventEmitter {
-  readyState = WS_READY_STATE.OPEN;
+  readyState: number = WS_READY_STATE.OPEN;
   send = vi.fn();
 }
 
@@ -21,27 +41,130 @@ function createLogger() {
   };
 }
 
+function createMockPty() {
+  return {
+    onData: vi.fn((callback: (data: string) => void) => {
+      onDataCallback = callback;
+    }),
+    onExit: vi.fn((callback: (event: { exitCode: number }) => void) => {
+      onExitCallback = callback;
+    }),
+    write: mockPtyWrite,
+    resize: mockPtyResize,
+    kill: mockPtyKill,
+  };
+}
+
+function createWss(ws: MockWebSocket) {
+  return {
+    handleUpgrade: vi.fn(
+      (
+        _request: IncomingMessage,
+        _socket: Duplex,
+        _head: Buffer,
+        callback: (socket: WebSocket) => void
+      ) => callback(ws as unknown as WebSocket)
+    ),
+  } as unknown as WebSocketServer;
+}
+
 describe('createSetupTerminalUpgradeHandler', () => {
-  it('rejects messages that fail schema validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    onDataCallback = null;
+    onExitCallback = null;
+    mockPtySpawn.mockReturnValue(createMockPty());
+  });
+
+  it('creates terminal and routes lifecycle messages', () => {
     const logger = createLogger();
+    const configService = {
+      getShellPath: vi.fn(() => '/bin/zsh'),
+      getChildProcessEnv: vi.fn(() => ({ PATH: '/usr/bin' })),
+    };
     const appContext = {
       services: {
         createLogger: vi.fn(() => logger),
+        configService,
       },
     } as unknown as AppContext;
 
     const handler = createSetupTerminalUpgradeHandler(appContext);
     const ws = new MockWebSocket();
-    const wss = {
-      handleUpgrade: vi.fn(
-        (
-          _request: IncomingMessage,
-          _socket: Duplex,
-          _head: Buffer,
-          callback: (socket: WebSocket) => void
-        ) => callback(ws as unknown as WebSocket)
-      ),
-    } as unknown as WebSocketServer;
+    const wss = createWss(ws);
+    const request = {} as IncomingMessage;
+    const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
+    const wsAliveMap = new WeakMap<WebSocket, boolean>();
+
+    handler(
+      request,
+      socket,
+      Buffer.alloc(0),
+      new URL('http://localhost/setup-terminal'),
+      wss,
+      wsAliveMap
+    );
+
+    ws.emit('message', JSON.stringify({ type: 'create', cols: 120, rows: 40 }));
+
+    expect(mockPtySpawn).toHaveBeenCalledWith(
+      '/bin/zsh',
+      [],
+      expect.objectContaining({
+        name: 'xterm-256color',
+        cols: 120,
+        rows: 40,
+        env: expect.objectContaining({
+          PATH: '/usr/bin',
+          TERM: 'xterm-256color',
+          COLORTERM: 'truecolor',
+        }),
+      })
+    );
+    expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: 'created' }));
+
+    onDataCallback?.('hello from shell');
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: 'output', data: 'hello from shell' })
+    );
+
+    ws.emit('message', JSON.stringify({ type: 'input', data: 'echo hi\n' }));
+    expect(mockPtyWrite).toHaveBeenCalledWith('echo hi\n');
+
+    ws.emit('message', JSON.stringify({ type: 'resize', cols: 150, rows: 50 }));
+    expect(mockPtyResize).toHaveBeenCalledWith(150, 50);
+
+    ws.emit('message', JSON.stringify({ type: 'ping' }));
+    expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: 'pong' }));
+
+    ws.emit('message', JSON.stringify({ type: 'create' }));
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: 'error', message: 'Terminal already exists' })
+    );
+
+    onExitCallback?.({ exitCode: 9 });
+    expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: 'exit', exitCode: 9 }));
+
+    ws.emit('message', JSON.stringify({ type: 'create' }));
+    expect(mockPtySpawn).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects messages that fail schema validation', () => {
+    const logger = createLogger();
+    const configService = {
+      getShellPath: vi.fn(() => '/bin/zsh'),
+      getChildProcessEnv: vi.fn(() => ({})),
+    };
+    const appContext = {
+      services: {
+        createLogger: vi.fn(() => logger),
+        configService,
+      },
+    } as unknown as AppContext;
+
+    const handler = createSetupTerminalUpgradeHandler(appContext);
+    const ws = new MockWebSocket();
+    const wss = createWss(ws);
     const request = {} as IncomingMessage;
     const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
     const wsAliveMap = new WeakMap<WebSocket, boolean>();
@@ -60,5 +183,73 @@ describe('createSetupTerminalUpgradeHandler', () => {
     expect(ws.send).toHaveBeenCalledWith(
       JSON.stringify({ type: 'error', message: 'Invalid message format' })
     );
+    expect(logger.warn).toHaveBeenCalledWith('Invalid setup terminal message format', {
+      errors: expect.any(Array),
+    });
+  });
+
+  it('reports runtime parsing/spawn failures and cleans up on close', () => {
+    const logger = createLogger();
+    const configService = {
+      getShellPath: vi.fn(() => '/bin/zsh'),
+      getChildProcessEnv: vi.fn(() => ({})),
+    };
+    const appContext = {
+      services: {
+        createLogger: vi.fn(() => logger),
+        configService,
+      },
+    } as unknown as AppContext;
+
+    const handler = createSetupTerminalUpgradeHandler(appContext);
+    const ws = new MockWebSocket();
+    const wss = createWss(ws);
+    const request = {} as IncomingMessage;
+    const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
+    const wsAliveMap = new WeakMap<WebSocket, boolean>();
+
+    handler(
+      request,
+      socket,
+      Buffer.alloc(0),
+      new URL('http://localhost/setup-terminal'),
+      wss,
+      wsAliveMap
+    );
+
+    ws.emit('message', '{');
+    expect(logger.error).toHaveBeenCalledWith('Error in setup terminal', expect.any(SyntaxError));
+    expect(ws.send).toHaveBeenCalledWith(
+      expect.stringMatching(/^{"type":"error","message":".+"}$/)
+    );
+
+    mockPtySpawn.mockImplementationOnce(() => {
+      throw new Error('spawn failed');
+    });
+    ws.emit('message', JSON.stringify({ type: 'create' }));
+    expect(logger.error).toHaveBeenCalledWith(
+      'Error in setup terminal',
+      expect.objectContaining({ message: 'spawn failed' })
+    );
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: 'error', message: 'spawn failed' })
+    );
+
+    ws.emit('message', JSON.stringify({ type: 'create' }));
+    ws.emit('close');
+    expect(mockPtyKill).toHaveBeenCalledTimes(1);
+
+    ws.emit('error', new Error('socket error'));
+    expect(logger.error).toHaveBeenCalledWith(
+      'Setup terminal WebSocket error',
+      expect.objectContaining({ message: 'socket error' })
+    );
+
+    ws.readyState = WS_READY_STATE.CLOSED;
+    const sentBeforeClosed = ws.send.mock.calls.length;
+    ws.emit('message', JSON.stringify({ type: 'ping' }));
+    ws.emit('message', JSON.stringify({ type: 'resize', cols: '120', rows: 40 }));
+    onDataCallback?.('ignored output');
+    expect(ws.send).toHaveBeenCalledTimes(sentBeforeClosed);
   });
 });


### PR DESCRIPTION
## Summary
- Add targeted websocket tests for `setup-terminal` and `post-run-logs` handlers, covering happy paths and error paths.
- Validate websocket message shape handling for setup-terminal (`schema-invalid` and malformed JSON branches).
- Raise backend stable coverage by covering two previously low/zero-coverage websocket handler modules.

## Changes
- **`setup-terminal.handler.test.ts`**: Added PTY lifecycle tests for `create`, `input`, `resize`, `ping`, duplicate create rejection, output/exit forwarding, close cleanup, and runtime parse/spawn error paths.
- **`post-run-logs.handler.test.ts`**: Added new test suite for missing `workspaceId` bad-request handling, buffered/live output streaming with ready-state gating, subscription cleanup, connection-map cleanup, and socket error logging.
- **Coverage deltas (`pnpm test:coverage:backend:stable`)**:
  - `setup-terminal.handler.ts`: `34.32%` -> `100.00%` lines (`+65.68pp`)
  - `post-run-logs.handler.ts`: `0.00%` -> `100.00%` lines (`+100.00pp`)
  - Backend overall lines: `75.43%` -> `76.10%` (`+0.67pp`)

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: N/A (backend websocket handlers validated via automated tests)

Closes #1354

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are test-only and primarily exercise WebSocket upgrade/message handling and cleanup paths without modifying production logic.
> 
> **Overview**
> Adds a new `post-run-logs.handler.test.ts` suite that covers missing `workspaceId` rejection, buffered + live log streaming, ready-state gating, error logging, and per-workspace connection/subscription cleanup (including multiple concurrent connections).
> 
> Greatly expands `setup-terminal.handler.test.ts` to mock `node-pty` and validate terminal lifecycle/message routing (`create`/`input`/`resize`/`ping`), schema-validation failures, JSON parse/spawn error handling, and close/error cleanup behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec7f213cb6dff8f945167888f945f20a4761a423. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->