### PR TITLE
Fix #1525: Allow STARTING run script cancellation

### DIFF
--- a/src/backend/services/run-script/service/run-script.service.test.ts
+++ b/src/backend/services/run-script/service/run-script.service.test.ts
@@ -602,6 +602,29 @@ describe('RunScriptService.stopRunScript', () => {
     expect(result).toEqual({ success: false, error: 'No run script is running' });
   });
 
+  it('returns success and transitions to IDLE when stopping STARTING with no process', async () => {
+    mockFindById.mockResolvedValue({
+      id: 'ws-1',
+      runScriptStatus: 'STARTING',
+      runScriptPid: null,
+      runScriptCommand: 'pnpm dev',
+      runScriptPostRunCommand: null,
+      runScriptCleanupCommand: null,
+      worktreePath: '/tmp/ws-1',
+      runScriptPort: null,
+    });
+    mockBeginStopping.mockResolvedValue(undefined);
+    mockCompleteStopping.mockResolvedValue(undefined);
+
+    const service = new RunScriptService();
+    const result = await service.stopRunScript('ws-1');
+
+    expect(result).toEqual({ success: true });
+    expect(mockBeginStopping).toHaveBeenCalledWith('ws-1');
+    expect(mockCompleteStopping).toHaveBeenCalledWith('ws-1');
+    expect(mockTreeKill).not.toHaveBeenCalled();
+  });
+
   it('handles beginStopping race where state moved to COMPLETED', async () => {
     mockFindById
       .mockResolvedValueOnce({

--- a/src/backend/services/run-script/service/run-script.service.ts
+++ b/src/backend/services/run-script/service/run-script.service.ts
@@ -10,12 +10,24 @@ import {
 } from '@/backend/services/run-script-config-persistence.service';
 import { runScriptProxyService } from '@/backend/services/run-script-proxy.service';
 import { workspaceAccessor } from '@/backend/services/workspace';
+import type { RunScriptStatus } from '@/shared/core';
 import { runScriptStateMachine } from './run-script-state-machine.service';
 
 const logger = createLogger('run-script-service');
 
 // Max output buffer size per run script (500KB)
 const MAX_OUTPUT_BUFFER_SIZE = 500 * 1024;
+
+function shouldRejectStopWithoutProcess(
+  status: RunScriptStatus,
+  childProcess: ChildProcess | undefined,
+  pid: number | null
+): boolean {
+  if (childProcess || pid) {
+    return false;
+  }
+  return status !== 'STARTING';
+}
 
 /**
  * Service for managing run script execution from factory-factory.json
@@ -480,8 +492,9 @@ export class RunScriptService {
         return result;
       }
 
-      // STARTING or RUNNING -- attempt STOPPING transition
-      if (!(childProcess || pid)) {
+      // STARTING or RUNNING -- attempt STOPPING transition.
+      // STARTING may not have spawned a process yet, but it is still cancellable.
+      if (shouldRejectStopWithoutProcess(status, childProcess, pid)) {
         return { success: false, error: 'No run script is running' };
       }
 


### PR DESCRIPTION
## Summary
- Fixes `stopRunScript()` so a `STARTING` run script with no spawned process can be cancelled successfully.
- Adds a regression test for the archive cleanup failure mode from #1525.

## Changes
- **RunScriptService**: Allow no-process stops only while the workspace run script is `STARTING`, preserving the existing error for no-process `RUNNING` workspaces.
- **Tests**: Cover `STARTING -> STOPPING -> IDLE` cancellation without calling `tree-kill`.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; backend service regression covered by automated tests

Closes #1525

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes stop-state validation in the run-script lifecycle; low blast radius but could affect cancellation behavior and state transitions in a process-management path.
> 
> **Overview**
> Fixes `RunScriptService.stopRunScript()` to treat `STARTING` as cancellable even when no child process/PID exists, while still rejecting no-process stops for `RUNNING`.
> 
> Adds a regression test covering `STARTING -> STOPPING -> IDLE` without invoking `tree-kill`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26cb9915ed0dc430efc2bd72872f4eef1260e3c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->