### PR TITLE
Fix Settings back link project selection

### DIFF
--- a/src/client/routes/admin-page.test.tsx
+++ b/src/client/routes/admin-page.test.tsx
@@ -51,7 +51,8 @@ vi.mock('@/components/factory-config-scripts', () => ({
 
 vi.mock('@/components/workspace', () => ({
   RatchetWrenchIcon: () => createElement('span', null, 'ratchet'),
-  WorkspacesBackLink: () => createElement('a', { href: '/projects' }, 'Back'),
+  WorkspacesBackLink: ({ projectSlug }: { projectSlug: string }) =>
+    createElement('a', { href: `/projects/${projectSlug}/workspaces` }, 'Back'),
 }));
 
 vi.mock('@/components/workspace/dev-server-setup-panel', () => ({
@@ -91,6 +92,13 @@ vi.mock('@/client/lib/trpc', () => {
       id: 'project-1',
       slug: 'alpha',
       name: 'Alpha',
+      issueProvider: 'github',
+      issueTrackerConfig: null,
+    },
+    {
+      id: 'project-2',
+      slug: 'beta',
+      name: 'Beta',
       issueProvider: 'github',
       issueTrackerConfig: null,
     },
@@ -218,6 +226,22 @@ describe('AdminDashboardPage settings tabs', () => {
     const activePanelAfter = container.querySelector('[role="tabpanel"][data-state="active"]');
     expect(activePanelAfter?.textContent).toContain('Factory Configuration');
     expect(activePanelAfter?.textContent).not.toContain('Notification Settings');
+
+    root.unmount();
+  });
+
+  it('renders workspaces back link for the selected project slug from storage', () => {
+    localStorage.setItem('factoryfactory_selected_project_slug', 'beta');
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    flushSync(() => {
+      root.render(createElement(AdminDashboardPage));
+    });
+
+    const backLink = container.querySelector('a[href="/projects/beta/workspaces"]');
+    expect(backLink).not.toBeNull();
 
     root.unmount();
   });

--- a/src/client/routes/admin-page.tsx
+++ b/src/client/routes/admin-page.tsx
@@ -179,6 +179,21 @@ function ProjectFactoryConfigCard({
 
 const SELECTED_PROJECT_KEY = 'factoryfactory_selected_project_slug';
 
+function resolveSelectedProjectSlug(
+  projects: Array<{ slug: string }> | undefined
+): string | undefined {
+  if (!projects || projects.length === 0) {
+    return undefined;
+  }
+
+  const storedSlug = localStorage.getItem(SELECTED_PROJECT_KEY);
+  if (storedSlug && projects.some((project) => project.slug === storedSlug)) {
+    return storedSlug;
+  }
+
+  return projects[0]?.slug;
+}
+
 function ProjectSettingsSection({
   projects,
 }: {
@@ -968,7 +983,7 @@ export default function AdminDashboardPage() {
     },
   });
 
-  const projectSlug = projects?.[0]?.slug;
+  const projectSlug = resolveSelectedProjectSlug(projects);
 
   // Show full loading only when stats are loading (first load)
   if (isLoadingStats) {


### PR DESCRIPTION
## Summary
- fix the Settings page "Workspaces" back link to use the currently selected project slug from localStorage (`factoryfactory_selected_project_slug`) instead of always using the first project
- add a fallback to the first project when the stored slug is missing or invalid
- add a regression test covering the selected-project back link behavior

## Testing
- pnpm exec vitest run src/client/routes/admin-page.test.tsx
- pnpm exec biome check src/client/routes/admin-page.tsx src/client/routes/admin-page.test.tsx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI navigation change that only affects which project slug is used to build the Settings page back link, with a safe fallback when storage is missing/invalid.
> 
> **Overview**
> Fixes the Settings page "Back to workspaces" link to use the *currently selected* project slug from `localStorage` (`factoryfactory_selected_project_slug`) instead of always using the first project in the list, falling back to the first project when the stored value is absent or no longer valid.
> 
> Adds a regression test that sets the stored slug and asserts the rendered back-link URL matches the selected project.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 081da0b07a79000eeacc41a50298bc4d792a8869. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->