### PR TITLE
Fix ACP binary resolution in Docker when pnpm symlinks break

### DIFF
--- a/src/backend/domains/session/acp/acp-runtime-manager.ts
+++ b/src/backend/domains/session/acp/acp-runtime-manager.ts
@@ -89,9 +89,13 @@ function resolveAcpBinary(packageName: string, binaryName: string): string {
     // to find the nearest node_modules and try to locate the package directly.
     const found = findPackageJsonByWalkUp(__dirname, packageName);
     if (found) {
-      const resolved = extractBinPath(found, binaryName);
-      if (resolved) {
-        return resolved;
+      try {
+        const resolved = extractBinPath(found, binaryName);
+        if (resolved) {
+          return resolved;
+        }
+      } catch {
+        // Ignore; fall through to PATH fallback below.
       }
     }
     logger.debug('Could not resolve binary via package.json, falling back to PATH', {

--- a/src/backend/domains/session/acp/acp-runtime-manager.ts
+++ b/src/backend/domains/session/acp/acp-runtime-manager.ts
@@ -40,6 +40,37 @@ export type AcpRuntimeEventHandlers = {
   permissionBridge?: AcpPermissionBridge;
 };
 
+/** Extract the bin entrypoint path from a package.json's bin field. */
+function extractBinPath(packageJsonPath: string, binaryName: string): string | undefined {
+  const pkg = require(packageJsonPath) as {
+    bin?: string | Record<string, string | undefined>;
+  };
+  const relative =
+    typeof pkg.bin === 'string'
+      ? pkg.bin
+      : typeof pkg.bin?.[binaryName] === 'string'
+        ? pkg.bin[binaryName]
+        : undefined;
+  return relative ? join(dirname(packageJsonPath), relative) : undefined;
+}
+
+/**
+ * Walk up from startDir looking for node_modules/<packageName>/package.json.
+ * Used as a fallback when require.resolve fails (e.g. broken pnpm symlinks
+ * after Docker multi-stage COPY).
+ */
+function findPackageJsonByWalkUp(startDir: string, packageName: string): string | undefined {
+  let dir = startDir;
+  while (dir !== dirname(dir)) {
+    const candidate = join(dir, 'node_modules', packageName, 'package.json');
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+    dir = dirname(dir);
+  }
+  return undefined;
+}
+
 /**
  * Resolves the full path to an ACP adapter binary by finding its package
  * directory and reading the bin field from package.json.
@@ -48,20 +79,21 @@ export type AcpRuntimeEventHandlers = {
 function resolveAcpBinary(packageName: string, binaryName: string): string {
   try {
     const packageJsonPath = require.resolve(`${packageName}/package.json`);
-    const packageDir = dirname(packageJsonPath);
-    const pkg = require(packageJsonPath) as {
-      bin?: string | Record<string, string | undefined>;
-    };
-    const binPath =
-      typeof pkg.bin === 'string'
-        ? pkg.bin
-        : typeof pkg.bin?.[binaryName] === 'string'
-          ? pkg.bin[binaryName]
-          : undefined;
-    if (binPath) {
-      return join(packageDir, binPath);
+    const resolved = extractBinPath(packageJsonPath, binaryName);
+    if (resolved) {
+      return resolved;
     }
   } catch {
+    // require.resolve can fail when pnpm symlinks break (e.g. Docker COPY
+    // between multi-stage builds flattens symlinks). Walk up from this file
+    // to find the nearest node_modules and try to locate the package directly.
+    const found = findPackageJsonByWalkUp(__dirname, packageName);
+    if (found) {
+      const resolved = extractBinPath(found, binaryName);
+      if (resolved) {
+        return resolved;
+      }
+    }
     logger.debug('Could not resolve binary via package.json, falling back to PATH', {
       packageName,
       binaryName,


### PR DESCRIPTION
## Summary
- Fixes `spawn claude-agent-acp ENOENT` error in Docker deployments that causes `ACP write error: EPIPE`
- Adds a walk-up directory fallback to `resolveAcpBinary` when `require.resolve` fails due to broken pnpm symlinks after Docker multi-stage `COPY`
- Extracts shared bin-path logic into `extractBinPath` and `findPackageJsonByWalkUp` helpers to stay within complexity limits

## Context
After `@zed-industries/claude-code-acp` was renamed to `@zed-industries/claude-agent-acp` in #1345, Docker deployments started failing because pnpm's symlinked `node_modules` structure can break when copied between Docker build stages. The `require.resolve` call fails, and the bare command fallback also fails because the `.bin` shim contains hardcoded build-machine paths.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm check:fix` passes (complexity refactored into helpers)
- [x] `pnpm test` passes (2788 tests)
- [x] Docker image builds successfully
- [x] Verified binary resolves correctly inside Docker container

🤖 Generated with [Claude Code](https://claude.com/claude-code)
