### PR TITLE
Fix project selector: clicking project name opens picker dropdown

### DIFF
--- a/src/client/components/project-selector.tsx
+++ b/src/client/components/project-selector.tsx
@@ -1,4 +1,5 @@
 import { ChevronRight, ChevronsUpDown } from 'lucide-react';
+import { useState } from 'react';
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { cn } from '@/lib/utils';
@@ -51,6 +52,7 @@ export function ProjectSelectorDropdown({
   trailingSeparatorType?: 'chevron' | 'slash';
 }) {
   const isMobile = useIsMobile();
+  const [selectOpen, setSelectOpen] = useState(false);
   const selectedProject = projects?.find((project) => project.slug === selectedProjectSlug);
   const selectedProjectName = selectedProject?.name ?? 'Select a project';
   const projectButtonLabel =
@@ -69,7 +71,7 @@ export function ProjectSelectorDropdown({
   };
 
   const handleCurrentProjectClick = () => {
-    onCurrentProjectSelect?.();
+    setSelectOpen(true);
   };
 
   return (
@@ -82,20 +84,21 @@ export function ProjectSelectorDropdown({
       <button
         type="button"
         onClick={handleCurrentProjectClick}
-        disabled={!onCurrentProjectSelect}
         className={cn(
-          'min-w-0 truncate text-left',
-          onCurrentProjectSelect
-            ? 'cursor-pointer hover:text-foreground hover:underline focus-visible:text-foreground focus-visible:underline'
-            : 'cursor-default',
+          'min-w-0 truncate text-left cursor-pointer hover:text-foreground hover:underline focus-visible:text-foreground focus-visible:underline',
           DEFAULT_PROJECT_BUTTON_CLASS,
           projectButtonClassName
         )}
-        aria-label={`Open ${selectedProjectName} kanban`}
+        aria-label={`Open project picker`}
       >
         {projectButtonLabel}
       </button>
-      <Select value={selectedProjectSlug} onValueChange={handleValueChange}>
+      <Select
+        value={selectedProjectSlug}
+        onValueChange={handleValueChange}
+        open={selectOpen}
+        onOpenChange={setSelectOpen}
+      >
         <SelectTrigger
           id={triggerId}
           aria-label="Open project menu"


### PR DESCRIPTION
## Summary

- Clicking the current project name in the top-left breadcrumb now opens the project picker dropdown, instead of calling `onCurrentProjectSelect` (which often did nothing or navigated away)
- The button is now always clickable (removed the `disabled` state tied to `onCurrentProjectSelect`)

## Test plan

- [ ] Click the project name in the top-left — verify the project picker dropdown opens
- [ ] Select a different project from the dropdown — verify navigation works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)