### PR TITLE
Increase backend critical-path coverage above 80%

### DIFF
--- a/src/backend/domains/session/acp/codex-app-server-adapter/session-config-resolver.test.ts
+++ b/src/backend/domains/session/acp/codex-app-server-adapter/session-config-resolver.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from 'vitest';
+import type { AdapterSession, CodexModelEntry, CollaborationModeEntry } from './adapter-state';
+import {
+  buildConfigOptions,
+  createSandboxPolicyFromMode,
+  getCollaborationModeValues,
+  getExecutionPresets,
+  isKnownModel,
+  isReasoningEffortSupportedForModel,
+  resolveCollaborationModeLabel,
+  resolveCurrentSandboxMode,
+  resolveDefaultCollaborationMode,
+  resolveDefaultModel,
+  resolveExecutionPresetId,
+  resolveReasoningEffortForModel,
+  resolveSandboxPolicy,
+  resolveSessionModel,
+  resolveTurnCollaborationMode,
+} from './session-config-resolver';
+
+const modelCatalog: CodexModelEntry[] = [
+  {
+    id: 'gpt-5',
+    displayName: 'GPT-5',
+    description: 'Primary model',
+    defaultReasoningEffort: 'medium',
+    supportedReasoningEfforts: [
+      { reasoningEffort: 'low', description: 'Fast' },
+      { reasoningEffort: 'medium', description: 'Balanced' },
+      { reasoningEffort: 'high', description: 'Deep' },
+    ],
+    inputModalities: ['text'],
+    isDefault: true,
+  },
+  {
+    id: 'gpt-5-mini',
+    displayName: 'GPT-5 Mini',
+    description: 'Fallback model',
+    defaultReasoningEffort: 'low',
+    supportedReasoningEfforts: [],
+    inputModalities: ['text'],
+    isDefault: false,
+  },
+];
+
+const collaborationModes: CollaborationModeEntry[] = [
+  {
+    mode: 'default',
+    name: 'Default',
+    model: 'gpt-5',
+    reasoningEffort: 'medium',
+    developerInstructions: null,
+  },
+  {
+    mode: 'plan',
+    name: 'Plan',
+    model: 'gpt-5',
+    reasoningEffort: 'high',
+    developerInstructions: 'think first',
+  },
+];
+
+function createSession(overrides?: Partial<AdapterSession>): AdapterSession {
+  return {
+    sessionId: 'session-1',
+    threadId: 'thread-1',
+    cwd: '/tmp/workspace',
+    defaults: {
+      model: 'gpt-5',
+      approvalPolicy: 'on-request',
+      sandboxPolicy: { type: 'workspaceWrite' },
+      reasoningEffort: 'medium',
+      collaborationMode: 'default',
+    },
+    activeTurn: null,
+    toolCallsByItemId: new Map(),
+    syntheticallyCompletedToolItemIds: new Set(),
+    reasoningDeltaItemIds: new Set(),
+    planTextByItemId: new Map(),
+    planApprovalRequestedByTurnId: new Set(),
+    pendingPlanApprovalsByTurnId: new Map(),
+    pendingTurnCompletionsByTurnId: new Map(),
+    commandApprovalScopes: new Set(),
+    replayedTurnItemKeys: new Set(),
+    ...overrides,
+  };
+}
+
+describe('session-config-resolver helpers', () => {
+  it('resolves default model from preferred default, then fallback, else throws', () => {
+    const fallbackOnlyModel: CodexModelEntry = { ...modelCatalog[1]!, isDefault: false };
+    expect(resolveDefaultModel(modelCatalog)).toBe('gpt-5');
+    expect(resolveDefaultModel([fallbackOnlyModel])).toBe('gpt-5-mini');
+    expect(() => resolveDefaultModel([])).toThrow('model/list returned no models');
+  });
+
+  it('resolves session model and sandbox policy with fallbacks', () => {
+    expect(resolveSessionModel('gpt-5-mini', 'gpt-5')).toBe('gpt-5-mini');
+    expect(resolveSessionModel('', 'gpt-5')).toBe('gpt-5');
+    expect(resolveSandboxPolicy({ type: 'dangerFullAccess' }, '/tmp/work')).toEqual({
+      type: 'dangerFullAccess',
+    });
+    expect(resolveSandboxPolicy(null, '/tmp/work')).toEqual({
+      type: 'workspaceWrite',
+      writableRoots: ['/tmp/work'],
+      readOnlyAccess: { type: 'fullAccess' },
+      networkAccess: true,
+      excludeTmpdirEnvVar: false,
+      excludeSlashTmp: false,
+    });
+  });
+
+  it('resolves default collaboration mode and validates invalid input', () => {
+    expect(resolveDefaultCollaborationMode(collaborationModes)).toBe('default');
+    expect(
+      resolveDefaultCollaborationMode([
+        {
+          mode: 'code',
+          name: 'Code',
+          model: null,
+          reasoningEffort: null,
+          developerInstructions: null,
+        },
+      ])
+    ).toBe('code');
+    expect(() => resolveDefaultCollaborationMode([])).toThrow('returned no modes');
+    expect(() =>
+      resolveDefaultCollaborationMode([
+        {
+          mode: '',
+          name: 'Broken',
+          model: null,
+          reasoningEffort: null,
+          developerInstructions: null,
+        },
+      ])
+    ).toThrow('invalid mode entry');
+  });
+
+  it('resolves reasoning effort from candidates and defaults', () => {
+    expect(resolveReasoningEffortForModel(modelCatalog, 'gpt-5', 'high')).toBe('high');
+    expect(resolveReasoningEffortForModel(modelCatalog, 'gpt-5', 'unsupported')).toBe('medium');
+    expect(resolveReasoningEffortForModel(modelCatalog, 'gpt-5-mini', 'high')).toBeNull();
+    expect(resolveReasoningEffortForModel(modelCatalog, 'missing', 'high')).toBeNull();
+  });
+
+  it('derives collaboration mode values and labels', () => {
+    expect(getCollaborationModeValues(collaborationModes, 'plan')).toEqual(['default', 'plan']);
+    expect(getCollaborationModeValues(collaborationModes, 'code')).toEqual([
+      'code',
+      'default',
+      'plan',
+    ]);
+    expect(resolveCollaborationModeLabel(collaborationModes, 'default')).toBe('Default');
+    expect(resolveCollaborationModeLabel(collaborationModes, 'accept_edits')).toBe('Accept Edits');
+  });
+
+  it('resolves current sandbox mode from policy or allowed values', () => {
+    expect(resolveCurrentSandboxMode(['read-only'], { type: 'readOnly' })).toBe('read-only');
+    expect(resolveCurrentSandboxMode(['workspace-write'], { type: 'unknown' })).toBe(
+      'workspace-write'
+    );
+    expect(() => resolveCurrentSandboxMode([], { type: 'unknown' })).toThrow(
+      'Unable to resolve current sandbox mode'
+    );
+  });
+
+  it('builds execution presets and chooses the current preset id when present', () => {
+    const session = createSession({
+      defaults: {
+        ...createSession().defaults,
+        approvalPolicy: 'on-request',
+        sandboxPolicy: createSandboxPolicyFromMode('workspace-write', '/tmp/workspace'),
+      },
+    });
+    const presets = getExecutionPresets(
+      session,
+      ['on-request', 'never'],
+      ['workspace-write', 'danger-full-access']
+    );
+
+    expect(presets[0]?.description).toContain('Current session');
+    expect(
+      presets.some((preset) => preset.id === JSON.stringify(['never', 'danger-full-access']))
+    ).toBe(true);
+
+    const current = resolveExecutionPresetId(session, presets, ['workspace-write']);
+    expect(current).toBe(JSON.stringify(['on-request', 'workspace-write']));
+
+    const fallback = resolveExecutionPresetId(
+      createSession({
+        defaults: {
+          ...createSession().defaults,
+          approvalPolicy: 'untrusted',
+          sandboxPolicy: createSandboxPolicyFromMode('danger-full-access', '/tmp/workspace'),
+        },
+      }),
+      presets,
+      ['workspace-write']
+    );
+    expect(fallback).toBe(presets[0]?.id);
+  });
+
+  it('builds config options including reasoning when supported', () => {
+    const session = createSession();
+    const options = buildConfigOptions(
+      session,
+      modelCatalog,
+      collaborationModes,
+      ['on-request', 'never'],
+      ['workspace-write', 'danger-full-access']
+    );
+
+    expect(options.map((option) => option.id)).toEqual([
+      'model',
+      'mode',
+      'execution_mode',
+      'reasoning_effort',
+    ]);
+  });
+
+  it('checks model and reasoning support helpers', () => {
+    expect(isKnownModel(modelCatalog, 'gpt-5')).toBe(true);
+    expect(isKnownModel(modelCatalog, 'missing')).toBe(false);
+    expect(isReasoningEffortSupportedForModel(modelCatalog, 'gpt-5', 'medium')).toBe(true);
+    expect(isReasoningEffortSupportedForModel(modelCatalog, 'gpt-5', 'invalid')).toBe(false);
+    expect(isReasoningEffortSupportedForModel(modelCatalog, 'missing', 'medium')).toBe(false);
+  });
+
+  it('resolves turn collaboration mode with mode defaults', () => {
+    const session = createSession({
+      defaults: {
+        ...createSession().defaults,
+        collaborationMode: 'plan',
+        model: 'gpt-5-mini',
+        reasoningEffort: 'low',
+      },
+    });
+    const mode = resolveTurnCollaborationMode(collaborationModes, session);
+    expect(mode).toEqual({
+      mode: 'plan',
+      settings: {
+        model: 'gpt-5',
+        reasoning_effort: 'high',
+        developer_instructions: 'think first',
+      },
+    });
+  });
+});

