### PR TITLE
Fix #1520: Preserve ratchet review comment placeholders

### DIFF
--- a/src/backend/prompts/ratchet-dispatch.test.ts
+++ b/src/backend/prompts/ratchet-dispatch.test.ts
@@ -64,4 +64,51 @@ describe('ratchet dispatch prompt', () => {
     expect(prompt).not.toContain('Reply to every review comment');
     expect(prompt).not.toContain('gh pr comment 42 --body');
   });
+
+  it('preserves literal placeholder syntax in review comments', () => {
+    readFileSyncMock.mockReturnValue(
+      [
+        '{{REVIEW_COMMENTS}}',
+        '{{MERGE_CONFLICT_STATUS}}',
+        '{{REVIEW_REPLY_INSTRUCTION}}',
+        '{{RE_REVIEW_COMMENT_INSTRUCTION}}',
+        '{{REVIEW_REPLY_COMPLETION}}',
+        '{{RE_REVIEW_COMMENT_COMPLETION}}',
+      ].join('\n')
+    );
+    clearRatchetDispatchPromptCache();
+
+    const prompt = buildRatchetDispatchPrompt('https://github.com/example/repo/pull/42', 42, [
+      {
+        author: 'reviewer',
+        body: 'I found {{MERGE_CONFLICT_STATUS}} in the logs',
+        path: 'src/example.ts',
+        line: 12,
+        url: 'https://github.com/example/repo/pull/42#discussion_r1',
+      },
+    ]);
+
+    expect(prompt).toContain('I found {{MERGE_CONFLICT_STATUS}} in the logs');
+    expect(prompt).toContain('No merge conflicts detected.');
+  });
+
+  it('preserves instruction placeholder syntax in review comments', () => {
+    readFileSyncMock.mockReturnValue(
+      '{{REVIEW_COMMENTS}}\n{{REVIEW_REPLY_INSTRUCTION}}\n{{RE_REVIEW_COMMENT_COMPLETION}}'
+    );
+    clearRatchetDispatchPromptCache();
+
+    const prompt = buildRatchetDispatchPrompt('https://github.com/example/repo/pull/42', 42, [
+      {
+        author: 'dev',
+        body: 'Check the {{REVIEW_REPLY_INSTRUCTION}} for guidance',
+        path: 'src/example.ts',
+        line: null,
+        url: 'https://github.com/example/repo/pull/42#discussion_r2',
+      },
+    ]);
+
+    expect(prompt).toContain('Check the {{REVIEW_REPLY_INSTRUCTION}} for guidance');
+    expect(prompt).toContain('Reply to every review comment');
+  });
 });

