### PR TITLE
Fix #1443: Correct ACP single-quote parsing

### DIFF
--- a/src/backend/services/session/service/acp/codex-app-server-adapter/command-metadata.test.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/command-metadata.test.ts
@@ -22,9 +22,9 @@ describe('command-metadata', () => {
     });
   });
 
-  it('parses escaped single quotes and escaped spaces', () => {
+  it('parses POSIX single-quote reopening for apostrophes', () => {
     const parsed = resolveCommandDisplay({
-      command: "cat 'it\\'s file.txt'",
+      command: "cat 'it'\\''s file.txt'",
       cwd: '/tmp/workspace',
     });
 
@@ -48,9 +48,9 @@ describe('command-metadata', () => {
     });
   });
 
-  it('keeps escaped apostrophes inside chained single-quoted args', () => {
+  it('parses POSIX apostrophes inside chained single-quoted args', () => {
     const parsed = resolveCommandDisplay({
-      command: "cat 'it\\'s file.txt' && rg TODO README.md",
+      command: "cat 'it'\\''s file.txt' && rg TODO README.md",
       cwd: '/tmp/workspace',
     });
 
@@ -59,6 +59,35 @@ describe('command-metadata', () => {
       kind: 'read',
       locations: [{ path: "/tmp/workspace/it's file.txt" }, { path: '/tmp/workspace/README.md' }],
     });
+  });
+
+  it('does not hide command separators after backslashes in single quotes', () => {
+    const command = "ls 'a\\' ; rm -rf /";
+
+    const parsed = resolveCommandDisplay({
+      command,
+      cwd: '/tmp/workspace',
+    });
+    const scopeKey = buildCommandApprovalScopeKey({
+      command,
+      cwd: '/tmp/workspace',
+    });
+
+    expect(parsed.title).toContain('rm -rf /');
+    expect(parseScopeKey(scopeKey, '/tmp/workspace')).toEqual([
+      {
+        type: 'cmd',
+        cwd: '/tmp/workspace',
+        tokens: ['ls', 'a\\'],
+        separator: ';',
+      },
+      {
+        type: 'cmd',
+        cwd: '/tmp/workspace',
+        tokens: ['rm', '/'],
+        separator: null,
+      },
+    ]);
   });
 
   it('builds command approval scope keys with cwd transitions', () => {

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/command-metadata.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/command-metadata.ts
@@ -46,13 +46,6 @@ function pushCommandToken(state: CommandTokenizeState): void {
   state.hasTokenContent = false;
 }
 
-function unescapeSingleQuotedChar(char: string): string {
-  if (char === "'" || char === '\\') {
-    return char;
-  }
-  return `\\${char}`;
-}
-
 function unescapeGeneralCommandChar(char: string): string {
   if (
     char === '"' ||
@@ -79,9 +72,7 @@ function consumeEscapedTokenChar(state: CommandTokenizeState, char: string): boo
   if (!state.escaped) {
     return false;
   }
-  if (state.quote === "'") {
-    state.current += unescapeSingleQuotedChar(char);
-  } else if (state.quote === '"') {
+  if (state.quote === '"') {
     state.current += unescapeDoubleQuotedChar(char);
   } else {
     state.current += unescapeGeneralCommandChar(char);
@@ -95,9 +86,7 @@ function consumeSingleQuotedTokenChar(state: CommandTokenizeState, char: string)
   if (state.quote !== "'") {
     return false;
   }
-  if (char === '\\') {
-    state.escaped = true;
-  } else if (char === "'") {
+  if (char === "'") {
     state.quote = null;
   } else {
     state.current += char;
@@ -273,25 +262,12 @@ function consumeEscapeInitiator(state: CommandChainSplitState, char: string): bo
   return true;
 }
 
-function hasOddTrailingBackslashes(value: string): boolean {
-  let count = 0;
-  for (let index = value.length - 1; index >= 0; index -= 1) {
-    if (value[index] !== '\\') {
-      break;
-    }
-    count += 1;
-  }
-  return count % 2 === 1;
-}
-
 function consumeQuotedCommandChar(state: CommandChainSplitState, char: string): boolean {
   if (!state.quote) {
     return false;
   }
-  const escapedSingleQuote =
-    state.quote === "'" && char === "'" && hasOddTrailingBackslashes(state.current);
   state.current += char;
-  if (char === state.quote && !escapedSingleQuote) {
+  if (char === state.quote) {
     state.quote = null;
   }
   return true;


### PR DESCRIPTION
## Summary
- Fixes ACP command metadata parsing so backslashes are literal inside single-quoted shell strings.
- Prevents hidden command separators after `\'` from being swallowed into an approval scope argument.
- Updates apostrophe coverage to use POSIX-compatible single-quote reopening.

## Changes
- **ACP command metadata**: Removed single-quote escape handling from command tokenization and chain splitting.
- **Tests**: Added a regression for `ls 'a\' ; rm -rf /` so the separator and second command are visible in the approval scope.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Manual testing: verified the focused command metadata regression with `pnpm vitest run src/backend/services/session/service/acp/codex-app-server-adapter/command-metadata.test.ts`

Closes #1443

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shell command tokenization and approval-scope key generation; a subtle parsing change could affect how commands are classified/approved, though changes are localized and covered by targeted tests.
> 
> **Overview**
> Fixes ACP command metadata parsing to treat backslashes as *literal* inside single-quoted shell strings, aligning with POSIX quoting rules and preventing `;`/`&&`/etc. from being accidentally swallowed into a single argument.
> 
> Updates tokenization/chain-splitting logic to stop interpreting `\` escapes while in single quotes, and adjusts tests to use POSIX single-quote reopening (`'it'\''s'`) plus a new regression ensuring separators after `\'` remain visible in `resolveCommandDisplay` and `buildCommandApprovalScopeKey`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 547016f54ebeb71ab0bcb21139c5e81bfcaa5eb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->