--- a/src/backend/domains/session/chat/chat-message-handlers/handlers/permission-response.handler.test.ts
+++ b/src/backend/domains/session/chat/chat-message-handlers/handlers/permission-response.handler.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  clearPendingInteractiveRequestIfMatches: vi.fn(),
+}));
+
+vi.mock('@/backend/domains/session/session-domain.service', () => ({
+  sessionDomainService: {
+    clearPendingInteractiveRequestIfMatches: mocks.clearPendingInteractiveRequestIfMatches,
+  },
+}));
+
+vi.mock('@/backend/services/logger.service', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+import { createPermissionResponseHandler } from './permission-response.handler';
+
+describe('createPermissionResponseHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('responds to pending ACP permission request', () => {
+    const ws = { send: vi.fn() };
+    const respondToAcpPermission = vi.fn(() => true);
+    const handler = createPermissionResponseHandler({
+      sessionService: {
+        isSessionRunning: vi.fn(),
+        sendSessionMessage: vi.fn(),
+        respondToAcpPermission,
+        setSessionModel: vi.fn(),
+        setSessionReasoningEffort: vi.fn(),
+        getChatBarCapabilities: vi.fn(),
+      },
+    });
+
+    void handler({
+      ws: ws as never,
+      sessionId: 'session-1',
+      workingDir: '/tmp/work',
+      message: {
+        type: 'permission_response',
+        requestId: 'req-1',
+        optionId: 'allow_once',
+        answers: { mode: ['default'] },
+      } as never,
+    });
+
+    expect(respondToAcpPermission).toHaveBeenCalledWith('session-1', 'req-1', 'allow_once', {
+      mode: ['default'],
+    });
+    expect(ws.send).not.toHaveBeenCalled();
+    expect(mocks.clearPendingInteractiveRequestIfMatches).toHaveBeenCalledWith(
+      'session-1',
+      'req-1'
+    );
+  });
+
+  it('sends websocket error when no pending request is found', () => {
+    const ws = { send: vi.fn() };
+    const respondToAcpPermission = vi.fn(() => false);
+    const handler = createPermissionResponseHandler({
+      sessionService: {
+        isSessionRunning: vi.fn(),
+        sendSessionMessage: vi.fn(),
+        respondToAcpPermission,
+        setSessionModel: vi.fn(),
+        setSessionReasoningEffort: vi.fn(),
+        getChatBarCapabilities: vi.fn(),
+      },
+    });
+
+    void handler({
+      ws: ws as never,
+      sessionId: 'session-1',
+      workingDir: '/tmp/work',
+      message: {
+        type: 'permission_response',
+        requestId: 'req-2',
+        optionId: 'deny_once',
+      } as never,
+    });
+
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({
+        type: 'error',
+        message: 'No pending ACP permission request found for this request ID',
+      })
+    );
+    expect(mocks.clearPendingInteractiveRequestIfMatches).toHaveBeenCalledWith(
+      'session-1',
+      'req-2'
+    );
+  });
+
+  it('sends websocket error when permission response throws', () => {
+    const ws = { send: vi.fn() };
+    const respondToAcpPermission = vi.fn(() => {
+      throw new Error('bridge down');
+    });
+    const handler = createPermissionResponseHandler({
+      sessionService: {
+        isSessionRunning: vi.fn(),
+        sendSessionMessage: vi.fn(),
+        respondToAcpPermission,
+        setSessionModel: vi.fn(),
+        setSessionReasoningEffort: vi.fn(),
+        getChatBarCapabilities: vi.fn(),
+      },
+    });
+
+    void handler({
+      ws: ws as never,
+      sessionId: 'session-1',
+      workingDir: '/tmp/work',
+      message: {
+        type: 'permission_response',
+        requestId: 'req-3',
+        optionId: 'allow_once',
+      } as never,
+    });
+
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({
+        type: 'error',
+        message: 'Failed to respond to permission: bridge down',
+      })
+    );
+    expect(mocks.clearPendingInteractiveRequestIfMatches).toHaveBeenCalledWith(
+      'session-1',
+      'req-3'
+    );
+  });
+});

--- a/src/backend/domains/session/chat/chat-message-handlers/handlers/queue-message.handler.test.ts
+++ b/src/backend/domains/session/chat/chat-message-handlers/handlers/queue-message.handler.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MessageState } from '@/shared/acp-protocol';
+
+const mocks = vi.hoisted(() => ({
+  enqueue: vi.fn(),
+  emitDelta: vi.fn(),
+}));
+
+vi.mock('@/backend/domains/session/session-domain.service', () => ({
+  sessionDomainService: {
+    enqueue: mocks.enqueue,
+    emitDelta: mocks.emitDelta,
+  },
+}));
+
+import { createQueueMessageHandler } from './queue-message.handler';
+
+describe('createQueueMessageHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects empty queue messages', async () => {
+    const ws = { send: vi.fn() };
+    const handler = createQueueMessageHandler({
+      getClientCreator: () => null,
+      tryDispatchNextMessage: vi.fn(),
+      setManualDispatchResume: vi.fn(),
+    });
+
+    await handler({
+      ws: ws as never,
+      sessionId: 'session-1',
+      workingDir: '/tmp/work',
+      message: { type: 'queue_message', id: 'msg-1', text: '   ', attachments: [] } as never,
+    });
+
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: 'error', message: 'Empty message' })
+    );
+    expect(mocks.enqueue).not.toHaveBeenCalled();
+  });
+
+  it('rejects queue messages without an id', async () => {
+    const ws = { send: vi.fn() };
+    const handler = createQueueMessageHandler({
+      getClientCreator: () => null,
+      tryDispatchNextMessage: vi.fn(),
+      setManualDispatchResume: vi.fn(),
+    });
+
+    await handler({
+      ws: ws as never,
+      sessionId: 'session-1',
+      workingDir: '/tmp/work',
+      message: { type: 'queue_message', text: 'hello' } as never,
+    });
+
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: 'error', message: 'Missing message id' })
+    );
+    expect(mocks.enqueue).not.toHaveBeenCalled();
+  });
+
+  it('emits rejected state when enqueue fails', async () => {
+    mocks.enqueue.mockReturnValue({ error: 'Queue full' });
+    const ws = { send: vi.fn() };
+    const tryDispatchNextMessage = vi.fn();
+    const handler = createQueueMessageHandler({
+      getClientCreator: () => null,
+      tryDispatchNextMessage,
+      setManualDispatchResume: vi.fn(),
+    });
+
+    await handler({
+      ws: ws as never,
+      sessionId: 'session-1',
+      workingDir: '/tmp/work',
+      message: { type: 'queue_message', id: 'msg-1', text: 'hello' } as never,
+    });
+
+    expect(mocks.emitDelta).toHaveBeenCalledWith('session-1', {
+      type: 'message_state_changed',
+      id: 'msg-1',
+      newState: MessageState.REJECTED,
+      errorMessage: 'Queue full',
+    });
+    expect(tryDispatchNextMessage).not.toHaveBeenCalled();
+  });
+
+  it('accepts queued message and dispatches next message', async () => {
+    mocks.enqueue.mockReturnValue({ position: 2 });
+    const ws = { send: vi.fn() };
+    const tryDispatchNextMessage = vi.fn(async () => undefined);
+    const handler = createQueueMessageHandler({
+      getClientCreator: () => null,
+      tryDispatchNextMessage,
+      setManualDispatchResume: vi.fn(),
+    });
+
+    await handler({
+      ws: ws as never,
+      sessionId: 'session-1',
+      workingDir: '/tmp/work',
+      message: {
+        type: 'queue_message',
+        id: 'msg-1',
+        text: 'hello',
+        settings: {
+          selectedModel: 'sonnet',
+          reasoningEffort: 'medium',
+          thinkingEnabled: true,
+          planModeEnabled: false,
+        },
+      } as never,
+    });
+
+    expect(mocks.emitDelta).toHaveBeenCalledWith(
+      'session-1',
+      expect.objectContaining({
+        type: 'message_state_changed',
+        id: 'msg-1',
+        newState: MessageState.ACCEPTED,
+        queuePosition: 2,
+        userMessage: expect.objectContaining({
+          text: 'hello',
+          settings: expect.objectContaining({
+            selectedModel: 'sonnet',
+            reasoningEffort: 'medium',
+          }),
+        }),
+      })
+    );
+    expect(tryDispatchNextMessage).toHaveBeenCalledWith('session-1');
+  });
+});

