### PR TITLE
Use HTTP/2 for cloudflared tunnel to fix QUIC timeouts

### DIFF
--- a/factory-factory.json
+++ b/factory-factory.json
@@ -2,6 +2,6 @@
   "scripts": {
     "setup": "pnpm install",
     "run": "pnpm dev",
-    "postRun": "while [ ! -f .factory-factory-port ]; do sleep 0.5; done; cloudflared tunnel --url http://localhost:$(cat .factory-factory-port)"
+    "postRun": "while [ ! -f .factory-factory-port ]; do sleep 0.5; done; cloudflared tunnel --protocol http2 --url http://localhost:$(cat .factory-factory-port)"
   }
 }


### PR DESCRIPTION
## Summary
- Switches cloudflared tunnel protocol from QUIC (default) to HTTP/2 in `factory-factory.json`
- Fixes repeated `failed to dial to edge with quic: timeout: handshake did not complete in time` errors in GCR/Docker environments where outbound UDP (port 7844) is blocked

## Test plan
- [ ] Deploy to GCR and verify cloudflared tunnel connects successfully without QUIC timeout errors
- [ ] Verify the app is reachable through the generated trycloudflare.com URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)