### PR TITLE
Fix #1444: Guard stopped ACP exits

### DIFF
--- a/src/backend/services/session/service/acp/acp-runtime-manager.test.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-manager.test.ts
@@ -904,6 +904,85 @@ describe('AcpRuntimeManager', () => {
       expect(handlers.onExit).not.toHaveBeenCalled();
     });
 
+    it('skips exit handler when a stopped process exits after stop timeout', async () => {
+      const child = setupSuccessfulSpawn();
+      const handlers = defaultHandlers();
+
+      await manager.getOrCreateClient('session-1', defaultOptions(), handlers, defaultContext());
+
+      child.kill = vi.fn((signal?: string) => {
+        if (signal) {
+          child.killed = true;
+        }
+        return true;
+      });
+
+      vi.useFakeTimers();
+
+      const stopPromise = manager.stopClient('session-1');
+      await vi.advanceTimersByTimeAsync(5100);
+      await stopPromise;
+
+      vi.useRealTimers();
+
+      expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+      expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+      expect(manager.isStopInProgress('session-1')).toBe(false);
+
+      (handlers.onExit as ReturnType<typeof vi.fn>).mockClear();
+      child.exitCode = 137;
+      child.emit('exit', 137, 'SIGKILL');
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(handlers.onExit).not.toHaveBeenCalled();
+    });
+
+    it('does not let a late stopped-process exit affect a replacement client', async () => {
+      const firstChild = setupSuccessfulSpawn();
+      const firstHandlers = defaultHandlers();
+
+      await manager.getOrCreateClient(
+        'session-1',
+        defaultOptions(),
+        firstHandlers,
+        defaultContext()
+      );
+
+      firstChild.kill = vi.fn((signal?: string) => {
+        if (signal) {
+          firstChild.killed = true;
+        }
+        return true;
+      });
+
+      vi.useFakeTimers();
+
+      const stopPromise = manager.stopClient('session-1');
+      await vi.advanceTimersByTimeAsync(5100);
+      await stopPromise;
+
+      vi.useRealTimers();
+
+      const secondChild = createMockChildProcess();
+      const secondHandlers = defaultHandlers();
+      mockSpawn.mockReturnValueOnce(secondChild);
+
+      const restartedHandle = await manager.getOrCreateClient(
+        'session-1',
+        defaultOptions(),
+        secondHandlers,
+        defaultContext()
+      );
+
+      (firstHandlers.onExit as ReturnType<typeof vi.fn>).mockClear();
+      firstChild.exitCode = 137;
+      firstChild.emit('exit', 137, 'SIGKILL');
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(firstHandlers.onExit).not.toHaveBeenCalled();
+      expect(manager.getClient('session-1')).toBe(restartedHandle);
+    });
+
     it('keeps newer client tracked when old stop exits later', async () => {
       const firstChild = setupSuccessfulSpawn();
 

--- a/src/backend/services/session/service/acp/acp-runtime-manager.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-manager.ts
@@ -562,6 +562,7 @@ export class AcpRuntimeManager {
   private readonly sessions = new Map<string, AcpProcessHandle>();
   private readonly pendingCreation = new Map<string, Promise<AcpProcessHandle>>();
   private readonly stoppingInProgress = new Set<string>();
+  private readonly managedStopChildren = new WeakSet<ChildProcess>();
   private readonly creationLocks = new Map<string, ReturnType<typeof pLimit>>();
   private readonly lockRefCounts = new Map<string, number>();
   private onClientCreatedCallback: AcpRuntimeCreatedCallback | null = null;
@@ -872,13 +873,7 @@ export class AcpRuntimeManager {
     handlers: AcpRuntimeEventHandlers
   ): void {
     child.on('exit', async (code) => {
-      const current = this.sessions.get(sessionId);
-      if (current?.child === child) {
-        this.sessions.delete(sessionId);
-      }
-
-      if (this.stoppingInProgress.has(sessionId)) {
-        logger.debug('Skipping exit handler - stop in progress', { sessionId, code });
+      if (this.shouldSkipChildExitHandler(sessionId, child, code)) {
         return;
       }
 
@@ -895,6 +890,37 @@ export class AcpRuntimeManager {
         }
       }
     });
+  }
+
+  private shouldSkipChildExitHandler(
+    sessionId: string,
+    child: ChildProcess,
+    code: number | null
+  ): boolean {
+    const current = this.sessions.get(sessionId);
+    const isCurrentProcess = current?.child === child;
+    const isManagedStopProcess = this.managedStopChildren.delete(child);
+
+    if (isCurrentProcess) {
+      this.sessions.delete(sessionId);
+    }
+
+    if (current && !isCurrentProcess) {
+      logger.debug('Skipping exit handler - stale ACP process exited', {
+        sessionId,
+        code,
+        pid: child.pid,
+        currentPid: current.getPid(),
+      });
+      return true;
+    }
+
+    if (isManagedStopProcess || this.stoppingInProgress.has(sessionId)) {
+      logger.debug('Skipping exit handler - managed stop process exited', { sessionId, code });
+      return true;
+    }
+
+    return false;
   }
 
   private async notifyClientCreated(
@@ -1018,6 +1044,7 @@ export class AcpRuntimeManager {
     }
 
     this.stoppingInProgress.add(sessionId);
+    this.managedStopChildren.add(handle.child);
     try {
       // Cancel prompt if in flight
       if (handle.isPromptInFlight) {

--- a/src/backend/services/session/service/chat/chat-message-handlers/handlers/stop.handler.test.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers/handlers/stop.handler.test.ts
@@ -47,4 +47,35 @@ describe('createStopHandler', () => {
     expect(mocks.resetDispatchState).toHaveBeenCalledWith('session-1');
     expect(mocks.tryDispatchNextMessage).toHaveBeenCalledWith('session-1');
   });
+
+  it('waits for stopSession before retrying queued dispatch', async () => {
+    let resolveStop!: () => void;
+    mocks.stopSession.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveStop = resolve;
+      })
+    );
+    const handler = createStopHandler({
+      getClientCreator: () => null,
+      tryDispatchNextMessage: mocks.tryDispatchNextMessage,
+      setManualDispatchResume: vi.fn(),
+      resetDispatchState: mocks.resetDispatchState,
+    });
+
+    const stopPromise = handler({
+      ws: { send: vi.fn() } as never,
+      sessionId: 'session-1',
+      workingDir: '/tmp/work',
+      message: { type: 'stop' } as never,
+    });
+
+    await Promise.resolve();
+
+    expect(mocks.tryDispatchNextMessage).not.toHaveBeenCalled();
+
+    resolveStop();
+    await stopPromise;
+
+    expect(mocks.tryDispatchNextMessage).toHaveBeenCalledWith('session-1');
+  });
 });


### PR DESCRIPTION
## Summary
- Prevent late exits from intentionally stopped ACP processes from running stale `onExit` cleanup.
- Preserve replacement clients when an old stopped child emits `exit` after a stop timeout.
- Add regression coverage for stop dispatch ordering and late stopped-process exits.

## Changes
- **ACP Runtime**: Track child processes stopped through `stopClient` and skip their eventual exit handlers, even if the session-level stop flag has already cleared.
- **ACP Runtime**: Treat exits from non-current child processes as stale so they cannot clear pending creation or invoke destructive session cleanup.
- **Tests**: Cover late force-kill exits, replacement-client preservation, and stop handler dispatch ordering.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; backend race covered by unit tests.

Closes #1444

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches ACP subprocess lifecycle/exit handling to avoid stale cleanup, which is concurrency-sensitive and could impact session tracking if wrong, but changes are localized and covered by new unit tests.
> 
> **Overview**
> Prevents late `exit` events from intentionally stopped ACP subprocesses from running `onExit` cleanup after the stop timeout by tracking managed-stop children and skipping their exit handlers.
> 
> Treats exits from *non-current* child processes as stale, avoiding deletion of the active session handle/pending creation when an older process finally exits, and adds regression tests covering late force-kill exits, replacement-client preservation, and stop-handler dispatch ordering (wait for `stopSession` before re-dispatch).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dbd6ed3d8c799ff07b1fb1f5e6fa64afae5672b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->