### PR TITLE
Fix #1383: Correct Electron prod backend import paths

### DIFF
--- a/electron/main/server-manager.test.ts
+++ b/electron/main/server-manager.test.ts
@@ -1,0 +1,112 @@
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockAppGetPath } = vi.hoisted(() => ({
+  mockAppGetPath: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: mockAppGetPath,
+  },
+}));
+
+import { ServerManager } from './server-manager';
+
+type ServerModuleImportShim = {
+  dynamicImport: (moduleSpecifier: string) => Promise<unknown>;
+};
+
+const ORIGINAL_ENV = { ...process.env };
+const ORIGINAL_RESOURCES_PATH = Object.getOwnPropertyDescriptor(process, 'resourcesPath');
+
+const setResourcesPath = (resourcesPath: string) => {
+  Object.defineProperty(process, 'resourcesPath', {
+    configurable: true,
+    value: resourcesPath,
+    writable: true,
+  });
+};
+
+const restoreResourcesPath = () => {
+  if (ORIGINAL_RESOURCES_PATH) {
+    Object.defineProperty(process, 'resourcesPath', ORIGINAL_RESOURCES_PATH);
+    return;
+  }
+
+  Reflect.deleteProperty(process, 'resourcesPath');
+};
+
+describe('ServerManager', () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    setResourcesPath('/opt/Factory Factory/resources');
+    mockAppGetPath.mockReset();
+    mockAppGetPath.mockReturnValue('/tmp');
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    restoreResourcesPath();
+  });
+
+  it('imports backend modules from app.asar.unpacked using file URLs', async () => {
+    const runMigrations = vi.fn();
+    const startServer = vi.fn().mockResolvedValue('http://127.0.0.1:4311');
+    const createServer = vi.fn(() => ({
+      start: startServer,
+      stop: vi.fn().mockResolvedValue(undefined),
+    }));
+
+    const importSpy = vi.fn((moduleSpecifier: string) => {
+      if (moduleSpecifier.includes('migrate.js')) {
+        return Promise.resolve({ runMigrations });
+      }
+      if (moduleSpecifier.includes('server.js')) {
+        return Promise.resolve({ createServer });
+      }
+      return Promise.reject(new Error(`Unexpected module import: ${moduleSpecifier}`));
+    });
+
+    const manager = new ServerManager();
+    (manager as unknown as ServerModuleImportShim).dynamicImport = importSpy;
+
+    const url = await manager.start();
+
+    const backendDistPath = join(
+      process.resourcesPath,
+      'app.asar.unpacked',
+      'dist',
+      'src',
+      'backend'
+    );
+    const expectedMigrateUrl = pathToFileURL(join(backendDistPath, 'migrate.js')).href;
+    const expectedServerUrl = pathToFileURL(join(backendDistPath, 'server.js')).href;
+
+    expect(url).toBe('http://127.0.0.1:4311');
+    expect(importSpy).toHaveBeenNthCalledWith(1, expectedMigrateUrl);
+    expect(importSpy).toHaveBeenNthCalledWith(2, expectedServerUrl);
+    expect(runMigrations).toHaveBeenCalledWith({
+      databasePath: '/tmp/data.db',
+      migrationsPath: join(process.resourcesPath, 'prisma', 'migrations'),
+      log: expect.any(Function),
+    });
+    expect(process.env.FRONTEND_STATIC_PATH).toBe(
+      join(process.resourcesPath, 'app.asar.unpacked', 'dist', 'client')
+    );
+  });
+
+  it('returns vite dev server URL without importing backend modules', async () => {
+    process.env.VITE_DEV_SERVER_URL = 'http://localhost:5173';
+    const manager = new ServerManager();
+    const importSpy = vi.fn();
+    (manager as unknown as ServerModuleImportShim).dynamicImport = importSpy;
+
+    const url = await manager.start();
+
+    expect(url).toBe('http://localhost:5173');
+    expect(importSpy).not.toHaveBeenCalled();
+    expect(mockAppGetPath).not.toHaveBeenCalled();
+  });
+});

