### PR TITLE
Pass image content through to ACP providers

### DIFF
--- a/src/backend/domains/session/acp/acp-process-handle.ts
+++ b/src/backend/domains/session/acp/acp-process-handle.ts
@@ -28,6 +28,13 @@ export class AcpProcessHandle {
     this.createdAt = new Date();
   }
 
+  supportsImages(): boolean {
+    const caps = this.agentCapabilities?.promptCapabilities;
+    return (
+      typeof caps === 'object' && caps !== null && (caps as Record<string, unknown>).image === true
+    );
+  }
+
   isRunning(): boolean {
     return this.child.exitCode === null && !this.child.killed;
   }

--- a/src/backend/domains/session/acp/acp-runtime-manager.test.ts
+++ b/src/backend/domains/session/acp/acp-runtime-manager.test.ts
@@ -1008,7 +1008,7 @@ describe('AcpRuntimeManager', () => {
 
       expect(handle.isPromptInFlight).toBe(false);
 
-      const result = await manager.sendPrompt('session-1', 'Hello world');
+      const result = await manager.sendPrompt('session-1', [{ type: 'text', text: 'Hello world' }]);
 
       expect(mockPrompt).toHaveBeenCalledWith({
         sessionId: 'provider-session-123',
@@ -1029,14 +1029,16 @@ describe('AcpRuntimeManager', () => {
         defaultContext()
       );
 
-      await expect(manager.sendPrompt('session-1', 'Hello')).rejects.toThrow('prompt failed');
+      await expect(
+        manager.sendPrompt('session-1', [{ type: 'text', text: 'Hello' }])
+      ).rejects.toThrow('prompt failed');
       expect(handle.isPromptInFlight).toBe(false);
     });
 
     it('throws if no session found', async () => {
-      await expect(manager.sendPrompt('nonexistent', 'Hello')).rejects.toThrow(
-        'No ACP session found'
-      );
+      await expect(
+        manager.sendPrompt('nonexistent', [{ type: 'text', text: 'Hello' }])
+      ).rejects.toThrow('No ACP session found');
     });
   });
 

--- a/src/backend/domains/session/acp/acp-runtime-manager.ts
+++ b/src/backend/domains/session/acp/acp-runtime-manager.ts
@@ -5,6 +5,7 @@ import { Readable, Writable } from 'node:stream';
 import { fileURLToPath } from 'node:url';
 import {
   ClientSideConnection,
+  type ContentBlock,
   type LoadSessionResponse,
   ndJsonStream,
   PROTOCOL_VERSION,
@@ -968,7 +969,7 @@ export class AcpRuntimeManager {
     }
   }
 
-  async sendPrompt(sessionId: string, content: string): Promise<{ stopReason: string }> {
+  async sendPrompt(sessionId: string, prompt: ContentBlock[]): Promise<{ stopReason: string }> {
     const handle = this.sessions.get(sessionId);
     if (!handle) {
       throw new Error(`No ACP session found for sessionId: ${sessionId}`);
@@ -978,7 +979,7 @@ export class AcpRuntimeManager {
     try {
       const result = await handle.connection.prompt({
         sessionId: handle.providerSessionId,
-        prompt: [{ type: 'text', text: content }],
+        prompt,
       });
       handle.isPromptInFlight = false;
       return { stopReason: result.stopReason };

--- a/src/backend/domains/session/lifecycle/session.service.coverage.test.ts
+++ b/src/backend/domains/session/lifecycle/session.service.coverage.test.ts
@@ -139,9 +139,9 @@ describe('SessionService coverage wrappers', () => {
     expect(sendAcpMessageSpy).not.toHaveBeenCalled();
   });
 
-  it('normalizes content blocks to text when sending through ACP', async () => {
+  it('converts content blocks to ACP ContentBlock[] with image support', async () => {
     const { service, runtimeManager } = createServiceWithPatchedInternals();
-    runtimeManager.getClient.mockReturnValue({ id: 'client' });
+    runtimeManager.getClient.mockReturnValue({ id: 'client', supportsImages: () => true });
     const sendAcpMessageSpy = vi
       .spyOn(service, 'sendAcpMessage')
       .mockResolvedValue('end_turn' as never);
@@ -149,27 +149,42 @@ describe('SessionService coverage wrappers', () => {
     await service.sendSessionMessage('session-1', [
       { type: 'text', text: 'hello' },
       { type: 'thinking', thinking: 'analyzing' },
-      { type: 'image', mimeType: 'image/png', data: 'abc' } as never,
+      { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'abc' } },
       { type: 'tool_result', content: 'tool output' },
       { type: 'tool_result', content: { ok: true } },
       { type: 'unsupported' } as never,
     ] as never);
 
-    expect(sendAcpMessageSpy).toHaveBeenCalledWith(
-      'session-1',
-      [
-        'hello',
-        'analyzing',
-        '[Image attachment omitted for this provider]',
-        'tool output',
-        '{"ok":true}',
-      ].join('\n\n')
-    );
+    expect(sendAcpMessageSpy).toHaveBeenCalledWith('session-1', [
+      { type: 'text', text: 'hello' },
+      { type: 'text', text: 'analyzing' },
+      { type: 'image', data: 'abc', mimeType: 'image/png' },
+      { type: 'text', text: 'tool output' },
+      { type: 'text', text: '{"ok":true}' },
+    ]);
+  });
+
+  it('falls back to text placeholder for images when provider lacks support', async () => {
+    const { service, runtimeManager } = createServiceWithPatchedInternals();
+    runtimeManager.getClient.mockReturnValue({ id: 'client', supportsImages: () => false });
+    const sendAcpMessageSpy = vi
+      .spyOn(service, 'sendAcpMessage')
+      .mockResolvedValue('end_turn' as never);
+
+    await service.sendSessionMessage('session-1', [
+      { type: 'text', text: 'hello' },
+      { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'abc' } },
+    ] as never);
+
+    expect(sendAcpMessageSpy).toHaveBeenCalledWith('session-1', [
+      { type: 'text', text: 'hello' },
+      { type: 'text', text: '[Image: not supported by this provider]' },
+    ]);
   });
 
   it('swallows sendAcpMessage errors to keep websocket flow alive', async () => {
     const { service, runtimeManager } = createServiceWithPatchedInternals();
-    runtimeManager.getClient.mockReturnValue({ id: 'client' });
+    runtimeManager.getClient.mockReturnValue({ id: 'client', supportsImages: () => false });
     vi.spyOn(service, 'sendAcpMessage').mockRejectedValue(new Error('prompt failed'));
 
     await expect(service.sendSessionMessage('session-1', 'hello')).resolves.toBeUndefined();

--- a/src/backend/domains/session/lifecycle/session.service.test.ts
+++ b/src/backend/domains/session/lifecycle/session.service.test.ts
@@ -1332,7 +1332,7 @@ describe('SessionService', () => {
       .spyOn(sessionDomainService, 'appendClaudeEvent')
       .mockReturnValue(77);
 
-    await sessionService.sendAcpMessage('session-1', 'hello');
+    await sessionService.sendAcpMessage('session-1', [{ type: 'text', text: 'hello' }]);
 
     expect(emitDeltaSpy).toHaveBeenCalledWith(
       'session-1',
@@ -1365,7 +1365,7 @@ describe('SessionService', () => {
     vi.mocked(acpRuntimeManager.sendPrompt).mockResolvedValue({ stopReason: 'end_turn' } as never);
     const appendClaudeEventSpy = vi.spyOn(sessionDomainService, 'appendClaudeEvent');
 
-    await sessionService.sendAcpMessage('session-1', 'hello');
+    await sessionService.sendAcpMessage('session-1', [{ type: 'text', text: 'hello' }]);
 
     expect(appendClaudeEventSpy).not.toHaveBeenCalled();
   });
@@ -1379,7 +1379,7 @@ describe('SessionService', () => {
         stopReason: 'end_turn',
       } as never);
 
-      await sessionService.sendAcpMessage('session-1', 'hello');
+      await sessionService.sendAcpMessage('session-1', [{ type: 'text', text: 'hello' }]);
 
       expect(onPromptTurnComplete).not.toHaveBeenCalled();
       await vi.runOnlyPendingTimersAsync();
@@ -1400,7 +1400,7 @@ describe('SessionService', () => {
       vi.mocked(acpRuntimeManager.stopClient).mockResolvedValue();
       vi.mocked(sessionRepository.updateSession).mockResolvedValue({} as never);
 
-      await sessionService.sendAcpMessage('session-1', 'hello');
+      await sessionService.sendAcpMessage('session-1', [{ type: 'text', text: 'hello' }]);
       await sessionService.stopSession('session-1');
 
       await vi.runOnlyPendingTimersAsync();
@@ -1419,7 +1419,9 @@ describe('SessionService', () => {
         stopReason: 'end_turn',
       } as never);
 
-      await expect(sessionService.sendAcpMessage('session-1', 'hello')).resolves.toBe('end_turn');
+      await expect(
+        sessionService.sendAcpMessage('session-1', [{ type: 'text', text: 'hello' }])
+      ).resolves.toBe('end_turn');
       await vi.runOnlyPendingTimersAsync();
       expect(onPromptTurnComplete).toHaveBeenCalledWith('session-1');
     } finally {

--- a/src/backend/domains/session/lifecycle/session.service.ts
+++ b/src/backend/domains/session/lifecycle/session.service.ts
@@ -1,4 +1,4 @@
-import type { SessionConfigOption } from '@agentclientprotocol/sdk';
+import type { ContentBlock, SessionConfigOption } from '@agentclientprotocol/sdk';
 import type { AcpRuntimeManager } from '@/backend/domains/session/acp';
 import { acpRuntimeManager } from '@/backend/domains/session/acp';
 import type { SessionLifecycleWorkspaceBridge } from '@/backend/domains/session/bridges';
@@ -195,9 +195,11 @@ export class SessionService {
   sendSessionMessage(sessionId: string, content: string | AgentContentItem[]): Promise<void> {
     const acpClient = this.runtimeManager.getClient(sessionId);
     if (acpClient) {
-      const normalizedText =
-        typeof content === 'string' ? content : this.normalizeContentToText(content);
-      return this.sendAcpMessage(sessionId, normalizedText).then(
+      const prompt: ContentBlock[] =
+        typeof content === 'string'
+          ? [{ type: 'text', text: content }]
+          : this.toContentBlocks(content, acpClient.supportsImages());
+      return this.sendAcpMessage(sessionId, prompt).then(
         () => {
           // Prompt completed successfully -- no action needed
         },
@@ -215,34 +217,41 @@ export class SessionService {
   }
 
   /**
-   * Normalize AgentContentItem[] to a plain text string for ACP.
+   * Convert internal AgentContentItem[] to ACP ContentBlock[].
    */
-  private normalizeContentToText(content: AgentContentItem[]): string {
-    const chunks: string[] = [];
+  private toContentBlocks(content: AgentContentItem[], supportsImages: boolean): ContentBlock[] {
+    const blocks: ContentBlock[] = [];
     for (const item of content) {
       switch (item.type) {
         case 'text':
-          chunks.push(item.text);
+          blocks.push({ type: 'text', text: item.text });
           break;
         case 'thinking':
-          chunks.push(item.thinking);
+          blocks.push({ type: 'text', text: item.thinking });
           break;
         case 'image':
-          chunks.push('[Image attachment omitted for this provider]');
+          if (supportsImages) {
+            blocks.push({
+              type: 'image',
+              data: item.source.data,
+              mimeType: item.source.media_type,
+            });
+          } else {
+            blocks.push({ type: 'text', text: '[Image: not supported by this provider]' });
+          }
           break;
         case 'tool_result':
           if (typeof item.content === 'string') {
-            chunks.push(item.content);
+            blocks.push({ type: 'text', text: item.content });
           } else {
-            chunks.push(JSON.stringify(item.content));
+            blocks.push({ type: 'text', text: JSON.stringify(item.content) });
           }
           break;
         default:
           break;
       }
     }
-
-    return chunks.join('\n\n');
+    return blocks;
   }
 
   /**
@@ -250,7 +259,7 @@ export class SessionService {
    * The prompt() call blocks until the turn completes; streaming events arrive
    * concurrently via the AcpClientHandler.sessionUpdate callback.
    */
-  async sendAcpMessage(sessionId: string, content: string): Promise<string> {
+  async sendAcpMessage(sessionId: string, prompt: ContentBlock[]): Promise<string> {
     const workspaceId = this.acpEventProcessor.getWorkspaceId(sessionId);
     // Scope orphan detection to each prompt turn.
     this.acpEventProcessor.beginPromptTurn(sessionId);
@@ -267,7 +276,7 @@ export class SessionService {
     }
 
     try {
-      const result = await this.runtimeManager.sendPrompt(sessionId, content);
+      const result = await this.runtimeManager.sendPrompt(sessionId, prompt);
       this.acpEventProcessor.finalizeOrphanedToolCalls(
         sessionId,
         `stop_reason:${result.stopReason}`


### PR DESCRIPTION
## Summary
- Pass pasted/dropped images through to ACP providers as proper `ContentBlock[]` instead of stripping them to placeholder text
- Add `supportsImages()` capability check on `AcpProcessHandle` to gracefully fall back for providers that don't support images (e.g., Codex)
- Convert `sendPrompt` and `sendAcpMessage` to accept `ContentBlock[]` instead of `string`, threading structured content all the way to the ACP `prompt()` call

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (2794 tests, including updated + new tests for image support and fallback)
- [x] `pnpm check:fix` passes
- [ ] Manual test: paste an image in the chat input, send it, and verify the agent can describe the image

🤖 Generated with [Claude Code](https://claude.com/claude-code)
