### PR TITLE
Fix #1527: Accept draft PR merge state

### DIFF
--- a/src/backend/services/github/service/github-cli.service.test.ts
+++ b/src/backend/services/github/service/github-cli.service.test.ts
@@ -560,6 +560,39 @@ describe('GitHubCLIService', () => {
     });
 
     describe('getPRFullDetails with malformed data', () => {
+      it('accepts DRAFT mergeStateStatus for draft PRs', async () => {
+        const fullPRData = {
+          number: 123,
+          title: 'Draft PR',
+          url: 'https://github.com/owner/repo/pull/123',
+          author: { login: 'octocat' },
+          createdAt: '2024-01-01T00:00:00Z',
+          updatedAt: '2024-01-02T00:00:00Z',
+          isDraft: true,
+          state: 'OPEN',
+          reviewDecision: null,
+          statusCheckRollup: null,
+          reviews: [],
+          comments: [],
+          labels: [],
+          additions: 10,
+          deletions: 2,
+          changedFiles: 1,
+          headRefName: 'feature-branch',
+          baseRefName: 'main',
+          mergeStateStatus: 'DRAFT',
+        };
+
+        mockExecFile.mockResolvedValue({
+          stdout: JSON.stringify(fullPRData),
+          stderr: '',
+        });
+
+        const result = await githubCLIService.getPRFullDetails('owner/repo', 123);
+
+        expect(result.mergeStateStatus).toBe('DRAFT');
+      });
+
       it('normalizes status check casing in statusCheckRollup entries', async () => {
         const fullPRData = {
           number: 123,

--- a/src/backend/services/github/service/github-cli/schemas.ts
+++ b/src/backend/services/github/service/github-cli/schemas.ts
@@ -137,7 +137,7 @@ export const fullPRDetailsSchema = z.object({
   headRefName: z.string().optional(),
   baseRefName: z.string().optional(),
   mergeStateStatus: z
-    .enum(['BEHIND', 'BLOCKED', 'CLEAN', 'DIRTY', 'HAS_HOOKS', 'UNKNOWN', 'UNSTABLE'])
+    .enum(['BEHIND', 'BLOCKED', 'CLEAN', 'DIRTY', 'DRAFT', 'HAS_HOOKS', 'UNKNOWN', 'UNSTABLE'])
     .optional(),
 });
 

--- a/src/shared/github-types.ts
+++ b/src/shared/github-types.ts
@@ -62,6 +62,7 @@ export type MergeStateStatus =
   | 'BLOCKED'
   | 'CLEAN'
   | 'DIRTY'
+  | 'DRAFT'
   | 'HAS_HOOKS'
   | 'UNKNOWN'
   | 'UNSTABLE';


### PR DESCRIPTION
## Summary
- Accept GitHub's `DRAFT` merge state for draft pull requests.
- Preserve `DRAFT` through the shared PR detail type.
- Add a regression test covering `getPRFullDetails()` parsing draft PR details.

## Changes
- **GitHub CLI schema**: Add `DRAFT` to the accepted `mergeStateStatus` enum.
- **Shared GitHub types**: Add `DRAFT` to `MergeStateStatus`.
- **Tests**: Cover mocked `gh pr view` output where GitHub returns `mergeStateStatus: "DRAFT"`.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not run; covered by schema/service regression test.

Closes #1527

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small schema/type widening plus a targeted regression test; behavior change is limited to accepting an additional enum value from GitHub.
> 
> **Overview**
> Updates GitHub CLI parsing to accept GitHub’s `mergeStateStatus: "DRAFT"` in `getPRFullDetails` responses, and propagates this through the shared `MergeStateStatus` type so draft PRs don’t fail schema validation.
> 
> Adds a regression test that mocks `gh pr view` returning `mergeStateStatus: "DRAFT"` and asserts the value is preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d07fd98ad67f24d768a2b51df38dc7a6922d11b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->