### PR TITLE
Fix #1522: Clean up terminals when session persistence fails

### DIFF
--- a/src/backend/routers/websocket/terminal.handler.test.ts
+++ b/src/backend/routers/websocket/terminal.handler.test.ts
@@ -322,6 +322,73 @@ describe('createTerminalUpgradeHandler', () => {
     expect(terminalService.destroyTerminal).toHaveBeenCalledWith(workspaceId, 'terminal-1');
   });
 
+  it('destroys a newly created terminal when session persistence fails', async () => {
+    const workspaceId = 'workspace-1';
+    vi.mocked(workspaceDataService.findById).mockResolvedValue({
+      id: workspaceId,
+      worktreePath: '/tmp/worktree',
+    } as never);
+    vi.mocked(sessionDataService.createTerminalSession).mockRejectedValueOnce(
+      new Error('database locked')
+    );
+
+    const terminalInstances = new Map<string, { id: string; pid: number }>();
+    const { terminalService } = createTerminalService();
+    terminalService.createTerminal.mockImplementationOnce(() => {
+      const terminalId = 'terminal-1';
+      terminalInstances.set(terminalId, { id: terminalId, pid: 4321 });
+      return Promise.resolve({ terminalId, pid: 4321 });
+    });
+    terminalService.destroyTerminal.mockImplementationOnce((_wsId, terminalId) => {
+      terminalInstances.delete(terminalId);
+      return true;
+    });
+
+    const logger = createLogger();
+    const appContext = {
+      services: {
+        terminalService,
+        createLogger: vi.fn(() => logger),
+      },
+    } as unknown as AppContext;
+
+    const handler = createTerminalUpgradeHandler(appContext);
+    const ws = new MockWebSocket();
+    const wss = createWss(ws);
+    const request = {} as IncomingMessage;
+    const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
+
+    handler(
+      request,
+      socket,
+      Buffer.alloc(0),
+      new URL(`http://localhost/terminal?workspaceId=${workspaceId}`),
+      wss,
+      new WeakMap<WebSocket, boolean>()
+    );
+
+    ws.emit('message', JSON.stringify({ type: 'create', cols: 80, rows: 24 }));
+
+    await vi.waitFor(() => {
+      expect(sessionDataService.createTerminalSession).toHaveBeenCalledWith({
+        workspaceId,
+        name: 'terminal-1',
+        pid: 4321,
+      });
+      expect(terminalService.destroyTerminal).toHaveBeenCalledWith(workspaceId, 'terminal-1');
+    });
+
+    expect(terminalInstances.size).toBe(0);
+    expect(terminalService.onOutput).not.toHaveBeenCalled();
+    expect(terminalService.onExit).not.toHaveBeenCalled();
+    expect(ws.send).not.toHaveBeenCalledWith(
+      JSON.stringify({ type: 'created', terminalId: 'terminal-1' })
+    );
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: 'error', message: 'Operation failed: database locked' })
+    );
+  });
+
   it('sends structured errors for invalid or failed terminal operations', async () => {
     const workspaceId = 'workspace-1';
     vi.mocked(workspaceDataService.findById).mockResolvedValue(null as never);

--- a/src/backend/routers/websocket/terminal.handler.ts
+++ b/src/backend/routers/websocket/terminal.handler.ts
@@ -159,11 +159,16 @@ async function handleCreateMessage(
     rows: message.rows ?? 24,
   });
 
-  await sessionDataService.createTerminalSession({
-    workspaceId,
-    name: terminalId,
-    pid,
-  });
+  try {
+    await sessionDataService.createTerminalSession({
+      workspaceId,
+      name: terminalId,
+      pid,
+    });
+  } catch (error) {
+    terminalService.destroyTerminal(workspaceId, terminalId);
+    throw error;
+  }
 
   const cleanupMap = terminalListenerCleanup.get(ws);
   attachTerminalListeners(ws, terminalId, terminalService, logger, cleanupMap);


### PR DESCRIPTION
## Summary
- Clean up newly created terminal processes when terminal session persistence fails.
- Add a regression test for the WebSocket create path to prevent orphaned terminal instances.

## Changes
- **Terminal WebSocket**: Wrap `createTerminalSession` in a try/catch and call `destroyTerminal` before rethrowing persistence failures.
- **Tests**: Verify failed persistence removes the mock terminal instance, avoids attaching listeners, and returns the existing structured error response.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; backend error path is covered by automated regression test.

Closes #1522

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized error-path change in the terminal WebSocket create flow with a regression test covering the new cleanup behavior.
> 
> **Overview**
> Fixes an orphan-terminal edge case in the terminal WebSocket `create` flow by wrapping `sessionDataService.createTerminalSession` in a `try/catch` and calling `terminalService.destroyTerminal` before rethrowing persistence failures.
> 
> Adds a regression test that simulates a persistence error and asserts the terminal is destroyed, listeners are not attached, no `created` message is sent, and the existing structured `error` response is returned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c708a5d5077eff7e50d148d554fb76353559215. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->