### PR TITLE
Add subtle working/waiting counts to workspace switcher

### DIFF
--- a/src/client/routes/projects/workspaces/workspace-detail-header/workspace-switcher-dropdown.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-header/workspace-switcher-dropdown.tsx
@@ -74,9 +74,9 @@ export function WorkspaceSwitcherDropdown({
       <SelectTrigger
         id="workspace-detail-workspace-select"
         aria-label={`Open workspace menu (${queueSummaryLabel})`}
-        className="h-7 w-auto max-w-[10rem] border-0 bg-transparent px-0.5 text-[11px] font-normal text-muted-foreground shadow-none focus:ring-0 hover:[&>span]:underline focus-visible:[&>span]:underline md:max-w-[18rem] md:px-1 md:text-sm lg:max-w-none [&>svg:last-of-type]:hidden"
+        className="h-7 w-auto max-w-[10rem] border-0 bg-transparent px-0.5 text-[11px] font-normal text-muted-foreground shadow-none focus:ring-0 hover:[&>.workspace-switcher-label]:underline focus-visible:[&>.workspace-switcher-label]:underline md:max-w-[18rem] md:px-1 md:text-sm lg:max-w-none [&>svg:last-of-type]:hidden"
       >
-        <span className="flex-1 min-w-0 truncate text-foreground font-semibold md:overflow-visible md:text-clip">
+        <span className="workspace-switcher-label flex-1 min-w-0 truncate text-foreground font-semibold md:overflow-visible md:text-clip">
           {currentWorkspaceLabel}
         </span>
         <span className="shrink-0" aria-hidden>


### PR DESCRIPTION
## Summary
- add a compact queue indicator to the top-menu workspace selector trigger showing `working` and `waiting` counts (`wk · wait`)
- keep the indicator subtle and minimal by using muted styling and only showing it on large screens
- include the same counts in the selector trigger `aria-label` for accessibility context

## Testing
- `pnpm test src/client/routes/projects/workspaces/workspace-detail-header/utils.test.ts`
- `pnpm exec biome check src/client/routes/projects/workspaces/workspace-detail-header/workspace-switcher-dropdown.tsx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: adds derived counts to the workspace switcher trigger text and `aria-label` without altering data fetching or navigation behavior.
> 
> **Overview**
> Adds a subtle queue indicator to the workspace switcher trigger, showing the current **working** and **waiting** workspace counts (visible only on large screens).
> 
> Improves accessibility by including the same counts in the trigger’s `aria-label`, and adjusts the underline hover/focus styling to target the label text specifically.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96f3242a7029b4b0ae296f6bd1e385992956a977. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->