### PR TITLE
Fix #1523: Enforce live kanban column filtering

### DIFF
--- a/src/backend/services/workspace/service/query/workspace-query.service.test.ts
+++ b/src/backend/services/workspace/service/query/workspace-query.service.test.ts
@@ -194,6 +194,47 @@ describe('WorkspaceQueryService', () => {
     });
   });
 
+  it('listWithKanbanState returns only workspaces matching the requested live kanbanColumn', async () => {
+    mockFindByProjectIdWithSessions.mockResolvedValue([
+      {
+        id: 'w1',
+        status: WorkspaceStatus.READY,
+        prUrl: null,
+        prState: PRState.NONE,
+        prCiStatus: CIStatus.UNKNOWN,
+        ratchetState: RatchetState.IDLE,
+        hasHadSessions: true,
+        cachedKanbanColumn: 'WAITING',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      },
+    ]);
+
+    mockDeriveWorkspaceRuntimeState.mockReturnValue({
+      sessionIds: ['s-1'],
+      isSessionWorking: true,
+      isWorking: true,
+      flowState: {
+        hasActivePr: false,
+        isWorking: true,
+        shouldAnimateRatchetButton: false,
+        phase: 'NO_PR',
+        ciObservation: 'NONE',
+      },
+    });
+    mockGetAllPendingRequests.mockReturnValue(new Map());
+
+    const result = await workspaceQueryService.listWithKanbanState({
+      projectId: 'proj-1',
+      kanbanColumn: 'WAITING',
+    });
+
+    expect(result).toHaveLength(0);
+    expect(mockFindByProjectIdWithSessions).toHaveBeenCalledWith('proj-1', {
+      kanbanColumn: 'WAITING',
+      excludeStatuses: [WorkspaceStatus.ARCHIVING, WorkspaceStatus.ARCHIVED],
+    });
+  });
+
   it('getProjectSummaryState computes git stats and caches review count', async () => {
     mockProjectFindById.mockResolvedValue({ id: 'p1', defaultBranch: 'main' });
     mockFindByProjectIdWithSessions.mockResolvedValue([

--- a/src/backend/services/workspace/service/query/workspace-query.service.ts
+++ b/src/backend/services/workspace/service/query/workspace-query.service.ts
@@ -286,7 +286,11 @@ class WorkspaceQueryService {
       })
       .filter((workspace) => {
         // Filter out workspaces with null kanbanColumn (hidden: READY + no sessions)
-        return workspace.kanbanColumn !== null;
+        if (workspace.kanbanColumn === null) {
+          return false;
+        }
+
+        return !input.kanbanColumn || workspace.kanbanColumn === input.kanbanColumn;
       })
       .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
   }


### PR DESCRIPTION
## Summary
- Enforces `listWithKanbanState` kanban filters against the live derived column returned by the API.
- Adds a regression test for cached WAITING / live WORKING divergence.

## Changes
- **Workspace query service**: Keeps the cached-column DB filter as a coarse query filter, then drops rows whose computed live `kanbanColumn` does not match the requested filter.
- **Workspace query tests**: Covers the archive-all risk case where a workspace cached in WAITING is actively working at runtime.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; backend query contract covered by regression test.

Closes #1523

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to post-query filtering plus a focused regression test; main impact is potentially returning fewer workspaces when cached and live kanban columns diverge.
> 
> **Overview**
> `listWithKanbanState` now enforces `kanbanColumn` filtering against the *runtime-derived* `kanbanColumn` (while still using the DB filter as a coarse prefilter), and continues to drop "hidden" workspaces where the derived column is `null`.
> 
> Adds a regression test covering the cached WAITING vs live WORKING divergence to ensure requests for a specific column don’t return mismatched workspaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe6e6e3c7206e0be71c559942a7ed7ce73d48e4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->