### PR TITLE
Fix #1442: Optimize terminal output buffering

### DIFF
--- a/src/backend/services/session/service/acp/codex-cli-import-resolution.integration.test.ts
+++ b/src/backend/services/session/service/acp/codex-cli-import-resolution.integration.test.ts
@@ -139,5 +139,5 @@ describe('CODEX CLI import resolution', () => {
     expect(result.status).toBe(0);
     expect(stderr).not.toContain('does not provide an export named');
     expect(stderr).not.toContain('SyntaxError');
-  });
+  }, 30_000);
 });

--- a/src/backend/services/terminal/service/terminal.service.test.ts
+++ b/src/backend/services/terminal/service/terminal.service.test.ts
@@ -395,6 +395,28 @@ describe('TerminalService', () => {
       expect(instance?.outputBuffer.endsWith('B'.repeat(50 * 1024))).toBe(true);
     });
 
+    it('keeps only the tail of a single oversized data event', async () => {
+      const { terminalId } = await service.createTerminal(defaultOpts);
+
+      onDataCallback?.('A'.repeat(40 * 1024) + 'B'.repeat(100 * 1024));
+
+      const instance = service.getTerminal('ws-1', terminalId);
+      expect(instance?.outputBuffer).toBe('B'.repeat(100 * 1024));
+    });
+
+    it('preserves the most recent chunks after many small data events', async () => {
+      const { terminalId } = await service.createTerminal(defaultOpts);
+
+      for (let index = 0; index < 120; index += 1) {
+        onDataCallback?.(`${index.toString().padStart(4, '0')}:${'x'.repeat(1019)}`);
+      }
+
+      const instance = service.getTerminal('ws-1', terminalId);
+      expect(instance?.outputBuffer.length).toBe(100 * 1024);
+      expect(instance?.outputBuffer.startsWith('0020:')).toBe(true);
+      expect(instance?.outputBuffer.endsWith('x'.repeat(1019))).toBe(true);
+    });
+
     it('preserves output buffer below the limit', async () => {
       const { terminalId } = await service.createTerminal(defaultOpts);
 

--- a/src/backend/services/terminal/service/terminal.service.ts
+++ b/src/backend/services/terminal/service/terminal.service.ts
@@ -19,6 +19,7 @@ import { createLogger } from '@/backend/services/logger.service';
 
 const logger = createLogger('terminal');
 const require = createRequire(import.meta.url);
+const MAX_TERMINAL_OUTPUT_BUFFER_SIZE = 100 * 1024;
 
 // =============================================================================
 // Types
@@ -48,7 +49,7 @@ export interface TerminalInstance {
   // Last resource usage snapshot
   lastResourceUsage?: TerminalResourceUsage;
   // Rolling output buffer for restoration after reconnect
-  outputBuffer: string;
+  readonly outputBuffer: string;
 }
 
 export interface CreateTerminalOptions {
@@ -69,13 +70,132 @@ export interface TerminalOutput {
   data: string;
 }
 
+class RollingOutputBuffer {
+  private chunks: string[] = [];
+  private startIndex = 0;
+  private bufferedSize = 0;
+
+  constructor(private readonly maxSize: number) {}
+
+  append(data: string): void {
+    if (data.length === 0) {
+      return;
+    }
+
+    if (data.length >= this.maxSize) {
+      const tail = data.slice(-this.maxSize);
+      this.chunks = [tail];
+      this.startIndex = 0;
+      this.bufferedSize = tail.length;
+      return;
+    }
+
+    this.chunks.push(data);
+    this.bufferedSize += data.length;
+    this.trimToMaxSize();
+  }
+
+  clear(): void {
+    this.chunks = [];
+    this.startIndex = 0;
+    this.bufferedSize = 0;
+  }
+
+  toString(): string {
+    if (this.bufferedSize === 0) {
+      return '';
+    }
+
+    return this.chunks.slice(this.startIndex).join('');
+  }
+
+  private trimToMaxSize(): void {
+    while (this.bufferedSize > this.maxSize && this.startIndex < this.chunks.length) {
+      const overflow = this.bufferedSize - this.maxSize;
+      const firstChunk = this.chunks[this.startIndex];
+      if (firstChunk === undefined) {
+        this.clear();
+        return;
+      }
+
+      if (firstChunk.length <= overflow) {
+        this.bufferedSize -= firstChunk.length;
+        this.startIndex += 1;
+        this.compactIfNeeded();
+        continue;
+      }
+
+      this.chunks[this.startIndex] = firstChunk.slice(overflow);
+      this.bufferedSize -= overflow;
+      return;
+    }
+  }
+
+  private compactIfNeeded(): void {
+    if (this.startIndex < 64 || this.startIndex * 2 < this.chunks.length) {
+      return;
+    }
+
+    this.chunks = this.chunks.slice(this.startIndex);
+    this.startIndex = 0;
+  }
+}
+
+interface ManagedTerminalInstance extends TerminalInstance {
+  appendOutput(data: string): void;
+  clearOutput(): void;
+}
+
+class BufferedTerminalInstance implements ManagedTerminalInstance {
+  private readonly output = new RollingOutputBuffer(MAX_TERMINAL_OUTPUT_BUFFER_SIZE);
+
+  id: string;
+  workspaceId: string;
+  pty: IPty;
+  cols: number;
+  rows: number;
+  createdAt: Date;
+  disposables: (() => void)[];
+  lastResourceUsage?: TerminalResourceUsage;
+
+  constructor(options: {
+    id: string;
+    workspaceId: string;
+    pty: IPty;
+    cols: number;
+    rows: number;
+    createdAt: Date;
+    disposables: (() => void)[];
+  }) {
+    this.id = options.id;
+    this.workspaceId = options.workspaceId;
+    this.pty = options.pty;
+    this.cols = options.cols;
+    this.rows = options.rows;
+    this.createdAt = options.createdAt;
+    this.disposables = options.disposables;
+  }
+
+  get outputBuffer(): string {
+    return this.output.toString();
+  }
+
+  appendOutput(data: string): void {
+    this.output.append(data);
+  }
+
+  clearOutput(): void {
+    this.output.clear();
+  }
+}
+
 // =============================================================================
 // Terminal Service Class
 // =============================================================================
 
 export class TerminalService {
   // Map of workspaceId -> Map of terminalId -> TerminalInstance
-  private terminals = new Map<string, Map<string, TerminalInstance>>();
+  private terminals = new Map<string, Map<string, ManagedTerminalInstance>>();
 
   // Output listeners by terminalId
   private outputListeners = new Map<string, Set<(data: string) => void>>();
@@ -89,9 +209,6 @@ export class TerminalService {
   // Resource monitoring interval
   private monitoringInterval: NodeJS.Timeout | null = null;
   private static readonly MONITORING_INTERVAL_MS = 5000; // 5 seconds
-
-  // Max output buffer size per terminal (100KB) for restoration after reconnect
-  private static readonly MAX_OUTPUT_BUFFER_SIZE = 100 * 1024;
 
   /**
    * Set the active terminal for a workspace.
@@ -261,13 +378,7 @@ export class TerminalService {
         // Accumulate output in buffer for restoration after reconnect
         const instance = this.terminals.get(workspaceId)?.get(terminalId);
         if (instance) {
-          instance.outputBuffer += data;
-          // Limit buffer size by trimming from the beginning
-          if (instance.outputBuffer.length > TerminalService.MAX_OUTPUT_BUFFER_SIZE) {
-            instance.outputBuffer = instance.outputBuffer.slice(
-              -TerminalService.MAX_OUTPUT_BUFFER_SIZE
-            );
-          }
+          instance.appendOutput(data);
         }
 
         const listeners = this.outputListeners.get(terminalId);
@@ -296,7 +407,7 @@ export class TerminalService {
       disposables.push(() => exitDisposable.dispose());
 
       // Create terminal instance
-      const instance: TerminalInstance = {
+      const instance = new BufferedTerminalInstance({
         id: terminalId,
         workspaceId,
         pty,
@@ -304,8 +415,7 @@ export class TerminalService {
         rows,
         createdAt: new Date(),
         disposables,
-        outputBuffer: '',
-      };
+      });
 
       // Store in workspace terminals map
       if (!this.terminals.has(workspaceId)) {
@@ -403,7 +513,7 @@ export class TerminalService {
 
     // Clear retained output aggressively to release memory even if external
     // references to the instance survive map removal.
-    instance.outputBuffer = '';
+    instance.clearOutput();
 
     logger.info('Terminal destroyed', { terminalId, workspaceId });
     return true;


### PR DESCRIPTION
## Summary
- Replace terminal reconnect buffering with a chunked rolling buffer to avoid per-output-event 100KB string copies.
- Preserve the existing `outputBuffer` API for websocket reconnects while joining chunks only when requested.
- Add edge-case coverage for oversized PTY chunks and many small high-output chunks.

## Changes
- **Terminal service**: Store terminal output in chunks with a running size counter and logical start index, trimming old chunks without repeated string concat/slice work.
- **Terminal tests**: Cover single oversized events and exact eviction after sustained small-chunk output.
- **Test stability**: Align the Codex CLI import integration test timeout with its existing subprocess retry window after it timed out during full-suite verification.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Lint/format pass (`pnpm check:fix`)
- [ ] Manual testing: Not applicable; backend buffering behavior is covered by automated tests.

Closes #1442

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core `TerminalService` buffering behavior for PTY output; while API is preserved, regressions could impact terminal reconnect/restore or memory usage under heavy output.
> 
> **Overview**
> **Optimizes terminal reconnect output buffering** by replacing per-event string concat/slice trimming with a chunked `RollingOutputBuffer` capped at 100KB, while keeping the `outputBuffer` string API via a lazy `toString()` join.
> 
> Adds test coverage for edge cases (single oversized PTY data event and sustained many-small-chunk output) and updates terminal destruction to clear the retained buffer via the new buffer API.
> 
> Separately increases the timeout on the pinned-tsconfig Codex CLI import-resolution integration test to reduce flakiness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0567097d1b10dbd12580deb77cf0cd7b1e2d5db4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->