### PR TITLE
Fix #1524: Preserve rejected chat recovery

### DIFF
--- a/src/components/chat/chat-reducer.test.ts
+++ b/src/components/chat/chat-reducer.test.ts
@@ -1082,6 +1082,49 @@ describe('chatReducer', () => {
   });
 
   // -------------------------------------------------------------------------
+  // SESSION_SNAPSHOT Action
+  // -------------------------------------------------------------------------
+
+  describe('SESSION_SNAPSHOT action', () => {
+    it('should preserve lastRejectedMessage for recovery', () => {
+      let state: ChatState = {
+        ...initialState,
+        pendingMessages: new Map([['msg-1', { text: 'My important message', attachments: [] }]]),
+      };
+
+      state = chatReducer(state, {
+        type: 'MESSAGE_STATE_CHANGED',
+        payload: {
+          id: 'msg-1',
+          newState: MessageState.REJECTED,
+          errorMessage: 'Unsupported image type',
+        },
+      });
+
+      expect(state.pendingMessages.size).toBe(0);
+      expect(state.queuedMessages.size).toBe(0);
+      expect(state.lastRejectedMessage?.text).toBe('My important message');
+
+      const newState = chatReducer(state, {
+        type: 'SESSION_SNAPSHOT',
+        payload: {
+          messages: [],
+          queuedMessages: [],
+          sessionRuntime: {
+            phase: 'idle',
+            processState: 'alive',
+            activity: 'IDLE',
+            updatedAt: '2026-02-08T00:00:00.000Z',
+          },
+        },
+      });
+
+      expect(newState.lastRejectedMessage?.text).toBe('My important message');
+      expect(newState.lastRejectedMessage?.error).toBe('Unsupported image type');
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // TOOL_INPUT_UPDATE Action (O(1) optimization)
   // -------------------------------------------------------------------------
 
@@ -1921,6 +1964,36 @@ describe('chatReducer', () => {
 
       expect(newState.sessionStatus).toEqual({ phase: 'running' });
       expect(newState.sessionRuntime.phase).toBe('running');
+    });
+
+    it('should preserve lastRejectedMessage for recovery', () => {
+      let state: ChatState = {
+        ...initialState,
+        pendingMessages: new Map([['msg-1', { text: 'My important message', attachments: [] }]]),
+      };
+
+      state = chatReducer(state, {
+        type: 'MESSAGE_STATE_CHANGED',
+        payload: {
+          id: 'msg-1',
+          newState: MessageState.REJECTED,
+          errorMessage: 'Unsupported image type',
+        },
+      });
+
+      expect(state.pendingMessages.size).toBe(0);
+      expect(state.queuedMessages.size).toBe(0);
+      expect(state.lastRejectedMessage?.text).toBe('My important message');
+
+      const newState = chatReducer(state, {
+        type: 'SESSION_REPLAY_BATCH',
+        payload: {
+          replayEvents: [],
+        },
+      });
+
+      expect(newState.lastRejectedMessage?.text).toBe('My important message');
+      expect(newState.lastRejectedMessage?.error).toBe('Unsupported image type');
     });
   });
 

--- a/src/components/chat/reducer/index.ts
+++ b/src/components/chat/reducer/index.ts
@@ -96,6 +96,8 @@ function createReplayBaseState(state: ChatState): ChatState {
     // Preserve queued messages - they will be reconstructed from replay events,
     // but preserving them ensures they remain visible during replay processing.
     queuedMessages: state.queuedMessages,
+    // Preserve rejected-message recovery content until the UI effect restores it.
+    lastRejectedMessage: state.lastRejectedMessage,
     sessionStatus: { phase: 'loading' },
     processStatus: { state: 'unknown' },
     sessionRuntime: {

--- a/src/components/chat/reducer/slices/messages/snapshot.ts
+++ b/src/components/chat/reducer/slices/messages/snapshot.ts
@@ -26,7 +26,7 @@ export function reduceMessageSnapshotSlice(state: ChatState, action: ChatAction)
         sessionRuntime: action.payload.sessionRuntime,
         toolUseIdToIndex: new Map(),
         pendingMessages: newPendingMessages,
-        lastRejectedMessage: null,
+        lastRejectedMessage: state.lastRejectedMessage,
         messageIdToUuid: new Map(),
         pendingUserMessageUuids: [],
         localUserMessageIds: new Set(),


### PR DESCRIPTION
## Summary
- Preserve rejected chat message recovery text across session snapshots.
- Preserve the same recovery buffer during replay-batch base resets.
- Add regression coverage for both update paths.

## Changes
- **Chat reducer**: Keep `lastRejectedMessage` when applying `SESSION_SNAPSHOT` and when creating the replay base state.
- **Tests**: Add reducer tests that first move pending message content into the rejected-message recovery buffer, then assert snapshot and replay processing keep it available.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; reducer-only state fix covered by automated tests.

Closes #1524

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk reducer-only change that keeps `lastRejectedMessage` from being cleared during `SESSION_SNAPSHOT` and `SESSION_REPLAY_BATCH` base resets; main risk is unintended persistence of stale recovery text in edge cases.
> 
> **Overview**
> Fixes rejected-message recovery being lost on reconnect/session refresh by **preserving `lastRejectedMessage`** when applying `SESSION_SNAPSHOT` and when building the `SESSION_REPLAY_BATCH` replay base state.
> 
> Adds regression tests that reject a pending message, then assert the recovery buffer (text + error) survives both snapshot application and replay-batch processing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3dc730d207b03bd0d6085196dab52b5c0fdba92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->