### PR TITLE
Fix #1445: Count only active workspace sessions

### DIFF
--- a/src/backend/services/resources.integration.test.ts
+++ b/src/backend/services/resources.integration.test.ts
@@ -438,7 +438,7 @@ describe('resource accessors integration', () => {
       });
     });
 
-    it('returns limit_reached when session cap is already met', async () => {
+    it('returns limit_reached when active session cap is already met', async () => {
       const project = await createProjectFixture();
       const workspace = await createWorkspaceFixture(project.id);
 
@@ -447,14 +447,14 @@ describe('resource accessors integration', () => {
           {
             workspaceId: workspace.id,
             workflow: 'explore',
-            status: SessionStatus.COMPLETED,
+            status: SessionStatus.RUNNING,
             model: 'sonnet',
             provider: 'CLAUDE',
           },
           {
             workspaceId: workspace.id,
             workflow: 'feature',
-            status: SessionStatus.COMPLETED,
+            status: SessionStatus.IDLE,
             model: 'opus',
             provider: 'CLAUDE',
           },
@@ -470,6 +470,40 @@ describe('resource accessors integration', () => {
       });
 
       expect(acquired).toEqual({ outcome: 'limit_reached' });
+    });
+
+    it('ignores completed and failed sessions when enforcing fixer session cap', async () => {
+      const project = await createProjectFixture();
+      const workspace = await createWorkspaceFixture(project.id);
+
+      await prisma.agentSession.createMany({
+        data: [
+          {
+            workspaceId: workspace.id,
+            workflow: 'explore',
+            status: SessionStatus.COMPLETED,
+            model: 'sonnet',
+            provider: 'CLAUDE',
+          },
+          {
+            workspaceId: workspace.id,
+            workflow: 'feature',
+            status: SessionStatus.FAILED,
+            model: 'opus',
+            provider: 'CLAUDE',
+          },
+        ],
+      });
+
+      const acquired = await agentSessionAccessor.acquireFixerSession({
+        workspaceId: workspace.id,
+        workflow: 'ci-fix',
+        sessionName: 'CI Fixer',
+        maxSessions: 2,
+        providerProjectPath: null,
+      });
+
+      expect(acquired.outcome).toBe('created');
     });
 
     it('creates fixer session and reuses recent model preference', async () => {

--- a/src/backend/services/session/resources/agent-session.accessor.test.ts
+++ b/src/backend/services/session/resources/agent-session.accessor.test.ts
@@ -6,6 +6,7 @@ import { SessionStatus } from '@/shared/core';
 const mockCreate = vi.fn();
 const mockFindUnique = vi.fn();
 const mockFindMany = vi.fn();
+const mockCount = vi.fn();
 const mockUpdate = vi.fn();
 const mockDelete = vi.fn();
 const mockUserSettingsGet = vi.fn();
@@ -16,6 +17,7 @@ vi.mock('@/backend/db', () => ({
       create: (...args: unknown[]) => mockCreate(...args),
       findUnique: (...args: unknown[]) => mockFindUnique(...args),
       findMany: (...args: unknown[]) => mockFindMany(...args),
+      count: (...args: unknown[]) => mockCount(...args),
       update: (...args: unknown[]) => mockUpdate(...args),
       delete: (...args: unknown[]) => mockDelete(...args),
     },
@@ -130,6 +132,19 @@ describe('agentSessionAccessor', () => {
       },
       take: 3,
       orderBy: { createdAt: 'asc' },
+    });
+  });
+
+  it('countActiveByWorkspaceId counts only running and idle sessions', async () => {
+    mockCount.mockResolvedValue(2);
+
+    await expect(agentSessionAccessor.countActiveByWorkspaceId('workspace-1')).resolves.toBe(2);
+
+    expect(mockCount).toHaveBeenCalledWith({
+      where: {
+        workspaceId: 'workspace-1',
+        status: { in: [SessionStatus.RUNNING, SessionStatus.IDLE] },
+      },
     });
   });
 

--- a/src/backend/services/session/resources/agent-session.accessor.ts
+++ b/src/backend/services/session/resources/agent-session.accessor.ts
@@ -10,6 +10,8 @@ export type AgentSessionRecordWithWorkspace = Prisma.AgentSessionGetPayload<{
   include: { workspace: true };
 }>;
 
+const ACTIVE_AGENT_SESSION_STATUSES: SessionStatus[] = [SessionStatus.RUNNING, SessionStatus.IDLE];
+
 export interface AgentSessionFilters {
   status?: SessionStatus;
   provider?: SessionProvider;
@@ -59,6 +61,7 @@ export interface AgentSessionAccessor {
     workspaceId: string,
     filters?: AgentSessionFilters
   ): Promise<AgentSessionRecord[]>;
+  countActiveByWorkspaceId(workspaceId: string): Promise<number>;
   update(id: string, data: UpdateAgentSessionInput): Promise<AgentSessionRecord>;
   delete(id: string): Promise<AgentSessionRecord>;
   findWithPid(): Promise<AgentSessionRecord[]>;
@@ -131,6 +134,15 @@ class PrismaAgentSessionAccessor implements AgentSessionAccessor {
     });
   }
 
+  countActiveByWorkspaceId(workspaceId: string): Promise<number> {
+    return prisma.agentSession.count({
+      where: {
+        workspaceId,
+        status: { in: ACTIVE_AGENT_SESSION_STATUSES },
+      },
+    });
+  }
+
   update(id: string, data: UpdateAgentSessionInput): Promise<AgentSessionRecord> {
     const updateData: Prisma.AgentSessionUpdateInput = {
       name: data.name,
@@ -177,7 +189,7 @@ class PrismaAgentSessionAccessor implements AgentSessionAccessor {
             workspaceId: input.workspaceId,
             workflow: input.workflow,
             provider,
-            status: { in: [SessionStatus.RUNNING, SessionStatus.IDLE] },
+            status: { in: ACTIVE_AGENT_SESSION_STATUSES },
           },
           orderBy: { createdAt: 'desc' },
         });
@@ -190,12 +202,14 @@ class PrismaAgentSessionAccessor implements AgentSessionAccessor {
           };
         }
 
-        const allSessions = await tx.agentSession.findMany({
-          where: { workspaceId: input.workspaceId },
-          select: { id: true },
+        const activeSessionCount = await tx.agentSession.count({
+          where: {
+            workspaceId: input.workspaceId,
+            status: { in: ACTIVE_AGENT_SESSION_STATUSES },
+          },
         });
 
-        if (allSessions.length >= input.maxSessions) {
+        if (activeSessionCount >= input.maxSessions) {
           return { outcome: 'limit_reached' as const };
         }
 

--- a/src/backend/services/session/service/data/session-data.service.ts
+++ b/src/backend/services/session/service/data/session-data.service.ts
@@ -29,6 +29,10 @@ class SessionDataService {
     return agentSessionAccessor.findByWorkspaceId(workspaceId, filters);
   }
 
+  countActiveAgentSessionsByWorkspaceId(workspaceId: string): Promise<number> {
+    return agentSessionAccessor.countActiveByWorkspaceId(workspaceId);
+  }
+
   createAgentSession(data: {
     workspaceId: string;
     name?: string;

--- a/src/backend/trpc/session.router.test.ts
+++ b/src/backend/trpc/session.router.test.ts
@@ -4,6 +4,7 @@ import type { CLIHealthStatus } from '@/backend/orchestration/cli-health.service
 
 const mockSessionDataService = vi.hoisted(() => ({
   findAgentSessionsByWorkspaceId: vi.fn(),
+  countActiveAgentSessionsByWorkspaceId: vi.fn(),
   findAgentSessionById: vi.fn(),
   createAgentSession: vi.fn(),
   updateAgentSession: vi.fn(),
@@ -82,6 +83,7 @@ function createCaller() {
 describe('sessionRouter', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSessionDataService.countActiveAgentSessionsByWorkspaceId.mockResolvedValue(0);
   });
 
   it('returns quick actions and augments sessions with runtime working state', async () => {
@@ -108,10 +110,7 @@ describe('sessionRouter', () => {
   it('enforces workspace session limits and creates a session with provider resolution', async () => {
     const { caller, cliHealthService } = createCaller();
 
-    mockSessionDataService.findAgentSessionsByWorkspaceId.mockResolvedValue([
-      { id: 's1' },
-      { id: 's2' },
-    ]);
+    mockSessionDataService.countActiveAgentSessionsByWorkspaceId.mockResolvedValueOnce(2);
     await expect(
       caller.createSession({
         workspaceId: 'w1',
@@ -119,7 +118,7 @@ describe('sessionRouter', () => {
       })
     ).rejects.toThrow('Maximum sessions per workspace (2) reached');
 
-    mockSessionDataService.findAgentSessionsByWorkspaceId.mockResolvedValue([{ id: 's1' }]);
+    mockSessionDataService.countActiveAgentSessionsByWorkspaceId.mockResolvedValueOnce(1);
     mockSessionProviderResolverService.resolveSessionProvider.mockResolvedValue(
       SessionProvider.CODEX
     );
@@ -133,6 +132,7 @@ describe('sessionRouter', () => {
       })
     ).resolves.toEqual({ id: 's3', workspaceId: 'w1' });
 
+    expect(mockSessionDataService.countActiveAgentSessionsByWorkspaceId).toHaveBeenCalledWith('w1');
     expect(mockSessionProviderResolverService.resolveSessionProvider).toHaveBeenCalledWith({
       workspaceId: 'w1',
       explicitProvider: undefined,
@@ -143,7 +143,7 @@ describe('sessionRouter', () => {
 
   it('blocks creating a session when the selected provider is unavailable', async () => {
     const { caller, cliHealthService } = createCaller();
-    mockSessionDataService.findAgentSessionsByWorkspaceId.mockResolvedValue([{ id: 's1' }]);
+    mockSessionDataService.countActiveAgentSessionsByWorkspaceId.mockResolvedValue(1);
     mockSessionProviderResolverService.resolveSessionProvider.mockResolvedValue(
       SessionProvider.CODEX
     );

--- a/src/backend/trpc/session.trpc.ts
+++ b/src/backend/trpc/session.trpc.ts
@@ -75,11 +75,11 @@ export const sessionRouter = router({
       const { configService, sessionDomainService } = ctx.appContext.services;
       // Check per-workspace session limit
       const maxSessions = configService.getMaxSessionsPerWorkspace();
-      const existingSessions = await sessionDataService.findAgentSessionsByWorkspaceId(
+      const activeSessionCount = await sessionDataService.countActiveAgentSessionsByWorkspaceId(
         input.workspaceId
       );
 
-      if (existingSessions.length >= maxSessions) {
+      if (activeSessionCount >= maxSessions) {
         throw new TRPCError({
           code: 'PRECONDITION_FAILED',
           message: `Maximum sessions per workspace (${maxSessions}) reached`,


### PR DESCRIPTION
## Summary
- Enforces per-workspace session caps using active agent sessions only.
- Prevents historical COMPLETED or FAILED sessions from blocking new manual and Ratchet fixer sessions.
- Adds focused unit and integration coverage for active-only session limit behavior.

## Changes
- **Session resources**: Added active-session counting via Prisma `count` with RUNNING/IDLE filtering and reused it in fixer acquisition.
- **Session TRPC**: Switched manual session creation limit checks to the active-session count.
- **Tests**: Covered active cap blocking and historical completed/failed sessions being ignored.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not run; backend limit behavior covered by unit and integration tests.

Closes #1445

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core session-limit enforcement for both manual session creation and fixer acquisition; miscounting active statuses could allow too many concurrent sessions or incorrectly block creation.
> 
> **Overview**
> **Session limit enforcement now counts only active sessions.** Manual `createSession` and fixer `acquireFixerSession` switch from listing all sessions to a Prisma `count` filtered to `RUNNING`/`IDLE`, preventing `COMPLETED`/`FAILED` history from blocking new sessions.
> 
> Adds a dedicated accessor/service method (`countActiveByWorkspaceId` / `countActiveAgentSessionsByWorkspaceId`) and updates unit/integration tests to cover the new active-only cap behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a15cc2631251994c143ada028413bcd75b302059. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->