### PR TITLE
Fix #1393: sanitize proxy fallback path

### DIFF
--- a/src/shared/proxy-utils.test.ts
+++ b/src/shared/proxy-utils.test.ts
@@ -1,6 +1,6 @@
 import type { IncomingMessage } from 'node:http';
 import { describe, expect, it } from 'vitest';
-import { authenticateRequest, sanitizePathWithoutToken } from './proxy-utils';
+import { authenticateRequest, createSessionValue, sanitizePathWithoutToken } from './proxy-utils';
 
 describe('proxy-utils', () => {
   it('falls back to root path when sanitizing malformed URLs', () => {
@@ -25,6 +25,56 @@ describe('proxy-utils', () => {
       viaToken: false,
       invalidToken: false,
       sanitizedPath: '/',
+    });
+  });
+
+  it('sanitizes repeated token params when first token is empty', () => {
+    const cookieSecret = Buffer.from('secret');
+    const session = createSessionValue(cookieSecret);
+    const request = {
+      url: '/foo?token=&token=SECRET_TOKEN&view=kanban',
+      headers: {
+        cookie: `session=${session.id}.${session.signature}`,
+      },
+    } as IncomingMessage;
+
+    const result = authenticateRequest({
+      req: request,
+      cookieSecret,
+      authToken: 'expected-token',
+      sessionCookieName: 'session',
+    });
+
+    expect(result).toEqual({
+      authenticated: true,
+      viaToken: false,
+      invalidToken: false,
+      sanitizedPath: '/foo?view=kanban',
+    });
+  });
+
+  it('returns a sanitized relative path for absolute request URLs', () => {
+    const cookieSecret = Buffer.from('secret');
+    const session = createSessionValue(cookieSecret);
+    const request = {
+      url: 'http://evil.com/bar?token=&next=1',
+      headers: {
+        cookie: `session=${session.id}.${session.signature}`,
+      },
+    } as IncomingMessage;
+
+    const result = authenticateRequest({
+      req: request,
+      cookieSecret,
+      authToken: 'expected-token',
+      sessionCookieName: 'session',
+    });
+
+    expect(result).toEqual({
+      authenticated: true,
+      viaToken: false,
+      invalidToken: false,
+      sanitizedPath: '/bar?next=1',
     });
   });
 });

--- a/src/shared/proxy-utils.ts
+++ b/src/shared/proxy-utils.ts
@@ -214,7 +214,7 @@ export function authenticateRequest(params: {
     authenticated: hasValidSession,
     viaToken: false,
     invalidToken: false,
-    sanitizedPath: rawUrl,
+    sanitizedPath,
   };
 }
 


### PR DESCRIPTION
## Summary
- Fix `authenticateRequest` to always return the computed sanitized path in the no-token fallback branch.
- Prevent leaking token query params when the first `token` value is empty and additional `token` params are present.
- Ensure absolute request URLs are normalized to relative proxy paths in fallback auth flow.

## Changes
- **Proxy auth sanitization**: Replaced fallback `sanitizedPath: rawUrl` with `sanitizedPath` in `src/shared/proxy-utils.ts`.
- **Regression coverage**: Added tests in `src/shared/proxy-utils.test.ts` for:
- empty + repeated token query params (`?token=&token=SECRET_TOKEN`)
- absolute URL inputs (`http://evil.com/bar?token=&next=1`)

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not run (unit/integration test coverage added for exploit scenarios)

Closes #1393

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches proxy authentication URL handling, which is security-adjacent; a small logic change could affect how paths are forwarded and tokens are stripped.
> 
> **Overview**
> `authenticateRequest` now always returns the computed `sanitizedPath` (instead of the raw URL) in the no-token/session fallback branch, ensuring token query params and absolute URLs don’t leak through.
> 
> Adds regression tests covering repeated `token` params where the first is empty and absolute request URLs being normalized to a relative, token-stripped path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d536b229c8a7d872baafd5c057c94e015dbf009. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->