### PR TITLE
Fix #1517: Handle Codex exits during active prompts

### DIFF
--- a/src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.test.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.test.ts
@@ -2521,6 +2521,64 @@ describe('CodexAppServerAcpAdapter', () => {
     ).resolves.toEqual({ stopReason: 'end_turn' });
   });
 
+  it('settles active prompts when codex exits after turn/start returns', async () => {
+    const { connection } = createMockConnection();
+    const { client: codexClient, mocks: codex } = createMockCodexClient();
+    const adapter = new CodexAppServerAcpAdapter(connection as AgentSideConnection, codexClient);
+
+    await initializeAdapterWithDefaultModel(adapter, codex);
+
+    codex.request.mockResolvedValueOnce({
+      thread: { id: 'thread_exit', cwd: '/tmp/workspace' },
+      approvalPolicy: DEFAULT_APPROVAL_POLICY,
+      reasoningEffort: 'medium',
+    });
+    const session = await adapter.newSession({
+      cwd: '/tmp/workspace',
+      mcpServers: [],
+    });
+
+    codex.request.mockResolvedValueOnce({
+      turn: { id: 'turn_exit', status: 'inProgress' },
+    });
+
+    const promptPromise = adapter.prompt({
+      sessionId: session.sessionId,
+      prompt: [{ type: 'text', text: 'hello' }],
+    });
+
+    await vi.waitFor(() => {
+      const adapterSession = (
+        adapter as unknown as {
+          sessions: Map<string, { activeTurn: { turnId: string } | null }>;
+        }
+      ).sessions.get(session.sessionId);
+      expect(adapterSession?.activeTurn?.turnId).toBe('turn_exit');
+    });
+
+    (
+      adapter as unknown as {
+        handleCodexExit: (event: {
+          code: number | null;
+          signal: NodeJS.Signals | null;
+          reason: string;
+        }) => void;
+      }
+    ).handleCodexExit({
+      code: 1,
+      signal: null,
+      reason: 'codex app-server exited (code=1, signal=null)',
+    });
+
+    await expect(promptPromise).resolves.toEqual({ stopReason: 'end_turn' });
+    const adapterSession = (
+      adapter as unknown as {
+        sessions: Map<string, { activeTurn: { turnId: string } | null }>;
+      }
+    ).sessions.get(session.sessionId);
+    expect(adapterSession?.activeTurn).toBeNull();
+  });
+
   it('clears stale tool call state when a turn ends without item/completed events', async () => {
     const { connection } = createMockConnection();
     const { client: codexClient, mocks: codex } = createMockCodexClient();

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.ts
@@ -44,7 +44,7 @@ import type {
   SandboxMode,
   ToolCallState,
 } from './adapter-state';
-import { CodexRequestError, CodexRpcClient } from './codex-rpc-client';
+import { CodexRequestError, CodexRpcClient, type CodexRpcExitEvent } from './codex-rpc-client';
 import { turnStartResponseSchema } from './codex-zod';
 import { resolveCommandDisplay } from './command-metadata';
 import { handleCodexServerPermissionRequest } from './protocol-permission-handler';
@@ -335,6 +335,9 @@ export class CodexAppServerAcpAdapter implements Agent {
               data: { error: message },
             });
           });
+        },
+        onExit: (event) => {
+          this.handleCodexExit(event);
         },
         onProtocolError: (error) => {
           process.stderr.write(`[codex-app-server-acp] protocol-error: ${error.reason}\n`);
@@ -1183,6 +1186,22 @@ export class CodexAppServerAcpAdapter implements Agent {
       emitSessionUpdate: (sessionId, update) => this.emitSessionUpdate(sessionId, update),
       reportShapeDrift: (event, details) => this.reportShapeDrift(event, details),
     });
