### PR TITLE
Fix clipped text in inline new-workspace prompt

### DIFF
--- a/src/client/components/kanban/inline-workspace-form.test.tsx
+++ b/src/client/components/kanban/inline-workspace-form.test.tsx
@@ -1,0 +1,202 @@
+// @vitest-environment jsdom
+
+import { createElement, forwardRef, type ReactNode } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { InlineWorkspaceForm } from './inline-workspace-form';
+
+const detectFileMentionMock = vi.fn();
+
+vi.mock('lucide-react', () => ({
+  Loader2: () => null,
+  Paperclip: () => null,
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/client/lib/trpc', () => ({
+  trpc: {
+    useUtils: () => ({
+      workspace: {
+        get: { setData: vi.fn() },
+        listWithKanbanState: { invalidate: vi.fn() },
+        list: { invalidate: vi.fn() },
+        getProjectSummaryState: { invalidate: vi.fn() },
+      },
+    }),
+    userSettings: {
+      get: {
+        useQuery: () => ({
+          data: {
+            ratchetEnabled: false,
+            defaultSessionProvider: 'CLAUDE',
+          },
+          isLoading: false,
+        }),
+      },
+    },
+    workspace: {
+      list: {
+        useQuery: () => ({
+          data: [],
+          isLoading: false,
+        }),
+      },
+      create: {
+        useMutation: () => ({
+          mutate: vi.fn(),
+          isPending: false,
+        }),
+      },
+    },
+  },
+}));
+
+vi.mock('@/client/lib/workspace-cache-helpers', () => ({
+  createOptimisticWorkspaceCacheData: vi.fn(),
+}));
+
+vi.mock('@/components/chat/attachment-preview', () => ({
+  AttachmentPreview: () => null,
+}));
+
+vi.mock('@/components/chat/chat-input/hooks/attachment-file-conversion', () => ({
+  collectAttachments: vi.fn(),
+}));
+
+vi.mock('@/components/chat/chat-input/hooks/use-paste-drop-handler', () => ({
+  usePasteDropHandler: () => ({
+    handlePaste: vi.fn(),
+    handleDrop: vi.fn(),
+    handleDragOver: vi.fn(),
+    handleDragLeave: vi.fn(),
+    isDragging: false,
+  }),
+}));
+
+vi.mock('@/components/chat/chat-input/hooks/use-project-file-mentions', () => ({
+  useProjectFileMentions: () => ({
+    files: [],
+    fileMentionMenuOpen: false,
+    filesLoading: false,
+    fileMentionFilter: '',
+    handleFileMentionMenuClose: vi.fn(),
+    handleFileMentionSelect: vi.fn(),
+    delegateToFileMentionMenu: () => 'passthrough',
+    detectFileMention: detectFileMentionMock,
+    paletteRef: { current: null },
+  }),
+}));
+
+vi.mock('@/components/chat/file-mention-palette', () => ({
+  FileMentionPalette: () => null,
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: import('react').ButtonHTMLAttributes<HTMLButtonElement>) =>
+    createElement('button', props, children),
+}));
+
+vi.mock('@/components/ui/card', () => ({
+  Card: ({ children, ...props }: import('react').HTMLAttributes<HTMLDivElement>) =>
+    createElement('div', props, children),
+  CardContent: ({ children, ...props }: import('react').HTMLAttributes<HTMLDivElement>) =>
+    createElement('div', props, children),
+}));
+
+vi.mock('@/components/ui/select', () => ({
+  Select: ({ children }: { children: ReactNode }) => createElement('div', null, children),
+  SelectContent: ({ children }: { children: ReactNode }) => createElement('div', null, children),
+  SelectItem: ({ children }: { children: ReactNode }) => createElement('div', null, children),
+  SelectTrigger: ({ children }: { children: ReactNode }) => createElement('button', null, children),
+  SelectValue: () => null,
+}));
+
+vi.mock('@/components/ui/textarea', () => ({
+  Textarea: forwardRef<HTMLTextAreaElement, import('react').ComponentProps<'textarea'>>(
+    function Textarea(props, ref) {
+      return createElement('textarea', { ...props, ref });
+    }
+  ),
+}));
+
+vi.mock('@/components/workspace', () => ({
+  RatchetToggleButton: () => null,
+}));
+
+function renderForm(): {
+  container: HTMLDivElement;
+  root: Root;
+  textarea: HTMLTextAreaElement;
+} {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  flushSync(() => {
+    root.render(
+      createElement(InlineWorkspaceForm, {
+        projectId: 'project-1',
+        existingNames: [],
+        onCancel: vi.fn(),
+        onCreated: vi.fn(),
+      })
+    );
+  });
+
+  const textarea = container.querySelector('textarea');
+  if (!textarea) {
+    throw new Error('Expected textarea to render');
+  }
+
+  return { container, root, textarea };
+}
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
+    configurable: true,
+    writable: true,
+    value: true,
+  });
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.clearAllMocks();
+});
+
+describe('InlineWorkspaceForm', () => {
+  it('auto-resizes the textarea while typing normally', () => {
+    const { container, root, textarea } = renderForm();
+    const setTextareaValue = Object.getOwnPropertyDescriptor(
+      HTMLTextAreaElement.prototype,
+      'value'
+    )?.set;
+
+    Object.defineProperty(textarea, 'scrollHeight', {
+      configurable: true,
+      value: 180,
+    });
+
+    if (!setTextareaValue) {
+      throw new Error('Expected textarea value setter');
+    }
+
+    flushSync(() => {
+      setTextareaValue.call(textarea, 'Investigate clipping');
+      textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    expect(detectFileMentionMock).toHaveBeenCalledWith('Investigate clipping');
+    expect(textarea.style.height).toBe('180px');
+    expect(textarea.style.overflowY).toBe('hidden');
+
+    root.unmount();
+    container.remove();
+  });
+});

--- a/src/client/components/kanban/inline-workspace-form.tsx
+++ b/src/client/components/kanban/inline-workspace-form.tsx
@@ -172,6 +172,7 @@ export function InlineWorkspaceForm({
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const newValue = e.target.value;
     setInitialPrompt(newValue);
+    autoResize();
     fileMentions.detectFileMention(newValue);
   };
 


### PR DESCRIPTION
## Summary
- fix the inline new workspace prompt textarea so long content is no longer clipped
- cap auto-resize height at 240px and switch to internal vertical scrolling once the cap is reached
- ensure programmatic prompt updates (like file mention insertion) also trigger resize/overflow recalculation
- remove forced `overflow-hidden` class from the textarea

## Testing
- `pnpm typecheck`
- repository pre-commit checks (Biome + typecheck + dependency checks) passed during commit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change limited to textarea sizing/overflow, with a small chance of layout regressions in the prompt form.
> 
> **Overview**
> Prevents the inline new-workspace prompt textarea from clipping long content by clamping auto-resize to `240px` and switching `overflowY` to `auto` once the cap is reached (otherwise `hidden`).
> 
> Ensures non-typing updates (e.g., file-mention insertion via `useProjectFileMentions` `onChange`) also trigger the same resize/overflow recalculation, and removes the forced `overflow-hidden` class. Adds a focused Vitest/JSDOM test asserting resize + overflow behavior and that `detectFileMention` is invoked on input.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 164156f690bec8a6ffbdb851ee242f25232f439b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->