### PR TITLE
Fix launched GitHub issues still appearing in Todo

### DIFF
--- a/src/client/components/kanban/issue-card.test.tsx
+++ b/src/client/components/kanban/issue-card.test.tsx
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+
+import { createElement } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { IssueCard } from './issue-card';
+
+const mocks = vi.hoisted(() => ({
+  listWithKanbanStateInvalidateMock: vi.fn(),
+  getProjectSummaryStateInvalidateMock: vi.fn(),
+  getSetDataMock: vi.fn(),
+  createWorkspaceMutateMock: vi.fn(),
+  createWorkspaceMutationOptions: undefined as Record<string, unknown> | undefined,
+  createOptimisticWorkspaceCacheDataMock: vi.fn(),
+}));
+
+vi.mock('lucide-react', () => ({
+  CircleDot: () => null,
+  Play: () => null,
+  User: () => null,
+}));
+
+vi.mock('@/client/lib/workspace-cache-helpers', () => ({
+  createOptimisticWorkspaceCacheData: mocks.createOptimisticWorkspaceCacheDataMock,
+}));
+
+vi.mock('@/client/lib/trpc', () => ({
+  trpc: {
+    useUtils: () => ({
+      workspace: {
+        get: { setData: mocks.getSetDataMock },
+        listWithKanbanState: {
+          invalidate: mocks.listWithKanbanStateInvalidateMock,
+        },
+        getProjectSummaryState: {
+          invalidate: mocks.getProjectSummaryStateInvalidateMock,
+        },
+      },
+    }),
+    userSettings: {
+      get: {
+        useQuery: () => ({
+          data: { ratchetEnabled: false },
+          isLoading: false,
+        }),
+      },
+    },
+    workspace: {
+      create: {
+        useMutation: (options: Record<string, unknown>) => {
+          mocks.createWorkspaceMutationOptions = options;
+          return {
+            mutate: mocks.createWorkspaceMutateMock,
+            isPending: false,
+          };
+        },
+      },
+    },
+  },
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: import('react').ButtonHTMLAttributes<HTMLButtonElement>) =>
+    createElement('button', props, children),
+}));
+
+vi.mock('@/components/ui/card', () => ({
+  Card: ({ children, ...props }: import('react').HTMLAttributes<HTMLDivElement>) =>
+    createElement('div', props, children),
+  CardContent: ({ children, ...props }: import('react').HTMLAttributes<HTMLDivElement>) =>
+    createElement('div', props, children),
+  CardHeader: ({ children, ...props }: import('react').HTMLAttributes<HTMLDivElement>) =>
+    createElement('div', props, children),
+  CardTitle: ({ children, ...props }: import('react').HTMLAttributes<HTMLDivElement>) =>
+    createElement('div', props, children),
+}));
+
+vi.mock('@/components/workspace', () => ({
+  RatchetToggleButton: () => null,
+}));
+
+function renderCard(): { container: HTMLDivElement; root: Root } {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  flushSync(() => {
+    root.render(
+      createElement(IssueCard, {
+        projectId: 'project-1',
+        issue: {
+          id: 'github-42',
+          provider: 'github',
+          title: 'Fix login redirect',
+          body: 'Issue body',
+          url: 'https://github.com/acme/repo/issues/42',
+          displayId: '#42',
+          author: 'octocat',
+          createdAt: '2026-03-14T12:00:00.000Z',
+          githubIssueNumber: 42,
+        },
+      })
+    );
+  });
+
+  return { container, root };
+}
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
+    configurable: true,
+    writable: true,
+    value: true,
+  });
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.clearAllMocks();
+});
+
+describe('IssueCard', () => {
+  it('invalidates sidebar project summary after creating a workspace from an issue', () => {
+    const { container, root } = renderCard();
+
+    const mutationOptions = mocks.createWorkspaceMutationOptions as {
+      onSuccess: (workspace: { id: string }) => void;
+    };
+
+    mocks.createOptimisticWorkspaceCacheDataMock.mockReturnValue({ id: 'ws-1' });
+
+    mutationOptions.onSuccess({ id: 'ws-1' });
+
+    expect(mocks.listWithKanbanStateInvalidateMock).toHaveBeenCalledWith({
+      projectId: 'project-1',
+    });
+    expect(mocks.getProjectSummaryStateInvalidateMock).toHaveBeenCalledWith({
+      projectId: 'project-1',
+    });
+
+    root.unmount();
+    container.remove();
+  });
+});

--- a/src/client/components/kanban/issue-card.tsx
+++ b/src/client/components/kanban/issue-card.tsx
@@ -50,6 +50,7 @@ export function IssueCard({ issue, projectId, onClick }: IssueCardProps) {
 
       // Invalidate workspace queries to refresh the board
       utils.workspace.listWithKanbanState.invalidate({ projectId });
+      utils.workspace.getProjectSummaryState.invalidate({ projectId });
     },
   });
 

--- a/src/client/components/kanban/issue-details-sheet.tsx
+++ b/src/client/components/kanban/issue-details-sheet.tsx
@@ -106,6 +106,7 @@ function IssueDetailsContent({
     onSuccess: () => {
       onOpenChange(false);
       utils.workspace.listWithKanbanState.invalidate({ projectId });
+      utils.workspace.getProjectSummaryState.invalidate({ projectId });
     },
   });
 


### PR DESCRIPTION
## Summary
- fix issue-launch flows to invalidate `workspace.getProjectSummaryState` after creating a workspace from a GitHub/Linear issue
- update both Kanban launch entry points (`IssueCard` and `IssueDetailsSheet`) so sidebar Todo data is refreshed immediately
- add a regression test for `IssueCard` that verifies both kanban and sidebar summary invalidations occur on success

## Root Cause
The sidebar Todo list filters issues using workspace issue linkage from `getProjectSummaryState`. Issue launch only invalidated `listWithKanbanState`, so the sidebar cache could retain stale workspace data and continue showing the launched issue.

## Testing
- pnpm test src/client/components/kanban/issue-card.test.tsx
- pnpm typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small client-side cache invalidation change plus a focused regression test; main risk is unintended extra refetching of `getProjectSummaryState` after workspace creation.
> 
> **Overview**
> Fixes stale sidebar Todo data after launching a GitHub/Linear issue by also invalidating `workspace.getProjectSummaryState` on successful workspace creation from both `IssueCard` and `IssueDetailsSheet`.
> 
> Adds a Vitest regression test for `IssueCard` asserting that both `listWithKanbanState` and `getProjectSummaryState` are invalidated after the create-workspace mutation succeeds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7614758c51eb3e68ec55ebc1bd748f3e2fb09b51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->