### PR TITLE
Reset stale merged CI state when workspace switches PRs

### DIFF
--- a/src/backend/orchestration/event-collector.orchestrator.test.ts
+++ b/src/backend/orchestration/event-collector.orchestrator.test.ts
@@ -631,6 +631,50 @@ describe('configureEventCollector', () => {
     expect(ratchetService.checkWorkspaceById).toHaveBeenCalledWith('ws-1');
   });
 
+  it('still triggers ratchet recompute when store mutates snapshot during immediate upsert', () => {
+    const existingSnapshot: { projectId: string; prNumber: number | null; prUrl: string | null } = {
+      projectId: 'proj-1',
+      prNumber: 41,
+      prUrl: 'https://github.com/org/repo/pull/41',
+    };
+    vi.mocked(workspaceSnapshotStore.getByWorkspaceId).mockReturnValue(
+      existingSnapshot as ReturnType<typeof workspaceSnapshotStore.getByWorkspaceId>
+    );
+    vi.mocked(workspaceSnapshotStore.upsert).mockImplementation((_, update) => {
+      if (update.prNumber !== undefined) {
+        existingSnapshot.prNumber = update.prNumber;
+      }
+      if (update.prUrl !== undefined) {
+        existingSnapshot.prUrl = update.prUrl;
+      }
+    });
+
+    configureEventCollector();
+
+    const onCall = vi
+      .mocked(prSnapshotService.on)
+      .mock.calls.find((call) => call[0] === 'pr_snapshot_updated');
+    const handler = onCall![1] as (event: {
+      workspaceId: string;
+      prNumber: number;
+      prState: string;
+      prCiStatus: string;
+      prReviewState: string | null;
+      prUrl?: string | null;
+    }) => void;
+
+    handler({
+      workspaceId: 'ws-1',
+      prNumber: 42,
+      prState: 'OPEN',
+      prCiStatus: 'PENDING',
+      prReviewState: null,
+      prUrl: 'https://github.com/org/repo/pull/42',
+    });
+
+    expect(ratchetService.checkWorkspaceById).toHaveBeenCalledWith('ws-1');
+  });
+
   it('does not trigger immediate ratchet recompute when PR identity is unchanged', () => {
     vi.mocked(workspaceSnapshotStore.getByWorkspaceId).mockReturnValue({
       projectId: 'proj-1',

--- a/src/backend/orchestration/event-collector.orchestrator.ts
+++ b/src/backend/orchestration/event-collector.orchestrator.ts
@@ -462,6 +462,7 @@ function configureEventCollectorWithState(
   // 2. PR snapshot updates
   prSnapshotService.on(PR_SNAPSHOT_UPDATED, (event: PRSnapshotUpdatedEvent) => {
     const previousSnapshot = workspaceSnapshotStore.getByWorkspaceId(event.workspaceId);
+    const shouldRefreshRatchet = shouldRefreshRatchetForPrSwitch(previousSnapshot, event);
     const snapshotUpdate: SnapshotUpdateInput = {
       ...(event.prUrl !== undefined ? { prUrl: event.prUrl } : {}),
       prNumber: event.prNumber,
@@ -473,7 +474,7 @@ function configureEventCollectorWithState(
       immediate: true,
     });
 
-    if (shouldRefreshRatchetForPrSwitch(previousSnapshot, event)) {
+    if (shouldRefreshRatchet) {
       void ratchetService.checkWorkspaceById(event.workspaceId).catch((error) => {
         logger.warn('Failed immediate ratchet refresh after PR switch', {
           workspaceId: event.workspaceId,


### PR DESCRIPTION
## Summary
- detect when `pr_snapshot_updated` changes the linked PR identity (PR number or URL)
- trigger an immediate `ratchetService.checkWorkspaceById` on PR switch so ratchet-derived state is recomputed without waiting for the next poll
- keep existing behavior unchanged when PR identity does not change
- add event-collector tests covering both switched and unchanged PR cases

## Testing
- pnpm test src/backend/orchestration/event-collector.orchestrator.test.ts src/backend/orchestration/scheduler.service.test.ts src/backend/services/github/service/pr-snapshot.service.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new conditional side-effect (`ratchetService.checkWorkspaceById`) on `pr_snapshot_updated` events; mistakes in the PR-identity change detection could cause missed recomputes or extra load, but scope is limited and guarded with error handling.
> 
> **Overview**
> When handling `pr_snapshot_updated`, the event collector now detects a *linked PR identity switch* (PR number and/or URL change) and triggers an immediate `ratchetService.checkWorkspaceById` to recompute ratchet-derived state without waiting for the next poll (with warning-level logging on failure).
> 
> Adds tests covering PR-switch vs unchanged-PR behavior, including a case where the snapshot store mutates the returned snapshot during the immediate upsert.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0125eeccce9f96cc84bb777e9f8fc2f9a1f8068a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->