### PR TITLE
Fix #1452: Drop stale WebSocket events

### DIFF
--- a/src/hooks/use-websocket-transport.replay.test.tsx
+++ b/src/hooks/use-websocket-transport.replay.test.tsx
@@ -53,6 +53,10 @@ class MockWebSocket {
     this.onopen?.({ type: 'open' });
   }
 
+  simulateMessage(data: unknown) {
+    this.onmessage?.({ type: 'message', data: JSON.stringify(data) });
+  }
+
   failNextSends(count: number) {
     this.failSendCount = count;
   }
@@ -71,12 +75,14 @@ function getLastSocket(): MockWebSocket {
 interface TransportHarnessProps {
   url: string | null;
   onConnected?: () => void;
+  onMessage?: (message: unknown) => void;
   transportRef: { current: UseWebSocketTransportReturn | null };
 }
 
-function TransportHarness({ url, onConnected, transportRef }: TransportHarnessProps) {
+function TransportHarness({ url, onConnected, onMessage, transportRef }: TransportHarnessProps) {
   const transport = useWebSocketTransport({
     url,
+    onMessage,
     onConnected,
     queuePolicy: 'replay',
   });
@@ -84,24 +90,39 @@ function TransportHarness({ url, onConnected, transportRef }: TransportHarnessPr
   return null;
 }
 
-function createHarness(options: { onConnected?: () => void } = {}) {
+function createHarness(
+  options: {
+    initialUrl?: string | null;
+    onConnected?: () => void;
+    onMessage?: (message: unknown) => void;
+  } = {}
+) {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const root = createRoot(container);
   const transportRef = { current: null as UseWebSocketTransportReturn | null };
-
-  flushSync(() => {
+  const render = (url: string | null) => {
     root.render(
       createElement(TransportHarness, {
-        url: 'ws://localhost:3000/chat',
+        url,
         onConnected: options.onConnected,
+        onMessage: options.onMessage,
         transportRef,
       })
     );
+  };
+
+  flushSync(() => {
+    render(options.initialUrl ?? 'ws://localhost:3000/chat');
   });
 
   return {
     transportRef,
+    rerenderUrl: (url: string | null) => {
+      flushSync(() => {
+        render(url);
+      });
+    },
     cleanup: () => {
       flushSync(() => {
         root.unmount();
@@ -273,6 +294,66 @@ describe('useWebSocketTransport replay queue', () => {
 
     expect(transport.send({ type: 'stop', id: 'fresh-stop' })).toBe(false);
     expect(extractMessageIds(socket)).toEqual(['queued-first', 'fresh-stop']);
+
+    harness.cleanup();
+  });
+
+  it('drops messages from sockets superseded by a URL change', async () => {
+    const receivedMessages: unknown[] = [];
+    const harness = createHarness({
+      initialUrl: 'ws://localhost:3000/chat?sessionId=one',
+      onMessage: (message) => {
+        receivedMessages.push(message);
+      },
+    });
+    await flushEffects();
+
+    const firstSocket = getLastSocket();
+    flushSync(() => {
+      firstSocket.simulateOpen();
+    });
+
+    harness.rerenderUrl('ws://localhost:3000/chat?sessionId=two');
+    await flushEffects();
+
+    const secondSocket = getLastSocket();
+    expect(secondSocket).not.toBe(firstSocket);
+
+    flushSync(() => {
+      firstSocket.simulateMessage({ type: 'session_snapshot', session: 'old' });
+      secondSocket.simulateOpen();
+      secondSocket.simulateMessage({ type: 'session_snapshot', session: 'new' });
+    });
+
+    expect(receivedMessages).toEqual([{ type: 'session_snapshot', session: 'new' }]);
+
+    harness.cleanup();
+  });
+
+  it('ignores open events from sockets superseded by a URL change', async () => {
+    let connectedCount = 0;
+    const harness = createHarness({
+      initialUrl: 'ws://localhost:3000/chat?sessionId=one',
+      onConnected: () => {
+        connectedCount += 1;
+      },
+    });
+    await flushEffects();
+
+    const firstSocket = getLastSocket();
+
+    harness.rerenderUrl('ws://localhost:3000/chat?sessionId=two');
+    await flushEffects();
+
+    const secondSocket = getLastSocket();
+    expect(secondSocket).not.toBe(firstSocket);
+
+    flushSync(() => {
+      firstSocket.simulateOpen();
+      secondSocket.simulateOpen();
+    });
+
+    expect(connectedCount).toBe(1);
 
     harness.cleanup();
   });

--- a/src/hooks/use-websocket-transport.ts
+++ b/src/hooks/use-websocket-transport.ts
@@ -214,6 +214,10 @@ export function useWebSocketTransport(
     wsRef.current = ws;
 
     ws.onopen = () => {
+      if (wsRef.current !== ws) {
+        return;
+      }
+
       setConnected(true);
       reconnectAttemptsRef.current = 0;
 
@@ -229,6 +233,10 @@ export function useWebSocketTransport(
     };
 
     ws.onmessage = (event) => {
+      if (wsRef.current !== ws) {
+        return;
+      }
+
       try {
         if (typeof event.data !== 'string') {
           return;


### PR DESCRIPTION
## Summary
- Drops WebSocket `open` and `message` events from sockets that have been superseded by a newer connection.
- Prevents late messages from an old chat session connection from hydrating or dispatching into the newly selected session.
- Adds regression coverage for stale message and stale open events after URL/session changes.

## Changes
- **WebSocket transport**: Verify the event's socket is still the active `wsRef.current` before running `onConnected` or `onMessage` callbacks.
- **Transport tests**: Extend the real hook harness to rerender with a new URL and assert old socket events are ignored.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not run; no visible UI change. Covered by transport regression tests.

Closes #1452

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core WebSocket transport event handling; incorrect guards could suppress legitimate `onConnected`/`onMessage` events during reconnects or rapid URL swaps.
> 
> **Overview**
> Prevents *stale WebSocket events* from superseded connections from mutating current state by ignoring `onopen` and `onmessage` callbacks unless the event’s socket is still `wsRef.current`.
> 
> Extends the replay-queue test harness to support URL rerenders and simulates late `open`/`message` events, adding regression coverage that only the newest connection can trigger `onConnected` or deliver parsed messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1638e9b72827be07f850a85b84bf11cc45dfc074. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->