### PR TITLE
Fix #1384: block broken symlink traversal in isPathSafe

### DIFF
--- a/src/backend/lib/file-helpers.test.ts
+++ b/src/backend/lib/file-helpers.test.ts
@@ -5,12 +5,16 @@ import { isBinaryContent, isPathSafe, pathExists } from './file-helpers';
 
 // Mock fs/promises
 vi.mock('node:fs/promises', () => ({
+  lstat: vi.fn(),
+  readlink: vi.fn(),
   realpath: vi.fn(),
   stat: vi.fn(),
 }));
 
-import { realpath, stat } from 'node:fs/promises';
+import { lstat, readlink, realpath, stat } from 'node:fs/promises';
 
+const mockedLstat = vi.mocked(lstat);
+const mockedReadlink = vi.mocked(readlink);
 const mockedRealpath = vi.mocked(realpath);
 const mockedStat = vi.mocked(stat);
 const createErrno = (code: string): NodeJS.ErrnoException => {
@@ -38,9 +42,38 @@ describe('file-helpers', () => {
 
   describe('isPathSafe', () => {
     const worktreePath = '/home/user/project';
+    const resolvedWorktreePath = path.resolve(worktreePath);
+    const createSymlinkStats = (): Awaited<ReturnType<typeof lstat>> =>
+      ({ isSymbolicLink: () => true }) as Awaited<ReturnType<typeof lstat>>;
+    const mockRealpathWithMap = (entries: [string, string][]) => {
+      const lookup = new Map(entries);
+      mockedRealpath.mockImplementation((targetPath) => {
+        const resolvedPath = lookup.get(String(targetPath));
+        if (resolvedPath !== undefined) {
+          return Promise.resolve(resolvedPath);
+        }
+        return Promise.reject(createErrno('ENOENT'));
+      });
+    };
+    const mockBrokenSymlink = (linkPath: string, linkTarget: string) => {
+      mockedLstat.mockImplementation((targetPath) => {
+        if (targetPath === linkPath) {
+          return Promise.resolve(createSymlinkStats());
+        }
+        return Promise.reject(createErrno('ENOENT'));
+      });
+      mockedReadlink.mockImplementation((targetPath) => {
+        if (targetPath === linkPath) {
+          return Promise.resolve(linkTarget);
+        }
+        return Promise.reject(createErrno('ENOENT'));
+      });
+    };
 
     beforeEach(() => {
       vi.clearAllMocks();
+      mockedLstat.mockImplementation(() => Promise.reject(createErrno('ENOENT')));
+      mockedReadlink.mockImplementation(() => Promise.reject(createErrno('ENOENT')));
     });
 
     afterEach(() => {
@@ -210,6 +243,33 @@ describe('file-helpers', () => {
 
         const result = await isPathSafe(worktreePath, 'link/deep/newfile.ts');
         expect(result).toBe(false);
+      });
+
+      it('should reject broken symlink targets that resolve outside worktree', async () => {
+        const brokenLinkPath = path.resolve(worktreePath, 'broken-link');
+        const outsideTarget = '/tmp/external/escape-success.txt';
+
+        mockBrokenSymlink(brokenLinkPath, outsideTarget);
+        mockRealpathWithMap([
+          [resolvedWorktreePath, resolvedWorktreePath],
+          ['/tmp/external', '/tmp/external'],
+        ]);
+
+        const result = await isPathSafe(worktreePath, 'broken-link');
+        expect(result).toBe(false);
+      });
+
+      it('should allow broken symlink targets that stay within worktree', async () => {
+        const brokenLinkPath = path.resolve(worktreePath, 'broken-link');
+
+        mockBrokenSymlink(brokenLinkPath, 'src/new-file.ts');
+        mockRealpathWithMap([
+          [resolvedWorktreePath, resolvedWorktreePath],
+          [path.resolve(worktreePath, 'src'), path.resolve(worktreePath, 'src')],
+        ]);
+
+        const result = await isPathSafe(worktreePath, 'broken-link');
+        expect(result).toBe(true);
       });
 
       it('should handle worktree path that is itself a symlink', async () => {

--- a/src/backend/lib/file-helpers.ts
+++ b/src/backend/lib/file-helpers.ts
@@ -1,4 +1,4 @@
-import { readdir, realpath, stat } from 'node:fs/promises';
+import { lstat, readdir, readlink, realpath, stat } from 'node:fs/promises';
 import path from 'node:path';
 import { LIB_LIMITS } from './constants';
 
@@ -24,6 +24,63 @@ export async function pathExists(targetPath: string): Promise<boolean> {
  * Maximum file size to read (1MB).
  */
 export const MAX_FILE_SIZE = LIB_LIMITS.maxFileReadBytes;
+
+const isErrnoCode = (error: unknown, code: string): boolean =>
+  (error as NodeJS.ErrnoException).code === code;
+
+const isWithinPath = (targetPath: string, rootPath: string): boolean =>
+  targetPath === rootPath || targetPath.startsWith(rootPath + path.sep);
+
+const resolveSymlinkTargetPath = async (candidatePath: string): Promise<string | null> => {
+  let candidateStats: Awaited<ReturnType<typeof lstat>>;
+
+  try {
+    candidateStats = await lstat(candidatePath);
+  } catch (error) {
+    if (isErrnoCode(error, 'ENOENT')) {
+      return null;
+    }
+    throw error;
+  }
+
+  if (!candidateStats.isSymbolicLink()) {
+    return null;
+  }
+
+  const linkTarget = await readlink(candidatePath);
+  return path.resolve(path.dirname(candidatePath), linkTarget);
+};
+
+const resolveParentPath = (candidatePath: string, error: unknown): string => {
+  const parentPath = path.dirname(candidatePath);
+  if (parentPath === candidatePath) {
+    throw error;
+  }
+  return parentPath;
+};
+
+const resolveNearestExistingPath = async (targetPath: string): Promise<string> => {
+  let candidatePath = targetPath;
+  const visitedPaths = new Set<string>();
+
+  while (true) {
+    if (visitedPaths.has(candidatePath)) {
+      throw new Error(`Detected symlink resolution loop for path: ${candidatePath}`);
+    }
+    visitedPaths.add(candidatePath);
+
+    try {
+      return await realpath(candidatePath);
+    } catch (error) {
+      if (!isErrnoCode(error, 'ENOENT')) {
+        throw error;
+      }
+
+      const symlinkTargetPath = await resolveSymlinkTargetPath(candidatePath);
+      candidatePath = symlinkTargetPath ?? resolveParentPath(candidatePath, error);
+    }
+  }
+};
 
 /**
  * Validate that a file path doesn't escape the worktree directory.
@@ -52,29 +109,6 @@ export async function isPathSafe(worktreePath: string, filePath: string): Promis
   if (!fullPath.startsWith(normalizedWorktree + path.sep) && fullPath !== normalizedWorktree) {
     return false;
   }
-
-  const isWithinPath = (targetPath: string, rootPath: string) =>
-    targetPath === rootPath || targetPath.startsWith(rootPath + path.sep);
-
-  const resolveNearestExistingPath = async (targetPath: string): Promise<string> => {
-    let candidatePath = targetPath;
-
-    while (true) {
-      try {
-        return await realpath(candidatePath);
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-          throw error;
-        }
-
-        const parentPath = path.dirname(candidatePath);
-        if (parentPath === candidatePath) {
-          throw error;
-        }
-        candidatePath = parentPath;
-      }
-    }
-  };
 
   // Resolve symlinks and verify the path (or nearest existing parent) stays within worktree.
   try {


### PR DESCRIPTION
## Summary
- Fixes `isPathSafe` so broken symlinks no longer bypass worktree boundary checks.
- Resolves symlink targets (including broken ones) before falling back to parent-directory validation.
- Adds regression tests for broken symlinks that point outside vs. inside the worktree.

## Changes
- **Path safety validation (`src/backend/lib/file-helpers.ts`)**: Added symlink-aware ENOENT handling using `lstat`/`readlink`, loop detection during resolution, and helper refactoring to keep logic explicit and lint-compliant.
- **Tests (`src/backend/lib/file-helpers.test.ts`)**: Extended fs mocks for `lstat` and `readlink`, added targeted broken-symlink regression coverage, and introduced small test helpers to keep cases readable.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Validate file write/read routes against a real broken symlink in a local worktree

Closes #1384

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes path-boundary enforcement used to prevent worktree escapes, including new symlink-target resolution and loop detection; mistakes here could reintroduce traversal vulnerabilities or incorrectly reject valid paths.
> 
> **Overview**
> Fixes `isPathSafe` to correctly handle *broken symlinks* by resolving symlink targets via `lstat`/`readlink` on `ENOENT` instead of immediately falling back to parent-directory `realpath` checks, and adds loop detection during resolution.
> 
> Extends unit tests to mock `lstat`/`readlink` and adds regression coverage proving broken symlinks are rejected when they would resolve outside the worktree and allowed when their targets stay inside.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2225903c0d7fb737cd1848c3be0ed3f3fc616db5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->