### PR TITLE
Fix #1454: Handle ACP free-form permission questions

### DIFF
--- a/src/backend/services/session/service/lifecycle/session.permission.service.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.permission.service.test.ts
@@ -147,6 +147,60 @@ describe('SessionPermissionService', () => {
     );
   });
 
+  it('normalizes free-form user question options before emitting and storing', () => {
+    const service = createService();
+
+    service.handlePermissionRequest(
+      'session-1',
+      unsafeCoerce({
+        type: 'acp_permission_request',
+        requestId: 'req-questions-freeform',
+        params: {
+          toolCall: {
+            toolCallId: 'tool-questions-freeform',
+            title: 'AskUserQuestion',
+            rawInput: {
+              questions: [
+                {
+                  id: 'q1',
+                  question: 'What should happen next?',
+                  header: 'Next',
+                  options: null,
+                },
+              ],
+            },
+          },
+          options: [{ optionId: 'allow_once', name: 'Allow once', kind: 'allow_once' }],
+        },
+      })
+    );
+
+    const expectedQuestions = [
+      {
+        id: 'q1',
+        question: 'What should happen next?',
+        header: 'Next',
+        options: [],
+      },
+    ];
+
+    expect(sessionDomain.emitDelta).toHaveBeenCalledWith(
+      'session-1',
+      expect.objectContaining({
+        type: 'user_question',
+        questions: expectedQuestions,
+      })
+    );
+    expect(sessionDomain.setPendingInteractiveRequest).toHaveBeenCalledWith(
+      'session-1',
+      expect.objectContaining({
+        input: expect.objectContaining({
+          questions: expectedQuestions,
+        }),
+      })
+    );
+  });
+
   it('extracts plan content for ExitPlanMode permission payloads', () => {
     const service = createService();
 
@@ -175,6 +229,45 @@ describe('SessionPermissionService', () => {
       expect.objectContaining({
         type: 'permission_request',
         planContent: '# Plan\n- Step 1',
+      })
+    );
+  });
+
+  it('uses stable ExitPlanMode input type when permission title is only a display label', () => {
+    const service = createService();
+
+    service.handlePermissionRequest(
+      'session-1',
+      unsafeCoerce({
+        type: 'acp_permission_request',
+        requestId: 'req-plan-display-title',
+        params: {
+          toolCall: {
+            toolCallId: 'tool-plan-display-title',
+            title: 'Review Proposed Plan',
+            rawInput: {
+              type: 'ExitPlanMode',
+              plan: '# My Plan',
+            },
+          },
+          options: [{ optionId: 'allow_once', name: 'Allow once', kind: 'allow_once' }],
+        },
+      })
+    );
+
+    expect(sessionDomain.emitDelta).toHaveBeenCalledWith(
+      'session-1',
+      expect.objectContaining({
+        type: 'permission_request',
+        toolName: 'ExitPlanMode',
+        planContent: '# My Plan',
+      })
+    );
+    expect(sessionDomain.setPendingInteractiveRequest).toHaveBeenCalledWith(
+      'session-1',
+      expect.objectContaining({
+        toolName: 'ExitPlanMode',
+        planContent: '# My Plan',
       })
     );
   });

--- a/src/backend/services/session/service/lifecycle/session.permission.service.ts
+++ b/src/backend/services/session/service/lifecycle/session.permission.service.ts
@@ -6,7 +6,7 @@ import type { SessionDomainService } from '@/backend/services/session/service/se
 import { sessionDomainService } from '@/backend/services/session/service/session-domain.service';
 import type { AskUserQuestion } from '@/shared/acp-protocol';
 import { extractPlanText } from '@/shared/acp-protocol/plan-content';
-import { isUserQuestionRequest } from '@/shared/pending-request-types';
+import { isExitPlanModeRequest, isUserQuestionRequest } from '@/shared/pending-request-types';
 
 export type SessionPermissionServiceDependencies = {
   sessionDomainService?: SessionDomainService;
@@ -52,17 +52,19 @@ export class SessionPermissionService {
 
   handlePermissionRequest(sessionId: string, event: AcpPermissionRequestEvent): void {
     const { requestId, params } = event;
-    const toolName = params.toolCall.title ?? 'ACP Tool';
     const toolInput = (params.toolCall.rawInput as Record<string, unknown>) ?? {};
+    const toolName = this.resolveToolName(params.toolCall.title, toolInput);
     const acpOptions = params.options.map((option) => ({
       optionId: option.optionId,
       name: option.name,
       kind: option.kind,
     }));
     const planContent = this.extractPlanContent(toolName, toolInput);
+    const isUserQuestion = isUserQuestionRequest({ toolName, input: toolInput });
+    const questions = isUserQuestion ? this.extractAskUserQuestions(toolInput) : [];
+    const pendingInput = isUserQuestion ? { ...toolInput, questions } : toolInput;
 
-    if (isUserQuestionRequest({ toolName, input: toolInput })) {
-      const questions = this.extractAskUserQuestions(toolInput);
+    if (isUserQuestion) {
       this.sessionDomainService.emitDelta(sessionId, {
         type: 'user_question',
         requestId,
@@ -86,7 +88,7 @@ export class SessionPermissionService {
       requestId,
       toolName,
       toolUseId: params.toolCall.toolCallId,
-      input: toolInput,
+      input: pendingInput,
       planContent,
       acpOptions,
       timestamp: new Date().toISOString(),
@@ -99,14 +101,66 @@ export class SessionPermissionService {
       return [];
     }
 
-    return questions as AskUserQuestion[];
+    return questions.flatMap((question): AskUserQuestion[] => {
+      if (!question || typeof question !== 'object') {
+        return [];
+      }
+
+      const record = question as Record<string, unknown>;
+      if (typeof record.question !== 'string') {
+        return [];
+      }
+
+      const options = Array.isArray(record.options)
+        ? record.options.flatMap((option): AskUserQuestion['options'] => {
+            if (!option || typeof option !== 'object') {
+              return [];
+            }
+
+            const optionRecord = option as Record<string, unknown>;
+            if (typeof optionRecord.label !== 'string') {
+              return [];
+            }
+
+            return [
+              {
+                label: optionRecord.label,
+                description:
+                  typeof optionRecord.description === 'string' ? optionRecord.description : '',
+              },
+            ];
+          })
+        : [];
+
+      return [
+        {
+          ...(typeof record.id === 'string' ? { id: record.id } : {}),
+          question: record.question,
+          ...(typeof record.header === 'string' ? { header: record.header } : {}),
+          options,
+          ...(typeof record.multiSelect === 'boolean' ? { multiSelect: record.multiSelect } : {}),
+        },
+      ];
+    });
   }
 
   private extractPlanContent(toolName: string, input: Record<string, unknown>): string | null {
-    if (toolName !== 'ExitPlanMode') {
+    if (!isExitPlanModeRequest({ toolName, input })) {
       return null;
     }
 
     return extractPlanText(input.plan);
+  }
+
+  private resolveToolName(
+    title: string | null | undefined,
+    input: Record<string, unknown>
+  ): string {
+    const type = input.type;
+    if (type === 'AskUserQuestion' || type === 'ExitPlanMode') {
+      return type;
+    }
+
+    return title ?? 'ACP Tool';
   }
 }

--- a/src/backend/services/workspace/service/state/pending-request-type.test.ts
+++ b/src/backend/services/workspace/service/state/pending-request-type.test.ts
@@ -14,6 +14,18 @@ describe('computePendingRequestType', () => {
     expect(result).toBe('plan_approval');
   });
 
+  it('returns plan_approval when stable input type is ExitPlanMode', () => {
+    const result = computePendingRequestType(
+      ['s1', 's2'],
+      new Map([
+        ['s1', { toolName: 'Review Proposed Plan', input: { type: 'ExitPlanMode' } }],
+        ['s2', { toolName: 'ReadFile' }],
+      ])
+    );
+
+    expect(result).toBe('plan_approval');
+  });
+
   it('returns user_question when any session has AskUserQuestion pending', () => {
     const result = computePendingRequestType(
       ['s1', 's2'],

--- a/src/backend/services/workspace/service/state/pending-request-type.ts
+++ b/src/backend/services/workspace/service/state/pending-request-type.ts
@@ -1,4 +1,4 @@
-import { isUserQuestionRequest } from '@/shared/pending-request-types';
+import { isExitPlanModeRequest, isUserQuestionRequest } from '@/shared/pending-request-types';
 
 export type WorkspacePendingRequestType =
   | 'plan_approval'
@@ -27,7 +27,7 @@ export function computePendingRequestType(
       continue;
     }
 
-    if (request.toolName === 'ExitPlanMode') {
+    if (isExitPlanModeRequest({ toolName: request.toolName, input: request.input })) {
       return 'plan_approval';
     }
     if (isUserQuestionRequest({ toolName: request.toolName, input: request.input })) {

--- a/src/components/chat/question-prompt.test.tsx
+++ b/src/components/chat/question-prompt.test.tsx
@@ -5,6 +5,7 @@ import { flushSync } from 'react-dom';
 import { createRoot } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { UserQuestionRequest } from '@/lib/chat-protocol';
+import { unsafeCoerce } from '@/test-utils/unsafe-coerce';
 import { QuestionPrompt } from './question-prompt';
 
 afterEach(() => {
@@ -69,6 +70,35 @@ describe('QuestionPrompt', () => {
     const iconWrapper = container.querySelector('svg.lucide-circle-question-mark')?.parentElement;
     expect(iconWrapper?.className).toContain('hidden');
     expect(iconWrapper?.className).toContain('sm:block');
+
+    root.unmount();
+  });
+
+  it('renders free-form questions with null options without crashing', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const onAnswer = vi.fn();
+
+    const question = unsafeCoerce<UserQuestionRequest>({
+      requestId: 'question-freeform-1',
+      timestamp: '2026-04-28T00:00:00.000Z',
+      questions: [
+        {
+          header: 'Clarify',
+          question: 'What should the agent do next?',
+          options: null,
+        },
+      ],
+    });
+
+    expect(() => {
+      flushSync(() => {
+        root.render(createElement(QuestionPrompt, { question, onAnswer }));
+      });
+    }).not.toThrow();
+
+    expect(container.querySelector('textarea[aria-label="Other response"]')).not.toBeNull();
 
     root.unmount();
   });

--- a/src/components/chat/question-prompt.tsx
+++ b/src/components/chat/question-prompt.tsx
@@ -298,6 +298,7 @@ function SingleSelectQuestion({
 }: SingleQuestionProps) {
   const selectedValue = typeof value === 'string' ? value : '';
   const idPrefix = `${requestId}-${index}`;
+  const options = Array.isArray(question.options) ? question.options : [];
 
   return (
     <div className="space-y-1.5">
@@ -307,7 +308,7 @@ function SingleSelectQuestion({
       <p className="text-sm font-medium break-words">{question.question}</p>
 
       <RadioGroup value={selectedValue} onValueChange={onChange} className="space-y-1.5">
-        {question.options.map((option) => (
+        {options.map((option) => (
           <label
             key={`${index}-${option.label}`}
             htmlFor={`question-${idPrefix}-option-${option.label}`}
@@ -392,6 +393,7 @@ function MultiSelectQuestion({
 }: SingleQuestionProps) {
   const selectedValues = Array.isArray(value) ? value : [];
   const idPrefix = `${requestId}-${index}`;
+  const options = Array.isArray(question.options) ? question.options : [];
 
   const handleCheckboxChange = useCallback(
     (optionLabel: string, checked: boolean) => {
@@ -412,7 +414,7 @@ function MultiSelectQuestion({
       <p className="text-sm font-medium break-words">{question.question}</p>
 
       <div className="space-y-1.5">
-        {question.options.map((option) => {
+        {options.map((option) => {
           const isSelected = selectedValues.includes(option.label);
 
           return (

--- a/src/shared/pending-request-types.test.ts
+++ b/src/shared/pending-request-types.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { hasAskUserQuestionInput, isUserQuestionRequest } from './pending-request-types';
+import {
+  hasAskUserQuestionInput,
+  hasExitPlanModeInput,
+  isExitPlanModeRequest,
+  isUserQuestionRequest,
+} from './pending-request-types';
 
 describe('pending-request-types helpers', () => {
   it('detects AskUserQuestion-style input shape', () => {
@@ -22,6 +27,17 @@ describe('pending-request-types helpers', () => {
       isUserQuestionRequest({
         toolName: 'Tool input request',
         input: { questions: [{ question: 'Q1' }] },
+      })
+    ).toBe(true);
+  });
+
+  it('detects ExitPlanMode by stable input type', () => {
+    expect(hasExitPlanModeInput({ type: 'ExitPlanMode' })).toBe(true);
+    expect(hasExitPlanModeInput({ type: 'Review Proposed Plan' })).toBe(false);
+    expect(
+      isExitPlanModeRequest({
+        toolName: 'Review Proposed Plan',
+        input: { type: 'ExitPlanMode' },
       })
     ).toBe(true);
   });

--- a/src/shared/pending-request-types.ts
+++ b/src/shared/pending-request-types.ts
@@ -37,6 +37,26 @@ export function hasAskUserQuestionInput(
 }
 
 /**
+ * Returns true when the tool input identifies an ACP ExitPlanMode request.
+ * ACP tool titles are display labels, so request classification should prefer
+ * the stable input type when it is present.
+ */
+export function hasExitPlanModeInput(input: Record<string, unknown> | null | undefined): boolean {
+  return input?.type === 'ExitPlanMode';
+}
+
+/**
+ * Returns true when a pending request should be treated as plan approval.
+ */
+export function isExitPlanModeRequest(
+  request: Pick<PendingInteractiveRequest, 'toolName'> & {
+    input?: Record<string, unknown>;
+  }
+): boolean {
+  return request.toolName === 'ExitPlanMode' || hasExitPlanModeInput(request.input);
+}
+
+/**
  * Returns true when a pending request should be treated as a user-question prompt.
  */
 export function isUserQuestionRequest(


### PR DESCRIPTION
## Summary
- Fix ACP free-form user questions by normalizing null or missing question options to empty arrays.
- Identify ExitPlanMode using the stable ACP input type instead of the display title.
- Add regression coverage for title-independent plan approval and null-option question rendering.

## Changes
- **Session permissions**: Resolve known interactive ACP tools from `rawInput.type`, sanitize AskUserQuestion payloads before emitting deltas and storing pending requests, and extract plan content from stable ExitPlanMode requests.
- **Workspace pending state**: Classify pending plan approvals when stored request input has `type: 'ExitPlanMode'`, even if `toolName` is a display label.
- **Question prompt UI**: Defensively render malformed legacy questions with `options: null` without crashing.
- **Tests**: Cover free-form question normalization, stable ExitPlanMode classification, and the renderer fallback.

## Testing
- [x] Tests pass (`pnpm test -- --maxWorkers=1 --hookTimeout=30000 --testTimeout=30000`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Manual testing: verified targeted regression tests for null options and display-title ExitPlanMode handling

Note: the default parallel `pnpm test` command repeatedly hit unrelated integration-test timeouts in this workspace; the full suite passed when run with the Vitest worker/timeout flags above.

Closes #1454

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how permission requests are classified and how pending interactive request payloads are stored, which can affect session restore and workspace state; changes are guarded with added regression tests.
> 
> **Overview**
> Fixes ACP interactive permission handling by **normalizing `AskUserQuestion` payloads** (treating missing/`null` `options` as `[]` and sanitizing question/option shapes) before emitting deltas and storing pending requests.
> 
> Updates plan-approval detection to **recognize `ExitPlanMode` via stable `rawInput.type`** (including when the displayed permission title differs), and uses this helper for plan content extraction and workspace `computePendingRequestType` classification.
> 
> Hardens the chat `QuestionPrompt` renderer against legacy/free-form questions with `options: null`, and adds regression tests covering the normalization, title-independent `ExitPlanMode` handling, and UI non-crash behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e640641dd6539413e89567d78c9c2f0eae90db68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->