### PR TITLE
Add notepad panel, merge-to-main button, sidebar state persistence, and misc fixes

### DIFF
--- a/prisma/migrations/20260318000000_add_workspace_notepad/migration.sql
+++ b/prisma/migrations/20260318000000_add_workspace_notepad/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Workspace" ADD COLUMN "notepad" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -217,6 +217,9 @@ model Workspace {
   cachedKanbanColumn  KanbanColumn      @default(WAITING)
   stateComputedAt     DateTime?         // Last kanban column computation
 
+  // Human-written notepad for workspace notes
+  notepad             String?
+
   @@index([projectId])
   @@index([status])
   @@index([cachedKanbanColumn])

--- a/src/backend/orchestration/data-backup.service.test.ts
+++ b/src/backend/orchestration/data-backup.service.test.ts
@@ -143,6 +143,7 @@ const mockWorkspace: Workspace = {
   hasHadSessions: true,
   cachedKanbanColumn: KanbanColumn.WORKING,
   stateComputedAt: new Date('2025-01-01T00:35:00.000Z'),
+  notepad: null,
   createdAt: new Date('2025-01-01T00:00:00.000Z'),
   updatedAt: new Date('2025-01-01T00:35:00.000Z'),
 };

--- a/src/backend/services/session/service/acp/acp-runtime-manager.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-manager.ts
@@ -622,9 +622,13 @@ export class AcpRuntimeManager {
             const binaryName = 'claude-agent-acp';
             const packageName = '@zed-industries/claude-agent-acp';
             const binaryPath = resolveAcpBinary(packageName, binaryName);
+            const args: string[] = [];
+            if (options.permissionPreset === 'YOLO') {
+              args.push('--dangerously-skip-permissions');
+            }
             return {
               command: binaryPath,
-              args: [],
+              args,
               commandLabel: binaryPath,
             };
           })();

--- a/src/backend/services/session/service/chat/chat-message-handlers/attachment-processing.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers/attachment-processing.ts
@@ -140,12 +140,21 @@ export function buildContentArray(
     content.push({ type: 'text', text: combinedText });
   }
 
