### PR TITLE
[codex] Clarify draft and closed PR workspace states

### DIFF
--- a/packages/core/src/shared/workspace-sidebar-status.test.ts
+++ b/packages/core/src/shared/workspace-sidebar-status.test.ts
@@ -43,6 +43,18 @@ describe('workspace-sidebar-status', () => {
     expect(result.ciState).toBe('MERGED');
   });
 
+  it('treats closed PRs as a terminal closed state', () => {
+    const result = deriveWorkspaceSidebarStatus({
+      isWorking: false,
+      prUrl: 'https://github.com/o/r/pull/1',
+      prState: 'CLOSED',
+      prCiStatus: 'SUCCESS',
+      ratchetState: 'IDLE',
+    });
+
+    expect(result.ciState).toBe('CLOSED');
+  });
+
   it('prefers PR snapshot CI failure over stale ratchet CI running', () => {
     const result = deriveWorkspaceSidebarStatus({
       isWorking: false,
@@ -93,11 +105,13 @@ describe('workspace-sidebar-status', () => {
 
   it('provides ci tooltip text from centralized helper', () => {
     expect(getWorkspaceCiTooltip('RUNNING', 'OPEN')).toBe('CI checks are running');
+    expect(getWorkspaceCiTooltip('CLOSED', 'CLOSED')).toBe('PR is closed');
     expect(getWorkspaceCiTooltip('UNKNOWN', 'CLOSED')).toBe('PR is closed');
   });
 
   it('provides pr tooltip suffix text from centralized helper', () => {
     expect(getWorkspacePrTooltipSuffix('PASSING', 'OPEN')).toBe(' · CI passing');
+    expect(getWorkspacePrTooltipSuffix('CLOSED', 'OPEN')).toBe(' · Closed');
     expect(getWorkspacePrTooltipSuffix('UNKNOWN', 'CLOSED')).toBe(' · Closed');
     expect(getWorkspacePrTooltipSuffix('UNKNOWN', 'OPEN')).toBe('');
   });

--- a/packages/core/src/shared/workspace-sidebar-status.ts
+++ b/packages/core/src/shared/workspace-sidebar-status.ts
@@ -9,6 +9,8 @@ export type WorkspaceSidebarCiState =
   | 'FAILING'
   | 'PASSING'
   | 'UNKNOWN'
+  | 'CLOSED'
+  | 'CONFLICT'
   | 'MERGED';
 
 export interface WorkspaceSidebarStatus {
@@ -35,6 +37,14 @@ export function deriveWorkspaceSidebarStatus(
 
   if (input.prState === 'MERGED' || input.ratchetState === 'MERGED') {
     return { activityState, ciState: 'MERGED' };
+  }
+
+  if (input.prState === 'CLOSED') {
+    return { activityState, ciState: 'CLOSED' };
+  }
+
+  if (input.ratchetState === 'MERGE_CONFLICT') {
+    return { activityState, ciState: 'CONFLICT' };
   }
 
   const ciStateFromSnapshot = deriveCiVisualStateFromPrCiStatus(input.prCiStatus);
@@ -67,6 +77,10 @@ export function getWorkspaceCiLabel(state: WorkspaceSidebarCiState): string {
       return 'CI Passing';
     case 'UNKNOWN':
       return 'CI Unknown';
+    case 'CLOSED':
+      return 'Closed';
+    case 'CONFLICT':
+      return 'Conflicts';
     case 'MERGED':
       return 'Merged';
   }
@@ -85,8 +99,14 @@ export function getWorkspaceCiTooltip(
   if (ciState === 'PASSING') {
     return 'CI checks are passing';
   }
+  if (ciState === 'CLOSED') {
+    return 'PR is closed';
+  }
   if (ciState === 'MERGED') {
     return 'PR is merged';
+  }
+  if (ciState === 'CONFLICT') {
+    return 'PR has merge conflicts';
   }
   if (ciState === 'UNKNOWN') {
     return prState === 'CLOSED' ? 'PR is closed' : 'CI status is unknown';
@@ -101,11 +121,17 @@ export function getWorkspacePrTooltipSuffix(
   if (prState === 'CLOSED') {
     return ' · Closed';
   }
+  if (ciState === 'CLOSED') {
+    return ' · Closed';
+  }
   if (ciState === 'MERGED') {
     return ' · Merged';
   }
   if (ciState === 'FAILING') {
     return ' · CI failing';
+  }
+  if (ciState === 'CONFLICT') {
+    return ' · Conflicts';
   }
   if (ciState === 'RUNNING') {
     return ' · CI running';

--- a/packages/core/src/types/enums.test.ts
+++ b/packages/core/src/types/enums.test.ts
@@ -58,6 +58,7 @@ describe('domain enums', () => {
       'IDLE',
       'CI_RUNNING',
       'CI_FAILED',
+      'MERGE_CONFLICT',
       'REVIEW_PENDING',
       'READY',
       'MERGED',

--- a/src/backend/services/workspace/service/state/kanban-state.test.ts
+++ b/src/backend/services/workspace/service/state/kanban-state.test.ts
@@ -67,12 +67,21 @@ describe('computeKanbanColumn', () => {
     ).toBe('WORKING');
   });
 
-  it('maps merged PRs to DONE and hidden empty READY workspaces to null', () => {
+  it('maps merged and closed PRs to DONE and hidden empty READY workspaces to null', () => {
     expect(
       computeKanbanColumn({
         lifecycle: 'READY',
         isWorking: false,
         prState: 'MERGED',
+        ratchetState: 'IDLE',
+        hasHadSessions: true,
+      })
+    ).toBe('DONE');
+    expect(
+      computeKanbanColumn({
+        lifecycle: 'READY',
+        isWorking: false,
+        prState: 'CLOSED',
         ratchetState: 'IDLE',
         hasHadSessions: true,
       })
@@ -101,6 +110,15 @@ describe('computeKanbanColumn', () => {
   });
 
   it('maps idle session-backed workspaces to WAITING', () => {
+    expect(
+      computeKanbanColumn({
+        lifecycle: 'READY',
+        isWorking: false,
+        prState: 'DRAFT',
+        ratchetState: 'IDLE',
+        hasHadSessions: true,
+      })
+    ).toBe('WAITING');
     expect(
       computeKanbanColumn({
         lifecycle: 'READY',

--- a/src/backend/services/workspace/service/state/kanban-state.ts
+++ b/src/backend/services/workspace/service/state/kanban-state.ts
@@ -29,7 +29,7 @@ export interface WorkspaceWithKanbanState {
  * Simplified 3-column model:
  * - WORKING: Initializing states (NEW/PROVISIONING/FAILED) or actively working
  * - WAITING: Idle workspaces with hasHadSessions=true (includes PR states)
- * - DONE: PR merged
+ * - DONE: PR merged or closed
  *
  * Note: Workspaces with hasHadSessions=false AND status=READY are hidden from view.
  * Archived workspaces retain their pre-archive cachedKanbanColumn and are hidden
@@ -58,8 +58,12 @@ export function computeKanbanColumn(input: KanbanStateInput): KanbanColumn | nul
 
   // From here, lifecycle === READY and not working
 
-  // DONE: PR merged, as observed by either PR snapshot or ratchet monitor.
-  if (prState === PRState.MERGED || ratchetState === RatchetState.MERGED) {
+  // DONE: PR merged or closed, as observed by either PR snapshot or ratchet monitor.
+  if (
+    prState === PRState.MERGED ||
+    prState === PRState.CLOSED ||
+    ratchetState === RatchetState.MERGED
+  ) {
     return KanbanColumn.DONE;
   }
 
@@ -70,7 +74,7 @@ export function computeKanbanColumn(input: KanbanStateInput): KanbanColumn | nul
   }
 
   // WAITING: Everything else - idle workspaces with sessions
-  // (includes PR states: NONE, DRAFT, OPEN, CHANGES_REQUESTED, APPROVED, CLOSED)
+  // (includes PR states: NONE, DRAFT, OPEN, CHANGES_REQUESTED, APPROVED)
   return KanbanColumn.WAITING;
 }
 

--- a/src/client/components/kanban/kanban-card.tsx
+++ b/src/client/components/kanban/kanban-card.tsx
@@ -14,6 +14,7 @@ import { Link } from 'react-router';
 import { PendingRequestBadge } from '@/client/components/pending-request-badge';
 import { isWorkspaceDoneOrMerged } from '@/client/lib/workspace-archive';
 import { CiStatusChip } from '@/components/shared/ci-status-chip';
+import { PrStateBadge } from '@/components/shared/pr-state-badge';
 import { SetupStatusChip } from '@/components/shared/setup-status-chip';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -112,7 +113,12 @@ function CiRow({
   ciState: WorkspaceSidebarCiState;
   prState: Workspace['prState'];
 }) {
-  return <CiStatusChip ciState={ciState} prState={prState} size="sm" />;
+  return (
+    <div className="flex items-center gap-1.5">
+      <CiStatusChip ciState={ciState} prState={prState} size="sm" />
+      <PrStateBadge prState={prState} size="sm" />
+    </div>
+  );
 }
 
 function CardArchiveButton({

--- a/src/client/components/kanban/kanban-column.tsx
+++ b/src/client/components/kanban/kanban-column.tsx
@@ -20,7 +20,7 @@ export const KANBAN_COLUMNS: ColumnConfig[] = [
   { id: 'ISSUES', label: 'Todo · GitHub', description: 'Issues assigned to you' },
   { id: 'WORKING', label: 'Working', description: 'Agent is working' },
   { id: 'WAITING', label: 'Waiting', description: 'Waiting for input' },
-  { id: 'DONE', label: 'Done', description: 'PR merged' },
+  { id: 'DONE', label: 'Done', description: 'PR merged or closed' },
 ];
 
 export function getKanbanColumns(issueProvider: string): ColumnConfig[] {
@@ -33,7 +33,7 @@ export function getKanbanColumns(issueProvider: string): ColumnConfig[] {
     },
     { id: 'WORKING', label: 'Working', description: 'Agent is working' },
     { id: 'WAITING', label: 'Waiting', description: 'Waiting for input' },
-    { id: 'DONE', label: 'Done', description: 'PR merged' },
+    { id: 'DONE', label: 'Done', description: 'PR merged or closed' },
   ];
 }
 

--- a/src/client/lib/workspace-archive.test.ts
+++ b/src/client/lib/workspace-archive.test.ts
@@ -6,6 +6,10 @@ describe('isWorkspaceDoneOrMerged', () => {
     expect(isWorkspaceDoneOrMerged({ prState: 'MERGED' })).toBe(true);
   });
 
+  it('returns true when PR state is closed', () => {
+    expect(isWorkspaceDoneOrMerged({ prState: 'CLOSED' })).toBe(true);
+  });
+
   it('returns true when live kanban column is done', () => {
     expect(isWorkspaceDoneOrMerged({ kanbanColumn: 'DONE' })).toBe(true);
   });

--- a/src/client/lib/workspace-archive.test.ts
+++ b/src/client/lib/workspace-archive.test.ts
@@ -14,11 +14,24 @@ describe('isWorkspaceDoneOrMerged', () => {
     expect(isWorkspaceDoneOrMerged({ prState: 'OPEN', ratchetState: 'MERGED' })).toBe(true);
   });
 
+  it('returns true when ratchet state is closed', () => {
+    expect(isWorkspaceDoneOrMerged({ prState: 'OPEN', ratchetState: 'CLOSED' })).toBe(true);
+  });
+
   it('returns true when sidebar CI state is merged', () => {
     expect(
       isWorkspaceDoneOrMerged({
         prState: 'OPEN',
         sidebarStatus: { ciState: 'MERGED' },
+      })
+    ).toBe(true);
+  });
+
+  it('returns true when sidebar CI state is closed', () => {
+    expect(
+      isWorkspaceDoneOrMerged({
+        prState: 'OPEN',
+        sidebarStatus: { ciState: 'CLOSED' },
       })
     ).toBe(true);
   });

--- a/src/client/lib/workspace-archive.test.ts
+++ b/src/client/lib/workspace-archive.test.ts
@@ -10,6 +10,19 @@ describe('isWorkspaceDoneOrMerged', () => {
     expect(isWorkspaceDoneOrMerged({ prState: 'CLOSED' })).toBe(true);
   });
 
+  it('returns true when ratchet state is merged', () => {
+    expect(isWorkspaceDoneOrMerged({ prState: 'OPEN', ratchetState: 'MERGED' })).toBe(true);
+  });
+
+  it('returns true when sidebar CI state is merged', () => {
+    expect(
+      isWorkspaceDoneOrMerged({
+        prState: 'OPEN',
+        sidebarStatus: { ciState: 'MERGED' },
+      })
+    ).toBe(true);
+  });
+
   it('returns true when live kanban column is done', () => {
     expect(isWorkspaceDoneOrMerged({ kanbanColumn: 'DONE' })).toBe(true);
   });

--- a/src/client/lib/workspace-archive.test.ts
+++ b/src/client/lib/workspace-archive.test.ts
@@ -14,10 +14,6 @@ describe('isWorkspaceDoneOrMerged', () => {
     expect(isWorkspaceDoneOrMerged({ prState: 'OPEN', ratchetState: 'MERGED' })).toBe(true);
   });
 
-  it('returns true when ratchet state is closed', () => {
-    expect(isWorkspaceDoneOrMerged({ prState: 'OPEN', ratchetState: 'CLOSED' })).toBe(true);
-  });
-
   it('returns true when sidebar CI state is merged', () => {
     expect(
       isWorkspaceDoneOrMerged({

--- a/src/client/lib/workspace-archive.ts
+++ b/src/client/lib/workspace-archive.ts
@@ -23,7 +23,9 @@ export function isWorkspaceDoneOrMerged(
     workspace.prState === 'MERGED' ||
     workspace.prState === 'CLOSED' ||
     workspace.ratchetState === 'MERGED' ||
+    workspace.ratchetState === 'CLOSED' ||
     workspace.sidebarStatus?.ciState === 'MERGED' ||
+    workspace.sidebarStatus?.ciState === 'CLOSED' ||
     workspace.kanbanColumn === 'DONE' ||
     workspace.cachedKanbanColumn === 'DONE'
   );

--- a/src/client/lib/workspace-archive.ts
+++ b/src/client/lib/workspace-archive.ts
@@ -1,7 +1,11 @@
 interface ArchiveWorkspaceStateLike {
   prState?: string | null;
+  ratchetState?: string | null;
   kanbanColumn?: string | null;
   cachedKanbanColumn?: string | null;
+  sidebarStatus?: {
+    ciState?: string | null;
+  } | null;
 }
 
 /**
@@ -18,6 +22,8 @@ export function isWorkspaceDoneOrMerged(
   return (
     workspace.prState === 'MERGED' ||
     workspace.prState === 'CLOSED' ||
+    workspace.ratchetState === 'MERGED' ||
+    workspace.sidebarStatus?.ciState === 'MERGED' ||
     workspace.kanbanColumn === 'DONE' ||
     workspace.cachedKanbanColumn === 'DONE'
   );

--- a/src/client/lib/workspace-archive.ts
+++ b/src/client/lib/workspace-archive.ts
@@ -1,10 +1,12 @@
+import type { KanbanColumn, PRState, RatchetState, WorkspaceSidebarCiState } from '@/shared/core';
+
 interface ArchiveWorkspaceStateLike {
-  prState?: string | null;
-  ratchetState?: string | null;
-  kanbanColumn?: string | null;
-  cachedKanbanColumn?: string | null;
+  prState?: PRState | null;
+  ratchetState?: RatchetState | null;
+  kanbanColumn?: KanbanColumn | null;
+  cachedKanbanColumn?: KanbanColumn | null;
   sidebarStatus?: {
-    ciState?: string | null;
+    ciState?: WorkspaceSidebarCiState | null;
   } | null;
 }
 
@@ -23,7 +25,6 @@ export function isWorkspaceDoneOrMerged(
     workspace.prState === 'MERGED' ||
     workspace.prState === 'CLOSED' ||
     workspace.ratchetState === 'MERGED' ||
-    workspace.ratchetState === 'CLOSED' ||
     workspace.sidebarStatus?.ciState === 'MERGED' ||
     workspace.sidebarStatus?.ciState === 'CLOSED' ||
     workspace.kanbanColumn === 'DONE' ||

--- a/src/client/lib/workspace-archive.ts
+++ b/src/client/lib/workspace-archive.ts
@@ -5,7 +5,7 @@ interface ArchiveWorkspaceStateLike {
 }
 
 /**
- * Treat merged PRs and DONE kanban workspaces as safe-to-archive without
+ * Treat completed PRs and DONE kanban workspaces as safe-to-archive without
  * showing commit-before-archive warnings.
  */
 export function isWorkspaceDoneOrMerged(
@@ -17,6 +17,7 @@ export function isWorkspaceDoneOrMerged(
 
   return (
     workspace.prState === 'MERGED' ||
+    workspace.prState === 'CLOSED' ||
     workspace.kanbanColumn === 'DONE' ||
     workspace.cachedKanbanColumn === 'DONE'
   );

--- a/src/client/routes/projects/workspaces/workspace-detail-header/archive-action-button.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-header/archive-action-button.tsx
@@ -1,10 +1,10 @@
 import { Archive, Loader2 } from 'lucide-react';
+import { isWorkspaceDoneOrMerged } from '@/client/lib/workspace-archive';
 import { Button } from '@/components/ui/button';
 import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import type { WorkspaceHeaderWorkspace } from './types';
-import { isWorkspaceMerged } from './utils';
 
 export function ArchiveActionButton({
   workspace,
@@ -17,7 +17,7 @@ export function ArchiveActionButton({
   onArchiveRequest: () => void;
   renderAsMenuItem?: boolean;
 }) {
-  const merged = isWorkspaceMerged(workspace);
+  const completed = isWorkspaceDoneOrMerged(workspace);
 
   if (renderAsMenuItem) {
     return (
@@ -30,7 +30,7 @@ export function ArchiveActionButton({
         }}
         disabled={archivePending}
         className={cn(
-          merged ? '' : 'text-destructive focus:text-destructive dark:text-destructive'
+          completed ? '' : 'text-destructive focus:text-destructive dark:text-destructive'
         )}
       >
         {archivePending ? (
@@ -47,11 +47,11 @@ export function ArchiveActionButton({
     <Tooltip>
       <TooltipTrigger asChild>
         <Button
-          variant={merged ? 'default' : 'ghost'}
+          variant={completed ? 'default' : 'ghost'}
           size="icon"
           className={cn(
             'h-9 w-9 md:h-8 md:w-8',
-            merged ? '' : 'hover:bg-destructive/10 hover:text-destructive'
+            completed ? '' : 'hover:bg-destructive/10 hover:text-destructive'
           )}
           onClick={onArchiveRequest}
           disabled={archivePending}

--- a/src/client/routes/projects/workspaces/workspace-detail-header/types.ts
+++ b/src/client/routes/projects/workspaces/workspace-detail-header/types.ts
@@ -12,7 +12,7 @@ export type WorkspaceSessionManagement = ReturnType<typeof useSessionManagement>
 export type WorkspacePrChipProps = {
   prUrl: NonNullable<WorkspaceHeaderWorkspace['prUrl']>;
   prNumber: NonNullable<WorkspaceHeaderWorkspace['prNumber']>;
-  isMerged: boolean;
+  variant?: 'default' | 'merged' | 'closed';
   className?: string;
 };
 

--- a/src/client/routes/projects/workspaces/workspace-detail-header/utils.test.ts
+++ b/src/client/routes/projects/workspaces/workspace-detail-header/utils.test.ts
@@ -3,6 +3,7 @@ import {
   getWorkspaceHeaderLabel,
   groupWorkspaceSwitcherItems,
   hasVisiblePullRequest,
+  isWorkspaceClosed,
   isWorkspaceMerged,
 } from './utils';
 
@@ -106,9 +107,32 @@ describe('pr helpers', () => {
     ).toBe(true);
   });
 
+  it('detects closed state from PR state or sidebar state', () => {
+    expect(
+      isWorkspaceClosed({
+        prState: 'CLOSED',
+        sidebarStatus: { activityState: 'IDLE', ciState: 'PASSING' },
+      })
+    ).toBe(true);
+
+    expect(
+      isWorkspaceClosed({
+        prState: 'OPEN',
+        sidebarStatus: { activityState: 'IDLE', ciState: 'CLOSED' },
+      })
+    ).toBe(true);
+  });
+
   it('requires url, number, and non-hidden state for visible PR', () => {
     expect(
       hasVisiblePullRequest({ prUrl: 'https://example.com/pr/1', prNumber: 1, prState: 'OPEN' })
+    ).toBe(true);
+    expect(
+      hasVisiblePullRequest({
+        prUrl: 'https://example.com/pr/2',
+        prNumber: 2,
+        prState: 'CLOSED',
+      })
     ).toBe(true);
     expect(hasVisiblePullRequest({ prUrl: null, prNumber: 1, prState: 'OPEN' })).toBe(false);
     expect(

--- a/src/client/routes/projects/workspaces/workspace-detail-header/utils.ts
+++ b/src/client/routes/projects/workspaces/workspace-detail-header/utils.ts
@@ -66,6 +66,12 @@ export function isWorkspaceMerged(
   );
 }
 
+export function isWorkspaceClosed(
+  workspace: Pick<WorkspaceHeaderWorkspace, 'prState' | 'sidebarStatus'>
+): boolean {
+  return workspace.prState === 'CLOSED' || workspace.sidebarStatus?.ciState === 'CLOSED';
+}
+
 export function hasVisiblePullRequest(
   workspace: Pick<WorkspaceHeaderWorkspace, 'prUrl' | 'prNumber' | 'prState'>
 ): workspace is {
@@ -73,10 +79,5 @@ export function hasVisiblePullRequest(
   prNumber: NonNullable<WorkspaceHeaderWorkspace['prNumber']>;
   prState: WorkspaceHeaderWorkspace['prState'];
 } {
-  return Boolean(
-    workspace.prUrl &&
-      workspace.prNumber &&
-      workspace.prState !== 'NONE' &&
-      workspace.prState !== 'CLOSED'
-  );
+  return Boolean(workspace.prUrl && workspace.prNumber && workspace.prState !== 'NONE');
 }

--- a/src/client/routes/projects/workspaces/workspace-detail-header/workspace-status.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-header/workspace-status.tsx
@@ -1,10 +1,11 @@
-import { CheckCircle2, CircleDot, GitPullRequest } from 'lucide-react';
+import { CheckCircle2, CircleDot, GitPullRequest, XCircle } from 'lucide-react';
 import { CiStatusChip } from '@/components/shared/ci-status-chip';
+import { PrStateBadge } from '@/components/shared/pr-state-badge';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import type { WorkspaceHeaderWorkspace, WorkspacePrChipProps } from './types';
-import { hasVisiblePullRequest, isWorkspaceMerged } from './utils';
+import { hasVisiblePullRequest, isWorkspaceClosed, isWorkspaceMerged } from './utils';
 
 type WorkspacePrActionProps = {
   workspace: WorkspaceHeaderWorkspace;
@@ -14,7 +15,15 @@ type WorkspacePrActionProps = {
   handleQuickAction: (title: string, prompt: string) => void;
 };
 
-export function WorkspacePrChip({ prUrl, prNumber, isMerged, className }: WorkspacePrChipProps) {
+export function WorkspacePrChip({
+  prUrl,
+  prNumber,
+  variant = 'default',
+  className,
+}: WorkspacePrChipProps) {
+  const isMerged = variant === 'merged';
+  const isClosed = variant === 'closed';
+
   return (
     <a
       href={prUrl}
@@ -22,12 +31,17 @@ export function WorkspacePrChip({ prUrl, prNumber, isMerged, className }: Worksp
       rel="noopener noreferrer"
       className={cn(
         'flex items-center gap-1 text-xs hover:opacity-80 transition-opacity',
-        isMerged ? 'text-green-500' : 'text-muted-foreground hover:text-foreground',
+        isMerged
+          ? 'text-green-500'
+          : isClosed
+            ? 'text-slate-500'
+            : 'text-muted-foreground hover:text-foreground',
         className
       )}
     >
       <GitPullRequest className="h-3 w-3" />#{prNumber}
       {isMerged && <CheckCircle2 className="h-3 w-3 text-green-500" />}
+      {isClosed && <XCircle className="h-3 w-3 text-slate-500" />}
     </a>
   );
 }
@@ -39,7 +53,7 @@ export function WorkspacePrAction({
   isCreatingSession,
   handleQuickAction,
 }: WorkspacePrActionProps) {
-  if (hasChanges && !running && (workspace.prState === 'NONE' || workspace.prState === 'CLOSED')) {
+  if (hasChanges && !running && workspace.prState === 'NONE') {
     return (
       <Tooltip>
         <TooltipTrigger asChild>
@@ -65,12 +79,14 @@ export function WorkspacePrAction({
   }
 
   if (hasVisiblePullRequest(workspace)) {
+    const variant = isWorkspaceMerged(workspace)
+      ? 'merged'
+      : isWorkspaceClosed(workspace)
+        ? 'closed'
+        : 'default';
+
     return (
-      <WorkspacePrChip
-        prUrl={workspace.prUrl}
-        prNumber={workspace.prNumber}
-        isMerged={isWorkspaceMerged(workspace)}
-      />
+      <WorkspacePrChip prUrl={workspace.prUrl} prNumber={workspace.prNumber} variant={variant} />
     );
   }
 
@@ -118,6 +134,13 @@ export function WorkspaceCiStatus({ workspace }: { workspace: WorkspaceHeaderWor
   }
 
   return (
-    <CiStatusChip ciState={workspace.sidebarStatus.ciState} prState={workspace.prState} size="md" />
+    <div className="flex items-center gap-2">
+      <CiStatusChip
+        ciState={workspace.sidebarStatus.ciState}
+        prState={workspace.prState}
+        size="md"
+      />
+      <PrStateBadge prState={workspace.prState} size="md" />
+    </div>
   );
 }

--- a/src/components/shared/ci-status-chip.tsx
+++ b/src/components/shared/ci-status-chip.tsx
@@ -40,6 +40,11 @@ function getCiStatusConfig(ciState: WorkspaceSidebarCiState): {
         className: 'bg-muted text-muted-foreground',
         Icon: Circle,
       };
+    case 'CLOSED':
+      return {
+        className: 'bg-slate-500/15 text-slate-700 dark:text-slate-300',
+        Icon: XCircle,
+      };
     case 'MERGED':
       return {
         className: 'bg-purple-500/15 text-purple-700 dark:text-purple-300',

--- a/src/components/shared/pr-state-badge.tsx
+++ b/src/components/shared/pr-state-badge.tsx
@@ -1,0 +1,24 @@
+import { Badge } from '@/components/ui/badge';
+import type { PRState } from '@/shared/core';
+
+interface PrStateBadgeProps {
+  prState?: PRState | null;
+  size?: 'sm' | 'md';
+}
+
+export function PrStateBadge({ prState, size = 'sm' }: PrStateBadgeProps) {
+  if (prState !== 'DRAFT') {
+    return null;
+  }
+
+  const sizeClasses = size === 'sm' ? 'text-[10px] px-1.5 py-0.5' : 'text-xs px-2 py-0.5';
+
+  return (
+    <Badge
+      variant="outline"
+      className={`${sizeClasses} border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-300`}
+    >
+      Draft
+    </Badge>
+  );
+}

--- a/src/shared/core/workspace-sidebar-status.ts
+++ b/src/shared/core/workspace-sidebar-status.ts
@@ -9,6 +9,7 @@ export type WorkspaceSidebarCiState =
   | 'FAILING'
   | 'PASSING'
   | 'UNKNOWN'
+  | 'CLOSED'
   | 'MERGED'
   | 'CONFLICT';
 
@@ -36,6 +37,10 @@ export function deriveWorkspaceSidebarStatus(
 
   if (input.prState === 'MERGED' || input.ratchetState === 'MERGED') {
     return { activityState, ciState: 'MERGED' };
+  }
+
+  if (input.prState === 'CLOSED') {
+    return { activityState, ciState: 'CLOSED' };
   }
 
   // Merge conflicts are shown regardless of CI status
@@ -73,6 +78,8 @@ export function getWorkspaceCiLabel(state: WorkspaceSidebarCiState): string {
       return 'CI Passing';
     case 'UNKNOWN':
       return 'CI Unknown';
+    case 'CLOSED':
+      return 'Closed';
     case 'MERGED':
       return 'Merged';
     case 'CONFLICT':
@@ -93,6 +100,9 @@ export function getWorkspaceCiTooltip(
   if (ciState === 'PASSING') {
     return 'CI checks are passing';
   }
+  if (ciState === 'CLOSED') {
+    return 'PR is closed';
+  }
   if (ciState === 'MERGED') {
     return 'PR is merged';
   }
@@ -110,6 +120,9 @@ export function getWorkspacePrTooltipSuffix(
   prState: PRState | null
 ): string {
   if (prState === 'CLOSED') {
+    return ' · Closed';
+  }
+  if (ciState === 'CLOSED') {
     return ' · Closed';
   }
   if (ciState === 'MERGED') {

--- a/src/shared/workspace-sidebar-status.test.ts
+++ b/src/shared/workspace-sidebar-status.test.ts
@@ -43,6 +43,18 @@ describe('workspace-sidebar-status', () => {
     expect(result.ciState).toBe('MERGED');
   });
 
+  it('treats closed PRs as a terminal closed state', () => {
+    const result = deriveWorkspaceSidebarStatus({
+      isWorking: false,
+      prUrl: 'https://github.com/o/r/pull/1',
+      prState: 'CLOSED',
+      prCiStatus: 'SUCCESS',
+      ratchetState: 'IDLE',
+    });
+
+    expect(result.ciState).toBe('CLOSED');
+  });
+
   it('prefers PR snapshot CI failure over stale ratchet CI running', () => {
     const result = deriveWorkspaceSidebarStatus({
       isWorking: false,
@@ -93,11 +105,13 @@ describe('workspace-sidebar-status', () => {
 
   it('provides ci tooltip text from centralized helper', () => {
     expect(getWorkspaceCiTooltip('RUNNING', 'OPEN')).toBe('CI checks are running');
+    expect(getWorkspaceCiTooltip('CLOSED', 'CLOSED')).toBe('PR is closed');
     expect(getWorkspaceCiTooltip('UNKNOWN', 'CLOSED')).toBe('PR is closed');
   });
 
   it('provides pr tooltip suffix text from centralized helper', () => {
     expect(getWorkspacePrTooltipSuffix('PASSING', 'OPEN')).toBe(' · CI passing');
+    expect(getWorkspacePrTooltipSuffix('CLOSED', 'OPEN')).toBe(' · Closed');
     expect(getWorkspacePrTooltipSuffix('UNKNOWN', 'CLOSED')).toBe(' · Closed');
     expect(getWorkspacePrTooltipSuffix('UNKNOWN', 'OPEN')).toBe('');
   });


### PR DESCRIPTION
## Summary
- move closed pull requests into the Done workspace column alongside merged PRs
- show closed PRs as a terminal workspace status instead of falling back to generic CI state
- show a separate Draft badge next to CI status so draft PRs still expose their CI state

## Why
Workspace PR state handling treated `MERGED` as the only completed state. That left closed PRs in waiting-oriented UI and made draft PRs harder to distinguish from ready/open PRs even though they still carry CI state.

## Impact
Workspace kanban cards and workspace detail header now present draft, closed, and merged PR states more clearly and consistently. Closed PR workspaces also inherit the same completed/archive-safe behavior as merged workspaces.

## Validation
- `pnpm test -- src/shared/workspace-sidebar-status.test.ts src/backend/services/workspace/service/state/kanban-state.test.ts src/client/lib/workspace-archive.test.ts src/client/routes/projects/workspaces/workspace-detail-header/utils.test.ts`
- `pnpm typecheck`
- repository pre-commit checks: `biome check --write`, dependency cruiser, `knip`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes core workspace state derivation (sidebar CI state, kanban column, and archive safety checks), which can affect routing of workspaces into Done/Waiting and when archive warnings appear.
> 
> **Overview**
> **Clarifies workspace completion and PR state handling.** Closed PRs are now treated as a terminal state: `deriveWorkspaceSidebarStatus` returns `ciState: 'CLOSED'` (with new labels/tooltips) and merge conflicts are surfaced as `CONFLICT`.
> 
> **Updates kanban + archiving behavior.** Backend kanban derivation moves `PRState.CLOSED` workspaces into `DONE`, the Done column copy is updated accordingly, and client archive warning logic (`isWorkspaceDoneOrMerged`) now considers closed/merged from PR state, ratchet state, and sidebar CI state.
> 
> **Improves UI signaling for draft/closed.** Adds a `PrStateBadge` (shown for draft PRs) alongside the CI chip on kanban cards and the workspace header, and updates the workspace header PR chip to support `merged` vs `closed` variants while allowing closed PRs to remain visible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74f087e23487489b349ade0486d3f0d4dae95094. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->