+  }
+
+  private handleCodexExit(event: CodexRpcExitEvent): void {
+    const activeSessions = [...this.sessions.values()].filter(
+      (session) => session.activeTurn && !session.activeTurn.settled
+    );
+    if (activeSessions.length === 0) {
+      return;
+    }
+
+    process.stderr.write(
+      `[codex-app-server-acp] ${event.reason}; settling ${activeSessions.length} active turn(s)\n`
+    );
+    for (const session of activeSessions) {
+      this.settleTurn(session, session.activeTurn?.cancelRequested ? 'cancelled' : 'end_turn');
+    }
   }
 
   private settleTurn(session: AdapterSession, stopReason: StopReason): void {

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/codex-rpc-client.test.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/codex-rpc-client.test.ts
@@ -128,9 +128,11 @@ describe('CodexRpcClient', () => {
   it('rejects pending requests when codex process exits', async () => {
     const child = createMockChild();
     mockSpawn.mockReturnValue(child);
+    const onExit = vi.fn();
     const client = new CodexRpcClient({
       cwd: '/tmp/workspace',
       env: {},
+      onExit,
     });
 
     client.start();
@@ -138,6 +140,35 @@ describe('CodexRpcClient', () => {
     child.emit('exit', 1, null);
 
     await expect(responsePromise).rejects.toThrow(/codex app-server exited/);
+    expect(onExit).toHaveBeenCalledWith({
+      code: 1,
+      signal: null,
+      reason: 'codex app-server exited (code=1, signal=null)',
+    });
+  });
+
+  it('notifies exit listeners once when codex process errors then exits', () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+    const onExit = vi.fn();
+    const client = new CodexRpcClient({
+      cwd: '/tmp/workspace',
+      env: {},
+      onExit,
+    });
+
+    client.start();
+    const error = new Error('spawn failed');
+    child.emit('error', error);
+    child.emit('exit', 1, null);
+
+    expect(onExit).toHaveBeenCalledTimes(1);
+    expect(onExit).toHaveBeenCalledWith({
+      code: null,
+      signal: null,
+      reason: 'codex app-server error: spawn failed',
+      error,
+    });
   });
 
   it('rejects new requests after codex process exits', async () => {

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/codex-rpc-client.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/codex-rpc-client.ts
@@ -18,6 +18,13 @@ type CodexJsonRpcError = {
   data?: unknown;
 };
 
+export type CodexRpcExitEvent = {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  reason: string;
+  error?: Error;
+};
+
 export class CodexRequestError extends Error {
   readonly code: number;
   readonly data: unknown;
@@ -35,6 +42,7 @@ export type CodexRpcClientOptions = {
   onStderr?: (line: string) => void;
   onNotification?: (notification: { method: string; params: unknown }) => void;
   onRequest?: (request: CodexRpcServerRequest) => void;
+  onExit?: (event: CodexRpcExitEvent) => void;
   onProtocolError?: (error: { reason: string; payload?: unknown }) => void;
 };
 
@@ -92,23 +100,43 @@ export class CodexRpcClient {
     this.lineReader = createInterface({ input: stdout, crlfDelay: Number.POSITIVE_INFINITY });
     this.lineReader.on('line', (line) => this.handleLine(line));
 
-    child.on('exit', (code, signal) => {
+    let exitHandled = false;
+    const handleExit = (event: CodexRpcExitEvent, rejectError: Error) => {
+      if (exitHandled) {
+        return;
+      }
+      exitHandled = true;
       if (this.child === child) {
         this.child = null;
       }
       this.lineReader?.close();
       this.lineReader = null;
+      this.rejectPending(rejectError);
+      try {
+        this.options.onExit?.(event);
+      } catch (error) {
+        this.options.onProtocolError?.({
+          reason: 'exit_callback_error',
+          payload: error instanceof Error ? error.message : String(error),
+        });
+      }
+    };
+
+    child.on('exit', (code, signal) => {
       const reason = `codex app-server exited (code=${code ?? 'null'}, signal=${signal ?? 'null'})`;
-      this.rejectPending(new Error(reason));
+      handleExit({ code, signal, reason }, new Error(reason));
     });
 
     child.on('error', (error) => {
-      if (this.child === child) {
-        this.child = null;
-      }
-      this.lineReader?.close();
-      this.lineReader = null;
-      this.rejectPending(error);
+      handleExit(
+        {
+          code: null,
+          signal: null,
+          reason: `codex app-server error: ${error.message}`,
+          error,
+        },
+        error
+      );
     });
 
     this.child = child;

--- a/src/backend/services/session/service/lifecycle/session.service.coverage.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.service.coverage.test.ts
@@ -167,13 +167,17 @@ describe('SessionService coverage wrappers', () => {
       { type: 'unsupported' } as never,
     ] as never);
 
-    expect(sendAcpMessageSpy).toHaveBeenCalledWith('session-1', [
-      { type: 'text', text: 'hello' },
-      { type: 'text', text: 'analyzing' },
-      { type: 'image', data: 'abc', mimeType: 'image/png' },
-      { type: 'text', text: 'tool output' },
-      { type: 'text', text: '{"ok":true}' },
-    ]);
+    expect(sendAcpMessageSpy).toHaveBeenCalledWith(
+      'session-1',
+      [
+        { type: 'text', text: 'hello' },
+        { type: 'text', text: 'analyzing' },
+        { type: 'image', data: 'abc', mimeType: 'image/png' },
+        { type: 'text', text: 'tool output' },
+        { type: 'text', text: '{"ok":true}' },
+      ],
+      3_600_000
+    );
   });
 
   it('falls back to text placeholder for images when provider lacks support', async () => {
@@ -188,10 +192,14 @@ describe('SessionService coverage wrappers', () => {
       { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'abc' } },
     ] as never);
 
-    expect(sendAcpMessageSpy).toHaveBeenCalledWith('session-1', [
-      { type: 'text', text: 'hello' },
-      { type: 'text', text: '[Image: not supported by this provider]' },
-    ]);
+    expect(sendAcpMessageSpy).toHaveBeenCalledWith(
+      'session-1',
+      [
+        { type: 'text', text: 'hello' },
+        { type: 'text', text: '[Image: not supported by this provider]' },
+      ],
+      3_600_000
+    );
   });
 
   it('propagates sendAcpMessage errors', async () => {

--- a/src/backend/services/session/service/lifecycle/session.service.ts
+++ b/src/backend/services/session/service/lifecycle/session.service.ts
@@ -31,6 +31,7 @@ import { sessionRepository } from './session.repository';
 import { SessionRetryService } from './session.retry.service';
 
 const logger = createLogger('session');
+const DEFAULT_USER_PROMPT_TIMEOUT_MS = 60 * 60 * 1000;
 type SessionStartupModePreset = 'non_interactive' | 'plan';
 type PromptTurnCompleteHandler = (sessionId: string) => Promise<void> | void;
 
@@ -226,7 +227,7 @@ export class SessionService {
         typeof content === 'string'
           ? [{ type: 'text', text: content }]
           : this.toContentBlocks(content, acpClient.supportsImages());
-      return this.sendAcpMessage(sessionId, prompt)
+      return this.sendAcpMessage(sessionId, prompt, DEFAULT_USER_PROMPT_TIMEOUT_MS)
         .then(() => undefined)
         .catch((error) => {
           logger.error('ACP prompt failed', {


### PR DESCRIPTION
## Summary
- Adds Codex app-server exit notification plumbing so active adapter turns settle when Codex exits mid-turn.
- Adds a default timeout for user-initiated ACP prompts to prevent indefinite hangs.
- Covers the post-`turn/start` crash window and RPC exit notification behavior with regression tests.

## Changes
- **Codex RPC client**: Emits a one-shot `onExit` callback for child `exit` and `error` events while still rejecting in-flight RPC requests.
- **Codex ACP adapter**: Settles any active, unsettled turns when the Codex app-server exits before `turn/completed` arrives.
- **Session lifecycle**: Applies a 60-minute timeout to user-initiated ACP prompts through the existing runtime prompt timeout path.
- **Tests**: Adds focused RPC and adapter crash-window tests and updates session coverage assertions for the timeout argument.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Manual testing: verified focused regression tests and full verification chain locally

Closes #1517

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session/prompt lifecycle and subprocess-exit handling; mistakes could prematurely end prompts or mask failures, though changes are localized and covered by regression tests.
> 
> **Overview**
> Fixes a hang window where the Codex app-server exits mid-turn by plumbing a new `CodexRpcClient` `onExit` callback and having `CodexAppServerAcpAdapter` settle any active, unsettled turns (respecting `cancelRequested`) when an exit/error occurs.
> 
> Adds a 60-minute default timeout for user-driven `sendSessionMessage` ACP prompts, and updates/extends tests to cover the post-`turn/start` crash window, one-shot exit notification semantics, and the new timeout argument expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81591af757727a4c3c47cf1fa41bd440833763cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->