### PR TITLE
Add execution_space_folder to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,6 +117,9 @@ COPY --from=builder /app/prisma/generated ./prisma/generated
 # Create data directory
 RUN mkdir -p /data
 
+# Create execution space folder
+RUN mkdir -p /execution_space_folder
+
 ENV NODE_ENV=production
 ENV PATH="/app/node_modules/.bin:/root/.local/bin:${PATH}"
 ENV BACKEND_PORT=7001


### PR DESCRIPTION
## Summary
- Adds `/execution_space_folder` directory to the production Docker image in the runner stage

## Test plan
- [ ] Build Docker image and verify `/execution_space_folder` exists in the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)