### PR TITLE
Fix maxBuffer overflow when fetching PR review comments

### DIFF
--- a/src/backend/services/github/service/github-cli.service.ts
+++ b/src/backend/services/github/service/github-cli.service.ts
@@ -526,7 +526,7 @@ class GitHubCLIService {
       const { stdout } = await execFileAsync(
         'gh',
         ['api', `repos/${repo}/pulls/${prNumber}/comments`, '--paginate'],
-        { timeout: GH_TIMEOUT_MS.default }
+        { timeout: GH_TIMEOUT_MS.default, maxBuffer: GH_MAX_BUFFER_BYTES.reviewComments }
       );
 
       if (!stdout.trim()) {

--- a/src/backend/services/github/service/github-cli/constants.ts
+++ b/src/backend/services/github/service/github-cli/constants.ts
@@ -9,4 +9,5 @@ export const GH_TIMEOUT_MS = Object.freeze({
 
 export const GH_MAX_BUFFER_BYTES = Object.freeze({
   diff: 10 * 1024 * 1024, // 10MB buffer for large diffs
+  reviewComments: 10 * 1024 * 1024, // 10MB buffer for paginated review comments
 } as const);


### PR DESCRIPTION
## Summary
- The `getReviewComments` call in the GitHub CLI service used Node.js's default 1MB `maxBuffer` for `execFile`, causing "stdout maxBuffer length exceeded" errors on PRs with many/large review comments
- Adds a `reviewComments` entry to `GH_MAX_BUFFER_BYTES` (10MB, matching the existing `diff` entry) and passes it to the `execFileAsync` call

## Test plan
- [x] `pnpm test` — all 245 test files pass
- [x] `pnpm typecheck` — passes (via pre-commit hook)
- [x] `pnpm check:fix` — passes (via pre-commit hook)