+  const SUPPORTED_IMAGE_TYPES = new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp']);
+
   for (const attachment of imageAttachments) {
+    if (!SUPPORTED_IMAGE_TYPES.has(attachment.type)) {
+      logger.warn('Unsupported image media type, defaulting to image/png', {
+        originalType: attachment.type,
+        attachmentName: attachment.name,
+      });
+    }
+    const mediaType = SUPPORTED_IMAGE_TYPES.has(attachment.type) ? attachment.type : 'image/png';
     const imageContent: Extract<AgentContentItem, { type: 'image' }> = {
       type: 'image',
       source: {
         type: 'base64',
-        media_type: attachment.type,
+        media_type: mediaType,
         data: attachment.data,
       },
     };

--- a/src/backend/services/session/service/data/session-provider-resolver.service.test.ts
+++ b/src/backend/services/session/service/data/session-provider-resolver.service.test.ts
@@ -52,6 +52,7 @@ const createWorkspace = (overrides?: Partial<Workspace>): Workspace =>
     hasHadSessions: false,
     cachedKanbanColumn: 'WAITING',
     stateComputedAt: null,
+    notepad: null,
     createdAt: new Date('2026-01-01T00:00:00.000Z'),
     updatedAt: new Date('2026-01-01T00:00:00.000Z'),
     ...overrides,

--- a/src/backend/services/workspace/resources/workspace.accessor.ts
+++ b/src/backend/services/workspace/resources/workspace.accessor.ts
@@ -66,6 +66,8 @@ interface UpdateWorkspaceInput {
   ratchetLastCiRunId?: string | null;
   // Activity tracking
   hasHadSessions?: boolean;
+  // Notepad
+  notepad?: string | null;
   // Cached kanban column
   cachedKanbanColumn?: KanbanColumn;
   stateComputedAt?: Date | null;

--- a/src/backend/services/workspace/service/lifecycle/creation.service.test.ts
+++ b/src/backend/services/workspace/service/lifecycle/creation.service.test.ts
@@ -58,6 +58,7 @@ describe('WorkspaceCreationService', () => {
     hasHadSessions: false,
     cachedKanbanColumn: 'WAITING',
     stateComputedAt: null,
+    notepad: null,
     initErrorMessage: null,
     initOutput: null,
     initStartedAt: null,

--- a/src/backend/services/workspace/service/lifecycle/data.service.ts
+++ b/src/backend/services/workspace/service/lifecycle/data.service.ts
@@ -64,6 +64,10 @@ class WorkspaceDataService {
     });
   }
 
+  updateNotepad(id: string, notepad: string | null) {
+    return workspaceAccessor.update(id, { notepad });
+  }
+
   delete(id: string): Promise<Workspace> {
     return workspaceAccessor.delete(id);
   }

--- a/src/backend/trpc/workspace.trpc.ts
+++ b/src/backend/trpc/workspace.trpc.ts
@@ -400,6 +400,18 @@ export const workspaceRouter = router({
     .input(z.object({ workspaceId: z.string() }))
     .query(({ input }) => workspaceQueryService.hasChanges(input.workspaceId)),
 
+  // Update workspace notepad
+  updateNotepad: publicProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        notepad: z.string().nullable(),
+      })
+    )
+    .mutation(({ input }) => {
+      return workspaceDataService.updateNotepad(input.workspaceId, input.notepad);
+    }),
+
   // Merge sub-routers
   ...workspaceFilesRouter._def.procedures,
   ...workspaceGitRouter._def.procedures,

--- a/src/backend/trpc/workspace/git.trpc.ts
+++ b/src/backend/trpc/workspace/git.trpc.ts
@@ -1,9 +1,11 @@
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
+import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 import { isPathSafe } from '@/backend/lib/file-helpers';
 import { getMergeBase, parseGitStatusOutput } from '@/backend/lib/git-helpers';
-import { gitCommand } from '@/backend/lib/shell';
+import { execCommand, gitCommand } from '@/backend/lib/shell';
+import { archiveWorkspace } from '@/backend/orchestration/workspace-archive.orchestrator';
 import { workspaceDataService } from '@/backend/services/workspace';
 import { type Context, publicProcedure, router } from '@/backend/trpc/trpc';
 import {
@@ -215,5 +217,121 @@ export const workspaceGitRouter = router({
       }
 
       return { diff: result.stdout };
+    }),
+
+  // Merge workspace branch directly into the default branch (no PR)
+  mergeToMain: publicProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const logger = getLogger(ctx);
+      const { workspace, worktreePath } = await getWorkspaceWithProjectAndWorktreeOrThrow(
+        input.workspaceId
+      );
+
+      const branchName = workspace.branchName;
+      if (!branchName) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Workspace has no branch name',
+        });
+      }
+
+      const defaultBranch = workspace.project?.defaultBranch ?? 'main';
+      const repoPath = workspace.project?.repoPath;
+      if (!repoPath) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Project has no repo path',
+        });
+      }
+
+      logger.info('Merging workspace branch to default branch', {
+        workspaceId: input.workspaceId,
+        branchName,
+        defaultBranch,
+      });
+
+      // 1. Commit any uncommitted changes in the worktree
+      const statusResult = await gitCommand(['status', '--porcelain'], worktreePath);
+      if (statusResult.stdout.trim()) {
+        await gitCommand(['add', '-A'], worktreePath);
+        const commitResult = await gitCommand(
+          ['commit', '-m', `Auto-commit before merge to ${defaultBranch}`],
+          worktreePath
+        );
+        if (commitResult.code !== 0) {
+          throw new TRPCError({
+            code: 'INTERNAL_SERVER_ERROR',
+            message: `Failed to commit changes: ${commitResult.stderr}`,
+          });
+        }
+      }
+
+      // 2. Push the branch to remote
+      const pushResult = await gitCommand(['push', '-u', 'origin', branchName], worktreePath);
+      if (pushResult.code !== 0) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: `Failed to push branch: ${pushResult.stderr}`,
+        });
+      }
+
+      // 3. Use `gh api` to merge via GitHub API (avoids touching local main checkout)
+      const mergeResult = await execCommand(
+        'gh',
+        [
+          'api',
+          'repos/{owner}/{repo}/merges',
+          '-f',
+          `base=${defaultBranch}`,
+          '-f',
+          `head=${branchName}`,
+          '-f',
+          `commit_message=Merge ${branchName} into ${defaultBranch}`,
+        ],
+        { cwd: worktreePath }
+      );
+      if (mergeResult.code !== 0) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: `Merge failed: ${mergeResult.stderr}`,
+        });
+      }
+
+      // 4. Pull the merge into the main repo so local is up to date
+      await gitCommand(['pull', 'origin', defaultBranch], repoPath);
+
+      // 5. Clean up: delete remote branch
+      await gitCommand(['push', 'origin', '--delete', branchName], worktreePath).catch(() => {
+        logger.warn('Failed to delete remote branch after merge', { branchName });
+      });
+
+      // 6. Archive the workspace
+      const workspaceWithProject = await workspaceDataService.findByIdWithProject(
+        input.workspaceId
+      );
+      if (workspaceWithProject) {
+        try {
+          await archiveWorkspace(
+            workspaceWithProject,
+            { commitUncommitted: false },
+            ctx.appContext.services
+          );
+          logger.info('Archived workspace after merge', { workspaceId: input.workspaceId });
+        } catch (archiveError) {
+          logger.warn('Failed to archive workspace after merge', {
+            workspaceId: input.workspaceId,
+            error: archiveError instanceof Error ? archiveError.message : String(archiveError),
+          });
+        }
+      }
+
+      logger.info('Successfully merged workspace branch', {
+        workspaceId: input.workspaceId,
+        branchName,
+        defaultBranch,
+      });
+
+      return { success: true, defaultBranch, branchName };
     }),
 });

