### PR TITLE
Fix #1532: Handle startup failure CI snapshots

### DIFF
--- a/src/backend/services/ratchet/service/ratchet-pr-state.helpers.test.ts
+++ b/src/backend/services/ratchet/service/ratchet-pr-state.helpers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { CIStatus, RatchetState } from '@/shared/core';
 import type { PRStateInfo } from './ratchet.types';
 import {
+  buildFailedCheckDiagnostics,
   computeCiSnapshotKey,
   computeDispatchSnapshotKey,
   determineRatchetState,
@@ -146,6 +147,21 @@ describe('computeDispatchSnapshotKey', () => {
 });
 
 describe('computeCiSnapshotKey', () => {
+  it('includes STARTUP_FAILURE checks in the failure signature', () => {
+    const key = computeCiSnapshotKey(CIStatus.FAILURE, [
+      {
+        name: 'ci',
+        workflowName: 'CI',
+        status: 'COMPLETED',
+        conclusion: 'STARTUP_FAILURE',
+        detailsUrl: 'https://github.com/org/repo/actions/runs/100/job/1',
+      },
+    ]);
+
+    expect(key).toBe('ci:FAILURE:ci:STARTUP_FAILURE:100');
+    expect(key).not.toBe('ci:FAILURE:unknown');
+  });
+
   it('ignores stale failures from superseded runs of the same check', () => {
     const key = computeCiSnapshotKey(CIStatus.FAILURE, [
       {
@@ -174,5 +190,33 @@ describe('computeCiSnapshotKey', () => {
     expect(key).toContain('commitlint:FAILURE');
     expect(key).not.toContain('ci:FAILURE:100');
     expect(key).toBe('ci:FAILURE:commitlint:FAILURE:101');
+  });
+});
+
+describe('buildFailedCheckDiagnostics', () => {
+  it('includes STARTUP_FAILURE checks in failed check diagnostics', () => {
+    const diagnostics = buildFailedCheckDiagnostics(
+      makePRState({
+        statusCheckRollup: [
+          {
+            name: 'ci',
+            workflowName: 'CI',
+            status: 'COMPLETED',
+            conclusion: 'STARTUP_FAILURE',
+            detailsUrl: 'https://github.com/org/repo/actions/runs/100/job/1',
+          },
+        ],
+      })
+    );
+
+    expect(diagnostics).toEqual([
+      {
+        name: 'ci',
+        status: 'COMPLETED',
+        conclusion: 'STARTUP_FAILURE',
+        runId: '100',
+        detailsUrl: 'https://github.com/org/repo/actions/runs/100/job/1',
+      },
+    ]);
   });
 });

--- a/src/backend/services/ratchet/service/ratchet-pr-state.helpers.ts
+++ b/src/backend/services/ratchet/service/ratchet-pr-state.helpers.ts
@@ -27,6 +27,7 @@ const FAILURE_CONCLUSIONS = new Set([
   'CANCELLED',
   'ERROR',
   'ACTION_REQUIRED',
+  'STARTUP_FAILURE',
 ]);
 
 export function determineRatchetState(pr: PRStateInfo): RatchetState {


### PR DESCRIPTION
## Summary
- Adds `STARTUP_FAILURE` to ratchet failure conclusion handling.
- Covers startup-failure CI snapshot keys and failed-check diagnostics with regression tests.

## Changes
- **Ratchet CI snapshots**: Treat `STARTUP_FAILURE` as a failed conclusion when computing dispatch snapshot keys so consecutive failed runs remain distinguishable.
- **Ratchet diagnostics**: Include `STARTUP_FAILURE` checks in failed check diagnostics passed to fixer sessions.
- **Tests**: Add focused coverage for startup-failure snapshot key generation and diagnostics.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; backend CI snapshot helper regression covered by automated tests.

Closes #1532

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how ratchet computes CI failure signatures and which checks are surfaced to fixer sessions, potentially affecting dispatch/deduping behavior. Scope is small and covered by targeted tests.
> 
> **Overview**
> Ratchet now treats GitHub check conclusion `STARTUP_FAILURE` as a failure when building CI snapshot keys and failed-check diagnostics.
> 
> Adds regression tests ensuring `computeCiSnapshotKey` produces a stable failure signature for `STARTUP_FAILURE` runs (instead of `unknown`) and that `buildFailedCheckDiagnostics` includes these checks with extracted run IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6271fd0ad876a6b1815e73122b11fee9aad25347. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->