### PR TITLE
Fix #1395: allow missing model/list reasoning metadata

### DIFF
--- a/src/backend/services/session/service/acp/codex-app-server-adapter/adapter-state.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/adapter-state.ts
@@ -19,7 +19,7 @@ export type CodexModelEntry = {
   id: string;
   displayName: string;
   description: string;
-  defaultReasoningEffort: string;
+  defaultReasoningEffort: string | null;
   supportedReasoningEfforts: Array<{
     reasoningEffort: string;
     description?: string;

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.test.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.test.ts
@@ -175,6 +175,52 @@ describe('CodexAppServerAcpAdapter', () => {
     expect(codex.request).toHaveBeenNthCalledWith(5, 'model/list', { cursor: 'cursor-2' });
   });
 
+  it('initializes when model/list omits reasoning-effort metadata', async () => {
+    const { connection } = createMockConnection();
+    const { client: codexClient, mocks: codex } = createMockCodexClient();
+    const adapter = new CodexAppServerAcpAdapter(connection as AgentSideConnection, codexClient);
+
+    codex.request.mockResolvedValueOnce({});
+    codex.request.mockResolvedValueOnce({
+      requirements: {
+        allowedApprovalPolicies: DEFAULT_ALLOWED_APPROVAL_POLICIES,
+        allowedSandboxModes: DEFAULT_ALLOWED_SANDBOX_MODES,
+      },
+    });
+    codex.request.mockResolvedValueOnce({
+      data: DEFAULT_COLLABORATION_MODES,
+      nextCursor: null,
+    });
+    codex.request.mockResolvedValueOnce({
+      data: [
+        {
+          id: 'legacy-local',
+          displayName: 'Legacy Local',
+          description: 'No reasoning support',
+          isDefault: true,
+        },
+        {
+          id: 'gpt-5-lite',
+          displayName: 'GPT-5 Lite',
+          description: 'Reasoning descriptions are optional',
+          supportedReasoningEfforts: [{ reasoningEffort: 'low' }],
+          inputModalities: ['text'],
+          isDefault: false,
+        },
+      ],
+      nextCursor: null,
+    });
+
+    await expect(
+      adapter.initialize({
+        protocolVersion: 1,
+        clientCapabilities: {},
+        clientInfo: { name: 'test-client', version: '0.0.1' },
+      })
+    ).resolves.toBeDefined();
+    expect(codex.request).toHaveBeenCalledWith('model/list', {});
+  });
+
   it('assigns session ids as sess_<threadId> on newSession', async () => {
     const { connection } = createMockConnection();
     const { client: codexClient, mocks: codex } = createMockCodexClient();

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/codex-zod.test.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/codex-zod.test.ts
@@ -124,6 +124,35 @@ describe('codex-zod', () => {
     expect(parsed.data[0]?.isDefault).toBe(true);
   });
 
+  it('parses model/list responses when reasoning-effort fields are omitted', () => {
+    const parsed = modelListResponseSchema.parse({
+      data: [
+        {
+          id: 'legacy-local',
+          displayName: 'Legacy Local',
+          description: 'No reasoning support',
+          inputModalities: ['text'],
+          isDefault: false,
+        },
+        {
+          id: 'gpt-5-lite',
+          displayName: 'GPT-5 Lite',
+          description: 'Supports reasoning without metadata',
+          supportedReasoningEfforts: [
+            { reasoningEffort: 'low' },
+            { reasoningEffort: 'medium', description: null },
+          ],
+          isDefault: true,
+        },
+      ],
+      nextCursor: null,
+    });
+
+    expect(parsed.data[0]?.defaultReasoningEffort).toBeUndefined();
+    expect(parsed.data[1]?.supportedReasoningEfforts?.[0]?.description).toBeUndefined();
+    expect(parsed.data[1]?.supportedReasoningEfforts?.[1]?.description).toBeNull();
+  });
+
   it('parses thread/read responses used for session replay', () => {
     const parsed = threadReadResponseSchema.parse({
       thread: {

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/codex-zod.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/codex-zod.ts
@@ -321,12 +321,12 @@ export const modelListResponseSchema = z
               z
                 .object({
                   reasoningEffort: z.string(),
-                  description: z.string(),
+                  description: z.string().nullable().optional(),
                 })
                 .passthrough()
             )
             .optional(),
-          defaultReasoningEffort: z.string(),
+          defaultReasoningEffort: z.string().nullable().optional(),
           inputModalities: z.array(z.string()).optional(),
           isDefault: z.boolean().optional(),
         })

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/session-config-resolver.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/session-config-resolver.ts
@@ -196,11 +196,14 @@ function createReasoningEffortConfigOption(
   }
 
   const supportedValues = [...supportedByValue.keys()];
+  const defaultReasoningEffort = isNonEmptyString(modelEntry.defaultReasoningEffort)
+    ? modelEntry.defaultReasoningEffort
+    : null;
   const resolvedCurrent =
     currentReasoningEffort && supportedByValue.has(currentReasoningEffort)
       ? currentReasoningEffort
-      : supportedByValue.has(modelEntry.defaultReasoningEffort)
-        ? modelEntry.defaultReasoningEffort
+      : defaultReasoningEffort && supportedByValue.has(defaultReasoningEffort)
+        ? defaultReasoningEffort
         : supportedValues[0];
 
   if (!resolvedCurrent) {
@@ -319,7 +322,10 @@ export function resolveReasoningEffortForModel(
   ) {
     return candidateReasoningEffort;
   }
-  if (supportedValues.includes(modelEntry.defaultReasoningEffort)) {
+  if (
+    isNonEmptyString(modelEntry.defaultReasoningEffort) &&
+    supportedValues.includes(modelEntry.defaultReasoningEffort)
+  ) {
     return modelEntry.defaultReasoningEffort;
   }
   return supportedValues[0] ?? null;

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/session-negotiation.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/session-negotiation.ts
@@ -203,12 +203,12 @@ export async function loadModelCatalog(params: { codex: CodexClient }): Promise<
         id: model.id,
         displayName: model.displayName,
         description: model.description,
-        defaultReasoningEffort: model.defaultReasoningEffort,
+        defaultReasoningEffort: model.defaultReasoningEffort ?? null,
         supportedReasoningEfforts: (model.supportedReasoningEfforts ?? [])
           .filter((entry) => isNonEmptyString(entry.reasoningEffort))
           .map((entry) => ({
             reasoningEffort: entry.reasoningEffort,
-            description: entry.description,
+            description: entry.description ?? undefined,
           })),
         inputModalities: model.inputModalities ?? [],
         isDefault: model.isDefault ?? false,

--- a/src/backend/services/session/service/lifecycle/session.config.service.ts
+++ b/src/backend/services/session/service/lifecycle/session.config.service.ts
@@ -891,7 +891,7 @@ export class SessionConfigService {
 
   private resolveCodexReasoningValue(
     currentReasoningValue: string | null,
-    defaultReasoningValue: string | undefined,
+    defaultReasoningValue: string | null | undefined,
     reasoningValues: string[]
   ): string | null {
     const values = new Set(reasoningValues);


### PR DESCRIPTION
## Summary
- Relax Codex `model/list` Zod validation so missing reasoning-effort metadata no longer fails parsing.
- Normalize nullable/omitted `defaultReasoningEffort` values in catalog loading and resolver paths.
- Add regression tests for both schema parsing and adapter initialization with missing reasoning fields.

## Changes
- **Codex schema parsing**: Updated `modelListResponseSchema` to accept `defaultReasoningEffort` as nullable/optional and `supportedReasoningEfforts[].description` as nullable/optional.
- **Model catalog normalization**: Mapped missing `defaultReasoningEffort` to `null` and normalized nullable reasoning descriptions to `undefined` in `loadModelCatalog`.
- **Resolver/type alignment**: Updated `CodexModelEntry.defaultReasoningEffort` to `string | null` and guarded fallback reasoning-resolution logic accordingly.
- **Regression coverage**: Added tests for `model/list` payloads that omit reasoning-effort fields and adapter initialization against that payload shape.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not run (covered by automated adapter + schema tests)

Closes #1395

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change relaxes schema validation and adds null/undefined normalization around optional reasoning metadata, with added regression tests; primary risk is subtle fallback/selection behavior for reasoning-effort defaults.
> 
> **Overview**
> Codex `model/list` parsing is relaxed to accept missing/nullable reasoning-effort metadata (`defaultReasoningEffort`, `supportedReasoningEfforts[].description`) and the catalog loader now normalizes these to consistent `null`/`undefined` values.
> 
> Reasoning-effort resolution logic is updated to guard against empty/missing defaults, and types are aligned (`CodexModelEntry.defaultReasoningEffort: string | null`). Regression tests cover schema parsing and adapter initialization when the reasoning fields are omitted.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9aab0b269b9f989665d4208ea1c4c3b627322ca1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->