### PR TITLE
Fix #1388: normalize CI rollup casing and terminal outcomes

### DIFF
--- a/src/backend/services/github/service/github-cli.service.test.ts
+++ b/src/backend/services/github/service/github-cli.service.test.ts
@@ -326,14 +326,23 @@ describe('GitHubCLIService', () => {
       expect(result).toBe('SUCCESS');
     });
 
-    it('should treat NEUTRAL, CANCELLED, and SKIPPED as success', () => {
+    it('should treat SKIPPED as success when paired with successful checks', () => {
       const result = githubCLIService.computeCIStatus([
         { status: 'COMPLETED', conclusion: 'SUCCESS' },
-        { status: 'COMPLETED', conclusion: 'NEUTRAL' },
         { status: 'COMPLETED', conclusion: 'SKIPPED' },
       ]);
 
       expect(result).toBe('SUCCESS');
+    });
+
+    it('should not treat CANCELLED or NEUTRAL checks as success', () => {
+      const result = githubCLIService.computeCIStatus([
+        { status: 'COMPLETED', conclusion: 'SUCCESS' },
+        { status: 'COMPLETED', conclusion: 'NEUTRAL' },
+        { status: 'COMPLETED', conclusion: 'CANCELLED' },
+      ]);
+
+      expect(result).toBe('UNKNOWN');
     });
   });
 
