### PR TITLE
Allow ratchet when sessions are idle

### DIFF
--- a/docs/design/ratchet-reliability-state-machine-plan.md
+++ b/docs/design/ratchet-reliability-state-machine-plan.md
@@ -342,8 +342,8 @@ Implement one global long-lived task and one per-workspace single-pass handler.
 
 Definition for this design:
 
-1. A session is **active** when `isSessionRunning(session)` is true (session process is running).
-2. A session that is `RUNNING` is considered active and blocks ratchet dispatch, regardless of whether it is working or idle.
+1. A session is **active** when `isSessionWorking(session)` is true.
+2. A live but idle session does not block ratchet dispatch; this matches the workspace UI state users see after a chat turn finishes.
 3. Ratchet must call one canonical helper for this decision (do not duplicate ad-hoc status checks in ratchet service).
 4. Add tests that pin this behavior so future session-state refactors do not accidentally change ratchet blocking behavior.
 

--- a/src/backend/services/ratchet/service/ratchet-active-session.helpers.ts
+++ b/src/backend/services/ratchet/service/ratchet-active-session.helpers.ts
@@ -182,5 +182,5 @@ export async function hasActiveSession(
   sessionBridge: RatchetSessionBridge
 ): Promise<boolean> {
   const sessions = await agentSessionAccessor.findByWorkspaceId(workspaceId);
-  return sessions.some((session) => sessionBridge.isSessionRunning(session.id));
+  return sessions.some((session) => sessionBridge.isSessionWorking(session.id));
 }

--- a/src/backend/services/ratchet/service/ratchet.service.test.ts
+++ b/src/backend/services/ratchet/service/ratchet.service.test.ts
@@ -240,7 +240,7 @@ describe('ratchet service (state-change + idle dispatch)', () => {
     expect(result).toMatchObject({
       action: {
         type: 'WAITING',
-        reason: 'Workspace is not idle (active session)',
+        reason: 'Workspace has another working session',
       },
     });
   });
@@ -300,7 +300,7 @@ describe('ratchet service (state-change + idle dispatch)', () => {
     );
   });
 
-  it('does not dispatch when session is running but idle', async () => {
+  it('dispatches when session is running but idle', async () => {
     const workspace = {
       id: 'ws-idle-session',
       prUrl: 'https://github.com/example/repo/pull/44',
@@ -337,19 +337,21 @@ describe('ratchet service (state-change + idle dispatch)', () => {
     ] as never);
     vi.mocked(mockSessionBridge.isSessionRunning).mockReturnValue(true);
     vi.mocked(mockSessionBridge.isSessionWorking).mockReturnValue(false);
+    vi.mocked(fixerSessionService.acquireAndDispatch).mockResolvedValue({
+      status: 'started',
+      sessionId: 'ratchet-session',
+      promptSent: true,
+    } as never);
 
     const result = await unsafeCoerce<{
       processWorkspace: (workspaceArg: typeof workspace) => Promise<unknown>;
     }>(ratchetService).processWorkspace(workspace);
 
     expect(result).toMatchObject({
-      action: {
-        type: 'WAITING',
-        reason: 'Workspace is not idle (active session)',
-      },
+      action: { type: 'TRIGGERED_FIXER' },
     });
-    expect(mockSessionBridge.isSessionRunning).toHaveBeenCalledWith('chat-idle-1');
-    expect(fixerSessionService.acquireAndDispatch).not.toHaveBeenCalled();
+    expect(mockSessionBridge.isSessionWorking).toHaveBeenCalledWith('chat-idle-1');
+    expect(fixerSessionService.acquireAndDispatch).toHaveBeenCalled();
   });
 
   it('does not dispatch when PR state unchanged since last dispatch', async () => {
@@ -1463,7 +1465,7 @@ describe('ratchet service (state-change + idle dispatch)', () => {
         hasStateChangedSinceLastDispatch: true,
         hasOtherActiveSession: true,
       }) as { type: string; action?: { reason: string } };
-      expect(result.action?.reason).toBe('Workspace is not idle (active session)');
+      expect(result.action?.reason).toBe('Workspace has another working session');
     });
 
     it('returns WAITING when there are no CI failures or PR review comments', () => {

--- a/src/backend/services/ratchet/service/ratchet.service.ts
+++ b/src/backend/services/ratchet/service/ratchet.service.ts
@@ -760,7 +760,7 @@ class RatchetService extends EventEmitter {
         type: 'RETURN_ACTION',
         action: {
           type: 'WAITING',
-          reason: 'Workspace is not idle (active session)',
+          reason: 'Workspace has another working session',
         },
       };
     }


### PR DESCRIPTION
## Summary
- Let ratchet dispatch when another workspace session is alive but idle by checking `isSessionWorking()` instead of `isSessionRunning()`.
- Keep ratchet blocked when another session is actively working, with a clearer waiting reason.
- Update ratchet tests and the reliability design note to reflect the working-session semantics.

## Testing
- `pnpm vitest run src/backend/services/ratchet/service/ratchet.service.test.ts src/backend/services/ratchet/service/ratchet-pr-state.helpers.test.ts`
- Commit hook ran `biome check --write`, `pnpm typecheck`, `pnpm deps:check`, and `pnpm knip`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the ratchet dispatch guard that prevents fixer runs while sessions exist; misclassification of session activity could lead to overlapping work or unexpected dispatch timing.
> 
> **Overview**
> Ratchet’s “other active session” guard now uses `sessionBridge.isSessionWorking()` instead of `isSessionRunning()`, so *live but idle* sessions no longer block fixer dispatch.
> 
> Updates ratchet decision messaging to `Workspace has another working session`, adjusts unit tests to expect dispatch in the running-but-idle case, and revises the reliability design note to document the new working-session semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6dff9665470e8c0ccfe1b750be49c421a00c982. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->