### PR TITLE
[codex] Clean up sessions when workspaces are archived

### DIFF
--- a/src/backend/orchestration/event-collector.orchestrator.test.ts
+++ b/src/backend/orchestration/event-collector.orchestrator.test.ts
@@ -28,7 +28,7 @@ function createMockStore(): MockStore {
 vi.mock('@/backend/services/workspace', () => ({
   WORKSPACE_STATE_CHANGED: 'workspace_state_changed',
   workspaceStateMachine: { on: vi.fn() },
-  workspaceActivityService: { on: vi.fn() },
+  workspaceActivityService: { on: vi.fn(), clearWorkspace: vi.fn() },
   computePendingRequestType: vi.fn().mockReturnValue(null),
 }));
 
@@ -70,6 +70,13 @@ vi.mock('@/backend/services/session', () => ({
       activity: 'IDLE',
       updatedAt: '2026-01-01T00:00:00.000Z',
     }),
+    stopWorkspaceSessions: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('@/backend/services/terminal', () => ({
+  terminalService: {
+    destroyWorkspaceTerminals: vi.fn(),
   },
 }));
 
@@ -98,7 +105,9 @@ import {
   chatEventForwarderService,
   sessionDataService,
   sessionDomainService,
+  sessionService,
 } from '@/backend/services/session';
+import { terminalService } from '@/backend/services/terminal';
 import {
   computePendingRequestType,
   workspaceActivityService,
@@ -486,7 +495,7 @@ describe('configureEventCollector', () => {
     expect(sessionDomainService.off).toHaveBeenCalledWith('runtime_changed', expect.any(Function));
   });
 
-  it('ARCHIVED workspace event calls store.remove() immediately', () => {
+  it('ARCHIVED workspace event removes snapshot and cleans up workspace resources immediately', async () => {
     configureEventCollector();
 
     // Get the workspace state changed handler
@@ -500,9 +509,13 @@ describe('configureEventCollector', () => {
     }) => void;
 
     handler({ workspaceId: 'ws-archived', fromStatus: 'READY', toStatus: 'ARCHIVED' });
+    await Promise.resolve();
 
     // store.remove() called immediately, not through coalescer
     expect(workspaceSnapshotStore.remove).toHaveBeenCalledWith('ws-archived');
+    expect(workspaceActivityService.clearWorkspace).toHaveBeenCalledWith('ws-archived');
+    expect(sessionService.stopWorkspaceSessions).toHaveBeenCalledWith('ws-archived');
+    expect(terminalService.destroyWorkspaceTerminals).toHaveBeenCalledWith('ws-archived');
     expect(workspaceSnapshotStore.upsert).not.toHaveBeenCalled();
   });
 

--- a/src/backend/orchestration/event-collector.orchestrator.ts
+++ b/src/backend/orchestration/event-collector.orchestrator.ts
@@ -45,6 +45,7 @@ import {
   sessionDomainService,
   sessionService,
 } from '@/backend/services/session';
+import { terminalService } from '@/backend/services/terminal';
 import {
   computePendingRequestType,
   WORKSPACE_STATE_CHANGED,
@@ -103,6 +104,7 @@ type EventCollectorSessionServices = {
   sessionDataService: typeof sessionDataService;
   sessionDomainService: typeof sessionDomainService;
   sessionService: typeof sessionService;
+  terminalService: typeof terminalService;
 };
 
 const defaultSessionServices: EventCollectorSessionServices = {
@@ -110,6 +112,7 @@ const defaultSessionServices: EventCollectorSessionServices = {
   sessionDataService,
   sessionDomainService,
   sessionService,
+  terminalService,
 };
 
 function shouldRefreshRatchetForPrSwitch(
@@ -449,6 +452,28 @@ function configureEventCollectorWithState(
     if (event.toStatus === 'ARCHIVED') {
       // Immediate removal for UI feedback -- no coalescing delay
       workspaceSnapshotStore.remove(event.workspaceId);
+      workspaceActivityService.clearWorkspace(event.workspaceId);
+      void Promise.allSettled([
+        state.eventCollectorSessionServices.sessionService.stopWorkspaceSessions(event.workspaceId),
+        Promise.resolve().then(() => {
+          state.eventCollectorSessionServices.terminalService.destroyWorkspaceTerminals(
+            event.workspaceId
+          );
+        }),
+      ]).then((results) => {
+        const cleanupErrors = results.flatMap((result) =>
+          result.status === 'rejected' ? [result.reason] : []
+        );
+
+        if (cleanupErrors.length > 0) {
+          logger.warn('Failed to cleanup archived workspace resources from state change event', {
+            workspaceId: event.workspaceId,
+            errors: cleanupErrors.map((error) =>
+              error instanceof Error ? error.message : String(error)
+            ),
+          });
+        }
+      });
       return;
     }
     coalescer.enqueue(


### PR DESCRIPTION
## Summary
- add an `ARCHIVED` workspace state-change cleanup backstop in the event collector
- stop workspace agent sessions and destroy workspace terminals when a workspace reaches `ARCHIVED`
- clear workspace activity state and cover the archived-event cleanup path in tests

## Why
The normal workspace archive orchestrator already tears down workspace resources, but a direct transition to `ARCHIVED` only removed the UI snapshot. This change makes session and terminal cleanup an invariant of the archived state instead of relying on a single archive entrypoint.

## Impact
Archived workspaces now reliably terminate any remaining agent or terminal processes even if they were archived through an alternate path.

## Validation
- `pnpm vitest run src/backend/orchestration/event-collector.orchestrator.test.ts src/backend/orchestration/workspace-archive.orchestrator.test.ts`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new resource-cleanup side effects to the `ARCHIVED` workspace state-change path (stopping sessions and destroying terminals) and runs them asynchronously, so failures or ordering issues could affect teardown reliability.
> 
> **Overview**
> Ensures that when a workspace transitions to `ARCHIVED`, the event collector immediately removes the workspace snapshot **and** proactively cleans up associated runtime resources.
> 
> On `ARCHIVED` state changes, it now calls `workspaceActivityService.clearWorkspace`, stops all workspace sessions via `sessionService.stopWorkspaceSessions`, and destroys workspace terminals via `terminalService.destroyWorkspaceTerminals`, logging warnings if any cleanup step fails. Tests are updated to mock the new services and assert the expanded cleanup behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 875bf19beb4d9eb2b0af3ca6d0eefece48c3f55c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->