### PR TITLE
Add auto-iteration logbook to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ tunnel-url/
 
 # Port file for postRun script discovery
 .factory-factory-port
+
+# Auto-iteration logbook (ephemeral runtime state)
+.factory-factory/auto-iteration-logbook.json


### PR DESCRIPTION
## Summary
- Adds `.factory-factory/auto-iteration-logbook.json` to `.gitignore` to prevent committing ephemeral runtime state.

## Test plan
- N/A — gitignore-only change.