### PR TITLE
Enable horizontal scrolling in workspace file viewer

### DIFF
--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -7,28 +7,37 @@ interface ScrollAreaProps extends React.ComponentPropsWithoutRef<typeof ScrollAr
   onScroll?: React.UIEventHandler<HTMLDivElement>;
   viewportRef?: React.Ref<HTMLDivElement>;
   smoothScroll?: boolean;
+  scrollbars?: 'vertical' | 'horizontal' | 'both';
 }
 
 const ScrollArea = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.Root>,
   ScrollAreaProps
->(({ className, children, onScroll, viewportRef, smoothScroll, ...props }, ref) => (
-  <ScrollAreaPrimitive.Root
-    ref={ref}
-    className={cn('relative overflow-hidden group/scroll', className)}
-    {...props}
-  >
-    <ScrollAreaPrimitive.Viewport
-      ref={viewportRef}
-      className={cn('h-full w-full rounded-[inherit]', smoothScroll && 'scroll-smooth')}
-      onScroll={onScroll}
+>(
+  (
+    { className, children, onScroll, viewportRef, smoothScroll, scrollbars = 'vertical', ...props },
+    ref
+  ) => (
+    <ScrollAreaPrimitive.Root
+      ref={ref}
+      className={cn('relative overflow-hidden group/scroll', className)}
+      {...props}
     >
-      {children}
-    </ScrollAreaPrimitive.Viewport>
-    <ScrollBar />
-    <ScrollAreaPrimitive.Corner />
-  </ScrollAreaPrimitive.Root>
-));
+      <ScrollAreaPrimitive.Viewport
+        ref={viewportRef}
+        className={cn('h-full w-full rounded-[inherit]', smoothScroll && 'scroll-smooth')}
+        onScroll={onScroll}
+      >
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      {(scrollbars === 'vertical' || scrollbars === 'both') && <ScrollBar />}
+      {(scrollbars === 'horizontal' || scrollbars === 'both') && (
+        <ScrollBar orientation="horizontal" />
+      )}
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  )
+);
 ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName;
 
 const ScrollBar = React.forwardRef<

--- a/src/components/workspace/file-viewer.tsx
+++ b/src/components/workspace/file-viewer.tsx
@@ -218,7 +218,7 @@ function FileViewerContent({
   }
 
   return (
-    <ScrollArea className="flex-1" onScroll={onScroll} viewportRef={viewportRef}>
+    <ScrollArea className="flex-1" onScroll={onScroll} viewportRef={viewportRef} scrollbars="both">
       <SyntaxHighlighter
         language={data.language}
         style={syntaxTheme}


### PR DESCRIPTION
## Summary
- add a `scrollbars` option to the shared `ScrollArea` component (`vertical` | `horizontal` | `both`)
- render both Radix scrollbars when `scrollbars="both"` is requested
- enable `scrollbars="both"` in workspace file code view so long lines can scroll horizontally instead of being clipped

## Testing
- pnpm typecheck
- pre-commit checks ran successfully (Biome, dependency-cruiser, Knip)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI change with a backwards-compatible default (`vertical`), though it may slightly affect layout where `ScrollArea` is reused.
> 
> **Overview**
> Adds a new `scrollbars` prop to the shared `ScrollArea` component to control whether vertical, horizontal, or both Radix scrollbars are rendered.
> 
> Updates the workspace `FileViewer` code view to request `scrollbars="both"`, allowing long lines to be scrolled horizontally instead of being clipped.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f59c0fce4ac679eb4f5932f17a722235e8b6fcfb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->