### PR TITLE
Fix auto-approved plan and user-input prompts in YOLO mode

### DIFF
--- a/src/backend/services/session/service/acp/acp-client-handler.test.ts
+++ b/src/backend/services/session/service/acp/acp-client-handler.test.ts
@@ -157,5 +157,104 @@ describe('AcpClientHandler', () => {
         optionId: 'allow_always',
       });
     });
+
+    it('does not auto-approve ExitPlanMode requests even in "all" mode', async () => {
+      const bridge = {
+        waitForUserResponse: vi.fn().mockResolvedValue({
+          outcome: { outcome: 'selected', optionId: 'plan' },
+        }),
+      } as unknown as AcpPermissionBridge;
+      const eventFn = vi.fn();
+      const handler = new AcpClientHandler('session-1', eventFn, bridge, onLog, 'all');
+      const params = createMockPermissionRequest({
+        toolCall: {
+          toolCallId: 'tc-exit-plan',
+          title: 'ExitPlanMode',
+          status: 'pending',
+          rawInput: { type: 'ExitPlanMode' },
+        },
+        options: [
+          { optionId: 'default', kind: 'allow_once', name: 'Approve Plan' },
+          { optionId: 'plan', kind: 'reject_once', name: 'Keep Planning' },
+        ],
+      });
+
+      const response = await handler.requestPermission(params);
+
+      expect(bridge.waitForUserResponse).toHaveBeenCalled();
+      expect(eventFn).toHaveBeenCalledWith(
+        'session-1',
+        expect.objectContaining({
+          type: 'acp_permission_request',
+        })
+      );
+      expect(response.outcome).toEqual({
+        outcome: 'selected',
+        optionId: 'plan',
+      });
+    });
+
+    it('does not auto-approve requestUserInput prompts even in "all" mode', async () => {
+      const bridge = {
+        waitForUserResponse: vi.fn().mockResolvedValue({
+          outcome: { outcome: 'selected', optionId: 'allow_once' },
+        }),
+      } as unknown as AcpPermissionBridge;
+      const eventFn = vi.fn();
+      const handler = new AcpClientHandler('session-1', eventFn, bridge, onLog, 'all');
+      const params = createMockPermissionRequest({
+        toolCall: {
+          toolCallId: 'tc-user-input',
+          title: 'item/tool/requestUserInput',
+          status: 'pending',
+          rawInput: {
+            questions: [{ id: 'q1', question: 'Select an option', options: [{ label: 'A' }] }],
+          },
+        },
+        options: [
+          { optionId: 'allow_once', kind: 'allow_once', name: 'Submit' },
+          { optionId: 'reject_once', kind: 'reject_once', name: 'Cancel' },
+        ],
+      });
+
+      const response = await handler.requestPermission(params);
+
+      expect(bridge.waitForUserResponse).toHaveBeenCalled();
+      expect(eventFn).toHaveBeenCalledWith(
+        'session-1',
+        expect.objectContaining({
+          type: 'acp_permission_request',
+        })
+      );
+      expect(response.outcome).toEqual({
+        outcome: 'selected',
+        optionId: 'allow_once',
+      });
+    });
+
+    it('fails closed for requestUserInput when permission bridge is missing', async () => {
+      const handler = new AcpClientHandler('session-1', onEvent, undefined, onLog, 'all');
+      const params = createMockPermissionRequest({
+        toolCall: {
+          toolCallId: 'tc-user-input-no-bridge',
+          title: 'item/tool/requestUserInput',
+          status: 'pending',
+          rawInput: {
+            questions: [{ id: 'q1', question: 'Select an option', options: [{ label: 'A' }] }],
+          },
+        },
+        options: [
+          { optionId: 'allow_once', kind: 'allow_once', name: 'Submit' },
+          { optionId: 'reject_once', kind: 'reject_once', name: 'Cancel' },
+        ],
+      });
+
+      const response = await handler.requestPermission(params);
+
+      expect(response.outcome).toEqual({
+        outcome: 'selected',
+        optionId: 'reject_once',
+      });
+    });
   });
 });

--- a/src/backend/services/session/service/acp/acp-client-handler.ts
+++ b/src/backend/services/session/service/acp/acp-client-handler.ts
@@ -17,6 +17,127 @@ export type AutoApprovePolicy = 'none' | 'all';
 
 const logger = createLogger('acp-client-handler');
 
