### PR TITLE
Avoid chat loading flash on transient reconnect

### DIFF
--- a/src/components/chat/use-chat-websocket-hydration.ts
+++ b/src/components/chat/use-chat-websocket-hydration.ts
@@ -1,5 +1,6 @@
 export type HydrationBatch = { loadRequestId?: string; type?: string };
 export type HydrationBatchDecision = 'pass' | 'drop' | 'match';
+export const CONNECT_LOADING_DEBOUNCE_MS = 300;
 
 export function parseHydrationBatch(data: unknown): HydrationBatch | null {
   if (typeof data !== 'object' || data === null || !('type' in data)) {
@@ -26,4 +27,33 @@ export function evaluateHydrationBatch(
   }
 
   return batch.loadRequestId ? 'drop' : 'pass';
+}
+
+export function shouldScheduleConnectLoading(hasHydratedSession: boolean): boolean {
+  return !hasHydratedSession;
+}
+
+export function scheduleConnectLoadingStart(options: {
+  hasHydratedSession: boolean;
+  onLoadingStart: () => void;
+  debounceMs?: number;
+  setTimeoutFn?: typeof setTimeout;
+  clearTimeoutFn?: typeof clearTimeout;
+}): () => void {
+  const {
+    hasHydratedSession,
+    onLoadingStart,
+    debounceMs = CONNECT_LOADING_DEBOUNCE_MS,
+    setTimeoutFn = setTimeout,
+    clearTimeoutFn = clearTimeout,
+  } = options;
+
+  if (!shouldScheduleConnectLoading(hasHydratedSession)) {
+    return () => undefined;
+  }
+
+  const timeout = setTimeoutFn(onLoadingStart, debounceMs);
+  return () => {
+    clearTimeoutFn(timeout);
+  };
 }


### PR DESCRIPTION
## Summary
- prevent the chat UI from flashing `Loading session...` during transient websocket reconnects after a session has already hydrated
- debounce connect-time loading transitions by 300ms so fast reconnects do not surface a loading state
- cancel pending connect-loading timers when hydration completes, when disconnecting, and on unmount to avoid stale loading transitions
- add unit coverage for connect-loading strategy helpers (hydrated-session gating and debounce cancellation)

## Root Cause
On every websocket reconnect, `useChatWebSocket` immediately dispatched `SESSION_LOADING_START`, then re-issued `load_session`. In flows like Chrome DevTools screenshot capture, short lifecycle blips can trigger reconnect/hydration without a real page reload, causing a visible loading flash.

## Changes
- `src/components/chat/use-chat-websocket.ts`
  - track whether the current `dbSessionId` has already hydrated
  - only schedule connect-loading when the current session has not hydrated yet
  - route loading start through a cancellable debounce helper
- `src/components/chat/use-chat-websocket-hydration.ts`
  - add `CONNECT_LOADING_DEBOUNCE_MS`
  - add `shouldScheduleConnectLoading(...)`
  - add `scheduleConnectLoadingStart(...)`
- `src/components/chat/use-chat-websocket.test.ts`
  - add tests for hydrated-session loading suppression and debounce cancellation

## Verification
- `pnpm test src/components/chat/use-chat-websocket.test.ts`
- `pnpm typecheck`
