### PR TITLE
Default markdown files to preview mode in file and diff viewers

### DIFF
--- a/src/components/workspace/diff-viewer.tsx
+++ b/src/components/workspace/diff-viewer.tsx
@@ -163,7 +163,7 @@ export function DiffViewer({ workspaceId, filePath, tabId }: DiffViewerProps) {
   // Check if file is markdown
   const isMarkdown = filePath.endsWith('.md') || filePath.endsWith('.markdown');
 
-  const [showPreview, setShowPreview] = useState(false);
+  const [showPreview, setShowPreview] = useState(isMarkdown);
   const diffViewportRef = useRef<HTMLDivElement>(null);
   const markdownViewportRef = useRef<HTMLDivElement>(null);
 

--- a/src/components/workspace/file-viewer.tsx
+++ b/src/components/workspace/file-viewer.tsx
@@ -2,7 +2,7 @@ import type { inferRouterOutputs } from '@trpc/server';
 import { AlertCircle, AlertTriangle, Eye, FileCode, Loader2 } from 'lucide-react';
 import { useTheme } from 'next-themes';
 import type { RefObject, UIEvent } from 'react';
-import { useRef, useState } from 'react';
+import { Component, useRef, useState } from 'react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneDark, oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import type { AppRouter } from '@/client/lib/trpc';
@@ -154,6 +154,32 @@ function FileViewerWarnings({ truncated, fileSizeLabel, isBinary }: FileViewerWa
   );
 }
 
+class MarkdownPreviewErrorBoundary extends Component<
+  { children: React.ReactNode },
+  { hasError: boolean }
+> {
+  constructor(props: { children: React.ReactNode }) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  override render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <AlertCircle className="h-4 w-4 shrink-0" />
+          <span>Failed to render preview.</span>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
 function FileViewerContent({
   data,
   isMarkdown,
@@ -183,7 +209,9 @@ function FileViewerContent({
     return (
       <ScrollArea className="flex-1" onScroll={onScroll} viewportRef={viewportRef}>
         <div className="p-4">
-          <MarkdownRenderer content={data.content} />
+          <MarkdownPreviewErrorBoundary>
+            <MarkdownRenderer content={data.content} />
+          </MarkdownPreviewErrorBoundary>
         </div>
       </ScrollArea>
     );
@@ -227,12 +255,12 @@ function FileViewerContent({
 }
 
 function FileViewerLoaded({ filePath, tabId, data, syntaxTheme }: FileViewerLoadedProps) {
-  const [showPreview, setShowPreview] = useState(false);
-  const codeViewportRef = useRef<HTMLDivElement>(null);
-  const markdownViewportRef = useRef<HTMLDivElement>(null);
-
   const isMarkdown =
     filePath.endsWith('.md') || filePath.endsWith('.markdown') || data.language === 'markdown';
+
+  const [showPreview, setShowPreview] = useState(isMarkdown && !data.isBinary);
+  const codeViewportRef = useRef<HTMLDivElement>(null);
+  const markdownViewportRef = useRef<HTMLDivElement>(null);
 
   const { handleScroll: handleCodeScroll } = usePersistentScroll({
     tabId,

--- a/src/components/workspace/main-view-content.tsx
+++ b/src/components/workspace/main-view-content.tsx
@@ -36,10 +36,20 @@ export function MainViewContent({ workspaceId, children, className }: MainViewCo
           This prevents unmounting/remounting which causes state loss. */}
       <div className={cn('h-full', !showChat && 'hidden')}>{children}</div>
       {filePath && activeTabKey && (
-        <FileViewer workspaceId={workspaceId} filePath={filePath} tabId={activeTabKey} />
+        <FileViewer
+          key={activeTabKey}
+          workspaceId={workspaceId}
+          filePath={filePath}
+          tabId={activeTabKey}
+        />
       )}
       {diffPath && activeTabKey && (
-        <DiffViewer workspaceId={workspaceId} filePath={diffPath} tabId={activeTabKey} />
+        <DiffViewer
+          key={activeTabKey}
+          workspaceId={workspaceId}
+          filePath={diffPath}
+          tabId={activeTabKey}
+        />
       )}
       {screenshotPath && activeTabKey && (
         <ScreenshotViewerTab


### PR DESCRIPTION
## Summary

- **FileViewer**: initializes `showPreview` to `true` for `.md`/`.markdown` files; replaces the error-boundary fallback that called `setShowPreview(false)` (which raced with React 19 StrictMode remounts) with an inline error message that keeps the viewer in preview mode
- **DiffViewer**: same default-to-preview behavior when opening a markdown file from the Changes panel
- **main-view-content**: adds `key={activeTabKey}` to both `FileViewer` and `DiffViewer` so each tab gets a fresh component instance on mount, ensuring the correct initial state is always applied

## Test plan

- [ ] Open a `.md` file from the **Files** panel → should open in preview mode by default
- [ ] Open a `.md` file from the **Changes** panel → should open in preview mode (rendered) by default
- [ ] Toggle **Code** / **Preview** / **Diff** buttons still work correctly
- [ ] Non-markdown files still open in source mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)