### PR TITLE
Fix #1528: Quit Electron after fatal errors

### DIFF
--- a/electron/main/fatal-error-handlers.test.ts
+++ b/electron/main/fatal-error-handlers.test.ts
@@ -1,0 +1,53 @@
+import { EventEmitter } from 'node:events';
+import { describe, expect, it, vi } from 'vitest';
+import { registerFatalErrorHandlers } from './fatal-error-handlers.js';
+
+function createHandlerHarness() {
+  const app = {
+    quit: vi.fn(),
+  };
+  const dialog = {
+    showErrorBox: vi.fn(),
+  };
+  const logger = {
+    error: vi.fn(),
+  };
+  const process = new EventEmitter();
+
+  registerFatalErrorHandlers({ app, dialog, logger, process });
+
+  return { app, dialog, logger, process };
+}
+
+describe('fatal Electron error handlers', () => {
+  it('shows uncaught exceptions and quits after the dialog', () => {
+    const { app, dialog, logger, process } = createHandlerHarness();
+    const error = new Error('fatal startup failure');
+
+    process.emit('uncaughtException', error);
+
+    expect(logger.error).toHaveBeenCalledWith('[electron] Uncaught exception:', error);
+    expect(dialog.showErrorBox).toHaveBeenCalledWith(
+      'Uncaught Exception',
+      expect.stringContaining('fatal startup failure')
+    );
+    expect(app.quit).toHaveBeenCalledTimes(1);
+    expect(dialog.showErrorBox.mock.invocationCallOrder[0]).toBeLessThan(
+      app.quit.mock.invocationCallOrder[0]
+    );
+  });
+
+  it('shows unhandled rejections and quits after the dialog', () => {
+    const { app, dialog, logger, process } = createHandlerHarness();
+    const reason = new Error('async setup failed');
+
+    process.emit('unhandledRejection', reason);
+
+    expect(logger.error).toHaveBeenCalledWith('[electron] Unhandled rejection:', reason);
+    expect(dialog.showErrorBox).toHaveBeenCalledWith('Unhandled Rejection', String(reason));
+    expect(app.quit).toHaveBeenCalledTimes(1);
+    expect(dialog.showErrorBox.mock.invocationCallOrder[0]).toBeLessThan(
+      app.quit.mock.invocationCallOrder[0]
+    );
+  });
+});

--- a/electron/main/fatal-error-handlers.ts
+++ b/electron/main/fatal-error-handlers.ts
@@ -1,0 +1,42 @@
+interface FatalErrorApp {
+  quit(): void;
+}
+
+interface FatalErrorDialog {
+  showErrorBox(title: string, content: string): void;
+}
+
+interface FatalErrorLogger {
+  error(message?: unknown, ...optionalParams: unknown[]): void;
+}
+
+interface FatalErrorProcess {
+  on(event: 'uncaughtException', listener: (error: Error) => void): this;
+  on(event: 'unhandledRejection', listener: (reason: unknown) => void): this;
+}
+
+interface FatalErrorHandlerDependencies {
+  app: FatalErrorApp;
+  dialog: FatalErrorDialog;
+  logger: FatalErrorLogger;
+  process: FatalErrorProcess;
+}
+
+export function registerFatalErrorHandlers({
+  app,
+  dialog,
+  logger,
+  process,
+}: FatalErrorHandlerDependencies): void {
+  process.on('uncaughtException', (error) => {
+    logger.error('[electron] Uncaught exception:', error);
+    dialog.showErrorBox('Uncaught Exception', error.stack || String(error));
+    app.quit();
+  });
+
+  process.on('unhandledRejection', (reason) => {
+    logger.error('[electron] Unhandled rejection:', reason);
+    dialog.showErrorBox('Unhandled Rejection', String(reason));
+    app.quit();
+  });
+}

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -1,21 +1,13 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { app, BrowserWindow, dialog, ipcMain } from 'electron';
+import { registerFatalErrorHandlers } from './fatal-error-handlers.js';
 import { createElectronLifecycle } from './lifecycle.js';
 import { ServerManager } from './server-manager.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-// Catch unhandled errors that could cause silent crashes
-process.on('uncaughtException', (error) => {
-  console.error('[electron] Uncaught exception:', error);
-  dialog.showErrorBox('Uncaught Exception', error.stack || String(error));
-});
-
-process.on('unhandledRejection', (reason) => {
-  console.error('[electron] Unhandled rejection:', reason);
-  dialog.showErrorBox('Unhandled Rejection', String(reason));
-});
+registerFatalErrorHandlers({ app, dialog, logger: console, process });
 
 const serverManager = new ServerManager();
 const lifecycle = createElectronLifecycle({


### PR DESCRIPTION
## Summary
- Quit the Electron app after fatal uncaught exceptions and unhandled rejections.
- Move Electron fatal-error registration into a focused helper with unit coverage.

## Changes
- **Electron main**: Register fatal process handlers through `registerFatalErrorHandlers`, preserving the existing dialog/logging behavior and calling `app.quit()` afterward.
- **Tests**: Add main-process tests covering both fatal handler paths and verifying quit happens after the error dialog is shown.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Manual testing: Not applicable; behavior is covered by Electron main-process unit tests.

Closes #1528

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes main-process crash handling by quitting the app after fatal errors, which can affect startup/shutdown behavior and user sessions, but the logic is small and covered by unit tests.
> 
> **Overview**
> Refactors Electron main-process fatal error handling into a new `registerFatalErrorHandlers` helper and updates `electron/main/index.ts` to use it.
> 
> **Behavior change:** on `uncaughtException` and `unhandledRejection`, the app now shows the same error dialog/log message and then calls `app.quit()`.
> 
> Adds Vitest coverage to verify both error paths and that `quit()` happens *after* `dialog.showErrorBox()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8aab298caf749aa33f3e5195c85e06d47f43437a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->