### PR TITLE
Improve auto-iteration eval visibility and fix live test output

### DIFF
--- a/docs/design-auto-iteration-eval-ui.md
+++ b/docs/design-auto-iteration-eval-ui.md
@@ -1,0 +1,100 @@
+# Design Doc: Auto-Iteration Eval Visibility UI Improvements
+
+## Problem Statement
+
+Three related issues make the auto-iteration UI opaque during the measure/evaluate phase:
+
+### Issue 1 — Live test output is not actually live (bug)
+
+The panel has a `LiveTestOutput` section intended to stream stdout/stderr from the test command. It doesn't work because:
+
+- `runTestCommand` buffers all output locally and resolves only when the process exits — no incremental updates
+- During the `measuring` phase, `lastTestOutput` in the progress object is **not updated** — it still holds the value from the previous phase transition. The current test's output is only written to `lastTestOutput` *after* the test completes, when the phase transitions to `evaluating`
+- So during the entire test run window (`measuring` phase, which can last 10s–5min), the panel shows either nothing or stale output from a prior iteration
+
+Relevant code:
+- `auto-iteration.service.ts:540` — `emitPhase(loop, 'measuring')` called with no output arg → `lastTestOutput` unchanged
+- `test-runner.service.ts:14–69` — `runTestCommand` returns a Promise; no streaming callback
+- `auto-iteration.service.ts:596` — `emitPhase(loop, 'evaluating', postOutput)` only called after test completes
+
+### Issue 2 — Eval phase is invisible in the stepper
+
+The 3-stage banner stepper maps:
+
+| Backend Phase | UI Stage |
+|---|---|
+| `implementing` | Improve |
+| `measuring` | **Measure** |
+| `evaluating` | **Measure** ← same stage |
+| `critiquing` | Critique |
+
+Both `measuring` (running the test command) and `evaluating` (LLM deciding `improved`/`targetReached`) collapse into one "Measure" step. Users cannot tell which sub-step is active.
+
+### Issue 3 — No indication of eval LLM result
+
+When the LLM evaluation finishes (`evaluating` → `critiquing`/`idle`), there's no moment where the panel surfaces the decision (`improved: true/false`, `metricSummary`). The result only appears post-hoc in the logbook entry.
+
+---
+
+## Proposed Design
+
+### Fix 1 — Stream test output incrementally
+
+**Approach:** Use an in-memory accumulator on the running loop rather than DB writes per-chunk.
+
+1. Add `currentTestOutputBuffer: string` to the `RunningLoop` in-memory object
+2. Modify `runTestCommand` to accept an optional `onChunk: (chunk: string) => void` callback
+3. In `runIteration`, pass a callback that appends to `loop.currentTestOutputBuffer` as stdout/stderr chunks arrive
+4. Modify `getStatus()` to return `currentTestOutputBuffer` as `lastTestOutput` when phase is `measuring`
+5. When `emitPhase('evaluating', postOutput)` is called, the final truncated output replaces it
+
+This keeps DB writes unchanged (still one write per phase transition) while making in-memory state reflect live output. Since the panel polls `getStatus` every 3s and `getStatus` reads from in-memory state when running, live chunks will appear within 3s of being emitted.
+
+**Impact:** No DB schema changes, no new endpoints. Minimal change surface.
+
+### Fix 2 — Sub-indicator inside "Measure" step
+
+In both the progress banner and the panel's phase indicator, distinguish between the two sub-states within the "Measure" stage:
+
+| `currentPhase` | Sub-indicator label |
+|---|---|
+| `measuring` | Running tests... |
+| `evaluating` | Evaluating with LLM... |
+
+**Banner:** Keep 3 steps (Improve → Measure → Critique). Inside the active "Measure" step, render a small secondary label showing the current sub-state.
+
+**Panel PhaseIndicator:** Same label distinction.
+
+### Fix 3 — Show eval result briefly after eval completes
+
+After the `evaluating` phase ends, surface the LLM's decision before the panel moves on:
+
+- During `evaluating`: show test output + "Evaluating with LLM..." spinner overlay at bottom of output pane
+- When eval completes and phase transitions: flash the result in the phase indicator area (e.g. "Improved ✓" or "Regressed — reverting") for the duration of the `critiquing` or revert phase
+
+**Implementation options:**
+- Option A (simplest): Store `lastEvalDecision: { improved: boolean; metricSummary: string } | null` in `AutoIterationProgress`, set it during `evaluating` phase, clear it at end of iteration
+- Option B: Derive from `currentMetricSummary` change — but this only updates on accepted iterations, so it misses regressions
+
+Recommend Option A.
+
+---
+
+## Files Affected
+
+| File | Change |
+|---|---|
+| `test-runner.service.ts` | Add `onChunk` callback param to `runTestCommand` |
+| `auto-iteration.types.ts` | Add `currentTestOutputBuffer` to `RunningLoop`; add `lastEvalDecision` to `AutoIterationProgress` |
+| `auto-iteration.service.ts` | Wire `onChunk` in `runIteration`; set `lastEvalDecision` in evaluate phase; clear on iteration end |
+| `auto-iteration.trpc.ts` | Return `currentTestOutputBuffer` as `lastTestOutput` override when phase is `measuring` |
+| `auto-iteration-progress-banner.tsx` | Add sub-label inside Measure step |
+| `auto-iteration-panel.tsx` | Update `PhaseIndicator` sub-labels; add eval result display |
+
+---
+
+## Out of Scope
+
+- Streaming LLM eval tokens (adds significant complexity; Option A decision display is sufficient)
+- Persisting eval logs to logbook (only show live)
+- Changes to the compact banner beyond sub-indicator label