+function isExitPlanModeApprovalRequest(params: RequestPermissionRequest): boolean {
+  if (params.toolCall.title === 'ExitPlanMode') {
+    return true;
+  }
+
+  const rawInput = params.toolCall.rawInput;
+  if (typeof rawInput !== 'object' || rawInput === null) {
+    return false;
+  }
+
+  const typeValue = (rawInput as { type?: unknown }).type;
+  return typeValue === 'ExitPlanMode';
+}
+
+function isUserInputPermissionRequest(params: RequestPermissionRequest): boolean {
+  if (
+    params.toolCall.title === 'AskUserQuestion' ||
+    params.toolCall.title === 'item/tool/requestUserInput'
+  ) {
+    return true;
+  }
+
+  const rawInput = params.toolCall.rawInput;
+  if (typeof rawInput !== 'object' || rawInput === null) {
+    return false;
+  }
+
+  const questions = (rawInput as { questions?: unknown }).questions;
+  return Array.isArray(questions);
+}
+
+function resolveFailClosedOptionId(params: RequestPermissionRequest): string {
+  const rejectOption = params.options.find(
+    (option) => option.kind === 'reject_once' || option.kind === 'reject_always'
+  );
+  if (rejectOption) {
+    return rejectOption.optionId;
+  }
+
+  return params.options[0]?.optionId ?? 'unknown';
+}
+
+function resolveAllowOptionId(params: RequestPermissionRequest): string | null {
+  const allowOption = params.options.find(
+    (option) => option.kind === 'allow_always' || option.kind === 'allow_once'
+  );
+  return allowOption?.optionId ?? null;
+}
+
+function resolveInteractiveRequestTypeLabel(
+  isPlanApproval: boolean
+): 'ExitPlanMode' | 'requestUserInput' {
+  if (isPlanApproval) {
+    return 'ExitPlanMode';
+  }
+  return 'requestUserInput';
+}
+
+function tryAutoApprovePermission(params: {
+  request: RequestPermissionRequest;
+  autoApprovePolicy: AutoApprovePolicy;
+  bypassesAutoApprove: boolean;
+  sessionId: string;
+}): RequestPermissionResponse | null {
+  if (params.autoApprovePolicy !== 'all' || params.bypassesAutoApprove) {
+    return null;
+  }
+
+  const allowOptionId = resolveAllowOptionId(params.request);
+  if (allowOptionId) {
+    logger.debug('Auto-approving permission request per configured preset', {
+      sessionId: params.sessionId,
+      toolCallId: params.request.toolCall.toolCallId,
+    });
+    return {
+      outcome: {
+        outcome: 'selected',
+        optionId: allowOptionId,
+      },
+    };
+  }
+
+  logger.warn('Auto-approve enabled but no allow option found; deferring to permission bridge', {
+    sessionId: params.sessionId,
+    toolCallId: params.request.toolCall.toolCallId,
+    availableOptions: params.request.options.map((option) => option.kind),
+  });
+  return null;
+}
+
+function resolveMissingBridgeOutcome(params: {
+  request: RequestPermissionRequest;
+  bypassesAutoApprove: boolean;
+  isPlanApproval: boolean;
+  sessionId: string;
+}): RequestPermissionResponse {
+  const optionId = params.bypassesAutoApprove
+    ? resolveFailClosedOptionId(params.request)
+    : (resolveAllowOptionId(params.request) ?? resolveFailClosedOptionId(params.request));
+
+  logger.warn(
+    params.bypassesAutoApprove
+      ? 'Permission bridge missing; rejecting interactive ACP permission request'
+      : 'Permission bridge missing; auto-approving ACP permission request',
+    {
+      sessionId: params.sessionId,
+      toolCallId: params.request.toolCall.toolCallId,
+      requestType: params.bypassesAutoApprove
+        ? resolveInteractiveRequestTypeLabel(params.isPlanApproval)
+        : 'permission',
+    }
+  );
+
+  return {
+    outcome: {
+      outcome: 'selected',
+      optionId,
+    },
+  };
+}
+
 export class AcpClientHandler implements Client {
   private readonly sessionId: string;
   private readonly onEvent: AcpEventCallback;
@@ -63,49 +184,37 @@ export class AcpClientHandler implements Client {
       options: params.options.map((o) => ({ optionId: o.optionId, kind: o.kind, name: o.name })),
     });
 
