### PR TITLE
Fix #1447: Clean up unregistered init worktrees

### DIFF
--- a/src/backend/orchestration/workspace-init.orchestrator.test.ts
+++ b/src/backend/orchestration/workspace-init.orchestrator.test.ts
@@ -49,6 +49,7 @@ vi.mock('@/backend/services/terminal', () => ({
 }));
 
 vi.mock('@/backend/services/workspace', () => ({
+  assertWorktreePathSafe: vi.fn(),
   workspaceStateMachine: {
     startProvisioning: vi.fn(),
     markFailed: vi.fn(),
@@ -77,6 +78,7 @@ vi.mock('@/backend/services/git-ops.service', () => ({
     ensureBaseBranchExists: vi.fn(),
     createWorktree: vi.fn(),
     createWorktreeFromExistingBranch: vi.fn(),
+    removeWorktree: vi.fn(),
   },
 }));
 
@@ -150,8 +152,9 @@ function makeWorkspaceWithProject(overrides = {}) {
     githubIssueUrl: null,
     project: {
       id: 'proj-1',
+      repoPath: '/repo',
       defaultBranch: 'main',
-      worktreeBasePath: '/base',
+      worktreeBasePath: '/worktrees',
       githubOwner: 'owner',
       githubRepo: 'repo',
       startupScriptCommand: null,
@@ -168,6 +171,7 @@ function setupHappyPath() {
   vi.mocked(workspaceAccessor.findById).mockResolvedValue(workspace as never);
   vi.mocked(workspaceAccessor.update).mockResolvedValue(workspace as never);
   vi.mocked(gitOpsService.ensureBaseBranchExists).mockResolvedValue(undefined);
+  vi.mocked(gitOpsService.removeWorktree).mockResolvedValue(undefined);
   vi.mocked(gitOpsService.createWorktree).mockResolvedValue({
     worktreePath: '/worktrees/workspace-ws-1',
     branchName: 'user/test-workspace',
@@ -1082,6 +1086,9 @@ describe('initializeWorkspaceWorktree', () => {
     it('clears init mode even when error occurs after worktree creation', async () => {
       setupHappyPath();
       vi.mocked(workspaceAccessor.update).mockRejectedValue(new Error('db error'));
+      vi.mocked(workspaceAccessor.findById).mockResolvedValue(
+        unsafeCoerce({ id: WORKSPACE_ID, worktreePath: null })
+      );
 
       await initializeWorkspaceWorktree(WORKSPACE_ID);
 
@@ -1089,9 +1096,53 @@ describe('initializeWorkspaceWorktree', () => {
       expect(worktreeLifecycleService.clearInitMode).toHaveBeenCalledWith(WORKSPACE_ID);
     });
 
+    it('removes unregistered worktree when persistence fails after creation', async () => {
+      const workspace = setupHappyPath();
+      vi.mocked(workspaceAccessor.update).mockRejectedValue(new Error('db update error'));
+      vi.mocked(workspaceAccessor.findById).mockResolvedValue(
+        unsafeCoerce({ id: WORKSPACE_ID, worktreePath: null })
+      );
+
+      await initializeWorkspaceWorktree(WORKSPACE_ID);
+
+      expect(gitOpsService.removeWorktree).toHaveBeenCalledWith(
+        '/worktrees/workspace-ws-1',
+        workspace.project
+      );
+    });
+
+    it('does not remove worktree when failure occurs after persistence succeeds', async () => {
+      setupHappyPath();
+      vi.mocked(workspaceStateMachine.markReady).mockRejectedValue(new Error('ready failed'));
+
+      await initializeWorkspaceWorktree(WORKSPACE_ID);
+
+      expect(gitOpsService.removeWorktree).not.toHaveBeenCalled();
+    });
+
+    it('does not throw when unregistered worktree cleanup fails', async () => {
+      setupHappyPath();
+      vi.mocked(workspaceAccessor.update).mockRejectedValue(new Error('db update error'));
+      vi.mocked(workspaceAccessor.findById).mockResolvedValue(
+        unsafeCoerce({ id: WORKSPACE_ID, worktreePath: null })
+      );
+      vi.mocked(gitOpsService.removeWorktree).mockRejectedValue(new Error('remove failed'));
+
+      await initializeWorkspaceWorktree(WORKSPACE_ID);
+
+      expect(workspaceStateMachine.markFailed).toHaveBeenCalledWith(
+        WORKSPACE_ID,
+        'db update error'
+      );
+      expect(sessionService.stopWorkspaceSessions).toHaveBeenCalledWith(WORKSPACE_ID);
+    });
+
     it('marks workspace failed when workspace update throws', async () => {
       setupHappyPath();
       vi.mocked(workspaceAccessor.update).mockRejectedValue(new Error('db update error'));
+      vi.mocked(workspaceAccessor.findById).mockResolvedValue(
+        unsafeCoerce({ id: WORKSPACE_ID, worktreePath: null })
+      );
 
       await initializeWorkspaceWorktree(WORKSPACE_ID);
 

--- a/src/backend/orchestration/workspace-init.orchestrator.ts
+++ b/src/backend/orchestration/workspace-init.orchestrator.ts
@@ -18,6 +18,7 @@ import {
 } from '@/backend/services/session';
 import { terminalService } from '@/backend/services/terminal';
 import {
+  assertWorktreePathSafe,
   workspaceAccessor,
   workspaceStateMachine,
   worktreeLifecycleService,
@@ -31,6 +32,16 @@ import { executeStartupScriptPipeline } from './workspace-init-script-pipeline';
 
 const logger = createLogger('workspace-init-orchestrator');
 const initialAttachmentsSchema = AttachmentSchema.array();
+
+type CreatedWorktreeInfo = {
+  worktreePath: string;
+  branchName: string;
+};
+
+type UnregisteredWorktreeCleanupCandidate = {
+  project: WorkspaceWithProject['project'];
+  worktreeInfo: CreatedWorktreeInfo;
+};
 
 type CachedGitHubUsernameEntry = {
   value: string | null;
@@ -127,10 +138,17 @@ async function readFactoryConfigSafe(
 async function handleWorkspaceInitFailure(
   workspaceId: string,
   error: Error,
-  autoCreatedTerminalId?: string
+  autoCreatedTerminalId?: string,
+  unregisteredWorktreeCleanupCandidate?: UnregisteredWorktreeCleanupCandidate
 ): Promise<void> {
   logger.error('Failed to initialize workspace worktree', error, { workspaceId });
   await workspaceStateMachine.markFailed(workspaceId, error.message);
+  if (unregisteredWorktreeCleanupCandidate) {
+    await cleanupUnregisteredWorktreeAfterInitFailure(
+      workspaceId,
+      unregisteredWorktreeCleanupCandidate
+    );
+  }
   if (autoCreatedTerminalId) {
     try {
       terminalService.destroyTerminal(workspaceId, autoCreatedTerminalId);
@@ -157,6 +175,43 @@ async function handleWorkspaceInitFailure(
     logger.warn('Failed to stop Claude sessions after init failure', {
       workspaceId,
       error: stopError instanceof Error ? stopError.message : String(stopError),
+    });
+  }
+}
+
+async function cleanupUnregisteredWorktreeAfterInitFailure(
+  workspaceId: string,
+  candidate: UnregisteredWorktreeCleanupCandidate
+): Promise<void> {
+  const { project, worktreeInfo } = candidate;
+
+  try {
+    const workspace = await workspaceAccessor.findById(workspaceId);
+    if (workspace?.worktreePath === worktreeInfo.worktreePath) {
+      return;
+    }
+
+    if (workspace?.worktreePath) {
+      logger.warn('Skipping unregistered worktree cleanup because workspace has another path', {
+        workspaceId,
+        createdWorktreePath: worktreeInfo.worktreePath,
+        persistedWorktreePath: workspace.worktreePath,
+      });
+      return;
+    }
+
+    assertWorktreePathSafe(worktreeInfo.worktreePath, project.worktreeBasePath);
+    await gitOpsService.removeWorktree(worktreeInfo.worktreePath, project);
+    logger.info('Removed unregistered worktree after init failure', {
+      workspaceId,
+      worktreePath: worktreeInfo.worktreePath,
+      branchName: worktreeInfo.branchName,
+    });
+  } catch (cleanupError) {
+    logger.warn('Failed to remove unregistered worktree after init failure', {
+      workspaceId,
+      worktreePath: worktreeInfo.worktreePath,
+      error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
     });
   }
 }
@@ -994,6 +1049,8 @@ export async function initializeWorkspaceWorktree(
 
   let project: WorkspaceWithProject['project'] | undefined;
   let worktreeCreated = false;
+  let worktreeRegistered = false;
+  let createdWorktreeInfo: CreatedWorktreeInfo | undefined;
   let agentSessionPromise: Promise<string | null> = Promise.resolve(null);
   let autoCreatedTerminalId: string | undefined;
 
@@ -1018,6 +1075,7 @@ export async function initializeWorkspaceWorktree(
       workspaceWithProject.name
     );
     worktreeCreated = true;
+    createdWorktreeInfo = worktreeInfo;
 
     const factoryConfig = await readFactoryConfigSafe(worktreeInfo.worktreePath, workspaceId);
 
@@ -1034,6 +1092,7 @@ export async function initializeWorkspaceWorktree(
           runScriptCleanupCommand: commands.runScriptCleanupCommand,
         }),
     });
+    worktreeRegistered = true;
 
     const defaultTerminal = await startDefaultTerminal(workspaceId, worktreeInfo.worktreePath);
     if (defaultTerminal?.autoCreated) {
@@ -1082,7 +1141,14 @@ export async function initializeWorkspaceWorktree(
     // Ensure any eager session start attempt has settled before cleanup so we
     // do not race stopWorkspaceSessions() with a late startSession() call.
     await agentSessionPromise;
-    await handleWorkspaceInitFailure(workspaceId, toError(error), autoCreatedTerminalId);
+    await handleWorkspaceInitFailure(
+      workspaceId,
+      toError(error),
+      autoCreatedTerminalId,
+      project && createdWorktreeInfo && !worktreeRegistered
+        ? { project, worktreeInfo: createdWorktreeInfo }
+        : undefined
+    );
   } finally {
     if (worktreeCreated) {
       await worktreeLifecycleService.clearInitMode(workspaceId);

--- a/src/backend/services/session/service/acp/codex-cli-import-resolution.integration.test.ts
+++ b/src/backend/services/session/service/acp/codex-cli-import-resolution.integration.test.ts
@@ -79,10 +79,14 @@ function spawnCodexCliWithRetry(
   args: string[]
 ): ReturnType<typeof spawnSync> {
   let result = spawnCodexCli(workspaceRoot, args, 10_000);
-  if (result.status === null) {
+  if (didSpawnTimeout(result)) {
     result = spawnCodexCli(workspaceRoot, args, 30_000);
   }
   return result;
+}
+
+function didSpawnTimeout(result: ReturnType<typeof spawnSync>): boolean {
+  return result.status === null || result.signal !== null || result.status === 143;
 }
 
 describe('CODEX CLI import resolution', () => {
@@ -101,7 +105,7 @@ describe('CODEX CLI import resolution', () => {
     ]);
     const stderr = String(result.stderr ?? '');
 
-    if (result.status === null) {
+    if (didSpawnTimeout(result)) {
       throw new Error(
         `Unpinned-tsconfig CLI run exited without status (signal=${String(result.signal ?? 'none')}). stderr: ${stderr}`
       );
@@ -117,7 +121,7 @@ describe('CODEX CLI import resolution', () => {
 
     expect(stderr).not.toContain('does not provide an export named');
     expect(stderr).not.toContain('ERR_MODULE_NOT_FOUND');
-  });
+  }, 45_000);
 
   it('avoids the import crash when tsconfig is pinned to repo root', () => {
     const workspaceRoot = createWorkspaceWithConflictingAlias();
@@ -130,7 +134,7 @@ describe('CODEX CLI import resolution', () => {
     ]);
     const stderr = String(result.stderr ?? '');
 
-    if (result.status === null) {
+    if (didSpawnTimeout(result)) {
       throw new Error(
         `Pinned-tsconfig CLI run exited without status (signal=${String(result.signal ?? 'none')}). stderr: ${stderr}`
       );
@@ -139,5 +143,5 @@ describe('CODEX CLI import resolution', () => {
     expect(result.status).toBe(0);
     expect(stderr).not.toContain('does not provide an export named');
     expect(stderr).not.toContain('SyntaxError');
-  }, 30_000);
+  }, 45_000);
 });

--- a/src/backend/services/workspace/service/worktree/worktree-init.test.ts
+++ b/src/backend/services/workspace/service/worktree/worktree-init.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   ensureBaseBranchExists: vi.fn(),
   createWorktree: vi.fn(),
   createWorktreeFromExistingBranch: vi.fn(),
+  removeWorktree: vi.fn(),
   getAuthenticatedUsername: vi.fn(),
   getIssue: vi.fn(),
   readConfig: vi.fn(),
@@ -34,9 +35,11 @@ const mocks = vi.hoisted(() => ({
   markFailed: vi.fn(),
   getInitMode: vi.fn(),
   clearInitMode: vi.fn(),
+  assertWorktreePathSafe: vi.fn(),
 }));
 
 vi.mock('@/backend/services/workspace', () => ({
+  assertWorktreePathSafe: mocks.assertWorktreePathSafe,
   workspaceStateMachine: {
     startProvisioning: mocks.startProvisioning,
     markReady: mocks.markReady,
@@ -89,6 +92,7 @@ vi.mock('@/backend/services/git-ops.service', () => ({
     ensureBaseBranchExists: mocks.ensureBaseBranchExists,
     createWorktree: mocks.createWorktree,
     createWorktreeFromExistingBranch: mocks.createWorktreeFromExistingBranch,
+    removeWorktree: mocks.removeWorktree,
   },
 }));
 
@@ -150,6 +154,7 @@ describe('initializeWorkspaceWorktree orchestrator', () => {
       worktreePath: '/worktrees/workspace-1',
       branchName: 'feature-1',
     });
+    mocks.removeWorktree.mockResolvedValue(undefined);
     mocks.getAuthenticatedUsername.mockResolvedValue(null);
     mocks.getIssue.mockResolvedValue(null);
     mocks.updateWorkspace.mockResolvedValue(undefined);


### PR DESCRIPTION
## Summary
- Cleans up worktrees created during failed workspace initialization before `worktreePath` is persisted.
- Preserves registered worktrees when later initialization steps fail.
- Stabilizes the Codex CLI import resolution integration test under slower process startup.

## Changes
- **Workspace Init**: Track whether the newly created worktree was successfully registered in the workspace record; on failure, safely remove the unregistered worktree so Retry can recreate it.
- **Tests**: Added coverage for pre-persistence cleanup, post-persistence failure protection, cleanup failure handling, and the required test mocks.
- **Test Stability**: Retry CLI import checks when the child process exits with timeout status 143 and give the integration cases enough time to honor their subprocess timeouts.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not run; covered by focused workspace-init unit tests and full suite.

Closes #1447

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workspace initialization and adds automatic deletion of newly-created git worktrees when DB persistence fails, which can impact developer worktrees if path checks/matching logic are wrong. Guardrails (`assertWorktreePathSafe` and persisted-path checks) reduce the blast radius, and changes are covered by new unit tests.
> 
> **Overview**
> Fixes a workspace-init leak by tracking whether a newly created worktree was actually persisted to the workspace record, and **removing the worktree on init failure only when it was created but not registered**.
> 
> Adds safe cleanup logic (`assertWorktreePathSafe`, verify current `workspace.worktreePath` before deleting) and new tests covering pre-persistence cleanup, no-cleanup after successful persistence, and non-fatal cleanup failures.
> 
> Stabilizes the Codex CLI import-resolution integration test by treating more child-process exit modes as timeouts (including exit code `143`) and increasing test timeouts to match the subprocess retry behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c426deaa426581bba2cf5ead394207f766f85610. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->