--- a/src/backend/domains/session/chat/chat-message-handlers/handlers/remove-queued-message.handler.test.ts
+++ b/src/backend/domains/session/chat/chat-message-handlers/handlers/remove-queued-message.handler.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MessageState } from '@/shared/acp-protocol';
+
+const mocks = vi.hoisted(() => ({
+  removeQueuedMessage: vi.fn(),
+  emitDelta: vi.fn(),
+}));
+
+vi.mock('@/backend/domains/session/session-domain.service', () => ({
+  sessionDomainService: {
+    removeQueuedMessage: mocks.removeQueuedMessage,
+    emitDelta: mocks.emitDelta,
+  },
+}));
+
+vi.mock('@/backend/services/logger.service', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+import { createRemoveQueuedMessageHandler } from './remove-queued-message.handler';
+
+describe('createRemoveQueuedMessageHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('emits cancelled state when queued message is removed', () => {
+    mocks.removeQueuedMessage.mockReturnValue(true);
+    const ws = { send: vi.fn() };
+    const handler = createRemoveQueuedMessageHandler();
+
+    void handler({
+      ws: ws as never,
+      sessionId: 'session-1',
+      workingDir: '/tmp/work',
+      message: { type: 'remove_queued_message', messageId: 'msg-1' } as never,
+    });
+
+    expect(mocks.removeQueuedMessage).toHaveBeenCalledWith('session-1', 'msg-1');
+    expect(mocks.emitDelta).toHaveBeenCalledWith('session-1', {
+      type: 'message_state_changed',
+      id: 'msg-1',
+      newState: MessageState.CANCELLED,
+    });
+    expect(ws.send).not.toHaveBeenCalled();
+  });
+
+  it('sends error when message id is not in queue', () => {
+    mocks.removeQueuedMessage.mockReturnValue(false);
+    const ws = { send: vi.fn() };
+    const handler = createRemoveQueuedMessageHandler();
+
+    void handler({
+      ws: ws as never,
+      sessionId: 'session-1',
+      workingDir: '/tmp/work',
+      message: { type: 'remove_queued_message', messageId: 'missing' } as never,
+    });
+
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: 'error', message: 'Message not found in queue' })
+    );
+  });
+});

--- a/src/backend/domains/session/chat/chat-message-handlers/handlers/set-config-option.handler.test.ts
+++ b/src/backend/domains/session/chat/chat-message-handlers/handlers/set-config-option.handler.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  setSessionConfigOption: vi.fn(),
+}));
+
+vi.mock('@/backend/domains/session/lifecycle/session.service', () => ({
+  sessionService: {
+    setSessionConfigOption: mocks.setSessionConfigOption,
+  },
+}));
+
+vi.mock('@/backend/services/logger.service', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+import { createSetConfigOptionHandler } from './set-config-option.handler';
+
+describe('createSetConfigOptionHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('updates session config option', async () => {
+    mocks.setSessionConfigOption.mockResolvedValue(undefined);
+    const ws = { send: vi.fn() };
+    const handler = createSetConfigOptionHandler();
+
+    await handler({
+      ws: ws as never,
+      sessionId: 'session-1',
+      workingDir: '/tmp/work',
+      message: {
+        type: 'set_config_option',
+        configId: 'execution_mode',
+        value: 'on-request',
+      } as never,
+    });
+
+    expect(mocks.setSessionConfigOption).toHaveBeenCalledWith(
+      'session-1',
+      'execution_mode',
+      'on-request'
+    );
+    expect(ws.send).not.toHaveBeenCalled();
+  });
+
+  it('sends websocket error when update throws an Error', async () => {
+    mocks.setSessionConfigOption.mockRejectedValue(new Error('boom'));
+    const ws = { send: vi.fn() };
+    const handler = createSetConfigOptionHandler();
+
+    await handler({
+      ws: ws as never,
+      sessionId: 'session-1',
+      workingDir: '/tmp/work',
+      message: { type: 'set_config_option', configId: 'model', value: 'gpt-5' } as never,
+    });
+
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: 'error', message: 'Failed to set config option: boom' })
+    );
+  });
+
+  it('uses structured data payload when error object has no message', async () => {
+    mocks.setSessionConfigOption.mockRejectedValue({ data: { reason: 'invalid preset' } });
+    const ws = { send: vi.fn() };
+    const handler = createSetConfigOptionHandler();
+
+    await handler({
+      ws: ws as never,
+      sessionId: 'session-1',
+      workingDir: '/tmp/work',
+      message: { type: 'set_config_option', configId: 'execution_mode', value: 'bad' } as never,
+    });
+
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({
+        type: 'error',
+        message: 'Failed to set config option: {"reason":"invalid preset"}',
+      })
+    );
+  });
+
+  it('falls back to ACP error code label for code-only errors', async () => {
+    mocks.setSessionConfigOption.mockRejectedValue({ code: 403 });
+    const ws = { send: vi.fn() };
+    const handler = createSetConfigOptionHandler();
+
+    await handler({
+      ws: ws as never,
+      sessionId: 'session-1',
+      workingDir: '/tmp/work',
+      message: { type: 'set_config_option', configId: 'mode', value: 'blocked' } as never,
+    });
+
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({
+        type: 'error',
+        message: 'Failed to set config option: ACP error (403)',
+      })
+    );
+  });
+
+  it('uses message property for non-Error objects', async () => {
+    mocks.setSessionConfigOption.mockRejectedValue({ message: 'invalid option' });
+    const ws = { send: vi.fn() };
+    const handler = createSetConfigOptionHandler();
+
+    await handler({
+      ws: ws as never,
+      sessionId: 'session-1',
+      workingDir: '/tmp/work',
+      message: { type: 'set_config_option', configId: 'model', value: 'bad' } as never,
+    });
+
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({
+        type: 'error',
+        message: 'Failed to set config option: invalid option',
+      })
+    );
+  });
+
+  it('falls back to JSON serialization for non-object errors', async () => {
+    mocks.setSessionConfigOption.mockRejectedValue(42);
+    const ws = { send: vi.fn() };
+    const handler = createSetConfigOptionHandler();
+
+    await handler({
+      ws: ws as never,
+      sessionId: 'session-1',
+      workingDir: '/tmp/work',
+      message: { type: 'set_config_option', configId: 'mode', value: 'bad' } as never,
+    });
+
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({
+        type: 'error',
+        message: 'Failed to set config option: 42',
+      })
+    );
+  });
+
+  it('falls back to String(error) when JSON serialization throws', async () => {
+    const circular: { self?: unknown } = {};
+    circular.self = circular;
+    mocks.setSessionConfigOption.mockRejectedValue(circular);
+    const ws = { send: vi.fn() };
+    const handler = createSetConfigOptionHandler();
+
+    await handler({
+      ws: ws as never,
+      sessionId: 'session-1',
+      workingDir: '/tmp/work',
+      message: { type: 'set_config_option', configId: 'mode', value: 'bad' } as never,
+    });
+
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({
+        type: 'error',
+        message: 'Failed to set config option: [object Object]',
+      })
+    );
+  });
+});