@@ -550,7 +559,7 @@ describe('GitHubCLIService', () => {
     });
 
     describe('getPRFullDetails with malformed data', () => {
-      it('should accept StatusContext entries in statusCheckRollup', async () => {
+      it('normalizes status check casing in statusCheckRollup entries', async () => {
         const fullPRData = {
           number: 123,
           title: 'Test PR',
@@ -565,13 +574,19 @@ describe('GitHubCLIService', () => {
             {
               __typename: 'StatusContext',
               context: 'ci/legacy-status',
-              state: 'PENDING',
+              state: 'pending',
               targetUrl: 'https://example.com/checks/legacy-status',
             },
             {
               __typename: 'StatusContext',
               context: 'ci/legacy-required',
-              state: 'ERROR',
+              state: 'error',
+            },
+            {
+              __typename: 'CheckRun',
+              name: 'ci/modern-check',
+              status: 'completed',
+              conclusion: 'cancelled',
             },
           ],
           reviews: [],
@@ -605,6 +620,13 @@ describe('GitHubCLIService', () => {
             name: 'ci/legacy-required',
             status: 'COMPLETED',
             conclusion: 'FAILURE',
+            detailsUrl: undefined,
+          },
+          {
+            __typename: 'CheckRun',
+            name: 'ci/modern-check',
+            status: 'COMPLETED',
+            conclusion: 'CANCELLED',
             detailsUrl: undefined,
           },
         ]);
@@ -695,6 +717,11 @@ describe('GitHubCLIService', () => {
       expect(result).toBe('PENDING');
     });
 
+    it('should return PENDING for lowercase in_progress status', () => {
+      const result = githubCLIService.computeCIStatus([{ status: 'in_progress' }]);
+      expect(result).toBe('PENDING');
+    });
+
     it('should return PENDING for EXPECTED legacy state', () => {
       const result = githubCLIService.computeCIStatus([{ state: 'EXPECTED' }]);
       expect(result).toBe('PENDING');
@@ -709,12 +736,19 @@ describe('GitHubCLIService', () => {
       expect(result).toBe('FAILURE');
     });
 
-    it('should return SUCCESS when all checks are CANCELLED', () => {
+    it('should return UNKNOWN when all checks are CANCELLED', () => {
       const result = githubCLIService.computeCIStatus([
         { status: 'COMPLETED', conclusion: 'CANCELLED' },
         { status: 'COMPLETED', conclusion: 'CANCELLED' },
       ]);
-      expect(result).toBe('SUCCESS');
+      expect(result).toBe('UNKNOWN');
+    });
+
+    it('should return FAILURE for lowercase completed + failure values', () => {
+      const result = githubCLIService.computeCIStatus([
+        { status: 'completed', conclusion: 'failure' },
+      ]);
+      expect(result).toBe('FAILURE');
     });
 
     it('should return PENDING when status is QUEUED even if conclusion is set', () => {
@@ -738,7 +772,7 @@ describe('GitHubCLIService', () => {
       const result = githubCLIService.computeCIStatus([
         { status: 'COMPLETED', conclusion: 'STALE' },
       ]);
-      // STALE is not SUCCESS/NEUTRAL/CANCELLED/SKIPPED, nor FAILURE/ERROR/ACTION_REQUIRED
+      // STALE is not SUCCESS/SKIPPED, nor FAILURE/ERROR/ACTION_REQUIRED
       // So allSuccess check will fail, returning UNKNOWN
       expect(result).toBe('UNKNOWN');
     });

--- a/src/backend/services/github/service/github-cli/mappers.ts
+++ b/src/backend/services/github/service/github-cli/mappers.ts
@@ -27,9 +27,14 @@ const REVIEW_STATE_VALUES = [
   'DISMISSED',
 ] as const;
 
+function normalizeEnumValue(value: string): string {
+  return value.toUpperCase();
+}
+
 function normalizeCheckStatus(status: string): GitHubStatusCheck['status'] {
-  return (CHECK_STATUS_VALUES as readonly string[]).includes(status)
-    ? (status as GitHubStatusCheck['status'])
+  const normalizedStatus = normalizeEnumValue(status);
+  return (CHECK_STATUS_VALUES as readonly string[]).includes(normalizedStatus)
+    ? (normalizedStatus as GitHubStatusCheck['status'])
     : 'PENDING';
 }
 
@@ -39,20 +44,22 @@ function normalizeCheckConclusion(
   if (conclusion === null || conclusion === undefined) {
     return null;
   }
-  return (CHECK_CONCLUSION_VALUES as readonly string[]).includes(conclusion)
-    ? (conclusion as NonNullable<GitHubStatusCheck['conclusion']>)
+  const normalizedConclusion = normalizeEnumValue(conclusion);
+  return (CHECK_CONCLUSION_VALUES as readonly string[]).includes(normalizedConclusion)
+    ? (normalizedConclusion as NonNullable<GitHubStatusCheck['conclusion']>)
     : null;
 }
 
 function normalizeStatusContextStatus(state: string): GitHubStatusCheck['status'] {
-  if (state === 'PENDING' || state === 'EXPECTED') {
+  const normalizedState = normalizeEnumValue(state);
+  if (normalizedState === 'PENDING' || normalizedState === 'EXPECTED') {
     return 'PENDING';
   }
   return 'COMPLETED';
 }
 
 function normalizeStatusContextConclusion(state: string): GitHubStatusCheck['conclusion'] {
-  switch (state) {
+  switch (normalizeEnumValue(state)) {
     case 'SUCCESS':
       return 'SUCCESS';
     case 'FAILURE':
@@ -74,8 +81,9 @@ function normalizeStatusContextConclusion(state: string): GitHubStatusCheck['con
 }
 
 function normalizeReviewState(state: string): GitHubReview['state'] {
-  return (REVIEW_STATE_VALUES as readonly string[]).includes(state)
-    ? (state as GitHubReview['state'])
+  const normalizedState = normalizeEnumValue(state);
+  return (REVIEW_STATE_VALUES as readonly string[]).includes(normalizedState)
+    ? (normalizedState as GitHubReview['state'])
     : 'PENDING';
 }
 

--- a/src/shared/ci-status.test.ts
+++ b/src/shared/ci-status.test.ts
@@ -43,14 +43,13 @@ describe('ci-status', () => {
     );
   });
 
-  it('returns PASSING when all checks are complete and non-failing', () => {
+  it('returns UNKNOWN when all checks are complete but non-success', () => {
     expect(
       deriveCiVisualStateFromChecks([
-        { conclusion: 'SUCCESS', status: 'COMPLETED' },
         { conclusion: 'NEUTRAL', status: 'COMPLETED' },
         { conclusion: 'CANCELLED', status: 'COMPLETED' },
       ])
-    ).toBe('PASSING');
+    ).toBe('UNKNOWN');
   });
 
   it('derives canonical CI status from check rollup', () => {
@@ -72,7 +71,15 @@ describe('ci-status', () => {
         { status: 'COMPLETED', conclusion: 'NEUTRAL' },
         { status: 'COMPLETED', conclusion: 'CANCELLED' },
       ])
-    ).toBe('SUCCESS');
+    ).toBe('UNKNOWN');
+  });
+
+  it('handles lowercase status and conclusion values', () => {
+    expect(deriveCiStatusFromCheckRollup([{ status: 'in_progress' }])).toBe('PENDING');
+
+    expect(deriveCiStatusFromCheckRollup([{ status: 'completed', conclusion: 'failure' }])).toBe(
+      'FAILURE'
+    );
   });
 
   it('derives UNKNOWN for unrecognized completed outcomes', () => {

--- a/src/shared/core/ci-status.test.ts
+++ b/src/shared/core/ci-status.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { deriveCiStatusFromCheckRollup } from './ci-status';
+import { CIStatus } from './enums';
+
+describe('deriveCiStatusFromCheckRollup', () => {
+  it('does not return SUCCESS when all checks are CANCELLED', () => {
+    const result = deriveCiStatusFromCheckRollup([
+      { status: 'COMPLETED', conclusion: 'CANCELLED' },
+    ]);
+
+    expect(result).toBe(CIStatus.UNKNOWN);
+  });
+
+  it('is case-insensitive for completed conclusions', () => {
+    const result = deriveCiStatusFromCheckRollup([{ status: 'completed', conclusion: 'failure' }]);
+
+    expect(result).toBe(CIStatus.FAILURE);
+  });
+
+  it('is case-insensitive for in-progress statuses', () => {
+    const result = deriveCiStatusFromCheckRollup([{ status: 'in_progress' }]);
+
+    expect(result).toBe(CIStatus.PENDING);
+  });
+
+  it('still allows SUCCESS when checks are SUCCESS or SKIPPED', () => {
+    const result = deriveCiStatusFromCheckRollup([
+      { status: 'completed', conclusion: 'success' },
+      { status: 'completed', conclusion: 'skipped' },
+    ]);
+
+    expect(result).toBe(CIStatus.SUCCESS);
+  });
+});

--- a/src/shared/core/ci-status.ts
+++ b/src/shared/core/ci-status.ts
@@ -8,11 +8,23 @@ interface CheckLike {
   state?: string | null;
 }
 
-function getEffectiveState(check: CheckLike): string {
-  if (check.status === 'COMPLETED' && check.conclusion) {
-    return check.conclusion;
+function normalizeCheckValue(value: string | null | undefined): string | null {
+  if (value === null || value === undefined) {
+    return null;
   }
-  return check.state ?? check.status ?? 'PENDING';
+  return value.toUpperCase();
+}
+
+function getEffectiveState(check: CheckLike): string {
+  const normalizedStatus = normalizeCheckValue(check.status);
+  const normalizedConclusion = normalizeCheckValue(check.conclusion);
+  const normalizedState = normalizeCheckValue(check.state);
+
+  if (normalizedStatus === 'COMPLETED' && normalizedConclusion) {
+    return normalizedConclusion;
+  }
+
+  return normalizedState ?? normalizedStatus ?? 'PENDING';
 }
 
 export function deriveCiStatusFromCheckRollup(
@@ -38,12 +50,7 @@ export function deriveCiStatusFromCheckRollup(
   const hasPending = checks.some((check) => {
     const state = getEffectiveState(check);
     return (
-      state === 'PENDING' ||
-      state === 'EXPECTED' ||
-      state === 'QUEUED' ||
-      state === 'IN_PROGRESS' ||
-      check.status === 'QUEUED' ||
-      check.status === 'IN_PROGRESS'
+      state === 'PENDING' || state === 'EXPECTED' || state === 'QUEUED' || state === 'IN_PROGRESS'
     );
   });
   if (hasPending) {
@@ -52,9 +59,7 @@ export function deriveCiStatusFromCheckRollup(
 
   const allSuccess = checks.every((check) => {
     const state = getEffectiveState(check);
-    return (
-      state === 'SUCCESS' || state === 'NEUTRAL' || state === 'CANCELLED' || state === 'SKIPPED'
-    );
+    return state === 'SUCCESS' || state === 'SKIPPED';
   });
   if (allSuccess) {
     return CIStatus.SUCCESS;


### PR DESCRIPTION
## Summary
- Fix CI rollup classification so `CANCELLED`/`NEUTRAL` checks no longer report as passing.
- Make CI status derivation and GitHub check mapping case-insensitive for `status`/`state`/`conclusion` values.
- Add regression tests across shared CI logic and GitHub CLI service mapping/classification paths.

## Changes
- **Shared CI rollup (`src/shared/core/ci-status.ts`)**: Normalize check values to uppercase before comparison, remove `CANCELLED` and `NEUTRAL` from success rollup criteria, and keep `SKIPPED` as non-failing pass-through.
- **GitHub mapper (`src/backend/services/github/service/github-cli/mappers.ts`)**: Normalize casing for check status/conclusion, status-context state mapping, and review-state normalization so lowercase external values map correctly.
- **Tests**: Updated `src/shared/ci-status.test.ts` expectations for cancelled/neutral behavior, added `src/shared/core/ci-status.test.ts`, and expanded `src/backend/services/github/service/github-cli.service.test.ts` for lowercase inputs and non-passing terminal rollups.

## Testing
- [ ] Tests pass (`pnpm test`) - fails in this branch due an unrelated existing timeout in `src/backend/services/session/service/acp/codex-cli-import-resolution.integration.test.ts` (`avoids the import crash when tsconfig is pinned to repo root`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not run (logic and automated tests only)

Closes #1388

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the canonical CI rollup classification so `CANCELLED`/`NEUTRAL` no longer count as success, which can alter PR status/badges and downstream automation. Logic is straightforward and well-covered by new/updated tests, but touches shared status derivation used across the app.
> 
> **Overview**
> Fixes CI rollup classification to be **case-insensitive** and to treat terminal non-success outcomes more strictly.
> 
> `deriveCiStatusFromCheckRollup` now normalizes `status`/`state`/`conclusion` casing before comparisons and only returns `SUCCESS` when outcomes are `SUCCESS` or `SKIPPED` (so all-`CANCELLED`/`NEUTRAL` rollups become `UNKNOWN`). GitHub CLI mappers now also uppercase incoming check and review enum values so mixed/lowercase API payloads map consistently.
> 
> Updates and expands regression tests across shared CI status tests, adds `src/shared/core/ci-status.test.ts`, and adjusts GitHub CLI service tests to cover lowercase inputs and the new `CANCELLED`/`NEUTRAL` behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ef7b6e9b8f06a4d3861f15849c5f0a64e457fc5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->