### PR TITLE
Fix workspace layout when init script fails

### DIFF
--- a/src/client/routes/projects/workspaces/workspace-overlays.stories.tsx
+++ b/src/client/routes/projects/workspaces/workspace-overlays.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { ArchivingOverlay, InitializationOverlay } from './workspace-overlays';
+import { ArchivingOverlay, InitializationOverlay, ScriptFailedBanner } from './workspace-overlays';
 
 const meta = {
   title: 'Workspaces/Overlays',
@@ -58,6 +58,17 @@ export const InitializationFailed: Story = {
       status="FAILED"
       initErrorMessage="Failed to run startup script: Command exited with code 1"
       initOutput="Installing dependencies...\nnpm install\nERROR: Package not found"
+      hasStartupScript={true}
+    />
+  ),
+};
+
+export const ScriptFailedLongMessage: Story = {
+  render: () => (
+    <ScriptFailedBanner
+      workspaceId="test-workspace"
+      initErrorMessage="Command failed: pnpm install --filter very-long-package-name --reporter append-only because the generated lockfile checksum did not match the expected workspace state after bootstrap and postinstall hooks"
+      initOutput="Installing dependencies...\npnpm install\nERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL"
       hasStartupScript={true}
     />
   ),

--- a/src/client/routes/projects/workspaces/workspace-overlays.test.tsx
+++ b/src/client/routes/projects/workspaces/workspace-overlays.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+import { createElement } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ScriptFailedBanner } from './workspace-overlays';
+
+vi.mock('./use-retry-workspace-init', () => ({
+  useRetryWorkspaceInit: () => ({
+    retry: vi.fn(),
+    retryInit: {
+      isPending: false,
+    },
+  }),
+}));
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('ScriptFailedBanner', () => {
+  it('uses wrapping layout classes for long init error messages', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    flushSync(() => {
+      root.render(
+        createElement(ScriptFailedBanner, {
+          workspaceId: 'workspace-1',
+          initErrorMessage:
+            'Command failed: pnpm install --filter this-is-an-intentionally-long-package-name --reporter append-only because the generated lockfile checksum did not match the expected workspace state after bootstrap',
+          initOutput: 'npm ERR! code ERESOLVE',
+          hasStartupScript: true,
+        })
+      );
+    });
+
+    const layoutRow = container.querySelector('.border-b > div');
+    expect(layoutRow?.className).toContain('flex-col');
+    expect(layoutRow?.className).toContain('sm:flex-row');
+
+    const message = Array.from(container.querySelectorAll('span')).find((node) =>
+      node.textContent?.startsWith('Init script failed:')
+    );
+    expect(message?.className).toContain('break-words');
+    expect(message?.className).toContain('whitespace-normal');
+
+    const actionRow = Array.from(container.querySelectorAll('div')).find((node) => {
+      const className = node.className;
+      return typeof className === 'string' && className.includes('flex-wrap');
+    });
+    expect(actionRow?.className).toContain('self-start');
+
+    root.unmount();
+  });
+});

--- a/src/client/routes/projects/workspaces/workspace-overlays.tsx
+++ b/src/client/routes/projects/workspaces/workspace-overlays.tsx
@@ -112,16 +112,16 @@ export function ScriptRunningBanner({ initOutput, hasStartupScript }: ScriptRunn
 
   return (
     <div className="border-b bg-muted/50 px-4 py-2">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <div className="h-3 w-3 animate-spin rounded-full border-2 border-primary border-t-transparent" />
-          <span>Running init script...</span>
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex min-w-0 items-center gap-2 text-sm text-muted-foreground">
+          <div className="h-3 w-3 shrink-0 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+          <span className="min-w-0 break-words">Running init script...</span>
         </div>
         {hasStartupScript && initOutput && (
           <Button
             variant="ghost"
             size="sm"
-            className="h-6 px-2 text-xs"
+            className="h-6 self-start px-2 text-xs sm:self-auto"
             onClick={() => setExpanded(!expanded)}
           >
             {expanded ? (
@@ -169,12 +169,14 @@ export function ScriptFailedBanner({
 
   return (
     <div className="border-b bg-destructive/10 px-4 py-2">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2 text-sm text-destructive">
-          <AlertTriangle className="h-3 w-3" />
-          <span>Init script failed{initErrorMessage ? `: ${initErrorMessage}` : ''}</span>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex min-w-0 items-start gap-2 text-sm text-destructive">
+          <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
+          <span className="min-w-0 break-words whitespace-normal">
+            Init script failed{initErrorMessage ? `: ${initErrorMessage}` : ''}
+          </span>
         </div>
-        <div className="flex items-center gap-1">
+        <div className="flex shrink-0 flex-wrap items-center gap-1 self-start sm:justify-end">
           {hasStartupScript && initOutput && (
             <Button
               variant="ghost"


### PR DESCRIPTION
## Summary
- make the init-script running and failed banners wrap cleanly instead of stretching the workspace layout
- keep banner actions aligned without forcing horizontal overflow when the error message is long
- add a regression test and Storybook case covering the long init failure message state

## Testing
- pnpm exec vitest run src/client/routes/projects/workspaces/workspace-overlays.test.tsx
- pnpm exec biome check src/client/routes/projects/workspaces/workspace-overlays.tsx src/client/routes/projects/workspaces/workspace-overlays.test.tsx src/client/routes/projects/workspaces/workspace-overlays.stories.tsx
- pnpm typecheck
- pnpm deps:check
- pnpm knip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: purely presentational Tailwind class tweaks to banner layout plus a regression test and Storybook story; no data/auth logic changes.
> 
> **Overview**
> Fixes the init-script *running* and *failed* workspace banners to wrap long messages and keep action buttons aligned without forcing horizontal overflow (responsive `flex-col`/`sm:flex-row`, `min-w-0`, `break-words`, and wrapped action row).
> 
> Adds a Storybook case for a long init-failure message and a jsdom/Vitest regression test asserting the new wrapping classes on `ScriptFailedBanner`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fe235c6b59e68d967c9b4d6d66414be75172a6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->