--- a/src/backend/domains/session/chat/chat-message-handlers/handlers/set-thinking-budget.handler.test.ts
+++ b/src/backend/domains/session/chat/chat-message-handlers/handlers/set-thinking-budget.handler.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  setSessionThinkingBudget: vi.fn(),
+}));
+
+vi.mock('@/backend/domains/session/lifecycle/session.service', () => ({
+  sessionService: {
+    setSessionThinkingBudget: mocks.setSessionThinkingBudget,
+  },
+}));
+
+vi.mock('@/backend/services/logger.service', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+import { createSetThinkingBudgetHandler } from './set-thinking-budget.handler';
+
+describe('createSetThinkingBudgetHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('updates session thinking budget', async () => {
+    mocks.setSessionThinkingBudget.mockResolvedValue(undefined);
+    const ws = { send: vi.fn() };
+    const handler = createSetThinkingBudgetHandler();
+
+    await handler({
+      ws: ws as never,
+      sessionId: 'session-1',
+      workingDir: '/tmp/work',
+      message: { type: 'set_thinking_budget', max_tokens: 12_000 } as never,
+    });
+
+    expect(mocks.setSessionThinkingBudget).toHaveBeenCalledWith('session-1', 12_000);
+    expect(ws.send).not.toHaveBeenCalled();
+  });
+
+  it('sends websocket error when update fails', async () => {
+    mocks.setSessionThinkingBudget.mockRejectedValue(new Error('invalid token budget'));
+    const ws = { send: vi.fn() };
+    const handler = createSetThinkingBudgetHandler();
+
+    await handler({
+      ws: ws as never,
+      sessionId: 'session-1',
+      workingDir: '/tmp/work',
+      message: { type: 'set_thinking_budget', max_tokens: 0 } as never,
+    });
+
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({
+        type: 'error',
+        message: 'Failed to set thinking budget: invalid token budget',
+      })
+    );
+  });
+});

--- a/src/backend/domains/session/chat/chat-message-handlers/handlers/user-input.handler.test.ts
+++ b/src/backend/domains/session/chat/chat-message-handlers/handlers/user-input.handler.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ChatMessageHandlerSessionService } from '@/backend/domains/session/chat/chat-message-handlers/types';
+import { createUserInputHandler } from './user-input.handler';
+
+function createDeps(overrides?: Partial<ChatMessageHandlerSessionService>) {
+  const deps: ChatMessageHandlerSessionService = {
+    isSessionRunning: vi.fn(() => false),
+    sendSessionMessage: vi.fn(async () => undefined),
+    respondToAcpPermission: vi.fn(),
+    setSessionModel: vi.fn(async () => undefined),
+    setSessionReasoningEffort: vi.fn(),
+    getChatBarCapabilities: vi.fn(async () => ({})),
+    ...overrides,
+  };
+  return deps;
+}
+
+describe('createUserInputHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('ignores empty or whitespace-only content', () => {
+    const sessionService = createDeps();
+    const handler = createUserInputHandler({ sessionService });
+    const ws = { send: vi.fn() };
+
+    void handler({
+      ws: ws as never,
+      sessionId: 'session-1',
+      workingDir: '/tmp/work',
+      message: { type: 'user_input', text: '   ' } as never,
+    });
+
+    void handler({
+      ws: ws as never,
+      sessionId: 'session-1',
+      workingDir: '/tmp/work',
+      message: { type: 'user_input' } as never,
+    });
+
+    expect(sessionService.sendSessionMessage).not.toHaveBeenCalled();
+    expect(ws.send).not.toHaveBeenCalled();
+  });
+
+  it('forwards text input to active session', async () => {
+    const sessionService = createDeps({ isSessionRunning: vi.fn(() => true) });
+    const handler = createUserInputHandler({ sessionService });
+    const ws = { send: vi.fn() };
+
+    void handler({
+      ws: ws as never,
+      sessionId: 'session-1',
+      workingDir: '/tmp/work',
+      message: { type: 'user_input', text: 'hello' } as never,
+    });
+
+    await Promise.resolve();
+    expect(sessionService.sendSessionMessage).toHaveBeenCalledWith('session-1', 'hello');
+    expect(ws.send).not.toHaveBeenCalled();
+  });
+
+  it('forwards structured content arrays to active session', async () => {
+    const sessionService = createDeps({ isSessionRunning: vi.fn(() => true) });
+    const handler = createUserInputHandler({ sessionService });
+    const ws = { send: vi.fn() };
+    const content = [{ type: 'text', text: 'from array' }];
+
+    void handler({
+      ws: ws as never,
+      sessionId: 'session-2',
+      workingDir: '/tmp/work',
+      message: { type: 'user_input', content } as never,
+    });
+
+    await Promise.resolve();
+    expect(sessionService.sendSessionMessage).toHaveBeenCalledWith('session-2', content);
+    expect(ws.send).not.toHaveBeenCalled();
+  });
+
+  it('returns websocket error when no active session exists', () => {
+    const sessionService = createDeps({ isSessionRunning: vi.fn(() => false) });
+    const handler = createUserInputHandler({ sessionService });
+    const ws = { send: vi.fn() };
+
+    void handler({
+      ws: ws as never,
+      sessionId: 'session-3',
+      workingDir: '/tmp/work',
+      message: { type: 'user_input', text: 'hello' } as never,
+    });
+
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({
+        type: 'error',
+        message: 'No active session. Use queue_message to queue messages.',
+      })
+    );
+  });
+});

