### PR TITLE
Expose server error details in compose dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:7001}
       - LOG_LEVEL=${LOG_LEVEL:-info}
       - CLOUD_MODE=${CLOUD_MODE:-cloudflare}
+      - FF_EXPOSE_SERVER_ERROR_DETAILS=${FF_EXPOSE_SERVER_ERROR_DETAILS:-true}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:7001/health"]
       interval: 30s

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -53,6 +53,19 @@ import type { ServerInstance } from './types/server-instance';
 
 export type { ServerInstance };
 
+type HttpError = Error & {
+  status?: number;
+  statusCode?: number;
+};
+
+function getHttpErrorStatus(error: HttpError): number {
+  const status = error.statusCode ?? error.status;
+  if (typeof status !== 'number' || status < 400 || status > 599) {
+    return 500;
+  }
+  return status;
+}
+
 /**
  * Create and configure the backend server.
  * Environment variables must be set before calling this function.
@@ -210,11 +223,19 @@ export function createServer(requestedPort?: number, appContext?: AppContext): S
   // Error Handling
   // ============================================================================
   app.use(
-    (err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    (err: HttpError, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+      const status = getHttpErrorStatus(err);
+      const exposeDetails = configService.shouldExposeServerErrorDetails();
+
       logger.error('Unhandled error', err);
-      res.status(500).json({
-        error: 'Internal server error',
-        message: configService.isDevelopment() ? err.message : 'An unexpected error occurred',
+      res.status(status).json({
+        error: status >= 500 ? 'Internal server error' : 'Request error',
+        message: exposeDetails
+          ? (err.stack ?? err.message)
+          : status >= 500
+            ? 'An unexpected error occurred'
+            : err.message,
+        ...(exposeDetails ? { name: err.name, stack: err.stack } : {}),
       });
     }
   );

--- a/src/backend/server.upgrade.test.ts
+++ b/src/backend/server.upgrade.test.ts
@@ -92,6 +92,7 @@ type TestHarnessOptions = {
   backendHost?: string;
   frontendStaticPath?: string | null;
   isRunScriptProxyEnabled?: boolean;
+  shouldExposeServerErrorDetails?: boolean;
   requestedPortResult?: number;
 };
 
@@ -112,6 +113,7 @@ function createTestHarness(options: TestHarnessOptions = {}) {
       getEnvironment: () => 'test',
       getFrontendStaticPath: () => options.frontendStaticPath ?? null,
       isDevelopment: () => false,
+      shouldExposeServerErrorDetails: () => options.shouldExposeServerErrorDetails ?? false,
       isRunScriptProxyEnabled: () => options.isRunScriptProxyEnabled ?? false,
       getCorsConfig: () => ({ allowedOrigins: ['http://localhost:3000'] }),
       getAppVersion: () => 'test-version',
@@ -470,5 +472,40 @@ describe('server websocket upgrade routing', () => {
         error: expect.any(String),
       })
     );
+  });
+
+  it('preserves non-500 statuses while hiding stack details by default', async () => {
+    const harness = createTestHarness();
+    const server = createTestServer(harness.context);
+
+    const response = await request(server.getHttpServer())
+      .post('/health')
+      .set('content-type', 'application/json')
+      .send('{"invalid": }');
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      error: 'Request error',
+      message: expect.any(String),
+    });
+    expect(response.body.message).not.toContain('SyntaxError');
+    expect(response.body.stack).toBeUndefined();
+    expect(harness.logger.error).toHaveBeenCalledWith('Unhandled error', expect.any(SyntaxError));
+  });
+
+  it('includes stack details in error responses when enabled', async () => {
+    const harness = createTestHarness({ shouldExposeServerErrorDetails: true });
+    const server = createTestServer(harness.context);
+
+    const response = await request(server.getHttpServer())
+      .post('/health')
+      .set('content-type', 'application/json')
+      .send('{"invalid": }');
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Request error');
+    expect(response.body.name).toBe('SyntaxError');
+    expect(response.body.message).toContain('SyntaxError');
+    expect(response.body.stack).toContain('SyntaxError');
   });
 });

--- a/src/backend/services/config.service.test.ts
+++ b/src/backend/services/config.service.test.ts
@@ -57,6 +57,7 @@ describe('configService environment accessors', () => {
     process.env.ACP_TRACE_LOGS_PATH = '/tmp/acp-trace';
     process.env.FF_RUN_SCRIPT_PROXY_ENABLED = '1';
     process.env.WS_LOGS_ENABLED = 'true';
+    process.env.FF_EXPOSE_SERVER_ERROR_DETAILS = 'true';
     process.env.DEBUG_CHAT_WS = 'true';
     process.env.NOTIFICATION_SOUND_ENABLED = 'false';
     process.env.NOTIFICATION_PUSH_ENABLED = 'true';
@@ -88,6 +89,7 @@ describe('configService environment accessors', () => {
     expect(configService.getAcpTraceLogsPath()).toBe('/tmp/acp-trace');
     expect(configService.isRunScriptProxyEnabled()).toBe(true);
     expect(configService.isWsLogsEnabled()).toBe(true);
+    expect(configService.shouldExposeServerErrorDetails()).toBe(true);
     expect(configService.getWebConcurrency()).toBe(3);
     expect(configService.getBranchRenameMessageThreshold()).toBe(4);
     expect(configService.getAppVersion()).toBe('9.9.9');
@@ -138,6 +140,7 @@ describe('configService environment accessors', () => {
     expect(configService.getMaxSessionsPerWorkspace()).toBeGreaterThan(0);
     expect(configService.getFrontendStaticPath()).toBe('/tmp/frontend');
     expect(configService.getMigrationsPath()).toBe('/tmp/migrations');
+    expect(configService.shouldExposeServerErrorDetails()).toBe(true);
     expect(configService.getAvailableModels()).toEqual(
       expect.arrayContaining([
         { alias: 'sonnet', model: expect.any(String) },
@@ -153,5 +156,18 @@ describe('configService environment accessors', () => {
     const systemConfig = configService.getSystemConfig();
     expect(systemConfig.backendPort).toBe(configService.getBackendPort());
     expect(systemConfig.logger.serviceName).toBeDefined();
+  });
+
+  it('allows overriding server error detail exposure outside development', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.FF_EXPOSE_SERVER_ERROR_DETAILS = 'false';
+    configService.reload();
+
+    expect(configService.shouldExposeServerErrorDetails()).toBe(false);
+
+    process.env.FF_EXPOSE_SERVER_ERROR_DETAILS = 'true';
+    configService.reload();
+
+    expect(configService.shouldExposeServerErrorDetails()).toBe(true);
   });
 });

--- a/src/backend/services/config.service.ts
+++ b/src/backend/services/config.service.ts
@@ -140,6 +140,7 @@ interface SystemConfig {
   acpTraceLogsEnabled: boolean;
   wsLogsEnabled: boolean;
   runScriptProxyEnabled: boolean;
+  exposeServerErrorDetails: boolean;
 
   // Event compression settings
   compression: CompressionConfig;
@@ -270,6 +271,7 @@ function loadSystemConfig(): SystemConfig {
   const nodeEnv = env.NODE_ENV;
   const debugLogDir = join(baseDir, 'debug');
   const acpTraceLogsEnabled = env.ACP_TRACE_LOGS_ENABLED ?? nodeEnv === 'development';
+  const exposeServerErrorDetails = env.FF_EXPOSE_SERVER_ERROR_DETAILS ?? nodeEnv === 'development';
   const databasePathFromEnv = env.DATABASE_PATH ? expandEnvVars(env.DATABASE_PATH) : undefined;
   const migrationsPath = env.MIGRATIONS_PATH ? expandEnvVars(env.MIGRATIONS_PATH) : undefined;
 
@@ -327,6 +329,7 @@ function loadSystemConfig(): SystemConfig {
     acpTraceLogsEnabled,
     wsLogsEnabled: env.WS_LOGS_ENABLED,
     runScriptProxyEnabled: env.FF_RUN_SCRIPT_PROXY_ENABLED,
+    exposeServerErrorDetails,
 
     // Event compression settings
     compression: {
@@ -583,6 +586,13 @@ class ConfigService {
    */
   isRunScriptProxyEnabled(): boolean {
     return this.config.runScriptProxyEnabled;
+  }
+
+  /**
+   * Check if server error responses should include internal details.
+   */
+  shouldExposeServerErrorDetails(): boolean {
+    return this.config.exposeServerErrorDetails;
   }
 
   /**

--- a/src/backend/services/env-schemas.ts
+++ b/src/backend/services/env-schemas.ts
@@ -73,6 +73,10 @@ export const ConfigEnvSchema = z.object({
   ACP_TRACE_LOGS_ENABLED: z.preprocess(parseBoolean, z.boolean()).optional().catch(undefined),
   ACP_TRACE_LOGS_PATH: z.preprocess(toTrimmedString, z.string()).optional().catch(undefined),
   WS_LOGS_ENABLED: z.preprocess(parseBoolean, z.boolean()).catch(false),
+  FF_EXPOSE_SERVER_ERROR_DETAILS: z
+    .preprocess(parseBoolean, z.boolean())
+    .optional()
+    .catch(undefined),
   WEB_CONCURRENCY: z
     .preprocess(parseInteger, z.number().int().nonnegative())
     .optional()


### PR DESCRIPTION
## Summary
- add an explicit `FF_EXPOSE_SERVER_ERROR_DETAILS` config/env flag instead of tying verbose server errors to `NODE_ENV`
- return stack traces in HTTP error responses when that flag is enabled while preserving explicit non-500 statuses
- enable the flag by default in Docker compose so local compose development surfaces stack traces

## Testing
- `pnpm exec vitest run src/backend/server.upgrade.test.ts src/backend/services/config.service.test.ts`

## Notes
- `pnpm typecheck` currently fails on unrelated existing repository issues around user settings fields and ratchet state typing in files such as `src/backend/orchestration/data-backup.service.ts`, `src/backend/services/settings/resources/user-settings.accessor.ts`, and `src/client/routes/admin-page.tsx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes HTTP error responses to optionally include stack traces and preserves non-500 status codes; if enabled in production it can leak internal details, so misconfiguration is the primary risk.
> 
> **Overview**
> Adds a new `FF_EXPOSE_SERVER_ERROR_DETAILS` env/config flag (validated in `env-schemas.ts` and exposed via `configService.shouldExposeServerErrorDetails()`) to control whether API error responses include internal stack details independent of `NODE_ENV`.
> 
> Updates the Express error handler in `server.ts` to **preserve explicit HTTP status codes** (e.g., 400 from JSON parsing) and to conditionally return stack/name/stacktrace when the flag is enabled; `docker-compose.yml` now enables this flag by default for compose runs. Tests are extended to cover the new config behavior and the two response modes (hidden vs exposed details).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1518ec3beb04939284944869ef15dd023554a167. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->