-    // Auto-approve when configured (YOLO/RELAXED permission preset)
-    if (this.autoApprovePolicy === 'all') {
-      const allowOption = params.options.find(
-        (o) => o.kind === 'allow_always' || o.kind === 'allow_once'
-      );
-      if (allowOption) {
-        logger.debug('Auto-approving permission request per configured preset', {
-          sessionId: this.sessionId,
-          toolCallId: params.toolCall.toolCallId,
-        });
-        return Promise.resolve({
-          outcome: {
-            outcome: 'selected',
-            optionId: allowOption.optionId,
-          },
-        });
-      }
-      // No allow option available; fall through to interactive permission bridge
-      logger.warn(
-        'Auto-approve enabled but no allow option found; deferring to permission bridge',
-        {
-          sessionId: this.sessionId,
-          toolCallId: params.toolCall.toolCallId,
-          availableOptions: params.options.map((o) => o.kind),
-        }
-      );
+    const isPlanApproval = isExitPlanModeApprovalRequest(params);
+    const isUserInputRequest = isUserInputPermissionRequest(params);
+    const bypassesAutoApprove = isPlanApproval || isUserInputRequest;
+
+    const autoApproved = tryAutoApprovePermission({
+      request: params,
+      autoApprovePolicy: this.autoApprovePolicy,
+      bypassesAutoApprove,
+      sessionId: this.sessionId,
+    });
+    if (autoApproved) {
+      return Promise.resolve(autoApproved);
+    }
+
+    if (bypassesAutoApprove && this.autoApprovePolicy === 'all') {
+      logger.debug('Bypassing auto-approve for interactive request', {
+        sessionId: this.sessionId,
+        toolCallId: params.toolCall.toolCallId,
+        requestType: isPlanApproval ? 'ExitPlanMode' : 'requestUserInput',
+      });
     }
 
     if (!this.permissionBridge) {
-      // Fallback for non-interactive contexts; production paths should inject permissionBridge.
-      logger.warn('Permission bridge missing; auto-approving ACP permission request', {
-        sessionId: this.sessionId,
-        toolCallId: params.toolCall.toolCallId,
-      });
-      const allowOption = params.options.find(
-        (o) => o.kind === 'allow_always' || o.kind === 'allow_once'
+      return Promise.resolve(
+        resolveMissingBridgeOutcome({
+          request: params,
+          bypassesAutoApprove,
+          isPlanApproval,
+          sessionId: this.sessionId,
+        })
       );
-      return Promise.resolve({
-        outcome: {
-          outcome: 'selected',
-          optionId: allowOption?.optionId ?? params.options[0]?.optionId ?? 'unknown',
-        },
-      });
     }
 
     const requestId = crypto.randomUUID();


### PR DESCRIPTION
## Summary
- prevent ACP `autoApprovePolicy=all` from auto-approving interactive prompts
- require explicit approval for `ExitPlanMode` plan approvals
- require explicit approval for `item/tool/requestUserInput` / `AskUserQuestion` prompts
- fail closed for interactive prompts when no permission bridge is present (select reject option)
- preserve existing auto-approve behavior for non-interactive permission requests

## Root Cause
User permission presets (`YOLO` / `RELAXED`) map to `autoApprovePolicy=all`. The ACP client handler applied that policy to all permission requests, including interactive plan and question prompts.

## Validation
- `pnpm vitest src/backend/services/session/service/acp/acp-client-handler.test.ts`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ACP permission decision logic for interactive prompts, which can affect when actions require explicit user confirmation. While behavior is safer (fail-closed), regressions could block workflows or change approval outcomes.
> 
> **Overview**
> Prevents `autoApprovePolicy='all'` from auto-approving **interactive** ACP permission requests, specifically `ExitPlanMode` approvals and `requestUserInput`/`AskUserQuestion` prompts, forcing these to go through the permission bridge.
> 
> Refactors auto-approve into helper functions, adds explicit logging for bypassed requests, and changes the no-bridge fallback to **reject (fail closed)** for interactive prompts while keeping existing auto-approve behavior for non-interactive requests. Tests are expanded to cover these new bypass and fail-closed cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78583a1c70cc618fc749137002b911a53d0cb39e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->