### PR TITLE
Show workspace card immediately after Launch

### DIFF
--- a/src/client/components/kanban/inline-workspace-form.test.tsx
+++ b/src/client/components/kanban/inline-workspace-form.test.tsx
@@ -6,7 +6,20 @@ import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { InlineWorkspaceForm } from './inline-workspace-form';
 
-const detectFileMentionMock = vi.fn();
+const mocks = vi.hoisted(() => ({
+  detectFileMentionMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+  listWithKanbanStateCancelMock: vi.fn(),
+  listWithKanbanStateGetDataMock: vi.fn(),
+  listWithKanbanStateSetDataMock: vi.fn(),
+  listWithKanbanStateInvalidateMock: vi.fn(),
+  listInvalidateMock: vi.fn(),
+  getProjectSummaryStateInvalidateMock: vi.fn(),
+  getSetDataMock: vi.fn(),
+  createWorkspaceMutateMock: vi.fn(),
+  createWorkspaceMutationOptions: undefined as Record<string, unknown> | undefined,
+  kanbanCache: undefined as unknown[] | undefined,
+}));
 
 vi.mock('lucide-react', () => ({
   Loader2: () => null,
@@ -15,7 +28,7 @@ vi.mock('lucide-react', () => ({
 
 vi.mock('sonner', () => ({
   toast: {
-    error: vi.fn(),
+    error: mocks.toastErrorMock,
   },
 }));
 
@@ -23,10 +36,15 @@ vi.mock('@/client/lib/trpc', () => ({
   trpc: {
     useUtils: () => ({
       workspace: {
-        get: { setData: vi.fn() },
-        listWithKanbanState: { invalidate: vi.fn() },
-        list: { invalidate: vi.fn() },
-        getProjectSummaryState: { invalidate: vi.fn() },
+        get: { setData: mocks.getSetDataMock },
+        listWithKanbanState: {
+          cancel: mocks.listWithKanbanStateCancelMock,
+          getData: mocks.listWithKanbanStateGetDataMock,
+          setData: mocks.listWithKanbanStateSetDataMock,
+          invalidate: mocks.listWithKanbanStateInvalidateMock,
+        },
+        list: { invalidate: mocks.listInvalidateMock },
+        getProjectSummaryState: { invalidate: mocks.getProjectSummaryStateInvalidateMock },
       },
     }),
     userSettings: {
@@ -48,10 +66,13 @@ vi.mock('@/client/lib/trpc', () => ({
         }),
       },
       create: {
-        useMutation: () => ({
-          mutate: vi.fn(),
-          isPending: false,
-        }),
+        useMutation: (options: Record<string, unknown>) => {
+          mocks.createWorkspaceMutationOptions = options;
+          return {
+            mutate: mocks.createWorkspaceMutateMock,
+            isPending: false,
+          };
+        },
       },
     },
   },
@@ -88,7 +109,7 @@ vi.mock('@/components/chat/chat-input/hooks/use-project-file-mentions', () => ({
     handleFileMentionMenuClose: vi.fn(),
     handleFileMentionSelect: vi.fn(),
     delegateToFileMentionMenu: () => 'passthrough',
-    detectFileMention: detectFileMentionMock,
+    detectFileMention: mocks.detectFileMentionMock,
     paletteRef: { current: null },
   }),
 }));
@@ -163,6 +184,14 @@ beforeEach(() => {
     writable: true,
     value: true,
   });
+  mocks.kanbanCache = undefined;
+  mocks.createWorkspaceMutationOptions = undefined;
+  mocks.listWithKanbanStateCancelMock.mockResolvedValue(undefined);
+  mocks.listWithKanbanStateGetDataMock.mockImplementation(() => mocks.kanbanCache);
+  mocks.listWithKanbanStateSetDataMock.mockImplementation((_input, updater) => {
+    mocks.kanbanCache = typeof updater === 'function' ? updater(mocks.kanbanCache) : updater;
+    return mocks.kanbanCache;
+  });
 });
 
 afterEach(() => {
@@ -192,9 +221,48 @@ describe('InlineWorkspaceForm', () => {
       textarea.dispatchEvent(new Event('input', { bubbles: true }));
     });
 
-    expect(detectFileMentionMock).toHaveBeenCalledWith('Investigate clipping');
+    expect(mocks.detectFileMentionMock).toHaveBeenCalledWith('Investigate clipping');
     expect(textarea.style.height).toBe('180px');
     expect(textarea.style.overflowY).toBe('hidden');
+
+    root.unmount();
+    container.remove();
+  });
+
+  it('restores an empty kanban cache when optimistic workspace creation fails', async () => {
+    const { container, root } = renderForm();
+    const mutationOptions = mocks.createWorkspaceMutationOptions as {
+      onMutate: (input: {
+        type: 'MANUAL';
+        projectId: string;
+        name: string;
+        ratchetEnabled?: boolean;
+      }) => Promise<{ optimisticWorkspaceId: string; previousWorkspaces: unknown[] | undefined }>;
+      onError: (error: Error, input: unknown, context: unknown) => void;
+    };
+
+    const context = await mutationOptions.onMutate({
+      type: 'MANUAL',
+      projectId: 'project-1',
+      name: 'New Workspace',
+      ratchetEnabled: true,
+    });
+
+    expect(Array.isArray(mocks.kanbanCache)).toBe(true);
+    expect(mocks.kanbanCache).toHaveLength(1);
+    expect(mocks.kanbanCache?.[0]).toMatchObject({
+      id: context.optimisticWorkspaceId,
+      name: 'New Workspace',
+    });
+
+    mutationOptions.onError(new Error('boom'), undefined, context);
+
+    expect(mocks.listWithKanbanStateSetDataMock).toHaveBeenLastCalledWith(
+      { projectId: 'project-1' },
+      undefined
+    );
+    expect(mocks.kanbanCache).toBeUndefined();
+    expect(mocks.toastErrorMock).toHaveBeenCalledWith('Failed to create workspace: boom');
 
     root.unmount();
     container.remove();

--- a/src/client/components/kanban/inline-workspace-form.tsx
+++ b/src/client/components/kanban/inline-workspace-form.tsx
@@ -225,7 +225,7 @@ export function InlineWorkspaceForm({
       onCreated(workspace.id);
     },
     onError: (error, _input, context) => {
-      if (context?.previousWorkspaces) {
+      if (context) {
         utils.workspace.listWithKanbanState.setData({ projectId }, context.previousWorkspaces);
       }
       toast.error(`Failed to create workspace: ${error.message}`);


### PR DESCRIPTION
## Summary
- add an optimistic workspace entry to the workspace list-with-kanban cache on inline Launch so a card appears in Working immediately
- replace the optimistic entry with the real workspace on mutation success to avoid flicker or duplicates
- roll back to the previous kanban list on mutation error
- keep the existing optimistic workspace detail cache seed and list invalidations

## Testing
- pnpm -s typecheck
- pnpm -s vitest run src/client/components/kanban/inline-workspace-form.test.tsx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds optimistic updates to the `listWithKanbanState` cache during workspace creation; incorrect cache shape or rollback handling could cause duplicate/missing cards or stale kanban state, but scope is limited to client-side cache behavior.
> 
> **Overview**
> Shows a newly launched workspace immediately by adding an **optimistic “WORKING” workspace entry** to the `workspace.listWithKanbanState` cache in `InlineWorkspaceForm` via `onMutate`.
> 
> On success, replaces the optimistic entry with the real workspace (avoiding flicker/duplicates) while keeping existing detail-cache seeding and invalidations; on error, **rolls back** the kanban cache to the previous list and toasts the failure.
> 
> Updates the unit test to capture mutation options, simulate cache `getData`/`setData`, and verify rollback/toast behavior when optimistic creation fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17e0b42299fc6e1b6cc6e6ae53bb975549023070. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->