### PR TITLE
Fix #1519: Cover stale ACP child exits

### DIFF
--- a/src/backend/services/session/service/acp/acp-runtime-manager.test.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-manager.test.ts
@@ -983,6 +983,49 @@ describe('AcpRuntimeManager', () => {
       expect(manager.getClient('session-1')).toBe(restartedHandle);
     });
 
+    it('does not call onExit for stale SIGKILL exit after stop completes and session restarts', async () => {
+      const firstChild = setupSuccessfulSpawn();
+      const handlers = defaultHandlers();
+
+      await manager.getOrCreateClient('session-1', defaultOptions(), handlers, defaultContext());
+
+      firstChild.kill = vi.fn((signal?: string) => {
+        if (signal) {
+          firstChild.killed = true;
+        }
+        if (signal === 'SIGKILL') {
+          firstChild.exitCode = 137;
+        }
+        return true;
+      });
+
+      vi.useFakeTimers();
+
+      const stopPromise = manager.stopClient('session-1');
+      await vi.advanceTimersByTimeAsync(5100);
+      await stopPromise;
+
+      vi.useRealTimers();
+
+      const secondChild = createMockChildProcess();
+      mockSpawn.mockReturnValueOnce(secondChild);
+
+      const newHandle = await manager.getOrCreateClient(
+        'session-1',
+        defaultOptions(),
+        handlers,
+        defaultContext()
+      );
+      expect(newHandle.child).toBe(secondChild);
+
+      (handlers.onExit as ReturnType<typeof vi.fn>).mockClear();
+      firstChild.emit('exit', 137, 'SIGKILL');
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(handlers.onExit).not.toHaveBeenCalled();
+      expect(manager.getClient('session-1')).toBe(newHandle);
+    });
+
     it('keeps newer client tracked when old stop exits later', async () => {
       const firstChild = setupSuccessfulSpawn();
 


### PR DESCRIPTION
## Summary
- Adds focused regression coverage for stale ACP child `exit` events after a timed-out stop and same-session restart.
- Verifies the replacement client remains tracked and `onExit` is not invoked for the old SIGKILLed child.

## Changes
- **ACP runtime tests**: Added the exact delayed SIGKILL/restart scenario from #1519 to prevent regressions in stale child exit handling.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; backend race regression covered by unit test.

Closes #1519

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that adds coverage for a known stop/restart race without modifying runtime logic.
> 
> **Overview**
> Adds a focused regression test in `acp-runtime-manager.test.ts` for a race where a timed-out `stopClient()` escalates to `SIGKILL`, the session is restarted, and the old child later emits an `exit` event.
> 
> The new test asserts the stale `SIGKILL` exit does **not** invoke `onExit` and does **not** displace the newly restarted client handle for the same session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa54f3ecd581c0a1b0d330a2625f9a84da120c95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->