### PR TITLE
Fix #1446: Persist ratchet transcripts before cleanup

### DIFF
--- a/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
+++ b/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
@@ -682,10 +682,11 @@ export class SessionLifecycleService {
     }
 
     try {
+      await this.persistRatchetTranscript(sessionId, session);
       await this.repository.deleteSession(sessionId);
       logger.debug('Deleted transient ratchet session after stop', { sessionId });
     } catch (error) {
-      logger.warn('Failed deleting transient ratchet session during stop', {
+      logger.warn('Failed persisting or deleting transient ratchet session during stop', {
         sessionId,
         error: error instanceof Error ? error.message : String(error),
       });

--- a/src/backend/services/session/service/lifecycle/session.service.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.service.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { chatConnectionService } from '@/backend/services/session/service/chat/chat-connection.service';
 import { sessionDomainService } from '@/backend/services/session/service/session-domain.service';
+import type { ChatMessage } from '@/shared/acp-protocol';
 import { SessionStatus } from '@/shared/core';
 import { unsafeCoerce } from '@/test-utils/unsafe-coerce';
 
@@ -1071,26 +1072,87 @@ describe('SessionService', () => {
     expect(pendingToolCalls.has('session-1')).toBe(false);
   });
 
-  it('deletes ratchet session record during manual stop', async () => {
+  it('persists transcript before deleting ratchet session record during manual stop', async () => {
+    const startedAt = new Date('2026-02-25T12:00:00.000Z');
+    const transcript: ChatMessage[] = [
+      unsafeCoerce({
+        id: 'message-1',
+        source: 'assistant',
+        text: 'Fixed the failing check',
+        timestamp: '2026-02-25T12:01:00.000Z',
+        order: 0,
+      }),
+    ];
+    const transcriptSpy = vi
+      .spyOn(sessionDomainService, 'getTranscriptSnapshot')
+      .mockReturnValue(transcript);
+
     vi.mocked(acpRuntimeManager.isStopInProgress).mockReturnValue(false);
     vi.mocked(acpRuntimeManager.stopClient).mockResolvedValue();
     vi.mocked(sessionRepository.getSessionById).mockResolvedValue(
       unsafeCoerce({
         id: 'session-1',
         workspaceId: 'workspace-1',
+        name: 'Auto-Fix',
         workflow: 'ratchet',
+        provider: 'CLAUDE',
+        model: 'sonnet',
+        createdAt: startedAt,
       })
     );
     vi.mocked(sessionRepository.updateSession).mockResolvedValue({} as never);
     vi.mocked(sessionRepository.deleteSession).mockResolvedValue({} as never);
 
+    try {
+      await sessionService.stopSession('session-1');
+
+      expect(mockClearRatchetActiveSessionIfMatching).toHaveBeenCalledWith(
+        'workspace-1',
+        'session-1'
+      );
+      expect(closedSessionPersistenceService.persistClosedSession).toHaveBeenCalledWith({
+        sessionId: 'session-1',
+        workspaceId: 'workspace-1',
+        worktreePath: '/tmp/work',
+        name: 'Auto-Fix',
+        workflow: 'ratchet',
+        provider: 'CLAUDE',
+        model: 'sonnet',
+        startedAt,
+        messages: transcript,
+      });
+      expect(sessionRepository.deleteSession).toHaveBeenCalledWith('session-1');
+      expect(
+        vi.mocked(closedSessionPersistenceService.persistClosedSession).mock.invocationCallOrder[0]
+      ).toBeLessThan(vi.mocked(sessionRepository.deleteSession).mock.invocationCallOrder[0]!);
+    } finally {
+      transcriptSpy.mockRestore();
+    }
+  });
+
+  it('does not delete ratchet session during manual stop when transcript persistence fails', async () => {
+    vi.mocked(acpRuntimeManager.isStopInProgress).mockReturnValue(false);
+    vi.mocked(acpRuntimeManager.stopClient).mockResolvedValue();
+    vi.mocked(sessionRepository.getSessionById).mockResolvedValue(
+      unsafeCoerce({
+        id: 'session-1',
+        workspaceId: 'workspace-1',
+        name: 'Auto-Fix',
+        workflow: 'ratchet',
+        provider: 'CLAUDE',
+        model: 'sonnet',
+        createdAt: new Date('2026-02-25T12:00:00.000Z'),
+      })
+    );
+    vi.mocked(sessionRepository.updateSession).mockResolvedValue({} as never);
+    vi.mocked(closedSessionPersistenceService.persistClosedSession).mockRejectedValue(
+      new Error('Disk full')
+    );
+
     await sessionService.stopSession('session-1');
 
-    expect(mockClearRatchetActiveSessionIfMatching).toHaveBeenCalledWith(
-      'workspace-1',
-      'session-1'
-    );
-    expect(sessionRepository.deleteSession).toHaveBeenCalledWith('session-1');
+    expect(closedSessionPersistenceService.persistClosedSession).toHaveBeenCalledTimes(1);
+    expect(sessionRepository.deleteSession).not.toHaveBeenCalled();
   });
 
   it('does not delete non-ratchet session during manual stop', async () => {
@@ -1130,6 +1192,7 @@ describe('SessionService', () => {
       'workspace-1',
       'session-3'
     );
+    expect(closedSessionPersistenceService.persistClosedSession).not.toHaveBeenCalled();
     expect(sessionRepository.deleteSession).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- Persist transient ratchet session transcripts during manual stop cleanup before deleting the session record.
- Preserve the ratchet session record if transcript persistence fails, matching the natural ACP exit path.
- Add regression coverage for manual stop cleanup, persistence ordering, and disabled cleanup behavior.

## Changes
- **Session lifecycle**: Call ratchet transcript persistence before deleting transient ratchet sessions on manual stop or timeout cleanup.
- **Tests**: Cover successful manual stop persistence, persistence failure avoiding deletion, and cleanup-disabled behavior.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not run; backend lifecycle behavior covered by regression tests.

Closes #1446

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes stop/cleanup behavior for transient `ratchet` sessions and can leave session records undeleted when persistence fails, which could affect storage/UX if persistence is flaky. Scope is small and covered by new unit tests.
> 
> **Overview**
> Ensures transient `ratchet` sessions **persist their transcript before being deleted** during manual-stop cleanup, aligning stop behavior with the existing runtime-exit cleanup path.
> 
> Adds regression tests covering successful persistence+deletion (including call ordering), transcript-persistence failure preventing deletion, and the `cleanupTransientRatchetSession: false` path skipping persistence/deletion while still clearing the ratchet pointer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a8d437825debb5bf56b405ccd51ce39e15296de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->