### PR TITLE
Fix #1390: Harden env var path expansion

### DIFF
--- a/src/backend/lib/env.test.ts
+++ b/src/backend/lib/env.test.ts
@@ -1,0 +1,61 @@
+import { homedir } from 'node:os';
+import { basename } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { expandEnvVars } from './env';
+
+const ORIGINAL_ENV = { ...process.env };
+
+describe('expandEnvVars', () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it('expands both braced and unbraced variables', () => {
+    process.env.HOME = '/tmp/home';
+    const bracedHomeToken = '$' + '{HOME}/data';
+
+    expect(expandEnvVars('$HOME/data')).toBe('/tmp/home/data');
+    expect(expandEnvVars(bracedHomeToken)).toBe('/tmp/home/data');
+  });
+
+  it('does not partially expand variables that start with USER', () => {
+    process.env.USER = 'alice';
+    process.env.USER_DATA = '/tmp/user-data';
+    Reflect.deleteProperty(process.env, 'USER_OTHER');
+
+    expect(expandEnvVars('$USER_DATA')).toBe('/tmp/user-data');
+    expect(expandEnvVars('$USER_OTHER')).toBe('$USER_OTHER');
+  });
+
+  it('keeps stray closing braces as literal characters', () => {
+    process.env.TEST_VAR = '/tmp/value';
+
+    expect(expandEnvVars('$TEST_VAR}')).toBe('/tmp/value}');
+    expect(expandEnvVars('$MISSING_VAR}')).toBe('$MISSING_VAR}');
+  });
+
+  it('does not recursively expand env values', () => {
+    process.env.A = '$HOME';
+    process.env.HOME = '/tmp/home';
+
+    expect(expandEnvVars('$A')).toBe('$HOME');
+  });
+
+  it('preserves dollar sequences in replacement values', () => {
+    process.env.USER = '$&-$1-$$';
+
+    expect(expandEnvVars('$USER')).toBe('$&-$1-$$');
+  });
+
+  it('falls back to homedir username when USER is unset', () => {
+    Reflect.deleteProperty(process.env, 'USER');
+    const bracedUserToken = '$' + '{USER}';
+
+    expect(expandEnvVars('$USER')).toBe(basename(homedir()) || 'user');
+    expect(expandEnvVars(bracedUserToken)).toBe(basename(homedir()) || 'user');
+  });
+});

--- a/src/backend/lib/env.ts
+++ b/src/backend/lib/env.ts
@@ -10,32 +10,26 @@ import { basename, join } from 'node:path';
 
 /**
  * Expand environment variables in a string.
- * Handles $VAR and ${VAR} syntax, including $USER.
+ * Handles $VAR and ${VAR} syntax.
  *
  * @example
  * expandEnvVars('$HOME/data') // '/Users/john/data'
  * expandEnvVars('${USER}') // 'john'
  */
-export function expandEnvVars(value: string, depth = 0): string {
-  // Prevent infinite recursion from circular env var references
-  const MAX_DEPTH = 10;
-  if (depth >= MAX_DEPTH) {
-    return value;
-  }
-
-  // Replace $USER with actual home directory username (cross-platform)
-  let result = value.replace(/\$USER|\$\{USER\}/g, basename(homedir()) || 'user');
-
-  // Replace other environment variables
-  result = result.replace(/\$\{?([A-Z_][A-Z0-9_]*)\}?/gi, (match, varName) => {
+export function expandEnvVars(value: string, _depth = 0): string {
+  return value.replace(/\$\{([A-Z_][A-Z0-9_]*)\}|\$([A-Z_][A-Z0-9_]*)/gi, (match, braced, bare) => {
+    const varName = braced || bare;
     const envValue = process.env[varName];
     if (envValue !== undefined) {
-      return expandEnvVars(envValue, depth + 1);
+      return envValue;
     }
+
+    if (varName.toUpperCase() === 'USER') {
+      return basename(homedir()) || 'user';
+    }
+
     return match;
   });
-
-  return result;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fix `expandEnvVars` token parsing so `$USER_DATA` is handled as a full variable token instead of partial `$USER` replacement.
- Preserve literal trailing braces for malformed inputs like `$VAR}` by separating braced and unbraced token parsing.
- Add focused regression tests for env expansion edge cases and non-recursive behavior.

## Changes
- **Env expansion (`src/backend/lib/env.ts`)**: Replaced the loose optional-brace regex with explicit `${VAR}` and `$VAR` alternatives, removed recursive expansion, and kept `$USER` fallback via callback-based replacement to avoid `$` replacement-sequence interpretation.
- **Unit tests (`src/backend/lib/env.test.ts`)**: Added regression tests covering `$USER_*` tokens, stray `}` handling, literal dollar sequences in values, braced/unbraced expansion, and non-recursive expansion.

## Testing
- [ ] Tests pass (`pnpm test`) - fails in existing integration test `src/backend/services/session/service/acp/codex-cli-import-resolution.integration.test.ts` (`avoids the import crash when tsconfig is pinned to repo root`, timeout/exit 143)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not run (backend env expansion covered by unit tests)

Closes #1390

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes environment-variable expansion behavior (token parsing and removal of recursive expansion), which can affect runtime path resolution (e.g., database paths) if deployments relied on the previous semantics.
> 
> **Overview**
> Hardens `expandEnvVars` parsing by explicitly matching `${VAR}` vs `$VAR` tokens to avoid partial expansions (e.g., `$USER_DATA`) and to preserve malformed literals like trailing `}`.
> 
> Removes recursive env-value expansion and keeps the special `$USER` fallback via callback replacement, and adds focused `vitest` coverage for these edge cases (braced/unbraced, `$USER_*` variables, stray braces, literal `$` sequences, and non-recursive behavior).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4db7cd0dd581f9ab1fdd17074ee18533c1e2e575. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->