### PR TITLE
Fix #1385: prevent command approval scope key collisions

### DIFF
--- a/src/backend/services/session/service/acp/codex-app-server-adapter/command-metadata.test.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/command-metadata.test.ts
@@ -130,6 +130,29 @@ describe('command-metadata', () => {
     ]);
   });
 
+  it('preserves backslashes for non-special escapes inside double quotes', () => {
+    const escapedScopeKey = buildCommandApprovalScopeKey({
+      command: 'cat "semi\\;pipe\\|amp\\&"',
+      cwd: '/tmp/workspace',
+    });
+    const literalScopeKey = buildCommandApprovalScopeKey({
+      command: 'cat "semi;pipe|amp&"',
+      cwd: '/tmp/workspace',
+    });
+
+    expect(escapedScopeKey).toBeTruthy();
+    expect(literalScopeKey).toBeTruthy();
+    expect(escapedScopeKey).not.toBe(literalScopeKey);
+    expect(parseScopeKey(escapedScopeKey, '/tmp/workspace')).toEqual([
+      {
+        type: 'cmd',
+        cwd: '/tmp/workspace',
+        tokens: ['cat', 'semi\\;pipe\\|amp\\&'],
+        separator: null,
+      },
+    ]);
+  });
+
   it('preserves whitespace-only quoted args in approval scope keys', () => {
     const quotedSpaceScopeKey = buildCommandApprovalScopeKey({
       command: 'ls " "',

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/command-metadata.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/command-metadata.ts
@@ -68,12 +68,24 @@ function unescapeGeneralCommandChar(char: string): string {
   return `\\${char}`;
 }
 
+function unescapeDoubleQuotedChar(char: string): string {
+  if (char === '"' || char === '\\' || char === '$' || char === '`') {
+    return char;
+  }
+  return `\\${char}`;
+}
+
 function consumeEscapedTokenChar(state: CommandTokenizeState, char: string): boolean {
   if (!state.escaped) {
     return false;
   }
-  state.current +=
-    state.quote === "'" ? unescapeSingleQuotedChar(char) : unescapeGeneralCommandChar(char);
+  if (state.quote === "'") {
+    state.current += unescapeSingleQuotedChar(char);
+  } else if (state.quote === '"') {
+    state.current += unescapeDoubleQuotedChar(char);
+  } else {
+    state.current += unescapeGeneralCommandChar(char);
+  }
   state.escaped = false;
   state.hasTokenContent = true;
   return true;


### PR DESCRIPTION
## Summary
- Replace regex tokenization in Codex command metadata with a shell-aware state machine parser
- Preserve quoted whitespace and quoted/unquoted argument concatenation when building approval scope keys
- Add regression tests that prevent approval key collisions for concatenated-vs-split path arguments

## Changes
- **Codex ACP command metadata**: Reworked command argument tokenization to parse quote/escape state across a full argument, so `"my dir"/file.txt` stays one token and escaped spaces are handled correctly.
- **Approval scope key safety**: Removed destructive post-token trimming behavior by preserving meaningful whitespace inside quoted args.
- **Regression coverage**: Added tests proving distinct scope keys for `ls "my dir"/file.txt` vs `ls "my dir" /file.txt`, and for `ls " "` vs `ls`.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not run (backend parser/test-only change)

Closes #1385

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Replaces core command argument tokenization used for approval scope keys and display metadata, which can change how commands are parsed and grouped. Risk is mitigated by added regression tests covering quoting/escaping edge cases.
> 
> **Overview**
> Prevents command approval scope key collisions by replacing regex-based command tokenization with a state-machine parser that tracks quote/escape state across full arguments.
> 
> This preserves meaningful distinctions like concatenated quoted paths vs split args (e.g. `"my dir"/file.txt`), whitespace-only quoted arguments, and backslashes for non-special escapes in double quotes, and adds regression tests to lock in these behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfebaf5a7be3c6f81292c0e4e508cbce8b4b82fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->