### PR TITLE
Fix #1530: Count only active sessions in UI limit

### DIFF
--- a/src/components/workspace/main-view-tab-bar.tsx
+++ b/src/components/workspace/main-view-tab-bar.tsx
@@ -13,6 +13,7 @@ import type { SessionStatus as DbSessionStatus } from '@/shared/core';
 import { ClosedSessionsDropdown } from './closed-sessions-dropdown';
 import { QuickActionsMenu } from './quick-actions-menu';
 import { RatchetWrenchIcon } from './ratchet-wrench-icon';
+import { isWorkspaceSessionLimitReached } from './session-limit';
 import {
   deriveSessionTabRuntime,
   type WorkspaceSessionRuntimeSummary,
@@ -222,9 +223,8 @@ export function MainViewTabBar({
   // Filter out the default 'chat' tab since we're showing sessions instead
   const nonChatTabs = tabs.filter((tab) => tab.type !== 'chat');
 
-  // Check if session limit is reached
-  const sessionCount = sessions?.length ?? 0;
-  const isAtLimit = maxSessions !== undefined && sessionCount >= maxSessions;
+  // Check if active session limit is reached
+  const isAtLimit = isWorkspaceSessionLimitReached(sessions, maxSessions);
   const isButtonDisabled = disabled || isAtLimit;
   const providerTriggerLabel = getSessionProviderLabel(selectedProvider);
 

--- a/src/components/workspace/session-limit.test.ts
+++ b/src/components/workspace/session-limit.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { SessionStatus } from '@/shared/core';
+import { getActiveWorkspaceSessionCount, isWorkspaceSessionLimitReached } from './session-limit';
+
+function session(status: SessionStatus) {
+  return { status };
+}
+
+describe('workspace session limit', () => {
+  it('counts only running and idle sessions as active', () => {
+    const sessions = [
+      session(SessionStatus.RUNNING),
+      session(SessionStatus.IDLE),
+      session(SessionStatus.COMPLETED),
+      session(SessionStatus.FAILED),
+      session(SessionStatus.PAUSED),
+    ];
+
+    expect(getActiveWorkspaceSessionCount(sessions)).toBe(2);
+  });
+
+  it('does not block new sessions when only completed or failed sessions exceed the limit', () => {
+    const sessions = [
+      session(SessionStatus.COMPLETED),
+      session(SessionStatus.FAILED),
+      session(SessionStatus.COMPLETED),
+    ];
+
+    expect(isWorkspaceSessionLimitReached(sessions, 2)).toBe(false);
+  });
+
+  it('blocks new sessions once active sessions reach the limit', () => {
+    const sessions = [
+      session(SessionStatus.RUNNING),
+      session(SessionStatus.IDLE),
+      session(SessionStatus.COMPLETED),
+    ];
+
+    expect(isWorkspaceSessionLimitReached(sessions, 2)).toBe(true);
+  });
+
+  it('does not apply a limit when max sessions is undefined', () => {
+    const sessions = [session(SessionStatus.RUNNING)];
+
+    expect(isWorkspaceSessionLimitReached(sessions, undefined)).toBe(false);
+  });
+});

--- a/src/components/workspace/session-limit.ts
+++ b/src/components/workspace/session-limit.ts
@@ -1,0 +1,21 @@
+import { type SessionStatus as DbSessionStatus, SessionStatus } from '@/shared/core';
+
+interface WorkspaceSessionLimitSession {
+  status: DbSessionStatus;
+}
+
+const ACTIVE_SESSION_STATUSES = new Set<DbSessionStatus>([
+  SessionStatus.RUNNING,
+  SessionStatus.IDLE,
+]);
+
+export function getActiveWorkspaceSessionCount(sessions?: WorkspaceSessionLimitSession[]): number {
+  return sessions?.filter((session) => ACTIVE_SESSION_STATUSES.has(session.status)).length ?? 0;
+}
+
+export function isWorkspaceSessionLimitReached(
+  sessions: WorkspaceSessionLimitSession[] | undefined,
+  maxSessions: number | undefined
+): boolean {
+  return maxSessions !== undefined && getActiveWorkspaceSessionCount(sessions) >= maxSessions;
+}


### PR DESCRIPTION
## Summary
- Align the workspace tab-bar session limit with backend active-session enforcement.
- Add focused regression coverage for active-only session counting.

## Changes
- **Workspace UI**: Count only `RUNNING` and `IDLE` sessions when deciding whether to disable New Chat and quick actions.
- **Tests**: Cover completed, failed, paused, active, and undefined-limit cases for the shared limit helper.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Formatting/lint passes (`pnpm check:fix`)
- [ ] Manual testing: Not run; state-dependent UI behavior is covered by regression tests.

Closes #1530

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI logic change that only affects when session-creation controls are disabled; behavior is covered by new unit tests for status filtering and undefined limits.
> 
> **Overview**
> Updates the workspace tab bar session-limit check to consider only *active* sessions (`RUNNING`/`IDLE`) when disabling “new session” and quick actions, instead of counting all sessions.
> 
> Introduces a small shared helper (`getActiveWorkspaceSessionCount`/`isWorkspaceSessionLimitReached`) plus focused tests to prevent regressions across completed/failed/paused sessions and the no-limit (`maxSessions` undefined) case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9a9742383a6fcfc1b415a35d4f3cdb1d3b43073. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->