### PR TITLE
[codex] Create GitHub releases for manual npm publishes

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -78,10 +78,15 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Compute release version
+        if: ${{ matrix.node-version == '20' && github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true' }}
+        id: release_version
+        run: echo "version=$(node -p \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
+
       - name: Create and push tag
         if: ${{ matrix.node-version == '20' && github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true' }}
         run: |
-          VERSION=$(node -p "require('./package.json').version")
+          VERSION="${{ steps.release_version.outputs.version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           if [ -n "$(git ls-remote --tags origin "refs/tags/v$VERSION")" ]; then
@@ -90,3 +95,11 @@ jobs:
             git tag -a "v$VERSION" -m "Release v$VERSION"
             git push origin "v$VERSION"
           fi
+
+      - name: Create GitHub release
+        if: ${{ matrix.node-version == '20' && github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true' }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.release_version.outputs.version }}
+          name: v${{ steps.release_version.outputs.version }}
+          generate_release_notes: true


### PR DESCRIPTION
## Summary
Manual `Publish to npm` runs now create a GitHub Release after publishing and pushing the version tag.

## Root Cause
The npm publish workflow handled `release` and `workflow_dispatch` differently:
- `release` runs published to npm after a GitHub Release already existed
- `workflow_dispatch` runs published to npm and pushed a git tag, but never created a GitHub Release entry

That left versions like `v0.3.12` and `v0.3.13` with tags but no Release objects in GitHub.

## Changes
- compute the package version once for manual publish runs
- reuse that version for tag creation
- create or update the matching GitHub Release via `softprops/action-gh-release@v2`
- enable generated release notes for the manual release path

## Validation
- `git diff --check`
- commit hooks ran successfully during `git commit`
- `actionlint` not installed in the local environment

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `npm-publish` GitHub Actions release automation for `workflow_dispatch` runs, which could create/overwrite tags/releases if misconfigured. No runtime code changes, but mistakes affect publishing and repository release state.
> 
> **Overview**
> Manual `workflow_dispatch` npm publishes now **compute the package version once** and reuse it for downstream release steps.
> 
> After publishing and (optionally) tagging `v<version>`, the workflow now **creates a matching GitHub Release** via `softprops/action-gh-release@v2` with auto-generated release notes, aligning manual publishes with the `release` trigger behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e87f2a05f6dd09b1fd117cf6f75c3fe1db371bc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->