### PR TITLE
[codex] Prepare 0.3.14 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to Factory Factory will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.14] - 2026-04-09
+
+### Added
+
+- Add ratchet PR comment reply setting (#1493)
+
+### Changed
+
+- Clarify draft and closed PR workspace states (#1492)
+- Create GitHub releases for manual npm publishes (#1494)
+
+### Fixed
+
+- Handle rerun-aware CI status classification (#1490)
+
 ## [0.3.13] - 2026-04-08
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "factory-factory",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "description": "Workspace-based coding environment for running multiple Claude Code and Codex sessions in parallel",
   "private": false,
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump the published package version from `0.3.13` to `0.3.14`
- add a `0.3.14` changelog entry for the changes shipped after `v0.3.13`
- prepare the next patch release PR without touching unrelated workspace package versions

## Why
The repository has four post-`v0.3.13` changes on `main`, so the release metadata needed to be advanced for the next patch publish.

## User impact
This prepares the next npm patch release with accurate version metadata and release notes for:
- rerun-aware CI status classification
- ratchet PR comment reply setting
- draft/closed PR workspace state clarification
- GitHub release creation for manual npm publishes

## Validation
- commit hooks ran successfully during `git commit`
- `biome check --write`
- `pnpm typecheck`
- `pnpm deps:check`
- `pnpm knip --include files,dependencies,unlisted`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release-metadata update only: bumps npm package version and adds release notes, with no runtime code changes.
> 
> **Overview**
> Prepares the `0.3.14` patch release by bumping `package.json` version from `0.3.13` to `0.3.14`.
> 
> Adds a new `CHANGELOG.md` entry for `0.3.14` documenting the latest added/changed/fixed items shipped since `0.3.13`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 561fa813b691a0698f462fe8599a54cc4804c7a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->