### PR TITLE
Fix #1440: Validate setup terminal WebSocket origin

### DIFF
--- a/src/backend/routers/websocket/setup-terminal.handler.test.ts
+++ b/src/backend/routers/websocket/setup-terminal.handler.test.ts
@@ -76,6 +76,81 @@ describe('createSetupTerminalUpgradeHandler', () => {
     mockPtySpawn.mockReturnValue(createMockPty());
   });
 
+  it('rejects upgrades from unauthorized origins before opening a WebSocket', () => {
+    const logger = createLogger();
+    const configService = {
+      getCorsConfig: vi.fn(() => ({ allowedOrigins: ['http://localhost:3000'] })),
+    };
+    const appContext = {
+      services: {
+        createLogger: vi.fn(() => logger),
+        configService,
+      },
+    } as unknown as AppContext;
+
+    const handler = createSetupTerminalUpgradeHandler(appContext);
+    const ws = new MockWebSocket();
+    const wss = createWss(ws);
+    const request = {
+      headers: { origin: 'https://evil-attacker.com' },
+    } as IncomingMessage;
+    const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
+    const wsAliveMap = new WeakMap<WebSocket, boolean>();
+
+    handler(
+      request,
+      socket,
+      Buffer.alloc(0),
+      new URL('http://localhost/setup-terminal'),
+      wss,
+      wsAliveMap
+    );
+
+    expect(wss.handleUpgrade).not.toHaveBeenCalled();
+    expect(socket.destroy).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Rejected setup terminal connection from unauthorized origin',
+      { origin: 'https://evil-attacker.com' }
+    );
+  });
+
+  it('accepts upgrades from configured allowed origins', () => {
+    const logger = createLogger();
+    const configService = {
+      getShellPath: vi.fn(() => '/bin/zsh'),
+      getChildProcessEnv: vi.fn(() => ({ PATH: '/usr/bin' })),
+      getCorsConfig: vi.fn(() => ({ allowedOrigins: ['http://localhost:3000'] })),
+    };
+    const appContext = {
+      services: {
+        createLogger: vi.fn(() => logger),
+        configService,
+      },
+    } as unknown as AppContext;
+
+    const handler = createSetupTerminalUpgradeHandler(appContext);
+    const ws = new MockWebSocket();
+    const wss = createWss(ws);
+    const request = {
+      headers: { origin: 'http://localhost:3000' },
+    } as IncomingMessage;
+    const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
+    const wsAliveMap = new WeakMap<WebSocket, boolean>();
+
+    handler(
+      request,
+      socket,
+      Buffer.alloc(0),
+      new URL('http://localhost/setup-terminal'),
+      wss,
+      wsAliveMap
+    );
+
+    expect(wss.handleUpgrade).toHaveBeenCalledTimes(1);
+    expect(socket.destroy).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith('Setup terminal WebSocket connected');
+  });
+
   it('creates terminal and routes lifecycle messages', () => {
     const logger = createLogger();
     const configService = {

--- a/src/backend/routers/websocket/setup-terminal.handler.test.ts
+++ b/src/backend/routers/websocket/setup-terminal.handler.test.ts
@@ -107,6 +107,8 @@ describe('createSetupTerminalUpgradeHandler', () => {
     );
 
     expect(wss.handleUpgrade).not.toHaveBeenCalled();
+    expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('400 Bad Request'));
+    expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('Unauthorized origin'));
     expect(socket.destroy).toHaveBeenCalledTimes(1);
     expect(logger.warn).toHaveBeenCalledWith(
       'Rejected setup terminal connection from unauthorized origin',

--- a/src/backend/routers/websocket/setup-terminal.handler.ts
+++ b/src/backend/routers/websocket/setup-terminal.handler.ts
@@ -143,6 +143,16 @@ export function createSetupTerminalUpgradeHandler(appContext: AppContext) {
     wss: WebSocketServer,
     wsAliveMap: WeakMap<WebSocket, boolean>
   ): void {
+    const origin = request.headers?.origin;
+    if (origin) {
+      const allowedOrigins = configService.getCorsConfig().allowedOrigins;
+      if (!allowedOrigins.includes(origin)) {
+        logger.warn('Rejected setup terminal connection from unauthorized origin', { origin });
+        socket.destroy();
+        return;
+      }
+    }
+
     wss.handleUpgrade(request, socket, head, (ws) => {
       logger.info('Setup terminal WebSocket connected');
       markWebSocketAlive(ws, wsAliveMap);

--- a/src/backend/routers/websocket/setup-terminal.handler.ts
+++ b/src/backend/routers/websocket/setup-terminal.handler.ts
@@ -20,7 +20,7 @@ import {
   SetupTerminalMessageSchema,
 } from '@/backend/schemas/websocket';
 import { toMessageString } from './message-utils';
-import { markWebSocketAlive } from './upgrade-utils';
+import { markWebSocketAlive, sendBadRequest } from './upgrade-utils';
 
 const require = createRequire(import.meta.url);
 
@@ -148,7 +148,7 @@ export function createSetupTerminalUpgradeHandler(appContext: AppContext) {
       const allowedOrigins = configService.getCorsConfig().allowedOrigins;
       if (!allowedOrigins.includes(origin)) {
         logger.warn('Rejected setup terminal connection from unauthorized origin', { origin });
-        socket.destroy();
+        sendBadRequest(socket, 'Unauthorized origin');
         return;
       }
     }


### PR DESCRIPTION
## Summary
- Reject setup terminal WebSocket upgrades from untrusted browser origins.
- Keep non-browser/no-Origin setup terminal clients working.
- Add focused tests for rejected and allowed Origin headers.

## Changes
- **Setup terminal WebSocket**: Validate `request.headers.origin` against configured CORS allowed origins before calling `handleUpgrade`.
- **Tests**: Cover unauthorized origin rejection before upgrade and allowed origin acceptance.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Manual testing: Verified focused setup terminal handler test covers untrusted and trusted origins.

Closes #1440

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the setup-terminal WebSocket upgrade path to reject requests whose `Origin` is not in configured CORS allowed origins, which could block legitimate clients if configuration is incorrect.
> 
> **Overview**
> **Adds Origin validation to the setup-terminal WebSocket upgrade flow.** If an `Origin` header is present and not in `configService.getCorsConfig().allowedOrigins`, the server now logs a warning and replies with a `400 Bad Request` ("Unauthorized origin") without calling `wss.handleUpgrade`.
> 
> **Tests updated** to cover both rejection of unauthorized origins *before* a WebSocket is opened and successful upgrades for allowed origins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f57b9ffaa2a24ed861dc63276a545eb4dc7b77e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->