--- a/src/backend/prompts/ratchet-dispatch.ts
+++ b/src/backend/prompts/ratchet-dispatch.ts
@@ -77,6 +77,19 @@ class RatchetDispatchTemplateCache {
 
 const templateCache = new RatchetDispatchTemplateCache();
 
+type RatchetDispatchTemplatePlaceholder =
+  | '{{PR_URL}}'
+  | '{{PR_NUMBER}}'
+  | '{{REVIEW_COMMENTS}}'
+  | '{{MERGE_CONFLICT_STATUS}}'
+  | '{{REVIEW_REPLY_INSTRUCTION}}'
+  | '{{RE_REVIEW_COMMENT_INSTRUCTION}}'
+  | '{{REVIEW_REPLY_COMPLETION}}'
+  | '{{RE_REVIEW_COMMENT_COMPLETION}}';
+
+const RATCHET_DISPATCH_PLACEHOLDER_PATTERN =
+  /\{\{(?:PR_URL|PR_NUMBER|REVIEW_COMMENTS|MERGE_CONFLICT_STATUS|REVIEW_REPLY_INSTRUCTION|RE_REVIEW_COMMENT_INSTRUCTION|REVIEW_REPLY_COMPLETION|RE_REVIEW_COMMENT_COMPLETION)\}\}/g;
+
 export interface ReviewCommentForPrompt {
   author: string;
   body: string;
@@ -141,6 +154,16 @@ function formatReviewComments(comments: ReviewCommentForPrompt[]): string {
     .join('\n\n');
 }
 
+function renderRatchetDispatchTemplate(
+  template: string,
+  replacements: Record<RatchetDispatchTemplatePlaceholder, string>
+): string {
+  return template.replace(
+    RATCHET_DISPATCH_PLACEHOLDER_PATTERN,
+    (placeholder) => replacements[placeholder as RatchetDispatchTemplatePlaceholder]
+  );
+}
+
 export function buildRatchetDispatchPrompt(
   prUrl: string,
   prNumber: number,
@@ -152,22 +175,16 @@ export function buildRatchetDispatchPrompt(
     ? 'WARNING: This PR has merge conflicts with the base branch. Resolving these conflicts is the top priority.'
     : 'No merge conflicts detected.';
   const replyInstructions = getReplyInstructions(context?.replyToPrComments ?? true, prNumber);
-  return templateCache
-    .getTemplate()
-    .replaceAll('{{PR_URL}}', () => prUrl)
-    .replaceAll('{{PR_NUMBER}}', () => String(prNumber))
-    .replaceAll('{{REVIEW_COMMENTS}}', () => comments)
-    .replaceAll('{{MERGE_CONFLICT_STATUS}}', () => mergeConflictNotice)
-    .replaceAll('{{REVIEW_REPLY_INSTRUCTION}}', () => replyInstructions.reviewReplyInstruction)
-    .replaceAll(
-      '{{RE_REVIEW_COMMENT_INSTRUCTION}}',
-      () => replyInstructions.reReviewCommentInstruction
-    )
-    .replaceAll('{{REVIEW_REPLY_COMPLETION}}', () => replyInstructions.reviewReplyCompletion)
-    .replaceAll(
-      '{{RE_REVIEW_COMMENT_COMPLETION}}',
-      () => replyInstructions.reReviewCommentCompletion
-    );
+  return renderRatchetDispatchTemplate(templateCache.getTemplate(), {
+    '{{PR_URL}}': prUrl,
+    '{{PR_NUMBER}}': String(prNumber),
+    '{{REVIEW_COMMENTS}}': comments,
+    '{{MERGE_CONFLICT_STATUS}}': mergeConflictNotice,
+    '{{REVIEW_REPLY_INSTRUCTION}}': replyInstructions.reviewReplyInstruction,
+    '{{RE_REVIEW_COMMENT_INSTRUCTION}}': replyInstructions.reReviewCommentInstruction,
+    '{{REVIEW_REPLY_COMPLETION}}': replyInstructions.reviewReplyCompletion,
+    '{{RE_REVIEW_COMMENT_COMPLETION}}': replyInstructions.reReviewCommentCompletion,
+  });
 }
 
 export function clearRatchetDispatchPromptCache(): void {


### PR DESCRIPTION
## Summary
- Fixes Ratchet dispatch prompt rendering so review comment text is not rescanned for template placeholders.
- Adds regression coverage for placeholder-like review comment bodies.

## Changes
- **Ratchet prompt rendering**: Replace sequential full-prompt substitutions with a single-pass renderer over known template placeholders.
- **Tests**: Verify review comments preserve `{{MERGE_CONFLICT_STATUS}}` and `{{REVIEW_REPLY_INSTRUCTION}}` literally while template placeholders still render.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; prompt rendering is covered by regression tests.

Closes #1520

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core prompt templating logic, so a mistake could alter the generated Ratchet instructions, but the scope is small and covered by new regression tests.
> 
> **Overview**
> Prevents `buildRatchetDispatchPrompt` from performing sequential full-string `replaceAll` passes that could inadvertently substitute `{{...}}` sequences inside review comment bodies.
> 
> Introduces a single-pass renderer (`renderRatchetDispatchTemplate`) that replaces only a fixed set of known placeholders via a regex, and adds regression tests ensuring placeholder-like text in review comments remains literal while actual template placeholders still render.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0d3f3952c825e35efa564f4b4d9f13ae6136bf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->