### PR TITLE
Auto-iteration: retry on prompt timeout and allow resume from failed

### DIFF
--- a/src/backend/services/auto-iteration/service/auto-iteration.service.ts
+++ b/src/backend/services/auto-iteration/service/auto-iteration.service.ts
@@ -41,6 +41,9 @@ type Logger = ReturnType<typeof createLogger>;
 /** Default prompt timeout: 5 minutes. A single focused code change should not take longer. */
 const DEFAULT_PROMPT_TIMEOUT_SECONDS = 300;
 
+/** Stop the loop after this many consecutive prompt timeouts — something is fundamentally wrong. */
+const MAX_CONSECUTIVE_TIMEOUT_RETRIES = 3;
+
 /** Get prompt timeout in milliseconds from config, or the default. */
 function getPromptTimeoutMs(config: AutoIterationConfig): number | undefined {
   const seconds = config.promptTimeoutSeconds ?? DEFAULT_PROMPT_TIMEOUT_SECONDS;
@@ -58,6 +61,8 @@ interface RunningLoop {
   failedByDeath: boolean;
   /** Tracks the active loop promise to prevent concurrent loops on resume. */
   loopPromise: Promise<void> | null;
+  /** Number of consecutive prompt timeouts. Reset on any successful iteration. */
+  consecutiveTimeoutCount: number;
 }
 
 /**
@@ -132,6 +137,7 @@ export class AutoIterationService {
       stopRequested: false,
       failedByDeath: false,
       loopPromise: null,
+      consecutiveTimeoutCount: 0,
     };
     this.loops.set(workspaceId, placeholder);
 
@@ -283,6 +289,67 @@ export class AutoIterationService {
     });
   }
 
+  /**
+   * Resume from FAILED state. Unlike `start()` which resets everything, this preserves
+   * existing progress and logbook, creating a fresh session with handoff context.
+   */
+  async resumeFromFailed(
+    workspaceId: string,
+    config: AutoIterationConfig,
+    progress: AutoIterationProgress
+  ): Promise<void> {
+    if (this.loops.has(workspaceId)) {
+      throw new Error(`Auto-iteration already running for workspace ${workspaceId}`);
+    }
+
+    const worktreePath = await this.workspace.getWorktreePath(workspaceId);
+
+    // Build a handoff prompt so the new session has context from prior iterations
+    const logbook = await this.logbook.read(worktreePath);
+    const recycleInsights = await insightsService.getOpenContent(worktreePath);
+    const handoffPrompt = buildHandoffPrompt(
+      config,
+      logbook?.iterations ?? [],
+      progress.currentMetricSummary,
+      recycleInsights
+    );
+
+    // Start a fresh session with the handoff context
+    const systemPrompt = buildSystemPrompt(config, recycleInsights);
+    const sessionId = await this.session.startSession(workspaceId, {
+      initialPrompt: systemPrompt,
+      startupModePreset: 'non_interactive',
+    });
+
+    // Send the handoff prompt to give the session context about prior work
+    await this.session.sendPrompt(sessionId, handoffPrompt, getPromptTimeoutMs(config));
+    await this.session.waitForIdle(sessionId);
+
+    const loop: RunningLoop = {
+      workspaceId,
+      sessionId,
+      config,
+      progress: { ...progress, currentPhase: 'idle' },
+      pauseRequested: false,
+      stopRequested: false,
+      failedByDeath: false,
+      loopPromise: null,
+      consecutiveTimeoutCount: 0,
+    };
+    this.loops.set(workspaceId, loop);
+    await this.workspace.updateAutoIterationStatus(workspaceId, AutoIterationStatus.RUNNING);
+    await this.workspace.updateAutoIterationSessionId(workspaceId, sessionId);
+
+    loop.loopPromise = this.runLoop(loop, worktreePath).catch((err) => {
+      this.logger.error('Auto-iteration loop failed on resumeFromFailed', {
+        workspaceId,
+        error: String(err),
+      });
+      void this.workspace.updateAutoIterationStatus(workspaceId, AutoIterationStatus.FAILED);
+      this.loops.delete(workspaceId);
+    });
+  }
+
   /** Stop the loop (finishes current iteration, then stops). */
   stop(workspaceId: string): void {
     const loop = this.loops.get(workspaceId);
@@ -404,13 +471,23 @@ export class AutoIterationService {
         const result = await this.runIteration(loop, worktreePath, iterationStart);
         entry = result.entry;
         targetReached = result.targetReached;
+        loop.consecutiveTimeoutCount = 0;
       } catch (error) {
         if (error instanceof Error && error.name === 'PromptTimeoutError') {
-          // Treat prompt timeout like a crash: revert any uncommitted work and continue the loop
+          loop.consecutiveTimeoutCount++;
           this.logger.warn('Prompt timed out during iteration, treating as crash', {
             workspaceId,
             iteration: progress.currentIteration,
+            consecutiveTimeouts: loop.consecutiveTimeoutCount,
           });
+          if (loop.consecutiveTimeoutCount >= MAX_CONSECUTIVE_TIMEOUT_RETRIES) {
+            this.logger.error(
+              `${MAX_CONSECUTIVE_TIMEOUT_RETRIES} consecutive prompt timeouts, aborting loop`,
+              { workspaceId }
+            );
+            await this.finalize(loop, AutoIterationStatus.FAILED);
+            return;
+          }
           try {
             if (loop.progress.currentPhase === 'implementing') {
               // During implement, changes are not yet committed — discard uncommitted work
@@ -427,6 +504,30 @@ export class AutoIterationService {
               workspaceId,
               iteration: progress.currentIteration,
               error: revertError instanceof Error ? revertError.message : String(revertError),
+            });
+            await this.finalize(loop, AutoIterationStatus.FAILED);
+            return;
+          }
+          // The timed-out session was killed by escalatePromptTimeout — recycle it so the
+          // next iteration has a live session to work with.
+          try {
+            await this.emitPhase(loop, 'recycling');
+            const logbook = await this.logbook.read(worktreePath);
+            const recycleInsights = await insightsService.getOpenContent(worktreePath);
+            const handoffPrompt = buildHandoffPrompt(
+              config,
+              logbook?.iterations ?? [],
+              progress.currentMetricSummary,
+              recycleInsights
+            );
+            loop.sessionId = await this.session.recycleSession(workspaceId, handoffPrompt);
+            await this.workspace.updateAutoIterationSessionId(workspaceId, loop.sessionId);
+            progress.sessionRecycleCount++;
+          } catch (recycleError) {
+            this.logger.error('Failed to recycle session after prompt timeout, aborting loop', {
+              workspaceId,
+              iteration: progress.currentIteration,
+              error: recycleError instanceof Error ? recycleError.message : String(recycleError),
             });
             await this.finalize(loop, AutoIterationStatus.FAILED);
             return;

--- a/src/backend/services/auto-iteration/service/auto-iteration.service.ts
+++ b/src/backend/services/auto-iteration/service/auto-iteration.service.ts
@@ -497,14 +497,8 @@ export class AutoIterationService {
             iteration: progress.currentIteration,
             consecutiveTimeouts: loop.consecutiveTimeoutCount,
           });
-          if (loop.consecutiveTimeoutCount >= MAX_CONSECUTIVE_TIMEOUT_RETRIES) {
-            this.logger.error(
-              `${MAX_CONSECUTIVE_TIMEOUT_RETRIES} consecutive prompt timeouts, aborting loop`,
-              { workspaceId }
-            );
-            await this.finalize(loop, AutoIterationStatus.FAILED);
-            return;
-          }
+          // Always clean up the worktree before checking whether to abort —
+          // otherwise the final timeout leaves dirty state behind.
           try {
             if (loop.progress.currentPhase === 'implementing') {
               // During implement, changes are not yet committed — discard uncommitted work
@@ -522,6 +516,14 @@ export class AutoIterationService {
               iteration: progress.currentIteration,
               error: revertError instanceof Error ? revertError.message : String(revertError),
             });
+            await this.finalize(loop, AutoIterationStatus.FAILED);
+            return;
+          }
+          if (loop.consecutiveTimeoutCount >= MAX_CONSECUTIVE_TIMEOUT_RETRIES) {
+            this.logger.error(
+              `${MAX_CONSECUTIVE_TIMEOUT_RETRIES} consecutive prompt timeouts, aborting loop`,
+              { workspaceId }
+            );
             await this.finalize(loop, AutoIterationStatus.FAILED);
             return;
           }

--- a/src/backend/services/auto-iteration/service/auto-iteration.service.ts
+++ b/src/backend/services/auto-iteration/service/auto-iteration.service.ts
@@ -298,36 +298,13 @@ export class AutoIterationService {
     config: AutoIterationConfig,
     progress: AutoIterationProgress
   ): Promise<void> {
+    // Atomic guard: register the loop synchronously before any await to prevent concurrent starts
     if (this.loops.has(workspaceId)) {
       throw new Error(`Auto-iteration already running for workspace ${workspaceId}`);
     }
-
-    const worktreePath = await this.workspace.getWorktreePath(workspaceId);
-
-    // Build a handoff prompt so the new session has context from prior iterations
-    const logbook = await this.logbook.read(worktreePath);
-    const recycleInsights = await insightsService.getOpenContent(worktreePath);
-    const handoffPrompt = buildHandoffPrompt(
-      config,
-      logbook?.iterations ?? [],
-      progress.currentMetricSummary,
-      recycleInsights
-    );
-
-    // Start a fresh session with the handoff context
-    const systemPrompt = buildSystemPrompt(config, recycleInsights);
-    const sessionId = await this.session.startSession(workspaceId, {
-      initialPrompt: systemPrompt,
-      startupModePreset: 'non_interactive',
-    });
-
-    // Send the handoff prompt to give the session context about prior work
-    await this.session.sendPrompt(sessionId, handoffPrompt, getPromptTimeoutMs(config));
-    await this.session.waitForIdle(sessionId);
-
-    const loop: RunningLoop = {
+    const placeholder: RunningLoop = {
       workspaceId,
-      sessionId,
+      sessionId: '',
       config,
       progress: { ...progress, currentPhase: 'idle' },
       pauseRequested: false,
@@ -336,18 +313,58 @@ export class AutoIterationService {
       loopPromise: null,
       consecutiveTimeoutCount: 0,
     };
-    this.loops.set(workspaceId, loop);
-    await this.workspace.updateAutoIterationStatus(workspaceId, AutoIterationStatus.RUNNING);
-    await this.workspace.updateAutoIterationSessionId(workspaceId, sessionId);
+    this.loops.set(workspaceId, placeholder);
 
-    loop.loopPromise = this.runLoop(loop, worktreePath).catch((err) => {
-      this.logger.error('Auto-iteration loop failed on resumeFromFailed', {
-        workspaceId,
-        error: String(err),
+    try {
+      const worktreePath = await this.workspace.getWorktreePath(workspaceId);
+
+      // Build a handoff prompt so the new session has context from prior iterations
+      const logbook = await this.logbook.read(worktreePath);
+      const recycleInsights = await insightsService.getOpenContent(worktreePath);
+      const handoffPrompt = buildHandoffPrompt(
+        config,
+        logbook?.iterations ?? [],
+        progress.currentMetricSummary,
+        recycleInsights
+      );
+
+      // Start a fresh session with the handoff context
+      const systemPrompt = buildSystemPrompt(config, recycleInsights);
+      const sessionId = await this.session.startSession(workspaceId, {
+        initialPrompt: systemPrompt,
+        startupModePreset: 'non_interactive',
       });
-      void this.workspace.updateAutoIterationStatus(workspaceId, AutoIterationStatus.FAILED);
+      placeholder.sessionId = sessionId;
+
+      // Send the handoff prompt to give the session context about prior work
+      await this.session.sendPrompt(sessionId, handoffPrompt, getPromptTimeoutMs(config));
+      await this.session.waitForIdle(sessionId);
+
+      await this.workspace.updateAutoIterationStatus(workspaceId, AutoIterationStatus.RUNNING);
+      await this.workspace.updateAutoIterationSessionId(workspaceId, sessionId);
+
+      placeholder.loopPromise = this.runLoop(placeholder, worktreePath).catch((err) => {
+        this.logger.error('Auto-iteration loop failed on resumeFromFailed', {
+          workspaceId,
+          error: String(err),
+        });
+        void this.workspace.updateAutoIterationStatus(workspaceId, AutoIterationStatus.FAILED);
+        this.loops.delete(workspaceId);
+      });
+    } catch (err) {
+      // Clean up the session if one was started before the failure
+      if (placeholder.sessionId) {
+        try {
+          await this.session.stopSession(placeholder.sessionId);
+        } catch {
+          // Session cleanup is best-effort
+        }
+        void this.workspace.updateAutoIterationSessionId(workspaceId, null);
+      }
       this.loops.delete(workspaceId);
-    });
+      void this.workspace.updateAutoIterationStatus(workspaceId, AutoIterationStatus.FAILED);
+      throw err;
+    }
   }
 
   /** Stop the loop (finishes current iteration, then stops). */

--- a/src/backend/trpc/auto-iteration.trpc.ts
+++ b/src/backend/trpc/auto-iteration.trpc.ts
@@ -16,6 +16,45 @@ const autoIterationConfigSchema = z.object({
   sessionRecycleInterval: z.number().int().min(1).default(10),
 });
 
+/** Handle resume-from-failed: validate config/progress and delegate to service. */
+async function handleResumeFromFailed(
+  workspace: { autoIterationConfig: unknown; autoIterationProgress: unknown },
+  workspaceId: string
+): Promise<void> {
+  if (!workspace.autoIterationConfig) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'Workspace has no auto-iteration config',
+    });
+  }
+  const configParsed = autoIterationConfigSchema.safeParse(workspace.autoIterationConfig);
+  if (!configParsed.success) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `Invalid auto-iteration config: ${configParsed.error.message}`,
+    });
+  }
+  const progress = workspace.autoIterationProgress as Record<string, unknown> | null;
+  if (!progress) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'No progress data to resume from — use restart instead',
+    });
+  }
+  try {
+    await autoIterationService.resumeFromFailed(
+      workspaceId,
+      configParsed.data,
+      progress as unknown as Parameters<typeof autoIterationService.resumeFromFailed>[2]
+    );
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('already running')) {
+      throw new TRPCError({ code: 'CONFLICT', message: err.message });
+    }
+    throw err;
+  }
+}
+
 export const autoIterationRouter = router({
   /** Start the auto-iteration loop for a workspace. */
   start: publicProcedure
@@ -75,7 +114,7 @@ export const autoIterationRouter = router({
       return { success: true };
     }),
 
-  /** Resume a paused auto-iteration loop. */
+  /** Resume a paused or failed auto-iteration loop. */
   resume: publicProcedure
     .input(z.object({ workspaceId: z.string() }))
     .mutation(async ({ input }) => {
@@ -83,12 +122,21 @@ export const autoIterationRouter = router({
       if (!workspace) {
         throw new TRPCError({ code: 'NOT_FOUND', message: 'Workspace not found' });
       }
-      if (workspace.autoIterationStatus !== 'PAUSED') {
+      if (
+        workspace.autoIterationStatus !== 'PAUSED' &&
+        workspace.autoIterationStatus !== 'FAILED'
+      ) {
         throw new TRPCError({
           code: 'BAD_REQUEST',
-          message: 'Auto-iteration can only be resumed from paused state',
+          message: 'Auto-iteration can only be resumed from paused or failed state',
         });
       }
+
+      if (workspace.autoIterationStatus === 'FAILED') {
+        await handleResumeFromFailed(workspace, input.workspaceId);
+        return { success: true };
+      }
+
       try {
         await autoIterationService.resume(input.workspaceId);
       } catch (err) {

--- a/src/components/workspace/auto-iteration-panel.tsx
+++ b/src/components/workspace/auto-iteration-panel.tsx
@@ -388,6 +388,7 @@ const TERMINAL_STATUSES = new Set(['FAILED', 'STOPPED', 'MAX_ITERATIONS', 'COMPL
 function AutoIterationControls({ workspaceId, status }: { workspaceId: string; status: string }) {
   const isRunning = status === 'RUNNING';
   const isPaused = status === 'PAUSED';
+  const isFailed = status === 'FAILED';
   const isTerminal = TERMINAL_STATUSES.has(status);
 
   const utils = trpc.useUtils();
@@ -447,6 +448,22 @@ function AutoIterationControls({ workspaceId, status }: { workspaceId: string; s
             </Button>
           </TooltipTrigger>
           <TooltipContent>Stop iteration</TooltipContent>
+        </Tooltip>
+      )}
+      {isFailed && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 w-6 p-0"
+              onClick={() => resumeMutation.mutate({ workspaceId })}
+              disabled={resumeMutation.isPending}
+            >
+              <Play className="h-3.5 w-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Resume from where it left off</TooltipContent>
         </Tooltip>
       )}
       {isTerminal && (


### PR DESCRIPTION
## Summary
- **Fix prompt timeout crash**: When an ACP prompt times out, the session is killed but the loop previously tried to reuse the dead session on the next iteration, causing an unrecoverable failure. Now recycles the session after timeout with a handoff prompt so iteration can continue.
- **Auto-retry with limit**: Tracks consecutive prompt timeouts and automatically retries up to 3 times before stopping with FAILED status.
- **Resume from FAILED**: Adds `resumeFromFailed()` that preserves existing progress and logbook, creating a fresh session with handoff context instead of starting over.
- **UI Resume button**: FAILED workspaces now show a Resume (play) button alongside the existing Restart button.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (2928 tests)
- [x] `pnpm check:fix` passes (no errors)
- [ ] Manually trigger a prompt timeout on an auto-iteration workspace and verify it recycles the session and continues
- [ ] Verify that after 3 consecutive timeouts the loop stops with FAILED
- [ ] Verify the Resume button appears for FAILED workspaces and successfully resumes iteration
- [ ] Verify Restart still works as before (full reset)
