### PR TITLE
Remove Docker from production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,9 +81,6 @@ RUN apk add --no-cache \
     make \
     g++ \
     github-cli \
-    docker \
-    docker-cli-compose \
-    containerd \
   && ARCH="$(uname -m)" \
   && case "$ARCH" in \
        x86_64)  CF_ARCH="amd64" ;; \


### PR DESCRIPTION
## Summary
- Removes `docker`, `docker-cli-compose`, and `containerd` packages from the production runner stage of the Dockerfile since they are no longer needed

## Test plan
- [ ] Verify Docker image builds successfully without the removed packages
- [ ] Confirm no runtime features depend on Docker-in-Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)