### PR TITLE
Fix asset paths for reverse proxy deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,11 @@ COPY . .
 
 # Build everything: core workspace, backend TS, frontend Vite SPA, prompts
 ENV NODE_ENV=production
+# Use relative asset paths so the app works behind a reverse proxy with a path prefix.
+# Relative paths (./assets/...) resolve correctly regardless of the proxy mount point,
+# whereas root-absolute paths (/assets/...) cause 404s for <link rel="preload"> tags
+# that the browser fires before JS runs.
+ENV VITE_BASE_PATH=./
 RUN pnpm build
 
 

--- a/src/components/chat/chat-input/chat-input.tsx
+++ b/src/components/chat/chat-input/chat-input.tsx
@@ -225,14 +225,14 @@ function getProviderLogo(provider: ChatBarCapabilities['provider'] | null): {
 } {
   if (provider === 'CODEX') {
     return {
-      light: '/logos/codex-light.svg',
-      dark: '/logos/codex-dark.svg',
+      light: `${import.meta.env.BASE_URL}logos/codex-light.svg`,
+      dark: `${import.meta.env.BASE_URL}logos/codex-dark.svg`,
       alt: 'Codex',
     };
   }
   return {
-    light: '/logos/claude-light.svg',
-    dark: '/logos/claude-dark.svg',
+    light: `${import.meta.env.BASE_URL}logos/claude-light.svg`,
+    dark: `${import.meta.env.BASE_URL}logos/claude-dark.svg`,
     alt: 'Claude',
   };
 }

--- a/src/components/workspace/WorkspaceNotificationManager.tsx
+++ b/src/components/workspace/WorkspaceNotificationManager.tsx
@@ -63,7 +63,7 @@ export function WorkspaceNotificationManager() {
  */
 function playNotificationSound(): void {
   try {
-    const audio = new Audio('/sounds/workspace-complete.mp3');
+    const audio = new Audio(`${import.meta.env.BASE_URL}sounds/workspace-complete.mp3`);
     // Set a reasonable volume
     audio.volume = 0.5;
     // Play the sound (browsers may block autoplay, so we catch errors)
@@ -110,7 +110,7 @@ function showNotification(workspaceName: string, sessionCount: number): void {
 
   new Notification(`Workspace Ready: ${workspaceName}`, {
     body: message,
-    icon: '/favicon.ico',
+    icon: `${import.meta.env.BASE_URL}favicon.svg`,
     tag: `workspace-complete-${workspaceName}`, // Prevents duplicates
     requireInteraction: false,
   });


### PR DESCRIPTION
## Summary
- Set `VITE_BASE_PATH=./` in the Dockerfile build stage so Vite emits relative asset URLs that resolve correctly when served behind a reverse proxy with a path prefix (e.g., `/machine/{id}/api/`)
- Update runtime references to public assets (`/logos/*.svg`, `/sounds/workspace-complete.mp3`, `/favicon.ico`) to use `import.meta.env.BASE_URL` instead of hardcoded root-absolute paths
- Fix notification icon referencing `favicon.ico` (doesn't exist) → `favicon.svg`

## Test plan
- [ ] Build Docker image and verify `dist/client/index.html` contains relative asset paths (`./assets/...`)
- [ ] Open app through reverse proxy — terminal pane CSS loads without "Unable to preload CSS" errors
- [ ] Verify provider logos (Claude/Codex) render in chat input through proxy
- [ ] Verify workspace completion notification sound and icon work through proxy
- [ ] Confirm app still works normally when served directly (not through proxy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
