### PR TITLE
Fix #1391: sanitize project update issue tracker config

### DIFF
--- a/src/backend/trpc/project.router.test.ts
+++ b/src/backend/trpc/project.router.test.ts
@@ -255,9 +255,19 @@ describe('projectRouter', () => {
       startupScriptCommand: null,
       startupScriptPath: null,
     });
-    mockProjectManagementService.update.mockResolvedValue({ id: 'p1', ok: true });
+    mockProjectManagementService.update.mockResolvedValue({
+      id: 'p1',
+      issueTrackerConfig: {
+        linear: {
+          apiKey: 'enc:lin-api-key',
+          teamId: 'team-1',
+          teamName: 'Platform',
+          viewerName: 'Martina',
+        },
+      },
+    });
 
-    await caller.update({
+    const updatedProject = await caller.update({
       id: 'p1',
       issueProvider: IssueProvider.LINEAR,
       issueTrackerConfig: {
@@ -269,6 +279,19 @@ describe('projectRouter', () => {
         },
       },
     });
+
+    expect(updatedProject).toEqual({
+      id: 'p1',
+      issueTrackerConfig: {
+        linear: {
+          teamId: 'team-1',
+          teamName: 'Platform',
+          viewerName: 'Martina',
+          hasApiKey: true,
+        },
+      },
+    });
+    expect(updatedProject.issueTrackerConfig?.linear).not.toHaveProperty('apiKey');
 
     expect(mockEncrypt).toHaveBeenCalledWith('lin-api-key');
     expect(mockProjectManagementService.update).toHaveBeenCalledWith(

--- a/src/backend/trpc/project.trpc.ts
+++ b/src/backend/trpc/project.trpc.ts
@@ -282,7 +282,11 @@ export const projectRouter = router({
         };
       }
 
-      return projectManagementService.update(id, updates);
+      const project = await projectManagementService.update(id, updates);
+      return {
+        ...project,
+        issueTrackerConfig: sanitizeIssueTrackerConfig(project.issueTrackerConfig),
+      };
     }),
 
   // Archive a project (soft delete)


### PR DESCRIPTION
## Summary
- Sanitize `project.update` tRPC response so `issueTrackerConfig` never returns encrypted API keys
- Keep behavior consistent with existing `project.list` and `project.getById` sanitization
- Add regression coverage to ensure update responses return `hasApiKey` metadata only

## Changes
- **Project Router**: `project.update` now sanitizes `issueTrackerConfig` before returning to the client
- **Tests**: Updated `project.router.test.ts` to assert update response does not expose `apiKey` and includes `hasApiKey: true`

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not run (covered by automated router tests)

Closes #1391

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the `project.update` API response shape by stripping `linear.apiKey` and adding `hasApiKey`, which could impact clients relying on the previous payload.
> 
> **Overview**
> `project.update` now returns a sanitized `issueTrackerConfig`, ensuring encrypted Linear API keys are never exposed and instead returning `hasApiKey` metadata.
> 
> Router tests were updated to assert the update response omits `linear.apiKey` while still encrypting before persistence.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa45d4983c8b4fd3a0cd59be9973d9b77dd69825. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->