### PR TITLE
Fix #1386: prevent FileLockMutex stale lock stealing

### DIFF
--- a/src/backend/lib/file-lock-mutex.test.ts
+++ b/src/backend/lib/file-lock-mutex.test.ts
@@ -138,6 +138,78 @@ describe('FileLockMutex', () => {
     }
   });
 
+  it('does not treat an active lock as stale while heartbeat is updating mtime', async () => {
+    const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ff-lock-mutex-'));
+    const lockPath = path.join(baseDir, 'heartbeat.lock');
+
+    const holder = new FileLockMutex({
+      heartbeatIntervalMs: 100,
+    });
+    const contender = new FileLockMutex({
+      acquireTimeoutMs: 100,
+      postTimeoutWaitMs: 1200,
+      initialRetryDelayMs: 5,
+      maxRetryDelayMs: 10,
+      maxStaleRetries: 2,
+      staleThresholdMs: 1000,
+    });
+
+    try {
+      const releaseHolder = await holder.acquire(lockPath);
+
+      await expect(contender.acquire(lockPath)).rejects.toBeInstanceOf(FileLockTimeoutError);
+      expect(await exists(lockPath)).toBe(true);
+
+      await releaseHolder();
+      expect(await exists(lockPath)).toBe(false);
+    } finally {
+      await fs.rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('clamps staleThresholdMs so zero does not allow lock stealing', async () => {
+    const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ff-lock-mutex-'));
+    const lockPath = path.join(baseDir, 'zero-threshold.lock');
+    const holder = new FileLockMutex();
+    const contender = new FileLockMutex({
+      acquireTimeoutMs: 20,
+      postTimeoutWaitMs: 40,
+      initialRetryDelayMs: 5,
+      maxRetryDelayMs: 10,
+      maxStaleRetries: 1,
+      staleThresholdMs: 0,
+    });
+
+    try {
+      const releaseHolder = await holder.acquire(lockPath);
+      await expect(contender.acquire(lockPath)).rejects.toBeInstanceOf(FileLockTimeoutError);
+      await releaseHolder();
+    } finally {
+      await fs.rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not derive stale threshold from acquireTimeoutMs', async () => {
+    const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ff-lock-mutex-'));
+    const lockPath = path.join(baseDir, 'timeout-zero-default-threshold.lock');
+    const holder = new FileLockMutex();
+    const contender = new FileLockMutex({
+      acquireTimeoutMs: 0,
+      postTimeoutWaitMs: 30,
+      initialRetryDelayMs: 5,
+      maxRetryDelayMs: 10,
+      maxStaleRetries: 1,
+    });
+
+    try {
+      const releaseHolder = await holder.acquire(lockPath);
+      await expect(contender.acquire(lockPath)).rejects.toBeInstanceOf(FileLockTimeoutError);
+      await releaseHolder();
+    } finally {
+      await fs.rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
   it('does not unlink a replaced lock file on release', async () => {
     const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ff-lock-mutex-'));
     const lockPath = path.join(baseDir, 'replaced.lock');

--- a/src/backend/lib/file-lock-mutex.ts
+++ b/src/backend/lib/file-lock-mutex.ts
@@ -7,6 +7,10 @@ const DEFAULT_LOCK_ACQUIRE_TIMEOUT_MS = 5000;
 const DEFAULT_LOCK_RETRY_DELAY_MS = 50;
 const DEFAULT_LOCK_MAX_RETRY_DELAY_MS = 500;
 const DEFAULT_LOCK_MAX_STALE_RETRIES = 3;
+const DEFAULT_LOCK_STALE_THRESHOLD_MS = 60 * 60 * 1000;
+const MIN_LOCK_STALE_THRESHOLD_MS = 1000;
+const DEFAULT_LOCK_HEARTBEAT_INTERVAL_MS = 10_000;
+const MIN_LOCK_HEARTBEAT_INTERVAL_MS = 100;
 
 export interface FileLockMutexOptions {
   acquireTimeoutMs: number;
@@ -15,6 +19,7 @@ export interface FileLockMutexOptions {
   maxRetryDelayMs: number;
   maxStaleRetries: number;
   staleThresholdMs: number;
+  heartbeatIntervalMs: number;
 }
 
 export class FileLockTimeoutError extends Error {
@@ -29,6 +34,21 @@ export class FileLockMutex {
 
   constructor(options: Partial<FileLockMutexOptions> = {}) {
     const acquireTimeoutMs = options.acquireTimeoutMs ?? DEFAULT_LOCK_ACQUIRE_TIMEOUT_MS;
+    const staleThresholdMs = Math.max(
+      options.staleThresholdMs ?? DEFAULT_LOCK_STALE_THRESHOLD_MS,
+      MIN_LOCK_STALE_THRESHOLD_MS
+    );
+    const heartbeatIntervalUpperBoundMs = Math.max(
+      MIN_LOCK_HEARTBEAT_INTERVAL_MS,
+      Math.floor(staleThresholdMs / 3)
+    );
+    const heartbeatIntervalMs = Math.max(
+      MIN_LOCK_HEARTBEAT_INTERVAL_MS,
+      Math.min(
+        options.heartbeatIntervalMs ?? DEFAULT_LOCK_HEARTBEAT_INTERVAL_MS,
+        heartbeatIntervalUpperBoundMs
+      )
+    );
 
     this.options = {
       acquireTimeoutMs,
@@ -36,7 +56,8 @@ export class FileLockMutex {
       initialRetryDelayMs: options.initialRetryDelayMs ?? DEFAULT_LOCK_RETRY_DELAY_MS,
       maxRetryDelayMs: options.maxRetryDelayMs ?? DEFAULT_LOCK_MAX_RETRY_DELAY_MS,
       maxStaleRetries: options.maxStaleRetries ?? DEFAULT_LOCK_MAX_STALE_RETRIES,
-      staleThresholdMs: options.staleThresholdMs ?? acquireTimeoutMs * 5,
+      staleThresholdMs,
+      heartbeatIntervalMs,
     };
   }
 
@@ -48,7 +69,8 @@ export class FileLockMutex {
     while (true) {
       try {
         const fileHandle = await fs.open(lockPath, 'wx');
-        return this.createLockCleanup(fileHandle, lockPath);
+        const stopHeartbeat = this.startLockHeartbeat(fileHandle, lockPath);
+        return this.createLockCleanup(fileHandle, lockPath, stopHeartbeat);
       } catch (error) {
         const resolution = await this.resolveAcquireContention({
           error,
@@ -112,7 +134,11 @@ export class FileLockMutex {
     };
   }
 
-  private createLockCleanup(fileHandle: fs.FileHandle, lockPath: string): () => Promise<void> {
+  private createLockCleanup(
+    fileHandle: fs.FileHandle,
+    lockPath: string,
+    stopHeartbeat: () => Promise<void>
+  ): () => Promise<void> {
     let released = false;
 
     return async () => {
@@ -121,6 +147,7 @@ export class FileLockMutex {
       }
       released = true;
 
+      await stopHeartbeat();
       const handleIno = await this.getInodeAndClose(fileHandle, lockPath);
       if (handleIno === undefined) {
         return;
@@ -179,6 +206,48 @@ export class FileLockMutex {
       logger.warn('Failed to stat lock file during cleanup', {
         lockPath,
         error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private startLockHeartbeat(fileHandle: fs.FileHandle, lockPath: string): () => Promise<void> {
+    let stopping = false;
+    let heartbeatInFlight = Promise.resolve();
+
+    const heartbeatTimer = setInterval(() => {
+      heartbeatInFlight = heartbeatInFlight.then(async () => {
+        if (stopping) {
+          return;
+        }
+
+        await this.touchLockHeartbeat(fileHandle, lockPath);
+      });
+    }, this.options.heartbeatIntervalMs);
+
+    heartbeatTimer.unref?.();
+
+    return async () => {
+      stopping = true;
+      clearInterval(heartbeatTimer);
+      await heartbeatInFlight;
+    };
+  }
+
+  private async touchLockHeartbeat(fileHandle: fs.FileHandle, lockPath: string): Promise<void> {
+    const now = new Date();
+
+    try {
+      await fileHandle.utimes(now, now);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException | undefined)?.code;
+      if (code === 'EBADF' || code === 'ENOENT') {
+        return;
+      }
+
+      logger.warn('Failed to update lock heartbeat', {
+        lockPath,
+        error: error instanceof Error ? error.message : String(error),
+        code,
       });
     }
   }


### PR DESCRIPTION
## Summary
- Add a lock-file heartbeat so active `FileLockMutex` holders refresh `mtime` while the lock is held.
- Decouple stale detection from acquire timeout by using a fixed, safer default stale threshold.
- Add regression coverage for lock-stealing scenarios and unsafe threshold configuration.

## Changes
- **Lock lifecycle**: Start a heartbeat loop on successful acquire and stop it before close/unlink during release.
- **Configuration safety**: Default `staleThresholdMs` to 1 hour, clamp stale threshold to at least 1 second, and clamp heartbeat interval to remain safely below the stale threshold.
- **Tests**: Add cases for heartbeat-protected active locks, `staleThresholdMs: 0` clamping, and `acquireTimeoutMs: 0` without stale-threshold coupling.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not run (backend mutex behavior validated through automated tests)

Closes #1386

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core file-lock acquisition/release behavior by adding a heartbeat and new default/clamped stale thresholds, which could affect concurrency timing and lock cleanup across processes.
> 
> **Overview**
> Prevents `FileLockMutex` from incorrectly removing/stealing *active* lock files by adding a periodic heartbeat that refreshes the lock file `mtime` while the lock is held, and stopping it during release.
> 
> Makes stale-lock detection safer by introducing a fixed default `staleThresholdMs` (1 hour), clamping `staleThresholdMs` to a minimum, and bounding `heartbeatIntervalMs` so it stays well below the stale threshold; adds regression tests covering heartbeat-protected locks and unsafe zero/timeout-derived threshold configurations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ccfde63ecb0434090af0a63ea224bba23682ccef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->