### PR TITLE
Pass serve port as CLI argument instead of Docker port remap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,15 +119,15 @@ RUN mkdir -p /data
 
 ENV NODE_ENV=production
 ENV PATH="/app/node_modules/.bin:/root/.local/bin:${PATH}"
-ENV BACKEND_PORT=3000
+ENV BACKEND_PORT=7001
 ENV DATABASE_PATH=/data/data.db
 ENV BASE_DIR=/data
 ENV WORKTREE_BASE_DIR=/data/worktrees
 
-EXPOSE 3000
+EXPOSE 7001
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
-    CMD curl -f http://localhost:3000/health || exit 1
+    CMD curl -f http://localhost:7001/health || exit 1
 
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     privileged: true
     restart: unless-stopped
     ports:
-      - "${PORT:-7001}:3000"
+      - "${PORT:-7001}:7001"
     volumes:
       - data:/data
       - ./tunnel-info:/app/tunnel-info
@@ -20,12 +20,12 @@ services:
       - DATABASE_PATH=/data/data.db
       - BASE_DIR=/data
       - WORKTREE_BASE_DIR=/data/worktrees
-      - BACKEND_PORT=3000
+      - BACKEND_PORT=7001
       - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:7001}
       - LOG_LEVEL=${LOG_LEVEL:-info}
       - CLOUD_MODE=${CLOUD_MODE:-cloudflare}
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:7001/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -35,10 +35,10 @@ if ! docker info >/dev/null 2>&1; then
   echo "Warning: Docker daemon not ready after 30s. Continuing without Docker."
 fi
 
-PORT="${BACKEND_PORT:-3000}"
+PORT="${BACKEND_PORT:-7001}"
 
 # Start the Factory Factory server in the background
-node dist/src/cli/index.js serve --host 0.0.0.0 --no-open &
+node dist/src/cli/index.js serve --host 0.0.0.0 --port "${BACKEND_PORT:-7001}" --no-open &
 SERVER_PID=$!
 
 # Wait for the server to become healthy


### PR DESCRIPTION
## Summary
- Pass `--port` as a CLI argument to the `serve` command in `docker-entrypoint.sh` instead of relying on asymmetric Docker port mapping (was `7001:3000`, now `7001:7001`)
- The app now listens on port 7001 inside the container, matching the externally exposed port
- Updated `BACKEND_PORT`, `EXPOSE`, and healthcheck references in Dockerfile and docker-compose.yml to 7001

## Test plan
- [ ] Build Docker image and verify the app starts and is reachable on port 7001
- [ ] Verify healthcheck passes (`curl http://localhost:7001/health`)
- [ ] Verify cloudflare tunnel still connects to the correct port

🤖 Generated with [Claude Code](https://claude.com/claude-code)