--- a/src/backend/services/auto-iteration/service/auto-iteration.service.ts
+++ b/src/backend/services/auto-iteration/service/auto-iteration.service.ts
@@ -41,14 +41,14 @@ type Logger = ReturnType<typeof createLogger>;
 /** Default prompt timeout: 20 minutes. */
 const DEFAULT_PROMPT_TIMEOUT_SECONDS = 1200;
 
-/** Cap streaming lastTestOutput at 512 KB to prevent unbounded in-memory growth. */
-const MAX_STREAMING_OUTPUT_BYTES = 512 * 1024;
+/** Cap streaming lastTestOutput at ~512K characters to prevent unbounded in-memory growth. */
+const MAX_STREAMING_OUTPUT_CHARS = 512 * 1024;
 
 /** Append a chunk to lastTestOutput, keeping only the tail when the cap is exceeded. */
 function appendStreamingOutput(current: string | null, chunk: string): string {
   const updated = (current ?? '') + chunk;
-  if (updated.length > MAX_STREAMING_OUTPUT_BYTES) {
-    return updated.slice(-MAX_STREAMING_OUTPUT_BYTES);
+  if (updated.length > MAX_STREAMING_OUTPUT_CHARS) {
+    return updated.slice(-MAX_STREAMING_OUTPUT_CHARS);
   }
   return updated;
 }

--- a/src/backend/services/auto-iteration/service/auto-iteration.service.ts
+++ b/src/backend/services/auto-iteration/service/auto-iteration.service.ts
@@ -127,6 +127,7 @@ export class AutoIterationService {
         lastIterationAt: null,
         currentPhase: 'baseline',
         lastTestOutput: null,
+        lastEvalDecision: null,
       },
       pauseRequested: false,
       stopRequested: false,
@@ -155,10 +156,14 @@ export class AutoIterationService {
       // Run baseline measurement
       this.logger.info('Running baseline measurement', { workspaceId });
       await this.emitPhase(placeholder, 'baseline');
+      placeholder.progress.lastTestOutput = null;
       const baselineResult = await runTestCommand(
         worktreePath,
         config.testCommand,
-        config.testTimeoutSeconds
+        config.testTimeoutSeconds,
+        (chunk) => {
+          placeholder.progress.lastTestOutput = (placeholder.progress.lastTestOutput ?? '') + chunk;
+        }
       );
       const baselineOutput = truncateTestOutput(
         `${baselineResult.stdout}\n${baselineResult.stderr}`
@@ -200,6 +205,7 @@ export class AutoIterationService {
         lastIterationAt: null,
         currentPhase: 'idle',
         lastTestOutput: baselineOutput,
+        lastEvalDecision: null,
       };
 
       // Update the placeholder with real data
@@ -496,12 +502,19 @@ export class AutoIterationService {
     const { config, progress } = loop;
     const metricBefore = progress.currentMetricSummary;
 
+    // Clear previous eval decision at the start of each iteration
+    loop.progress.lastEvalDecision = null;
+
     // --- IMPLEMENT PHASE ---
     await this.emitPhase(loop, 'measuring');
+    loop.progress.lastTestOutput = null;
     const testResult = await runTestCommand(
       worktreePath,
       config.testCommand,
-      config.testTimeoutSeconds
+      config.testTimeoutSeconds,
+      (chunk) => {
+        loop.progress.lastTestOutput = (loop.progress.lastTestOutput ?? '') + chunk;
+      }
     );
     const testOutput = truncateTestOutput(`${testResult.stdout}\n${testResult.stderr}`);
     await this.emitPhase(loop, 'implementing', testOutput);
@@ -553,10 +566,14 @@ export class AutoIterationService {
 
     // Run test command after changes
     await this.emitPhase(loop, 'measuring');
+    loop.progress.lastTestOutput = null;
     let postResult = await runTestCommand(
       worktreePath,
       config.testCommand,
-      config.testTimeoutSeconds
+      config.testTimeoutSeconds,
+      (chunk) => {
+        loop.progress.lastTestOutput = (loop.progress.lastTestOutput ?? '') + chunk;
+      }
     );
 
     // --- CRASH HANDLING ---
@@ -614,6 +631,12 @@ export class AutoIterationService {
     await this.session.waitForIdle(loop.sessionId);
     const measureResponse = await this.session.getLastAssistantMessage(loop.sessionId);
     const evalResult = parseMetricEvaluation(measureResponse);
+
+    // Surface eval decision in real-time for UI display
+    loop.progress.lastEvalDecision = {
+      improved: evalResult.improved,
+      metricSummary: evalResult.metricSummary,
+    };
 
     if (!evalResult.improved) {
       await revertHead(worktreePath);

--- a/src/backend/services/auto-iteration/service/auto-iteration.service.ts
+++ b/src/backend/services/auto-iteration/service/auto-iteration.service.ts
@@ -41,6 +41,18 @@ type Logger = ReturnType<typeof createLogger>;
 /** Default prompt timeout: 20 minutes. */
 const DEFAULT_PROMPT_TIMEOUT_SECONDS = 1200;
 
+/** Cap streaming lastTestOutput at 512 KB to prevent unbounded in-memory growth. */
+const MAX_STREAMING_OUTPUT_BYTES = 512 * 1024;
+
+/** Append a chunk to lastTestOutput, keeping only the tail when the cap is exceeded. */
+function appendStreamingOutput(current: string | null, chunk: string): string {
+  const updated = (current ?? '') + chunk;
+  if (updated.length > MAX_STREAMING_OUTPUT_BYTES) {
+    return updated.slice(-MAX_STREAMING_OUTPUT_BYTES);
+  }
+  return updated;
+}
+
 /** Get prompt timeout in milliseconds from config, or the default. */
 function getPromptTimeoutMs(config: AutoIterationConfig): number | undefined {
   const seconds = config.promptTimeoutSeconds ?? DEFAULT_PROMPT_TIMEOUT_SECONDS;
@@ -162,7 +174,10 @@ export class AutoIterationService {
         config.testCommand,
         config.testTimeoutSeconds,
         (chunk) => {
-          placeholder.progress.lastTestOutput = (placeholder.progress.lastTestOutput ?? '') + chunk;
+          placeholder.progress.lastTestOutput = appendStreamingOutput(
+            placeholder.progress.lastTestOutput,
+            chunk
+          );
         }
       );
       const baselineOutput = truncateTestOutput(
@@ -513,7 +528,7 @@ export class AutoIterationService {
       config.testCommand,
       config.testTimeoutSeconds,
       (chunk) => {
-        loop.progress.lastTestOutput = (loop.progress.lastTestOutput ?? '') + chunk;
+        loop.progress.lastTestOutput = appendStreamingOutput(loop.progress.lastTestOutput, chunk);
       }
     );
     const testOutput = truncateTestOutput(`${testResult.stdout}\n${testResult.stderr}`);
@@ -572,7 +587,7 @@ export class AutoIterationService {
       config.testCommand,
       config.testTimeoutSeconds,
       (chunk) => {
-        loop.progress.lastTestOutput = (loop.progress.lastTestOutput ?? '') + chunk;
+        loop.progress.lastTestOutput = appendStreamingOutput(loop.progress.lastTestOutput, chunk);
       }
     );
 

--- a/src/backend/services/auto-iteration/service/auto-iteration.types.ts
+++ b/src/backend/services/auto-iteration/service/auto-iteration.types.ts
@@ -34,8 +34,10 @@ export interface AutoIterationProgress {
   lastIterationAt: string | null;
   /** Current phase of the active iteration — drives the phase indicator in the UI. */
   currentPhase: IterationPhase;
-  /** Most recent test command output (truncated). Updated after each test run for live display. */
+  /** Most recent test command output (truncated). Updated live while the test runs. */
   lastTestOutput: string | null;
+  /** Result of the most recent LLM metric evaluation. Set after eval, cleared at next iteration start. */
+  lastEvalDecision: { improved: boolean; metricSummary: string } | null;
 }
 
 /** A single entry in the agent logbook. */

--- a/src/backend/services/auto-iteration/service/test-runner.service.ts
+++ b/src/backend/services/auto-iteration/service/test-runner.service.ts
@@ -9,7 +9,8 @@ const MAX_BUFFER_BYTES = 5 * 1024 * 1024;
 export function runTestCommand(
   worktreePath: string,
   command: string,
-  timeoutSeconds: number
+  timeoutSeconds: number,
+  onChunk?: (text: string) => void
 ): Promise<TestCommandResult> {
   return new Promise((resolve) => {
     const child = spawn('bash', ['-c', command], {
@@ -24,16 +25,20 @@ export function runTestCommand(
     let exited = false;
 
     child.stdout.on('data', (data: Buffer) => {
-      stdout += data.toString();
+      const text = data.toString();
+      stdout += text;
       if (Buffer.byteLength(stdout) > MAX_BUFFER_BYTES) {
         stdout = Buffer.from(stdout).subarray(-MAX_BUFFER_BYTES).toString('utf-8');
       }
+      onChunk?.(text);
     });
     child.stderr.on('data', (data: Buffer) => {
-      stderr += data.toString();
+      const text = data.toString();
+      stderr += text;
       if (Buffer.byteLength(stderr) > MAX_BUFFER_BYTES) {
         stderr = Buffer.from(stderr).subarray(-MAX_BUFFER_BYTES).toString('utf-8');
       }
+      onChunk?.(text);
     });
 
     const timer = setTimeout(() => {

--- a/src/client/routes/projects/workspaces/auto-iteration-progress-banner.tsx
+++ b/src/client/routes/projects/workspaces/auto-iteration-progress-banner.tsx
@@ -48,6 +48,7 @@ interface BannerProgress {
   baselineMetricSummary: string;
   currentMetricSummary: string;
   startedAt: string;
+  lastTestOutput?: string | null;
 }
 
 function getStepStates(currentStage: Stage | null): Record<Stage, StepState> {
@@ -309,10 +310,20 @@ function RunningBanner({
 
   // currentIteration === 0 means baseline hasn't completed yet
   if (currentIteration === 0) {
+    let baselineSubLabel: string;
+    if (currentPhase === 'evaluating') {
+      baselineSubLabel = 'evaluating with LLM';
+    } else if (progress?.lastTestOutput) {
+      baselineSubLabel = 'running tests';
+    } else {
+      baselineSubLabel = 'starting...';
+    }
     return (
       <div className="flex items-center gap-2 px-3 py-2 bg-primary/5 border-b text-xs">
         <Loader2 className="h-3 w-3 animate-spin text-primary shrink-0" />
-        <span className="text-muted-foreground">Running baseline measurement...</span>
+        <span className="font-medium">Baseline</span>
+        <span className="text-muted-foreground/50">·</span>
+        <span className="text-muted-foreground">{baselineSubLabel}</span>
       </div>
     );
   }

--- a/src/client/routes/projects/workspaces/auto-iteration-progress-banner.tsx
+++ b/src/client/routes/projects/workspaces/auto-iteration-progress-banner.tsx
@@ -76,36 +76,57 @@ function StepDot({ state }: { state: StepState }) {
   );
 }
 
-function StagesStepper({ currentStage }: { currentStage: Stage | null }) {
+const MEASURE_SUB_LABELS: Partial<Record<string, string>> = {
+  measuring: 'running tests',
+  evaluating: 'evaluating with LLM',
+};
+
+function StagesStepper({
+  currentStage,
+  currentPhase,
+}: {
+  currentStage: Stage | null;
+  currentPhase: string;
+}) {
   const stepStates = getStepStates(currentStage);
 
   return (
     <div className="flex items-center gap-1">
-      {STAGE_ORDER.map((stage, i) => (
-        <div key={stage} className="flex items-center gap-1">
-          {i > 0 && (
-            <ChevronRight
-              className={cn(
-                'h-3 w-3 flex-shrink-0',
-                stepStates[STAGE_ORDER[i - 1] as Stage] === 'completed'
-                  ? 'text-primary'
-                  : 'text-muted-foreground/40'
-              )}
-            />
-          )}
-          <div className="flex items-center gap-1.5">
-            <StepDot state={stepStates[stage]} />
-            <span
-              className={cn(
-                'text-xs font-medium',
-                stepStates[stage] === 'pending' && 'text-muted-foreground'
-              )}
-            >
-              {STAGE_LABELS[stage]}
-            </span>
+      {STAGE_ORDER.map((stage, i) => {
+        const subLabel =
+          stage === 'measure' && stepStates[stage] === 'active'
+            ? MEASURE_SUB_LABELS[currentPhase]
+            : undefined;
+
+        return (
+          <div key={stage} className="flex items-center gap-1">
+            {i > 0 && (
+              <ChevronRight
+                className={cn(
+                  'h-3 w-3 flex-shrink-0',
+                  stepStates[STAGE_ORDER[i - 1] as Stage] === 'completed'
+                    ? 'text-primary'
+                    : 'text-muted-foreground/40'
+                )}
+              />
+            )}
+            <div className="flex items-center gap-1.5">
+              <StepDot state={stepStates[stage]} />
+              <div className="flex flex-col leading-tight">
+                <span
+                  className={cn(
+                    'text-xs font-medium',
+                    stepStates[stage] === 'pending' && 'text-muted-foreground'
+                  )}
+                >
+                  {STAGE_LABELS[stage]}
+                </span>
+                {subLabel && <span className="text-[10px] text-muted-foreground">{subLabel}</span>}
+              </div>
+            </div>
           </div>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 }
@@ -300,7 +321,7 @@ function RunningBanner({
 
   return (
     <div className="flex items-center justify-between gap-4 px-3 py-2 bg-primary/5 border-b text-xs">
-      <StagesStepper currentStage={currentStage} />
+      <StagesStepper currentStage={currentStage} currentPhase={currentPhase} />
       {progress && (
         <IterationStats
           currentIteration={currentIteration}

--- a/src/client/routes/projects/workspaces/auto-iteration-progress-banner.tsx
+++ b/src/client/routes/projects/workspaces/auto-iteration-progress-banner.tsx
@@ -313,7 +313,7 @@ function RunningBanner({
     let baselineSubLabel: string;
     if (currentPhase === 'evaluating') {
       baselineSubLabel = 'evaluating with LLM';
-    } else if (progress?.lastTestOutput) {
+    } else if (currentPhase === 'measuring') {
       baselineSubLabel = 'running tests';
     } else {
       baselineSubLabel = 'starting...';

--- a/src/components/workspace/auto-iteration-panel.tsx
+++ b/src/components/workspace/auto-iteration-panel.tsx
@@ -199,9 +199,9 @@ function IterationEntry({ entry }: { entry: LogbookEntry }) {
   );
 }
 
-function PhaseIndicator({ phase }: { phase: string }) {
-  const label = PHASE_LABELS[phase] ?? phase;
-  const isActive = phase !== 'idle';
+function PhaseIndicator({ phase, labelOverride }: { phase: string; labelOverride?: string }) {
+  const label = labelOverride ?? PHASE_LABELS[phase] ?? phase;
+  const isActive = phase !== 'idle' || labelOverride !== undefined;
 
   return (
     <div
@@ -603,6 +603,102 @@ function IterationLog({ logbook, isRunning }: { logbook: LogbookData | null; isR
   );
 }
 
+function EvalDecisionStrip({
+  decision,
+}: {
+  decision: { improved: boolean; metricSummary: string };
+}) {
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-1.5 px-3 py-1 text-[11px] border-b',
+        decision.improved ? 'bg-green-500/5 text-green-600' : 'bg-orange-500/5 text-orange-600'
+      )}
+    >
+      <span>{decision.improved ? '↑ Improved' : '↓ Regressed'}:</span>
+      <span className="text-muted-foreground truncate">{decision.metricSummary}</span>
+    </div>
+  );
+}
+
+function BaselinePanelBody({
+  lastTestOutput,
+  isEvaluating,
+}: {
+  lastTestOutput: string | null | undefined;
+  isEvaluating: boolean;
+}) {
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      <div className="flex-1 min-h-0 flex flex-col border-b">
+        <div className="flex items-center gap-1 px-3 py-1 text-[10px] text-muted-foreground bg-muted/20 shrink-0">
+          <Terminal className="h-2.5 w-2.5" />
+          Baseline test output
+        </div>
+        {lastTestOutput ? (
+          <pre className="flex-1 min-h-0 overflow-y-auto text-[11px] font-mono whitespace-pre-wrap break-all px-3 py-1.5 text-muted-foreground">
+            {lastTestOutput}
+          </pre>
+        ) : (
+          <div className="flex items-center gap-1.5 px-3 py-2 text-[11px] text-muted-foreground">
+            <Loader2 className="h-2.5 w-2.5 animate-spin" />
+            Waiting for output...
+          </div>
+        )}
+      </div>
+      {isEvaluating && (
+        <div className="flex items-center gap-1.5 px-3 py-1.5 text-[11px] border-b bg-primary/5 shrink-0">
+          <Loader2 className="h-2.5 w-2.5 animate-spin text-primary" />
+          <span className="text-primary">Evaluating baseline with LLM...</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function IterationPanelBody({
+  workspaceId,
+  lastTestOutput,
+  isEvaluating,
+  showLiveOutput,
+  logbook,
+  isRunning,
+  activeTab,
+  setActiveTab,
+}: {
+  workspaceId: string;
+  lastTestOutput: string | null | undefined;
+  isEvaluating: boolean;
+  showLiveOutput: boolean;
+  logbook: LogbookData | null;
+  isRunning: boolean;
+  activeTab: PanelTab;
+  setActiveTab: (t: PanelTab) => void;
+}) {
+  return (
+    <>
+      {showLiveOutput && (
+        <>
+          <LiveTestOutput output={lastTestOutput} />
+          {isEvaluating && (
+            <div className="flex items-center gap-1.5 px-3 py-1.5 text-[11px] text-muted-foreground border-b bg-primary/5">
+              <Loader2 className="h-2.5 w-2.5 animate-spin text-primary" />
+              <span className="text-primary">Evaluating with LLM...</span>
+            </div>
+          )}
+        </>
+      )}
+      <TabBar active={activeTab} onChange={setActiveTab} />
+      <div className={cn('flex-1 min-h-0', activeTab !== 'log' && 'hidden')}>
+        <IterationLog logbook={logbook} isRunning={isRunning} />
+      </div>
+      <div className={cn('flex-1 min-h-0', activeTab !== 'insights' && 'hidden')}>
+        <InsightsEditor workspaceId={workspaceId} />
+      </div>
+    </>
+  );
+}
+
 export function AutoIterationPanel({ workspaceId }: AutoIterationPanelProps) {
   const [activeTab, setActiveTab] = useState<PanelTab>('log');
 
@@ -628,11 +724,17 @@ export function AutoIterationPanel({ workspaceId }: AutoIterationPanelProps) {
   const config = statusData?.config as IterationConfig | null;
   const logbook = logbookData as LogbookData | null;
   const isRunning = status === 'RUNNING';
+  const currentIteration = progress?.currentIteration ?? 0;
   const currentPhase = progress?.currentPhase ?? 'idle';
   const lastTestOutput = progress?.lastTestOutput;
   const lastEvalDecision = progress?.lastEvalDecision;
-  const showLiveOutput = isRunning && TEST_OUTPUT_PHASES.has(currentPhase);
+  // 4c: baseline = running + no completed iterations yet
+  const isBaseline = isRunning && currentIteration === 0;
+  const showLiveOutput = isRunning && !isBaseline && TEST_OUTPUT_PHASES.has(currentPhase);
   const isEvaluating = isRunning && currentPhase === 'evaluating';
+  // 4d: brief gap after baseline eval before first iteration — override the misleading "idle" label
+  const phaseLabel =
+    currentPhase === 'idle' && isBaseline ? 'Starting first iteration...' : undefined;
 
   return (
     <div className="flex flex-col h-full min-h-0">
@@ -643,46 +745,30 @@ export function AutoIterationPanel({ workspaceId }: AutoIterationPanelProps) {
         </span>
       </div>
 
-      {progress && config && (
+      {/* 4b: suppress ProgressSummary during baseline — all counters are 0 and meaningless */}
+      {progress && config && currentIteration > 0 && (
         <ProgressSummary progress={progress} config={config} status={status} />
       )}
 
-      {isRunning && <PhaseIndicator phase={currentPhase} />}
+      {isRunning && <PhaseIndicator phase={currentPhase} labelOverride={phaseLabel} />}
 
-      {isRunning && lastEvalDecision && (
-        <div
-          className={cn(
-            'flex items-center gap-1.5 px-3 py-1 text-[11px] border-b',
-            lastEvalDecision.improved
-              ? 'bg-green-500/5 text-green-600'
-              : 'bg-orange-500/5 text-orange-600'
-          )}
-        >
-          <span>{lastEvalDecision.improved ? '↑ Improved' : '↓ Regressed'}:</span>
-          <span className="text-muted-foreground truncate">{lastEvalDecision.metricSummary}</span>
-        </div>
+      {isRunning && lastEvalDecision && <EvalDecisionStrip decision={lastEvalDecision} />}
+
+      {/* 4c: during baseline show a full-height focused output view instead of the tab area */}
+      {isBaseline ? (
+        <BaselinePanelBody lastTestOutput={lastTestOutput} isEvaluating={isEvaluating} />
+      ) : (
+        <IterationPanelBody
+          workspaceId={workspaceId}
+          lastTestOutput={lastTestOutput}
+          isEvaluating={isEvaluating}
+          showLiveOutput={showLiveOutput}
+          logbook={logbook}
+          isRunning={isRunning}
+          activeTab={activeTab}
+          setActiveTab={setActiveTab}
+        />
       )}
-
-      {showLiveOutput && (
-        <>
-          <LiveTestOutput output={lastTestOutput} />
-          {isEvaluating && (
-            <div className="flex items-center gap-1.5 px-3 py-1.5 text-[11px] text-muted-foreground border-b bg-primary/5">
-              <Loader2 className="h-2.5 w-2.5 animate-spin text-primary" />
-              <span className="text-primary">Evaluating with LLM...</span>
-            </div>
-          )}
-        </>
-      )}
-
-      <TabBar active={activeTab} onChange={setActiveTab} />
-
-      <div className={cn('flex-1 min-h-0', activeTab !== 'log' && 'hidden')}>
-        <IterationLog logbook={logbook} isRunning={isRunning} />
-      </div>
-      <div className={cn('flex-1 min-h-0', activeTab !== 'insights' && 'hidden')}>
-        <InsightsEditor workspaceId={workspaceId} />
-      </div>
     </div>
   );
 }

--- a/src/components/workspace/auto-iteration-panel.tsx
+++ b/src/components/workspace/auto-iteration-panel.tsx
@@ -38,6 +38,7 @@ interface IterationProgress {
   lastIterationAt: string | null;
   currentPhase?: string;
   lastTestOutput?: string | null;
+  lastEvalDecision?: { improved: boolean; metricSummary: string } | null;
 }
 
 interface IterationConfig {
@@ -219,7 +220,7 @@ function PhaseIndicator({ phase }: { phase: string }) {
   );
 }
 
-function LiveTestOutput({ output }: { output: string }) {
+function LiveTestOutput({ output }: { output: string | null | undefined }) {
   // Auto-scroll to bottom on each render (component only re-renders when output prop changes)
   const scrollToBottom = (el: HTMLPreElement | null) => {
     if (el) {
@@ -231,14 +232,21 @@ function LiveTestOutput({ output }: { output: string }) {
     <div className="border-b">
       <div className="flex items-center gap-1 px-3 py-1 text-[10px] text-muted-foreground bg-muted/20">
         <Terminal className="h-2.5 w-2.5" />
-        Latest test output
+        Test output
       </div>
-      <pre
-        ref={scrollToBottom}
-        className="text-[11px] font-mono whitespace-pre-wrap break-all px-3 py-1.5 max-h-40 overflow-y-auto text-muted-foreground"
-      >
-        {output}
-      </pre>
+      {output ? (
+        <pre
+          ref={scrollToBottom}
+          className="text-[11px] font-mono whitespace-pre-wrap break-all px-3 py-1.5 max-h-40 overflow-y-auto text-muted-foreground"
+        >
+          {output}
+        </pre>
+      ) : (
+        <div className="flex items-center gap-1.5 px-3 py-2 text-[11px] text-muted-foreground">
+          <Loader2 className="h-2.5 w-2.5 animate-spin" />
+          Waiting for output...
+        </div>
+      )}
     </div>
   );
 }
@@ -622,7 +630,9 @@ export function AutoIterationPanel({ workspaceId }: AutoIterationPanelProps) {
   const isRunning = status === 'RUNNING';
   const currentPhase = progress?.currentPhase ?? 'idle';
   const lastTestOutput = progress?.lastTestOutput;
-  const showLiveOutput = isRunning && lastTestOutput && TEST_OUTPUT_PHASES.has(currentPhase);
+  const lastEvalDecision = progress?.lastEvalDecision;
+  const showLiveOutput = isRunning && TEST_OUTPUT_PHASES.has(currentPhase);
+  const isEvaluating = isRunning && currentPhase === 'evaluating';
 
   return (
     <div className="flex flex-col h-full min-h-0">
@@ -639,7 +649,31 @@ export function AutoIterationPanel({ workspaceId }: AutoIterationPanelProps) {
 
       {isRunning && <PhaseIndicator phase={currentPhase} />}
 
-      {showLiveOutput && <LiveTestOutput output={lastTestOutput} />}
+      {isRunning && lastEvalDecision && (
+        <div
+          className={cn(
+            'flex items-center gap-1.5 px-3 py-1 text-[11px] border-b',
+            lastEvalDecision.improved
+              ? 'bg-green-500/5 text-green-600'
+              : 'bg-orange-500/5 text-orange-600'
+          )}
+        >
+          <span>{lastEvalDecision.improved ? '↑ Improved' : '↓ Regressed'}:</span>
+          <span className="text-muted-foreground truncate">{lastEvalDecision.metricSummary}</span>
+        </div>
+      )}
+
+      {showLiveOutput && (
+        <>
+          <LiveTestOutput output={lastTestOutput} />
+          {isEvaluating && (
+            <div className="flex items-center gap-1.5 px-3 py-1.5 text-[11px] text-muted-foreground border-b bg-primary/5">
+              <Loader2 className="h-2.5 w-2.5 animate-spin text-primary" />
+              <span className="text-primary">Evaluating with LLM...</span>
+            </div>
+          )}
+        </>
+      )}
 
       <TabBar active={activeTab} onChange={setActiveTab} />
 

--- a/src/components/workspace/auto-iteration-panel.tsx
+++ b/src/components/workspace/auto-iteration-panel.tsx
@@ -636,7 +636,14 @@ function BaselinePanelBody({
           Baseline test output
         </div>
         {lastTestOutput ? (
-          <pre className="flex-1 min-h-0 overflow-y-auto text-[11px] font-mono whitespace-pre-wrap break-all px-3 py-1.5 text-muted-foreground">
+          <pre
+            ref={(el) => {
+              if (el) {
+                el.scrollTop = el.scrollHeight;
+              }
+            }}
+            className="flex-1 min-h-0 overflow-y-auto text-[11px] font-mono whitespace-pre-wrap break-all px-3 py-1.5 text-muted-foreground"
+          >
             {lastTestOutput}
           </pre>
         ) : (

--- a/src/components/workspace/auto-iteration-panel.tsx
+++ b/src/components/workspace/auto-iteration-panel.tsx
@@ -753,7 +753,7 @@ export function AutoIterationPanel({ workspaceId }: AutoIterationPanelProps) {
       </div>
 
       {/* 4b: suppress ProgressSummary during baseline — all counters are 0 and meaningless */}
-      {progress && config && currentIteration > 0 && (
+      {progress && config && !isBaseline && (
         <ProgressSummary progress={progress} config={config} status={status} />
       )}
 


### PR DESCRIPTION
## Summary

- **Fix live test output streaming** — `runTestCommand` now accepts an `onChunk` callback and flushes stdout/stderr chunks directly into `loop.progress.lastTestOutput` in memory as they arrive. Previously, `lastTestOutput` was only written after the test process exited, so the panel always showed stale output. Now `lastTestOutput` is also cleared to `null` at the start of each test run so users see a "Waiting for output..." placeholder instead of a prior iteration's stale output.
- **Eval decision display** — Added `lastEvalDecision: { improved, metricSummary } | null` to `AutoIterationProgress`. It's set immediately after the LLM eval completes and cleared at the start of the next iteration. The panel shows a green "↑ Improved" or orange "↓ Regressed" strip with the metric summary while the critiquing phase is active.
- **"Evaluating with LLM..." indicator** — During the `evaluating` phase the panel now shows a spinner below the test output so users can distinguish "test is running" from "LLM is deciding".
- **Banner sub-label** — The Measure step in the 3-stage stepper now shows a secondary label underneath when active: *running tests* (`measuring`) or *evaluating with LLM* (`evaluating`).

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes (2903 tests)
- [ ] `pnpm check:fix` clean
- [ ] Manually verify: start an auto-iteration workspace and confirm test output streams live in the panel during the measuring phase
- [ ] Manually verify: panel shows "Evaluating with LLM..." spinner during evaluating phase
- [ ] Manually verify: eval decision strip appears after eval completes
- [ ] Manually verify: banner Measure step shows "running tests" / "evaluating with LLM" sub-label
