### PR TITLE
Fix #1532: Handle startup failure CI snapshots

### DIFF
--- a/src/backend/services/ratchet/service/ratchet-pr-state.helpers.test.ts
+++ b/src/backend/services/ratchet/service/ratchet-pr-state.helpers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { CIStatus, RatchetState } from '@/shared/core';
 import type { PRStateInfo } from './ratchet.types';
 import {
+  buildFailedCheckDiagnostics,
   computeCiSnapshotKey,
   computeDispatchSnapshotKey,
   determineRatchetState,
@@ -174,5 +175,47 @@ describe('computeCiSnapshotKey', () => {
     expect(key).toContain('commitlint:FAILURE');
     expect(key).not.toContain('ci:FAILURE:100');
     expect(key).toBe('ci:FAILURE:commitlint:FAILURE:101');
+  });
+
+  it('includes STARTUP_FAILURE checks in failure snapshot keys', () => {
+    const key = computeCiSnapshotKey(CIStatus.FAILURE, [
+      {
+        name: 'ci',
+        workflowName: 'CI',
+        status: 'COMPLETED',
+        conclusion: 'STARTUP_FAILURE',
+        detailsUrl: 'https://github.com/org/repo/actions/runs/100/job/1',
+      },
+    ]);
+
+    expect(key).toBe('ci:FAILURE:ci:STARTUP_FAILURE:100');
+  });
+});
+
+describe('buildFailedCheckDiagnostics', () => {
+  it('includes STARTUP_FAILURE checks in failed check diagnostics', () => {
+    const diagnostics = buildFailedCheckDiagnostics(
+      makePRState({
+        statusCheckRollup: [
+          {
+            name: 'ci',
+            workflowName: 'CI',
+            status: 'COMPLETED',
+            conclusion: 'STARTUP_FAILURE',
+            detailsUrl: 'https://github.com/org/repo/actions/runs/100/job/1',
+          },
+        ],
+      })
+    );
+
+    expect(diagnostics).toEqual([
+      {
+        name: 'ci',
+        status: 'COMPLETED',
+        conclusion: 'STARTUP_FAILURE',
+        runId: '100',
+        detailsUrl: 'https://github.com/org/repo/actions/runs/100/job/1',
+      },
+    ]);
   });
 });

--- a/src/backend/services/ratchet/service/ratchet-pr-state.helpers.ts
+++ b/src/backend/services/ratchet/service/ratchet-pr-state.helpers.ts
@@ -27,6 +27,7 @@ const FAILURE_CONCLUSIONS = new Set([
   'CANCELLED',
   'ERROR',
   'ACTION_REQUIRED',
+  'STARTUP_FAILURE',
 ]);
 
 export function determineRatchetState(pr: PRStateInfo): RatchetState {


### PR DESCRIPTION
## Summary
- Treat GitHub `STARTUP_FAILURE` check conclusions as ratchet CI failures when computing dispatch snapshots.
- Preserve run-specific snapshot keys for repeated startup-failure CI runs so fixer sessions can be re-dispatched.
- Add regression coverage for snapshot keys and failed-check diagnostics.

## Changes
- **Ratchet CI snapshots**: Added `STARTUP_FAILURE` to the shared failure conclusion set used by snapshot and diagnostic helpers.
- **Tests**: Covered `STARTUP_FAILURE` snapshot key generation and failed-check diagnostic output.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; backend helper behavior covered by regression tests.

Closes #1532

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to failure classification for ratchet snapshot/diagnostic helpers with added test coverage; low risk aside from potentially altering dispatch key churn for PRs with startup failures.
> 
> **Overview**
> Ratchet now classifies GitHub Actions checks with conclusion `STARTUP_FAILURE` as failures via the shared `FAILURE_CONCLUSIONS` set, which affects both CI snapshot key generation (`computeCiSnapshotKey`) and failed-check diagnostics (`buildFailedCheckDiagnostics`).
> 
> Adds regression tests to ensure `STARTUP_FAILURE` runs are included in failure snapshot signatures (preserving run-specific IDs) and are surfaced in diagnostics output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44b72350347f07ae8bee06a365d8dd7d43719b7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->