--- a/src/backend/domains/session/lifecycle/session.service.coverage.test.ts
+++ b/src/backend/domains/session/lifecycle/session.service.coverage.test.ts
@@ -1,0 +1,235 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createSessionService } from './session.service';
+
+function createServiceWithPatchedInternals() {
+  const runtimeManager = {
+    getClient: vi.fn(),
+    sendPrompt: vi.fn(),
+    cancelPrompt: vi.fn(),
+    isSessionRunning: vi.fn(),
+    isSessionWorking: vi.fn(),
+    isAnySessionWorking: vi.fn(),
+  };
+
+  const sessionDomainService = {
+    setRuntimeSnapshot: vi.fn(),
+    getTranscriptSnapshot: vi.fn(),
+  };
+
+  const service = createSessionService({
+    runtimeManager: runtimeManager as never,
+    sessionDomainService: sessionDomainService as never,
+    repository: {} as never,
+  });
+
+  const lifecycleService = {
+    stopWorkspaceSessions: vi.fn(async () => undefined),
+    getOrCreateSessionClient: vi.fn(async () => ({ id: 'client' })),
+    getOrCreateSessionClientFromRecord: vi.fn(async () => ({ id: 'client-from-record' })),
+    getSessionClient: vi.fn(() => ({ id: 'existing-client' })),
+    getRuntimeSnapshot: vi.fn(() => ({ phase: 'idle' })),
+    getSessionOptions: vi.fn(async () => ({ workingDir: '/tmp', model: 'gpt-5' })),
+    stopAllClients: vi.fn(async () => undefined),
+  };
+
+  const sessionConfigService = {
+    getSessionConfigOptions: vi.fn(() => [{ id: 'mode' }]),
+    getSessionConfigOptionsWithFallback: vi.fn(async () => [{ id: 'model' }]),
+    setSessionModel: vi.fn(async () => undefined),
+    setSessionThinkingBudget: vi.fn(async () => undefined),
+    setSessionConfigOption: vi.fn(async () => undefined),
+    getChatBarCapabilities: vi.fn(async () => ({ provider: 'CODEX' })),
+  };
+
+  const sessionPermissionService = {
+    respondToPermission: vi.fn(() => true),
+  };
+
+  (service as unknown as { lifecycleService: unknown }).lifecycleService = lifecycleService;
+  (service as unknown as { sessionConfigService: unknown }).sessionConfigService =
+    sessionConfigService;
+  (service as unknown as { sessionPermissionService: unknown }).sessionPermissionService =
+    sessionPermissionService;
+  (service as unknown as { runtimeManager: unknown }).runtimeManager = runtimeManager;
+  (service as unknown as { sessionDomainService: unknown }).sessionDomainService =
+    sessionDomainService;
+
+  return {
+    service,
+    lifecycleService,
+    sessionConfigService,
+    sessionPermissionService,
+    runtimeManager,
+    sessionDomainService,
+  };
+}
+
+describe('SessionService coverage wrappers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('delegates lifecycle/config/permission wrappers', async () => {
+    const {
+      service,
+      lifecycleService,
+      sessionConfigService,
+      sessionPermissionService,
+      runtimeManager,
+    } = createServiceWithPatchedInternals();
+
+    await service.stopWorkspaceSessions('workspace-1');
+    await service.getOrCreateSessionClient('session-1', { model: 'gpt-5' });
+    await service.getOrCreateSessionClientFromRecord({ id: 'session-2' } as never, {
+      model: 'gpt-5-mini',
+    });
+    service.getSessionClient('session-1');
+    service.getSessionConfigOptions('session-1');
+    await service.getSessionConfigOptionsWithFallback('session-1');
+    await service.setSessionModel('session-1', 'gpt-5');
+    await service.setSessionThinkingBudget('session-1', 16_000);
+    await service.setSessionConfigOption('session-1', 'mode', 'plan');
+    service.respondToAcpPermission('session-1', 'req-1', 'allow_once', { mode: ['default'] });
+    service.getRuntimeSnapshot('session-1');
+    await service.getSessionOptions('session-1');
+    await service.getChatBarCapabilities('session-1');
+    await service.stopAllClients(2500);
+    service.isSessionRunning('session-1');
+    service.isSessionWorking('session-1');
+    service.isAnySessionWorking(['session-1']);
+
+    expect(lifecycleService.stopWorkspaceSessions).toHaveBeenCalledWith('workspace-1');
+    expect(lifecycleService.getOrCreateSessionClient).toHaveBeenCalledWith('session-1', {
+      model: 'gpt-5',
+    });
+    expect(lifecycleService.getOrCreateSessionClientFromRecord).toHaveBeenCalled();
+    expect(lifecycleService.getSessionClient).toHaveBeenCalledWith('session-1');
+    expect(sessionConfigService.getSessionConfigOptions).toHaveBeenCalledWith('session-1');
+    expect(sessionConfigService.getSessionConfigOptionsWithFallback).toHaveBeenCalledWith(
+      'session-1'
+    );
+    expect(sessionConfigService.setSessionModel).toHaveBeenCalledWith('session-1', 'gpt-5');
+    expect(sessionConfigService.setSessionThinkingBudget).toHaveBeenCalledWith('session-1', 16_000);
+    expect(sessionConfigService.setSessionConfigOption).toHaveBeenCalledWith(
+      'session-1',
+      'mode',
+      'plan'
+    );
+    expect(sessionPermissionService.respondToPermission).toHaveBeenCalledWith(
+      'session-1',
+      'req-1',
+      'allow_once',
+      { mode: ['default'] }
+    );
+    expect(lifecycleService.getRuntimeSnapshot).toHaveBeenCalledWith('session-1');
+    expect(lifecycleService.getSessionOptions).toHaveBeenCalledWith('session-1');
+    expect(sessionConfigService.getChatBarCapabilities).toHaveBeenCalledWith('session-1');
+    expect(lifecycleService.stopAllClients).toHaveBeenCalledWith(2500);
+    expect(runtimeManager.isSessionRunning).toHaveBeenCalledWith('session-1');
+    expect(runtimeManager.isSessionWorking).toHaveBeenCalledWith('session-1');
+    expect(runtimeManager.isAnySessionWorking).toHaveBeenCalledWith(['session-1']);
+  });
+
+  it('returns early when sendSessionMessage is called without an ACP client', async () => {
+    const { service, runtimeManager } = createServiceWithPatchedInternals();
+    runtimeManager.getClient.mockReturnValue(undefined);
+    const sendAcpMessageSpy = vi.spyOn(service, 'sendAcpMessage');
+
+    await expect(service.sendSessionMessage('session-1', 'hello')).resolves.toBeUndefined();
+    expect(sendAcpMessageSpy).not.toHaveBeenCalled();
+  });
+
+  it('normalizes content blocks to text when sending through ACP', async () => {
+    const { service, runtimeManager } = createServiceWithPatchedInternals();
+    runtimeManager.getClient.mockReturnValue({ id: 'client' });
+    const sendAcpMessageSpy = vi
+      .spyOn(service, 'sendAcpMessage')
+      .mockResolvedValue('end_turn' as never);
+
+    await service.sendSessionMessage('session-1', [
+      { type: 'text', text: 'hello' },
+      { type: 'thinking', thinking: 'analyzing' },
+      { type: 'image', mimeType: 'image/png', data: 'abc' } as never,
+      { type: 'tool_result', content: 'tool output' },
+      { type: 'tool_result', content: { ok: true } },
+      { type: 'unsupported' } as never,
+    ] as never);
+
+    expect(sendAcpMessageSpy).toHaveBeenCalledWith(
+      'session-1',
+      [
+        'hello',
+        'analyzing',
+        '[Image attachment omitted for this provider]',
+        'tool output',
+        '{"ok":true}',
+      ].join('\n\n')
+    );
+  });
+
+  it('swallows sendAcpMessage errors to keep websocket flow alive', async () => {
+    const { service, runtimeManager } = createServiceWithPatchedInternals();
+    runtimeManager.getClient.mockReturnValue({ id: 'client' });
+    vi.spyOn(service, 'sendAcpMessage').mockRejectedValue(new Error('prompt failed'));
+
+    await expect(service.sendSessionMessage('session-1', 'hello')).resolves.toBeUndefined();
+  });
+
+  it('maps transcript entries into conversation history', () => {
+    const { service, sessionDomainService } = createServiceWithPatchedInternals();
+    sessionDomainService.getTranscriptSnapshot.mockReturnValue([
+      {
+        source: 'user',
+        text: 'plain user text',
+        timestamp: '2026-02-27T00:00:00.000Z',
+      },
+      {
+        source: 'assistant',
+        timestamp: '2026-02-27T00:01:00.000Z',
+        message: {
+          type: 'assistant',
+          message: {
+            content: [
+              { type: 'text', text: 'chunk one' },
+              { type: 'image', mimeType: 'image/png', data: 'abc' },
+              { type: 'text', text: 'chunk two' },
+            ],
+          },
+        },
+      },
+      {
+        source: 'assistant',
+        timestamp: '2026-02-27T00:02:00.000Z',
+        message: {
+          type: 'assistant',
+          message: {
+            content: 'single assistant string',
+          },
+        },
+      },
+      {
+        source: 'assistant',
+        timestamp: '2026-02-27T00:03:00.000Z',
+        message: { type: 'tool' },
+      },
+    ]);
+
+    expect(service.getSessionConversationHistory('session-1', '/tmp/work')).toEqual([
+      {
+        type: 'user',
+        content: 'plain user text',
+        timestamp: '2026-02-27T00:00:00.000Z',
+      },
+      {
+        type: 'assistant',
+        content: 'chunk one\nchunk two',
+        timestamp: '2026-02-27T00:01:00.000Z',
+      },
+      {
+        type: 'assistant',
+        content: 'single assistant string',
+        timestamp: '2026-02-27T00:02:00.000Z',
+      },
+    ]);
+  });
+});