--- a/electron/main/server-manager.ts
+++ b/electron/main/server-manager.ts
@@ -1,9 +1,7 @@
 import { existsSync, mkdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { pathToFileURL } from 'node:url';
 import { app } from 'electron';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
 
 /**
  * Server instance interface matching what createServer() returns
@@ -72,24 +70,21 @@ export class ServerManager {
     // Dynamic import is required here because we must set environment variables
     // BEFORE importing the backend modules (they read env vars at load time)
     console.log('[electron] Running database migrations...');
-    const migratePath = join(
-      __dirname,
-      '..',
-      '..',
-      '..',
-      '..',
+    const backendDistPath = join(
+      process.resourcesPath,
+      'app.asar.unpacked',
       'dist',
       'src',
-      'backend',
-      'migrate.js'
+      'backend'
     );
+    const migratePath = join(backendDistPath, 'migrate.js');
     const migrateModule = await this.dynamicImport<{
       runMigrations: (opts: {
         databasePath: string;
         migrationsPath: string;
         log?: (msg: string) => void;
       }) => void;
-    }>(migratePath);
+    }>(this.toModuleImportSpecifier(migratePath));
     migrateModule.runMigrations({
       databasePath,
       migrationsPath,
@@ -98,20 +93,10 @@ export class ServerManager {
 
     // Import and start the backend server
     console.log('[electron] Starting backend server...');
-    const serverPath = join(
-      __dirname,
-      '..',
-      '..',
-      '..',
-      '..',
-      'dist',
-      'src',
-      'backend',
-      'server.js'
-    );
+    const serverPath = join(backendDistPath, 'server.js');
     const serverModule = await this.dynamicImport<{
       createServer: () => ServerInstance;
-    }>(serverPath);
+    }>(this.toModuleImportSpecifier(serverPath));
     this.serverInstance = serverModule.createServer();
 
     const url = await this.serverInstance.start();
@@ -151,5 +136,13 @@ export class ServerManager {
    */
   private dynamicImport<T>(modulePath: string): Promise<T> {
     return import(modulePath) as Promise<T>;
+  }
+
+  /**
+   * Convert filesystem paths to file URLs for ESM dynamic import compatibility,
+   * including Windows absolute paths.
+   */
+  private toModuleImportSpecifier(modulePath: string): string {
+    return pathToFileURL(modulePath).href;
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx', 'electron/**/*.test.ts'],
     exclude: ['node_modules', 'dist', '.next'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Summary
- Fixes Electron production startup to load backend modules from `app.asar.unpacked` instead of resolving relative to `__dirname`.
- Converts backend dynamic import paths to `file://` URLs so ESM imports work on Windows absolute paths.
- Adds regression tests for production path/import resolution and dev-mode bypass behavior.

## Changes
- **Electron ServerManager**: Build backend module paths from `process.resourcesPath/app.asar.unpacked/dist/src/backend` for `migrate.js` and `server.js`.
- **ESM import compatibility**: Convert filesystem module paths with `pathToFileURL(...).href` before `import()`.
- **Tests**: Added `electron/main/server-manager.test.ts` and expanded `vitest.config.ts` test include patterns to run Electron unit tests.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Build and launch packaged Electron app on macOS/Windows; verify startup, migrations, and backend boot.

Closes #1383

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes Electron production startup module resolution and dynamic import specifiers, which can break packaged app boot if paths differ across platforms.
> 
> **Overview**
> Fixes Electron production startup to resolve `migrate.js`/`server.js` from `process.resourcesPath/app.asar.unpacked/dist/src/backend` (instead of `__dirname`-relative paths) and imports them via `file://` URLs for ESM/Windows compatibility.
> 
> Adds Vitest coverage for `ServerManager` to assert production path/import behavior and dev-mode short-circuiting, and updates `vitest.config.ts` to include `electron/**/*.test.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eadef9e69522b404bff38db255f82b682f8bbc1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->