--- a/src/client/components/kanban/inline-workspace-form.tsx
+++ b/src/client/components/kanban/inline-workspace-form.tsx
@@ -108,6 +108,7 @@ function createOptimisticWorkingWorkspace(params: {
     hasHadSessions: false,
     cachedKanbanColumn: 'WORKING',
     stateComputedAt: null,
+    notepad: null,
     agentSessions: [],
     terminalSessions: [],
     kanbanColumn: 'WORKING',

--- a/src/client/components/kanban/kanban-board.stories.tsx
+++ b/src/client/components/kanban/kanban-board.stories.tsx
@@ -69,6 +69,7 @@ const baseWorkspace: WorkspaceWithKanban = {
   flowPhase: 'NO_PR',
   ratchetActiveSessionId: null,
   ratchetLastCiRunId: null,
+  notepad: null,
   isArchived: false,
 };
 

--- a/src/client/components/kanban/kanban-card.stories.tsx
+++ b/src/client/components/kanban/kanban-card.stories.tsx
@@ -78,6 +78,7 @@ const baseWorkspace: WorkspaceWithKanban = {
   flowPhase: 'NO_PR',
   ratchetActiveSessionId: null,
   ratchetLastCiRunId: null,
+  notepad: null,
   isArchived: false,
 };
 

--- a/src/client/components/kanban/kanban-column.stories.tsx
+++ b/src/client/components/kanban/kanban-column.stories.tsx
@@ -71,6 +71,7 @@ const baseWorkspace: WorkspaceWithKanban = {
   flowPhase: 'NO_PR',
   ratchetActiveSessionId: null,
   ratchetLastCiRunId: null,
+  notepad: null,
   isArchived: false,
 };
 

--- a/src/client/components/project-selector.tsx
+++ b/src/client/components/project-selector.tsx
@@ -1,4 +1,5 @@
 import { ChevronRight, ChevronsUpDown } from 'lucide-react';
+import { useState } from 'react';
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { cn } from '@/lib/utils';
@@ -51,6 +52,7 @@ export function ProjectSelectorDropdown({
   trailingSeparatorType?: 'chevron' | 'slash';
 }) {
   const isMobile = useIsMobile();
+  const [selectOpen, setSelectOpen] = useState(false);
   const selectedProject = projects?.find((project) => project.slug === selectedProjectSlug);
   const selectedProjectName = selectedProject?.name ?? 'Select a project';
   const projectButtonLabel =
@@ -69,7 +71,7 @@ export function ProjectSelectorDropdown({
   };
 
   const handleCurrentProjectClick = () => {
-    onCurrentProjectSelect?.();
+    setSelectOpen(true);
   };
 
   return (
@@ -82,20 +84,21 @@ export function ProjectSelectorDropdown({
       <button
         type="button"
         onClick={handleCurrentProjectClick}
-        disabled={!onCurrentProjectSelect}
         className={cn(
-          'min-w-0 truncate text-left',
-          onCurrentProjectSelect
-            ? 'cursor-pointer hover:text-foreground hover:underline focus-visible:text-foreground focus-visible:underline'
-            : 'cursor-default',
+          'min-w-0 truncate text-left cursor-pointer hover:text-foreground hover:underline focus-visible:text-foreground focus-visible:underline',
           DEFAULT_PROJECT_BUTTON_CLASS,
           projectButtonClassName
         )}
-        aria-label={`Open ${selectedProjectName} kanban`}
+        aria-label={`Open project picker`}
       >
         {projectButtonLabel}
       </button>
-      <Select value={selectedProjectSlug} onValueChange={handleValueChange}>
+      <Select
+        value={selectedProjectSlug}
+        onValueChange={handleValueChange}
+        open={selectOpen}
+        onOpenChange={setSelectOpen}
+      >
         <SelectTrigger
           id={triggerId}
           aria-label="Open project menu"

--- a/src/client/hooks/use-sidebar-default-open.ts
+++ b/src/client/hooks/use-sidebar-default-open.ts
@@ -49,9 +49,7 @@ function getPersistedState(category: RouteCategory): boolean | null {
 }
 
 // Categories where user overrides should NOT persist across navigations.
-// The board view should always start collapsed — the sidebar opens only
-// transiently (e.g. to click a link) and resets on next visit.
-const TRANSIENT_CATEGORIES: Set<RouteCategory> = new Set(['board']);
+const TRANSIENT_CATEGORIES: Set<RouteCategory> = new Set();
 
 export function clearTransientOverrideOnCategoryChange(
   overrides: Partial<Record<RouteCategory, boolean>>,

--- a/src/client/routes/projects/workspaces/workspace-detail-header.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-header.tsx
@@ -20,6 +20,7 @@ import {
   WorkspaceHeaderOverflowMenu,
   type WorkspaceHeaderProps,
   WorkspaceIssueLink,
+  WorkspaceMergeAction,
   WorkspacePrAction,
   WorkspaceProviderSettings,
   WorkspaceSwitcherDropdown,
@@ -84,6 +85,7 @@ export function WorkspaceDetailHeaderSlot({
             isCreatingSession={isCreatingSession}
             handleQuickAction={handleQuickAction}
           />
+          <WorkspaceMergeAction workspace={workspace} hasChanges={hasChanges} running={running} />
           <WorkspaceIssueLink workspace={workspace} />
           <WorkspaceCiStatus workspace={workspace} />
           <RunScriptPortBadge workspaceId={workspaceId} />

--- a/src/client/routes/projects/workspaces/workspace-detail-header/index.ts
+++ b/src/client/routes/projects/workspaces/workspace-detail-header/index.ts
@@ -8,5 +8,10 @@ export { getWorkspaceHeaderLabel } from './utils';
 export { WorkspaceBranchLink } from './workspace-branch-link';
 export { WorkspaceHeaderOverflowMenu } from './workspace-header-overflow-menu';
 export { WorkspaceProviderSettings } from './workspace-provider-settings';
-export { WorkspaceCiStatus, WorkspaceIssueLink, WorkspacePrAction } from './workspace-status';
+export {
+  WorkspaceCiStatus,
+  WorkspaceIssueLink,
+  WorkspaceMergeAction,
+  WorkspacePrAction,
+} from './workspace-status';
 export { WorkspaceSwitcherDropdown } from './workspace-switcher-dropdown';

--- a/src/client/routes/projects/workspaces/workspace-detail-header/workspace-status.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-header/workspace-status.tsx
@@ -1,4 +1,5 @@
-import { CheckCircle2, CircleDot, GitPullRequest } from 'lucide-react';
+import { CheckCircle2, CircleDot, GitMerge, GitPullRequest } from 'lucide-react';
+import { trpc } from '@/client/lib/trpc';
 import { CiStatusChip } from '@/components/shared/ci-status-chip';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -75,6 +76,48 @@ export function WorkspacePrAction({
   }
 
   return null;
+}
+
+type WorkspaceMergeActionProps = {
+  workspace: WorkspaceHeaderWorkspace;
+  hasChanges?: boolean;
+  running: boolean;
+};
+
+export function WorkspaceMergeAction({
+  workspace,
+  hasChanges,
+  running,
+}: WorkspaceMergeActionProps) {
+  const utils = trpc.useUtils();
+  const mergeMutation = trpc.workspace.mergeToMain.useMutation({
+    onSuccess: () => {
+      void utils.workspace.get.invalidate({ id: workspace.id });
+    },
+  });
+
+  // Show merge button when there are changes, no session running, and no PR
+  if (!hasChanges || running || isWorkspaceMerged(workspace) || hasVisiblePullRequest(workspace)) {
+    return null;
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 gap-1 text-xs px-2"
+          disabled={mergeMutation.isPending}
+          onClick={() => mergeMutation.mutate({ workspaceId: workspace.id })}
+        >
+          <GitMerge className="h-3 w-3" />
+          {mergeMutation.isPending ? 'Merging...' : 'Merge'}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>Merge this branch directly into the default branch</TooltipContent>
+    </Tooltip>
+  );
 }
 
 export function WorkspaceIssueLink({ workspace }: { workspace: WorkspaceHeaderWorkspace }) {

--- a/src/components/workspace/index.ts
+++ b/src/components/workspace/index.ts
@@ -7,6 +7,7 @@ export * from './file-viewer';
 export * from './git-summary-panel';
 export * from './main-view-content';
 export * from './main-view-tab-bar';
+export * from './notepad-panel';
 export * from './quick-actions-menu';
 export * from './ratchet-state';
 export * from './ratchet-toggle-button';

--- a/src/components/workspace/notepad-panel.tsx
+++ b/src/components/workspace/notepad-panel.tsx
@@ -1,0 +1,84 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { trpc } from '@/client/lib/trpc';
+import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
+
+interface NotepadPanelProps {
+  workspaceId: string;
+  className?: string;
+}
+
+export function NotepadPanel({ workspaceId, className }: NotepadPanelProps) {
+  const utils = trpc.useUtils();
+
+  const { data: workspace } = trpc.workspace.get.useQuery({ id: workspaceId });
+
+  // Read from React Query cache synchronously on mount
+  const cachedWorkspace = utils.workspace.get.getData({ id: workspaceId });
+
+  const [notepad, setNotepad] = useState(() => cachedWorkspace?.notepad ?? '');
+  const [isSaving, setIsSaving] = useState(false);
+
+  // If cache had data on mount, we're already initialized — skip server sync.
+  // Only sync from server on cold start (no cache).
+  const initializedRef = useRef(!!cachedWorkspace);
+
+  useEffect(() => {
+    if (!initializedRef.current && workspace?.notepad !== undefined) {
+      initializedRef.current = true;
+      setNotepad(workspace.notepad ?? '');
+    }
+  }, [workspace?.notepad]);
+
+  const updateNotepadMutation = trpc.workspace.updateNotepad.useMutation({
+    onMutate: async ({ notepad: newNotepad }) => {
+      await utils.workspace.get.cancel({ id: workspaceId });
+      utils.workspace.get.setData({ id: workspaceId }, (old) => {
+        if (!old) {
+          return old;
+        }
+        return { ...old, notepad: newNotepad };
+      });
+    },
+    onSettled: () => {
+      setIsSaving(false);
+    },
+  });
+
+  useEffect(() => {
+    if (!workspace || notepad === (workspace.notepad ?? '')) {
+      return;
+    }
+
+    const timeoutId = setTimeout(() => {
+      setIsSaving(true);
+      updateNotepadMutation.mutate({
+        workspaceId,
+        notepad: notepad || null,
+      });
+    }, 1000);
+
+    return () => clearTimeout(timeoutId);
+  }, [notepad, workspace, workspaceId, updateNotepadMutation]);
+
+  const handleChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setNotepad(e.target.value);
+  }, []);
+
+  return (
+    <div className={cn('flex flex-col h-full', className)}>
+      <div className="flex items-center justify-between px-3 py-2 border-b bg-muted/30">
+        <span className="text-sm font-medium">Notes</span>
+        {isSaving && <span className="text-xs text-muted-foreground">Saving...</span>}
+      </div>
+      <div className="flex-1 p-3 overflow-auto">
+        <Textarea
+          value={notepad}
+          onChange={handleChange}
+          placeholder="Add notes about this workspace..."
+          className="min-h-[200px] resize-none border-0 focus-visible:ring-0 focus-visible:ring-offset-0 p-0 font-mono text-sm"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/workspace/right-panel.tsx
+++ b/src/components/workspace/right-panel.tsx
@@ -1,4 +1,4 @@
-import { Camera, FileQuestion, Files, ListTodo, Plus, Terminal } from 'lucide-react';
+import { Camera, FileQuestion, Files, ListTodo, NotebookPen, Plus, Terminal } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { trpc } from '@/client/lib/trpc';
 import type { ChatMessage } from '@/components/chat';
@@ -10,6 +10,7 @@ import { cn } from '@/lib/utils';
 import { CombinedChangesPanel } from './combined-changes-panel';
 import { DevLogsPanel } from './dev-logs-panel';
 import { FileBrowserPanel } from './file-browser-panel';
+import { NotepadPanel } from './notepad-panel';
 import { ScreenshotsPanel } from './screenshots-panel';
 import { SetupLogsPanel } from './setup-logs-panel';
 import { TerminalPanel, type TerminalPanelRef, type TerminalTabState } from './terminal-panel';
@@ -29,7 +30,7 @@ const STORAGE_KEY_TOP_TAB_PREFIX = 'workspace-right-panel-tab-';
 // Types
 // =============================================================================
 
-type TopPanelTab = 'changes' | 'files' | 'tasks' | 'screenshots';
+type TopPanelTab = 'changes' | 'files' | 'tasks' | 'screenshots' | 'notes';
 type LogsBottomTab = Exclude<BottomPanelTab, 'terminal'>;
 
 interface PersistedTopPanelState {
@@ -41,7 +42,13 @@ function isLogsBottomTab(tab: BottomPanelTab): tab is LogsBottomTab {
 }
 
 function parseStoredTopTab(value: string | null): TopPanelTab | null {
-  if (value === 'changes' || value === 'files' || value === 'tasks' || value === 'screenshots') {
+  if (
+    value === 'changes' ||
+    value === 'files' ||
+    value === 'tasks' ||
+    value === 'screenshots' ||
+    value === 'notes'
+  ) {
     return value;
   }
   // Legacy migration: old values were direct changes sub-views.
@@ -106,6 +113,7 @@ function TopPanelArea({
   const showFiles = activeTopTab === 'files';
   const showTasks = activeTopTab === 'tasks';
   const showScreenshots = activeTopTab === 'screenshots';
+  const showNotes = activeTopTab === 'notes';
 
   const screenshotsButtonClassName = cn(
     'h-6 w-6 flex-shrink-0 flex items-center justify-center rounded-md transition-colors',
@@ -136,6 +144,12 @@ function TopPanelArea({
           isActive={showTasks}
           onSelect={() => onTopTabChange('tasks')}
         />
+        <TabButton
+          label="Notes"
+          icon={<NotebookPen className="h-3.5 w-3.5" />}
+          isActive={showNotes}
+          onSelect={() => onTopTabChange('notes')}
+        />
 
         <div className="flex-1" />
 
@@ -164,8 +178,13 @@ function TopPanelArea({
         {showFiles && <FileBrowserPanel workspaceId={workspaceId} />}
         {showTasks && <TodoPanelContainer messages={messages} />}
         {showScreenshots && (
-          <ScreenshotsPanel workspaceId={workspaceId} onTakeScreenshots={onTakeScreenshots} />
+          <ScreenshotsPanel
+            workspaceId={workspaceId}
+            onTakeScreenshots={onTakeScreenshots}
+            onNewScreenshot={() => onTopTabChange('screenshots')}
+          />
         )}
+        {showNotes && <NotepadPanel workspaceId={workspaceId} />}
       </div>
     </div>
   );

--- a/src/components/workspace/screenshots-panel.tsx
+++ b/src/components/workspace/screenshots-panel.tsx
@@ -13,13 +13,18 @@ import { useWorkspacePanel } from './workspace-panel-context';
 interface ScreenshotsPanelProps {
   workspaceId: string;
   onTakeScreenshots?: () => void;
+  onNewScreenshot?: () => void;
 }
 
 // =============================================================================
 // Main Component
 // =============================================================================
 
-export function ScreenshotsPanel({ workspaceId, onTakeScreenshots }: ScreenshotsPanelProps) {
+export function ScreenshotsPanel({
+  workspaceId,
+  onTakeScreenshots,
+  onNewScreenshot,
+}: ScreenshotsPanelProps) {
   const { openTab } = useWorkspacePanel();
   const utils = trpc.useUtils();
   const [isTaking, setIsTaking] = useState(false);
@@ -38,13 +43,16 @@ export function ScreenshotsPanel({ workspaceId, onTakeScreenshots }: Screenshots
 
   const screenshots = data?.screenshots ?? [];
 
-  // Clear isTaking when new screenshots appear
+  // Clear isTaking when new screenshots appear and notify parent
   useEffect(() => {
+    if (screenshots.length > prevCountRef.current && prevCountRef.current > 0) {
+      onNewScreenshot?.();
+    }
     if (isTaking && screenshots.length > prevCountRef.current) {
       setIsTaking(false);
     }
     prevCountRef.current = screenshots.length;
-  }, [screenshots.length, isTaking]);
+  }, [screenshots.length, isTaking, onNewScreenshot]);
 
   const handleTakeScreenshots = useCallback(() => {
     setIsTaking(true);


### PR DESCRIPTION
## Summary

- **Workspace notepad**: New persistent notes panel in the right sidebar with 1-second autosave debounce and optimistic updates
- **Merge-to-main button**: Directly merge a workspace branch into the default branch without creating a PR (commits uncommitted changes, pushes, merges via GitHub API, cleans up remote branch, archives workspace)
- **Sidebar state persistence**: Remember sidebar open/closed state across board navigation (removed `board` from transient categories so user preference sticks)
- **Project selector fix**: Clicking the current project name in the breadcrumb now opens the project picker dropdown instead of navigating away
- **Screenshots auto-switch**: Right panel auto-navigates to the screenshots tab when a new screenshot is captured
- **YOLO session fix**: Pass `--dangerously-skip-permissions` to `claude-agent-acp` when permission preset is YOLO
- **Attachment type fix**: Handle unsupported image media types gracefully (warn and default to `image/png` instead of sending an invalid type)

## Test plan

- [ ] Open a workspace, add notes in the Notes tab — verify autosave and persistence across navigation
- [ ] On a workspace with changes but no PR, click the Merge button in the header — verify branch merges and workspace archives
- [ ] Toggle sidebar open/closed on board view, navigate away and back — verify state is remembered
- [ ] Click the project name in the breadcrumb — verify project picker opens
- [ ] Take a screenshot from the chat — verify panel auto-switches to Screenshots tab
- [ ] Run `pnpm test` and `pnpm typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)