--- a/src/backend/interceptors/registry.test.ts
+++ b/src/backend/interceptors/registry.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { interceptorRegistry } from './registry';
+import type { InterceptorContext, ToolEvent, ToolInterceptor } from './types';
+
+const mockLogger = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock('@/backend/services/logger.service', () => ({
+  createLogger: () => mockLogger,
+}));
+
+function resetRegistryState() {
+  const mutableRegistry = interceptorRegistry as unknown as {
+    interceptors: ToolInterceptor[];
+    started: boolean;
+  };
+  mutableRegistry.interceptors = [];
+  mutableRegistry.started = false;
+}
+
+const event: ToolEvent = {
+  toolUseId: 'tool-1',
+  toolName: 'Bash',
+  input: { command: 'pnpm test' },
+};
+
+const context: InterceptorContext = {
+  sessionId: 'session-1',
+  workspaceId: 'workspace-1',
+  workingDir: '/tmp/workspace',
+  timestamp: new Date('2026-02-27T00:00:00.000Z'),
+};
+
+describe('interceptorRegistry', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await interceptorRegistry.stop();
+    resetRegistryState();
+  });
+
+  it('skips duplicate registrations by interceptor name', async () => {
+    const registry = interceptorRegistry;
+    const startA = vi.fn();
+    const startB = vi.fn();
+    const onToolStart = vi.fn(async () => undefined);
+
+    registry.register({
+      name: 'dup',
+      tools: ['Bash'],
+      start: startA,
+      onToolStart,
+    });
+    registry.register({
+      name: 'dup',
+      tools: ['Bash'],
+      start: startB,
+      onToolStart: vi.fn(async () => undefined),
+    });
+
+    await registry.start();
+    registry.notifyToolStart(event, context);
+
+    expect(startA).toHaveBeenCalledTimes(1);
+    expect(startB).not.toHaveBeenCalled();
+    expect(onToolStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('starts registered interceptors and starts newly-registered ones after start', async () => {
+    const registry = interceptorRegistry;
+    const startOne = vi.fn(async () => undefined);
+    const startTwo = vi.fn(async () => undefined);
+
+    registry.register({ name: 'one', tools: '*', start: startOne });
+    await registry.start();
+    registry.register({ name: 'two', tools: '*', start: startTwo });
+
+    expect(startOne).toHaveBeenCalledTimes(1);
+    expect(startTwo).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows start/stop hook errors and still processes others', async () => {
+    const registry = interceptorRegistry;
+    const goodStart = vi.fn(async () => undefined);
+    const goodStop = vi.fn(async () => undefined);
+    const badStart = vi.fn(() => Promise.reject(new Error('start failed')));
+    const badStop = vi.fn(() => Promise.reject(new Error('stop failed')));
+
+    registry.register({ name: 'good', tools: '*', start: goodStart, stop: goodStop });
+    registry.register({ name: 'bad', tools: '*', start: badStart, stop: badStop });
+
+    await expect(registry.start()).resolves.toBeUndefined();
+    await expect(registry.stop()).resolves.toBeUndefined();
+
+    expect(goodStart).toHaveBeenCalledTimes(1);
+    expect(goodStop).toHaveBeenCalledTimes(1);
+    expect(badStart).toHaveBeenCalledTimes(1);
+    expect(badStop).toHaveBeenCalledTimes(1);
+    expect(mockLogger.error).toHaveBeenCalled();
+  });
+
+  it('notifies only matching interceptors for start and complete events', () => {
+    const registry = interceptorRegistry;
+    const onStartAny = vi.fn(async () => undefined);
+    const onStartBash = vi.fn(async () => undefined);
+    const onStartOther = vi.fn(async () => undefined);
+    const onCompleteBash = vi.fn(async () => undefined);
+
+    registry.register({
+      name: 'any',
+      tools: '*',
+      onToolStart: onStartAny,
+    });
+    registry.register({
+      name: 'bash',
+      tools: ['Bash'],
+      onToolStart: onStartBash,
+      onToolComplete: onCompleteBash,
+    });
+    registry.register({
+      name: 'other',
+      tools: ['Edit'],
+      onToolStart: onStartOther,
+    });
+
+    registry.notifyToolStart(event, context);
+    registry.notifyToolComplete(event, context);
+
+    expect(onStartAny).toHaveBeenCalledWith(event, context);
+    expect(onStartBash).toHaveBeenCalledWith(event, context);
+    expect(onStartOther).not.toHaveBeenCalled();
+    expect(onCompleteBash).toHaveBeenCalledWith(event, context);
+  });
+
+  it('handles fire-and-forget interceptor failures for start/complete callbacks', async () => {
+    const registry = interceptorRegistry;
+    const failStart = vi.fn(() => Promise.reject(new Error('start callback failure')));
+    const failComplete = vi.fn(() => Promise.reject(new Error('complete callback failure')));
+
+    registry.register({
+      name: 'unstable',
+      tools: ['Bash'],
+      onToolStart: failStart,
+      onToolComplete: failComplete,
+    });
+
+    registry.notifyToolStart(event, context);
+    registry.notifyToolComplete(event, context);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(failStart).toHaveBeenCalledTimes(1);
+    expect(failComplete).toHaveBeenCalledTimes(1);
+    expect(mockLogger.error).toHaveBeenCalled();
+  });
+
+  it('is a no-op when start is called twice', async () => {
+    const registry = interceptorRegistry;
+    const interceptor: ToolInterceptor = {
+      name: 'idempotent',
+      tools: '*',
+      start: vi.fn(async () => undefined),
+    };
+    registry.register(interceptor);
+
+    await registry.start();
+    await registry.start();
+
+    expect(interceptor.start).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/backend/orchestration/cli-health.service.test.ts
+++ b/src/backend/orchestration/cli-health.service.test.ts
@@ -1,111 +1,254 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockExecFile = vi.hoisted(() => vi.fn());
+const mockGithubCheckHealth = vi.hoisted(() => vi.fn());
+const mockLogger = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn(),
+}));
+
+vi.mock('node:util', () => ({
+  promisify: (fn: unknown) => fn,
+}));
 
 vi.mock('@/backend/domains/github', () => ({
   githubCLIService: {
-    checkHealth: vi.fn(),
+    checkHealth: (...args: unknown[]) => mockGithubCheckHealth(...args),
   },
 }));
 
 vi.mock('@/backend/services/logger.service', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  }),
+  createLogger: () => mockLogger,
 }));
 
-import { githubCLIService } from '@/backend/domains/github';
+import { execFile } from 'node:child_process';
 import { cliHealthService } from './cli-health.service';
+
+vi.mocked(execFile).mockImplementation(mockExecFile as never);
 
 describe('cliHealthService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     cliHealthService.clearCache();
+    vi.stubGlobal('fetch', vi.fn());
   });
 
