### PR TITLE
Fix #1450: Block ratchet on idle running sessions

### DIFF
--- a/src/backend/services/ratchet/service/ratchet-active-session.helpers.ts
+++ b/src/backend/services/ratchet/service/ratchet-active-session.helpers.ts
@@ -182,5 +182,5 @@ export async function hasActiveSession(
   sessionBridge: RatchetSessionBridge
 ): Promise<boolean> {
   const sessions = await agentSessionAccessor.findByWorkspaceId(workspaceId);
-  return sessions.some((session) => sessionBridge.isSessionWorking(session.id));
+  return sessions.some((session) => sessionBridge.isSessionRunning(session.id));
 }

--- a/src/backend/services/ratchet/service/ratchet.service.test.ts
+++ b/src/backend/services/ratchet/service/ratchet.service.test.ts
@@ -230,6 +230,7 @@ describe('ratchet service (state-change + idle dispatch)', () => {
         status: 'RUNNING',
       },
     ] as never);
+    vi.mocked(mockSessionBridge.isSessionRunning).mockReturnValue(true);
     vi.mocked(mockSessionBridge.isSessionWorking).mockReturnValue(true);
 
     const result = await unsafeCoerce<{
@@ -299,7 +300,7 @@ describe('ratchet service (state-change + idle dispatch)', () => {
     );
   });
 
-  it('does dispatch when session is running but idle', async () => {
+  it('does not dispatch when session is running but idle', async () => {
     const workspace = {
       id: 'ws-idle-session',
       prUrl: 'https://github.com/example/repo/pull/44',
@@ -334,21 +335,21 @@ describe('ratchet service (state-change + idle dispatch)', () => {
         status: 'RUNNING',
       },
     ] as never);
+    vi.mocked(mockSessionBridge.isSessionRunning).mockReturnValue(true);
     vi.mocked(mockSessionBridge.isSessionWorking).mockReturnValue(false);
-
-    vi.mocked(fixerSessionService.acquireAndDispatch).mockResolvedValue({
-      status: 'started',
-      sessionId: 'ratchet-session-idle-ok',
-      promptSent: true,
-    } as never);
 
     const result = await unsafeCoerce<{
       processWorkspace: (workspaceArg: typeof workspace) => Promise<unknown>;
     }>(ratchetService).processWorkspace(workspace);
 
     expect(result).toMatchObject({
-      action: { type: 'TRIGGERED_FIXER', sessionId: 'ratchet-session-idle-ok' },
+      action: {
+        type: 'WAITING',
+        reason: 'Workspace is not idle (active session)',
+      },
     });
+    expect(mockSessionBridge.isSessionRunning).toHaveBeenCalledWith('chat-idle-1');
+    expect(fixerSessionService.acquireAndDispatch).not.toHaveBeenCalled();
   });
 
   it('does not dispatch when PR state unchanged since last dispatch', async () => {


### PR DESCRIPTION
## Summary
- Prevent Ratchet from starting background fixer sessions while any session process is alive in the workspace.
- Update the idle running session regression test to assert Ratchet waits instead of dispatching.

## Changes
- **Ratchet**: Changed active-session detection from `isSessionWorking` to `isSessionRunning` so idle manual sessions block automated fixer dispatch.
- **Tests**: Flipped the idle running session case to expect `WAITING` and verify no fixer session is acquired.

## Testing
- [x] Targeted Ratchet tests pass (`pnpm test src/backend/services/ratchet/service/ratchet.service.test.ts`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Full test suite: `pnpm test` is blocked by unrelated `src/backend/services/session/service/acp/codex-cli-import-resolution.integration.test.ts` failure (`status 143` / timeout in the internal ACP CLI import-resolution test)
- [ ] Manual testing: Not run; backend dispatch guard only

Closes #1450

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ratchet’s dispatch guard to treat any *running* session process (even if idle) as blocking, which could reduce unintended concurrent automation but may also delay/stop expected fixer runs if session-running signals are noisy or stale.
> 
> **Overview**
> Ratchet now considers a workspace “not idle” if **any session process is running**, switching the active-session check from `isSessionWorking` to `isSessionRunning` so idle-but-alive manual sessions block automated fixer dispatch.
> 
> Tests update the idle-running-session regression case to expect `WAITING` (no `acquireAndDispatch`) and add mocks/assertions around `isSessionRunning`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e046ee9f7e8699a595e6aac76a93536dad75346c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->