### PR TITLE
Fix #1396: Harden blank worktree and workingDir guards

### DIFF
--- a/src/backend/services/session/service/acp/acp-runtime-manager.test.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-manager.test.ts
@@ -213,6 +213,19 @@ describe('AcpRuntimeManager', () => {
       expect(mockSpawn).not.toHaveBeenCalled();
     });
 
+    it('rejects before spawn when workingDir is whitespace only', async () => {
+      await expect(
+        manager.getOrCreateClient(
+          'session-whitespace-cwd',
+          { ...defaultOptions(), workingDir: '   ' },
+          defaultHandlers(),
+          defaultContext()
+        )
+      ).rejects.toThrow('ACP working directory is required before spawning adapter process');
+
+      expect(mockSpawn).not.toHaveBeenCalled();
+    });
+
     it('spawns subprocess with detached:false, wires streams, initializes, creates session, returns handle', async () => {
       setupSuccessfulSpawn();
 

--- a/src/backend/services/session/service/acp/acp-runtime-manager.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-manager.ts
@@ -88,6 +88,10 @@ function normalizeUnknownError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
 }
 
+function hasUsableWorkingDir(workingDir: string | null | undefined): boolean {
+  return typeof workingDir === 'string' && workingDir.trim().length > 0;
+}
+
 function createAcpSpawnError(commandLabel: string, error: unknown): Error {
   const normalized = normalizeUnknownError(error);
   return new Error(`Failed to spawn ACP adapter "${commandLabel}": ${normalized.message}`);
@@ -601,7 +605,7 @@ export class AcpRuntimeManager {
     handlers: AcpRuntimeEventHandlers,
     context: { workspaceId: string; workingDir: string }
   ): Promise<AcpProcessHandle> {
-    if (!options.workingDir) {
+    if (!hasUsableWorkingDir(options.workingDir)) {
       throw new Error('ACP working directory is required before spawning adapter process');
     }
 

--- a/src/backend/services/workspace/service/state/init-policy.test.ts
+++ b/src/backend/services/workspace/service/state/init-policy.test.ts
@@ -26,6 +26,18 @@ describe('getWorkspaceInitPolicy', () => {
     expect(policy.banner?.message).toBe('Running init script...');
   });
 
+  it('treats whitespace worktree as missing for PROVISIONING workspace', () => {
+    const policy = getWorkspaceInitPolicy({
+      status: 'PROVISIONING',
+      worktreePath: '   ',
+      initErrorMessage: null,
+    });
+
+    expect(policy.phase).toBe('CREATING_WORKTREE');
+    expect(policy.dispatchPolicy).toBe('blocked');
+    expect(policy.banner?.message).toBe('Creating worktree...');
+  });
+
   it('returns manual_resume policy for startup script failures after worktree creation', () => {
     const policy = getWorkspaceInitPolicy({
       status: 'FAILED',
@@ -57,6 +69,18 @@ describe('getWorkspaceInitPolicy', () => {
     const policy = getWorkspaceInitPolicy({
       status: 'READY',
       worktreePath: null,
+      initErrorMessage: 'init warning',
+    });
+
+    expect(policy.phase).toBe('BLOCKED_FAILED');
+    expect(policy.dispatchPolicy).toBe('blocked');
+    expect(policy.banner?.message).toBe('Workspace is marked ready, but its worktree is missing.');
+  });
+
+  it('blocks dispatch when workspace is READY with whitespace worktree path', () => {
+    const policy = getWorkspaceInitPolicy({
+      status: 'READY',
+      worktreePath: '   ',
       initErrorMessage: 'init warning',
     });
 

--- a/src/backend/services/workspace/service/state/init-policy.ts
+++ b/src/backend/services/workspace/service/state/init-policy.ts
@@ -84,7 +84,7 @@ export function getWorkspaceInitPolicy(input: WorkspaceInitPolicyInput): Workspa
 }
 
 function deriveWorkspaceInitPhase(input: WorkspaceInitPolicyInput): WorkspaceInitPhase {
-  const hasWorktree = Boolean(input.worktreePath);
+  const hasWorktree = hasUsableWorktreePath(input.worktreePath);
   const hasWarning = Boolean(input.initErrorMessage);
 
   if (input.status === 'ARCHIVING' || input.status === 'ARCHIVED') {
@@ -116,9 +116,13 @@ function deriveWorkspaceInitPhase(input: WorkspaceInitPolicyInput): WorkspaceIni
 }
 
 function getBlockedFailedMessage(input: WorkspaceInitPolicyInput): string {
-  if (!input.worktreePath && input.status === 'READY') {
+  if (!hasUsableWorktreePath(input.worktreePath) && input.status === 'READY') {
     return 'Workspace is marked ready, but its worktree is missing.';
   }
 
   return input.initErrorMessage || 'Workspace setup failed while creating the worktree.';
+}
+
+function hasUsableWorktreePath(worktreePath: string | null | undefined): boolean {
+  return typeof worktreePath === 'string' && worktreePath.trim().length > 0;
 }


### PR DESCRIPTION
## Summary
- Harden workspace/session safety checks so blank or whitespace worktree paths are treated as missing.
- Block ACP runtime spawn when `workingDir` is whitespace-only to prevent unsafe process cwd behavior.
- Add regression coverage for both policy and ACP runtime guard paths.

## Changes
- **Workspace init policy**: Updated worktree presence checks to require a non-empty trimmed path before allowing ready/resumable phases.
- **ACP runtime manager**: Tightened pre-spawn validation so whitespace-only `workingDir` values are rejected.
- **Tests**: Added new cases in init-policy and ACP runtime manager test suites for whitespace-path edge cases.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Validate session start behavior from a workspace with missing/blank worktree path in the UI

Closes #1396

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens guards that can change when workspaces are considered runnable and when ACP subprocesses are allowed to spawn, potentially affecting startup flows for edge-case inputs. Scope is small and covered by targeted regression tests.
> 
> **Overview**
> **Hardens path presence checks** so whitespace-only `worktreePath` values are treated as missing when deriving workspace init phase, which can now block dispatch or keep workspaces in `CREATING_WORKTREE`/`BLOCKED_FAILED`.
> 
> **Prevents unsafe ACP spawns** by rejecting whitespace-only `workingDir` values before spawning the adapter process, with new test coverage for both guards.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3baa271beeb8710d420290ed033b6c410da3656. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->