-  it('treats Codex CLI as optional for allHealthy', async () => {
-    vi.spyOn(cliHealthService, 'checkClaudeCLI').mockResolvedValue({
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('checks Claude CLI install/auth state and version freshness', async () => {
+    mockExecFile.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'claude' && args[0] === '--version') {
+        return Promise.resolve({ stdout: 'claude code 1.2.3\n', stderr: '' });
+      }
+      if (cmd === 'claude' && args[0] === 'auth') {
+        return Promise.resolve({ stdout: '{"loggedIn":true}', stderr: '' });
+      }
+      throw new Error(`unexpected command: ${cmd} ${args.join(' ')}`);
+    });
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: '1.3.0' }),
+    } as never);
+
+    const status = await cliHealthService.checkClaudeCLI();
+
+    expect(status).toEqual(
+      expect.objectContaining({
+        isInstalled: true,
+        isAuthenticated: true,
+        version: '1.2.3',
+        latestVersion: '1.3.0',
+        isOutdated: true,
+      })
+    );
+  });
+
+  it('treats Claude auth check failures as unauthenticated and handles missing npm freshness', async () => {
+    mockExecFile.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'claude' && args[0] === '--version') {
+        return Promise.resolve({ stdout: 'claude 1.2.3\n', stderr: '' });
+      }
+      if (cmd === 'claude' && args[0] === 'auth') {
+        return Promise.reject(new Error('auth unavailable'));
+      }
+      throw new Error(`unexpected command: ${cmd} ${args.join(' ')}`);
+    });
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      json: async () => ({}),
+    } as never);
+
+    const status = await cliHealthService.checkClaudeCLI();
+
+    expect(status.isInstalled).toBe(true);
+    expect(status.isAuthenticated).toBe(false);
+    expect(status.latestVersion).toBeUndefined();
+  });
+
+  it('returns a not-installed error for missing Claude CLI', async () => {
+    mockExecFile.mockRejectedValue(new Error('spawn claude ENOENT'));
+
+    const status = await cliHealthService.checkClaudeCLI();
+
+    expect(status).toEqual({
+      isInstalled: false,
+      isAuthenticated: false,
+      error: 'Claude CLI is not installed. Install from https://claude.ai/download',
+    });
+  });
+
+  it('checks Codex CLI install/auth state and freshness', async () => {
+    mockExecFile.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'codex' && args[0] === '--version') {
+        return Promise.resolve({ stdout: '0.5.0\n', stderr: '' });
+      }
+      if (cmd === 'codex' && args[0] === 'login') {
+        return Promise.resolve({ stdout: 'authenticated', stderr: '' });
+      }
+      throw new Error(`unexpected command: ${cmd} ${args.join(' ')}`);
+    });
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: '0.4.0' }),
+    } as never);
+
+    const status = await cliHealthService.checkCodexCLI();
+
+    expect(status).toEqual(
+      expect.objectContaining({
+        isInstalled: true,
+        isAuthenticated: true,
+        version: '0.5.0',
+        latestVersion: '0.4.0',
+        isOutdated: false,
+      })
+    );
+  });
+
+  it('returns unauthenticated status when Codex login check fails', async () => {
+    mockExecFile.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'codex' && args[0] === '--version') {
+        return Promise.resolve({ stdout: '0.5.0\n', stderr: '' });
+      }
+      if (cmd === 'codex' && args[0] === 'login') {
+        return Promise.reject(new Error('login required'));
+      }
+      throw new Error(`unexpected command: ${cmd} ${args.join(' ')}`);
+    });
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: '0.6.0' }),
+    } as never);
+
+    const status = await cliHealthService.checkCodexCLI();
+
+    expect(status).toEqual(
+      expect.objectContaining({
+        isInstalled: true,
+        isAuthenticated: false,
+        latestVersion: '0.6.0',
+        isOutdated: true,
+        error: 'Codex CLI is not authenticated. Run `codex login` to authenticate.',
+      })
+    );
+  });
+
+  it('returns a not-installed error for missing Codex CLI', async () => {
+    mockExecFile.mockRejectedValue(new Error('spawn codex ENOENT'));
+
+    const status = await cliHealthService.checkCodexCLI();
+
+    expect(status).toEqual({
+      isInstalled: false,
+      isAuthenticated: false,
+      error:
+        'Codex CLI is not installed. Install from https://developers.openai.com/codex/app-server/',
+    });
+  });
+
+  it('upgrades provider CLI and returns refreshed health', async () => {
+    mockExecFile.mockResolvedValue({ stdout: 'installed\n', stderr: '' });
+    const refreshed = {
+      claude: { isInstalled: true, isAuthenticated: true, version: '1.0.0' },
+      codex: { isInstalled: true, isAuthenticated: true, version: '0.5.0' },
+      github: { isInstalled: true, isAuthenticated: true, version: '2.0.0' },
+      allHealthy: true,
+    };
+    const checkHealthSpy = vi.spyOn(cliHealthService, 'checkHealth').mockResolvedValue(refreshed);
+
+    const result = await cliHealthService.upgradeProviderCLI('CODEX');
+
+    expect(result.provider).toBe('CODEX');
+    expect(result.packageName).toBe('@openai/codex');
+    expect(result.command).toBe('npm install -g @openai/codex');
+    expect(result.output).toContain('installed');
+    expect(result.health).toBe(refreshed);
+    expect(checkHealthSpy).toHaveBeenCalledWith(true);
+    expect(mockExecFile).toHaveBeenCalledWith(
+      'npm',
+      ['install', '-g', '@openai/codex'],
+      expect.objectContaining({ timeout: expect.any(Number) })
+    );
+  });
+
+  it('includes process stdout/stderr when CLI upgrade fails', async () => {
+    mockExecFile.mockRejectedValue({
+      message: 'npm failed',
+      stderr: 'EACCES',
+      stdout: 'partial output',
+    });
+
+    await expect(cliHealthService.upgradeProviderCLI('CLAUDE')).rejects.toThrow(
+      'Failed to upgrade Claude CLI via npm'
+    );
+  });
+
+  it('uses cached health result unless force refresh is requested', async () => {
+    const checkClaudeSpy = vi.spyOn(cliHealthService, 'checkClaudeCLI').mockResolvedValue({
       isInstalled: true,
       isAuthenticated: true,
+      version: 'claude 1.2.3',
+    });
+    const checkCodexSpy = vi.spyOn(cliHealthService, 'checkCodexCLI').mockResolvedValue({
+      isInstalled: true,
+      isAuthenticated: false,
+      version: 'codex 0.5.0',
+    });
+    mockGithubCheckHealth.mockResolvedValue({
+      isInstalled: true,
+      isAuthenticated: true,
+      version: '2.0.0',
+    });
+
+    const first = await cliHealthService.checkHealth(true);
+    const second = await cliHealthService.checkHealth(false);
+
+    expect(first).toBe(second);
+    expect(checkClaudeSpy).toHaveBeenCalledTimes(1);
+    expect(checkCodexSpy).toHaveBeenCalledTimes(1);
+    expect(mockGithubCheckHealth).toHaveBeenCalledTimes(1);
+    expect(first.allHealthy).toBe(true);
+  });
+
+  it('reports unhealthy when Claude or GitHub are unauthenticated', async () => {
+    vi.spyOn(cliHealthService, 'checkClaudeCLI').mockResolvedValue({
+      isInstalled: true,
+      isAuthenticated: false,
       version: 'claude 1.2.3',
     });
     vi.spyOn(cliHealthService, 'checkCodexCLI').mockResolvedValue({
       isInstalled: false,
       isAuthenticated: false,
-      error: 'Codex not installed',
     });
-    vi.mocked(githubCLIService.checkHealth).mockResolvedValue({
-      isInstalled: true,
-      isAuthenticated: true,
-      version: '2.0.0',
-    });
-
-    const status = await cliHealthService.checkHealth(true);
-
-    expect(status.codex.isInstalled).toBe(false);
-    expect(status.allHealthy).toBe(true);
-  });
-
-  it('reports Codex as installed but unauthenticated', async () => {
-    vi.spyOn(cliHealthService, 'checkClaudeCLI').mockResolvedValue({
-      isInstalled: true,
-      isAuthenticated: true,
-      version: 'claude 1.2.3',
-    });
-    vi.spyOn(cliHealthService, 'checkCodexCLI').mockResolvedValue({
-      isInstalled: true,
-      isAuthenticated: false,
-      version: 'codex-cli 0.99.0',
-      error: 'Codex CLI is not authenticated. Run `codex login` to authenticate.',
-    });
-    vi.mocked(githubCLIService.checkHealth).mockResolvedValue({
-      isInstalled: true,
-      isAuthenticated: true,
-      version: '2.0.0',
-    });
-
-    const status = await cliHealthService.checkHealth(true);
-
-    expect(status.codex.isInstalled).toBe(true);
-    expect(status.codex.isAuthenticated).toBe(false);
-    expect(status.allHealthy).toBe(true); // Codex auth is optional for allHealthy
-  });
-
-  it('reports unhealthy when Claude CLI is not authenticated', async () => {
-    vi.spyOn(cliHealthService, 'checkClaudeCLI').mockResolvedValue({
-      isInstalled: true,
-      isAuthenticated: false,
-      version: 'claude 1.2.3',
-    });
-    vi.spyOn(cliHealthService, 'checkCodexCLI').mockResolvedValue({
-      isInstalled: true,
-      isAuthenticated: true,
-      version: 'codex-cli 0.99.0',
-    });
-    vi.mocked(githubCLIService.checkHealth).mockResolvedValue({
-      isInstalled: true,
-      isAuthenticated: true,
-      version: '2.0.0',
-    });
-
-    const status = await cliHealthService.checkHealth(true);
-
-    expect(status.allHealthy).toBe(false);
-  });
-
-  it('reports unhealthy when required GitHub auth is missing', async () => {
-    vi.spyOn(cliHealthService, 'checkClaudeCLI').mockResolvedValue({
-      isInstalled: true,
-      isAuthenticated: true,
-      version: 'claude 1.2.3',
-    });
-    vi.spyOn(cliHealthService, 'checkCodexCLI').mockResolvedValue({
-      isInstalled: true,
-      isAuthenticated: true,
-      version: 'codex-cli 0.99.0',
-    });
-    vi.mocked(githubCLIService.checkHealth).mockResolvedValue({
+    mockGithubCheckHealth.mockResolvedValue({
       isInstalled: true,
       isAuthenticated: false,
       version: '2.0.0',
@@ -114,5 +257,6 @@ describe('cliHealthService', () => {
     const status = await cliHealthService.checkHealth(true);
 
     expect(status.allHealthy).toBe(false);
+    expect(mockLogger.warn).toHaveBeenCalled();
   });
 });

--- a/src/backend/services/config.service.test.ts
+++ b/src/backend/services/config.service.test.ts
@@ -41,4 +41,117 @@ describe('configService environment accessors', () => {
 
     expect(configService.getMigrationsPath()).toBe('/tmp/migrations');
   });
+
+  it('builds profile/configuration values from environment aliases and toggles', () => {
+    process.env.DEFAULT_MODEL = 'opus';
+    process.env.DEFAULT_PERMISSIONS = 'strict';
+    process.env.NODE_ENV = 'production';
+    process.env.BACKEND_PORT = '4242';
+    process.env.BACKEND_HOST = '0.0.0.0';
+    process.env.BASE_DIR = '/tmp/factory-home';
+    process.env.WORKTREE_BASE_DIR = '/tmp/factory-worktrees';
+    process.env.REPOS_DIR = '/tmp/factory-repos';
+    process.env.WS_LOGS_PATH = '/tmp/ws-logs';
+    process.env.CLAUDE_CONFIG_DIR = '/tmp/claude-config';
+    process.env.ACP_TRACE_LOGS_ENABLED = 'true';
+    process.env.ACP_TRACE_LOGS_PATH = '/tmp/acp-trace';
+    process.env.FF_RUN_SCRIPT_PROXY_ENABLED = '1';
+    process.env.WS_LOGS_ENABLED = 'true';
+    process.env.DEBUG_CHAT_WS = 'true';
+    process.env.NOTIFICATION_SOUND_ENABLED = 'false';
+    process.env.NOTIFICATION_PUSH_ENABLED = 'true';
+    process.env.NOTIFICATION_SOUND_FILE = '/tmp/sound.wav';
+    process.env.NOTIFICATION_QUIET_HOURS_START = '22';
+    process.env.NOTIFICATION_QUIET_HOURS_END = '7';
+    process.env.CORS_ALLOWED_ORIGINS = 'http://localhost:9999, https://example.com';
+    process.env.BRANCH_RENAME_MESSAGE_THRESHOLD = '4';
+    process.env.EVENT_COMPRESSION_ENABLED = 'false';
+    process.env.WEB_CONCURRENCY = '3';
+    process.env.npm_package_version = '9.9.9';
+    process.env.DATABASE_PATH = '/tmp/custom.db';
+    process.env.SERVICE_NAME = 'factory-test';
+    process.env.LOG_LEVEL = 'debug';
+
+    configService.reload();
+
+    expect(configService.getEnvironment()).toBe('production');
+    expect(configService.isProduction()).toBe(true);
+    expect(configService.isDevelopment()).toBe(false);
+    expect(configService.getBackendPort()).toBe(4242);
+    expect(configService.getBackendHost()).toBe('0.0.0.0');
+    expect(configService.getBaseDir()).toBe('/tmp/factory-home');
+    expect(configService.getWorktreeBaseDir()).toBe('/tmp/factory-worktrees');
+    expect(configService.getReposDir()).toBe('/tmp/factory-repos');
+    expect(configService.getWsLogsPath()).toBe('/tmp/ws-logs');
+    expect(configService.getClaudeConfigDir()).toBe('/tmp/claude-config');
+    expect(configService.isAcpTraceLoggingEnabled()).toBe(true);
+    expect(configService.getAcpTraceLogsPath()).toBe('/tmp/acp-trace');
+    expect(configService.isRunScriptProxyEnabled()).toBe(true);
+    expect(configService.isWsLogsEnabled()).toBe(true);
+    expect(configService.getWebConcurrency()).toBe(3);
+    expect(configService.getBranchRenameMessageThreshold()).toBe(4);
+    expect(configService.getAppVersion()).toBe('9.9.9');
+    expect(configService.getDatabasePath()).toBe('/tmp/custom.db');
+    expect(configService.getDatabasePathFromEnv()).toBe('/tmp/custom.db');
+    expect(configService.getDefaultSessionProfile()).toEqual({
+      model: 'claude-opus-4-5-20251101',
+      permissionMode: 'strict',
+      maxTokens: 8192,
+      temperature: 1,
+    });
+
+    expect(configService.getRateLimiterConfig()).toEqual(
+      expect.objectContaining({
+        claudeRequestsPerMinute: expect.any(Number),
+        claudeRequestsPerHour: expect.any(Number),
+        maxQueueSize: expect.any(Number),
+        queueTimeoutMs: expect.any(Number),
+      })
+    );
+    expect(configService.getNotificationConfig()).toEqual({
+      soundEnabled: false,
+      pushEnabled: true,
+      soundFile: '/tmp/sound.wav',
+      quietHoursStart: 22,
+      quietHoursEnd: 7,
+    });
+    expect(configService.getCorsConfig()).toEqual({
+      allowedOrigins: ['http://localhost:9999', 'https://example.com'],
+    });
+    expect(configService.getDebugConfig()).toEqual({ chatWebSocket: true });
+    expect(configService.getCompressionConfig()).toEqual({ enabled: false });
+    expect(configService.getFrontendStaticPath()).toBe(
+      process.env.FRONTEND_STATIC_PATH?.trim() || undefined
+    );
+  });
+
+  it('exposes additional getters and returns defensive copies', () => {
+    process.env.NODE_ENV = 'development';
+    process.env.SHELL = '/bin/zsh';
+    process.env.FRONTEND_STATIC_PATH = '/tmp/frontend';
+    process.env.MIGRATIONS_PATH = '/tmp/migrations';
+    configService.reload();
+
+    expect(configService.getShellPath()).toBe('/bin/zsh');
+    expect(configService.getDebugLogDir()).toContain('debug');
+    expect(configService.getAcpStartupTimeoutMs()).toBeGreaterThan(0);
+    expect(configService.getMaxSessionsPerWorkspace()).toBeGreaterThan(0);
+    expect(configService.getFrontendStaticPath()).toBe('/tmp/frontend');
+    expect(configService.getMigrationsPath()).toBe('/tmp/migrations');
+    expect(configService.getAvailableModels()).toEqual(
+      expect.arrayContaining([
+        { alias: 'sonnet', model: expect.any(String) },
+        { alias: 'opus', model: expect.any(String) },
+      ])
+    );
+    expect(configService.getAvailablePermissionModes()).toEqual(['strict', 'relaxed', 'yolo']);
+
+    const childEnv = configService.getChildProcessEnv();
+    childEnv.__TEST_CONFIG_COPY__ = 'mutated';
+    expect(process.env.__TEST_CONFIG_COPY__).toBeUndefined();
+
+    const systemConfig = configService.getSystemConfig();
+    expect(systemConfig.backendPort).toBe(configService.getBackendPort());
+    expect(systemConfig.logger.serviceName).toBeDefined();
+  });
 });


### PR DESCRIPTION
## Summary
Increase backend test coverage on critical-path services and handlers, with focused additions aimed at pushing targeted files above 80% line coverage.

## What Changed
- Expanded existing backend tests for:
  - `cli-health.service`
  - `github-cli.service`
  - `codex-app-server-acp-adapter`
  - `config.service`
  - `notification.service`
- Added new backend tests for:
  - `interceptors/registry`
  - `session-config-resolver`
  - `session.service` coverage wrappers
  - chat message handlers:
    - `queue-message`
    - `set-config-option`
    - `permission-response`
    - `user-input`
    - `remove-queued-message`
    - `set-thinking-budget`
- Covered additional error and branch paths (serialization fallbacks, permission response failures, queue/remove edge cases, adapter merge/rollback behavior).

## Coverage Outcomes
Targeted backend files are now above 80% line coverage, including:
- `cli-health.service.ts`: 97.70%
- `session.service.ts`: 90.62%
- `github-cli.service.ts`: 100.00%
- `notification.service.ts`: 83.14%
- `config.service.ts`: 91.35%
- `registry.ts`: 91.30%
- `session-config-resolver.ts`: 90.38%
- `codex-app-server-acp-adapter.ts`: 83.11%
- targeted chat handlers: 88.88%-100.00%

Overall backend lines coverage is 84.73%.

## Verification
- `pnpm test:coverage:backend:stable`
- `pnpm check:coverage:critical`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that broaden coverage across multiple backend services; primary risk is added test runtime/flakiness due to more mocking/timers, not production behavior changes.
> 
> **Overview**
> Raises backend critical-path coverage by **adding/expanding Vitest suites** across core services and websocket handlers.
> 
> Coverage additions exercise more branches and failure modes in `cliHealthService` (install/auth/freshness/caching + upgrade flows), `githubCLIService` (higher-level PR/issue actions and error mapping), the Codex ACP adapter (prompt block serialization, plan-approval edge cases, MCP config merge/rollback, tool-call state), plus new tests for `interceptors/registry`, `session-config-resolver`, `session.service` wrapper methods, and chat handlers (`queue_message`, `user_input`, `permission_response`, `remove_queued_message`, `set_config_option`, `set_thinking_budget`), along with extra `configService` and `notificationService` scenarios (env aliases/toggles, quiet hours, Linux fallbacks).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11523fb5448829b94fff2b4f78353260855857d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->