### PR TITLE
feat: manual PR association for workspaces

### DIFF
--- a/src/backend/trpc/workspace.trpc.ts
+++ b/src/backend/trpc/workspace.trpc.ts
@@ -298,8 +298,17 @@ export const workspaceRouter = router({
         throw new TRPCError({ code: 'NOT_FOUND', message: `Workspace not found: ${input.id}` });
       }
       const result = await prSnapshotService.attachAndRefreshPR(input.id, input.prUrl);
-      if (!result.success && result.reason === 'workspace_not_found') {
-        throw new TRPCError({ code: 'NOT_FOUND', message: `Workspace not found: ${input.id}` });
+      if (!result.success) {
+        if (result.reason === 'workspace_not_found') {
+          throw new TRPCError({ code: 'NOT_FOUND', message: `Workspace not found: ${input.id}` });
+        }
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message:
+            result.reason === 'fetch_failed'
+              ? `PR was associated but snapshot fetch failed for: ${input.prUrl}`
+              : `Failed to attach PR: ${input.prUrl}`,
+        });
       }
       return workspaceDataService.findById(input.id);
     }),

--- a/src/backend/trpc/workspace.trpc.ts
+++ b/src/backend/trpc/workspace.trpc.ts
@@ -310,7 +310,11 @@ export const workspaceRouter = router({
               : `Failed to attach PR: ${input.prUrl}`,
         });
       }
-      return workspaceDataService.findById(input.id);
+      const updatedWorkspace = await workspaceDataService.findById(input.id);
+      if (!updatedWorkspace) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: `Workspace not found: ${input.id}` });
+      }
+      return updatedWorkspace;
     }),
 
   // Toggle workspace-level ratcheting

--- a/src/backend/trpc/workspace.trpc.ts
+++ b/src/backend/trpc/workspace.trpc.ts
@@ -10,6 +10,7 @@ import { assembleWorkspaceDerivedState } from '@/backend/lib/workspace-derived-s
 import { archiveWorkspace } from '@/backend/orchestration/workspace-archive.orchestrator';
 import { initializeWorkspaceWorktree } from '@/backend/orchestration/workspace-init.orchestrator';
 import { DEFAULT_FOLLOWUP } from '@/backend/prompts/workflows';
+import { prSnapshotService } from '@/backend/services/github';
 import { ratchetService } from '@/backend/services/ratchet';
 import {
   sessionDataService,
@@ -275,6 +276,32 @@ export const workspaceRouter = router({
         throw new TRPCError({ code: 'NOT_FOUND', message: `Workspace not found: ${input.id}` });
       }
       return workspaceDataService.rename(input.id, input.name);
+    }),
+
+  // Manually associate a GitHub PR URL with a workspace
+  attachPR: publicProcedure
+    .input(
+      z.object({
+        id: z.string(),
+        prUrl: z
+          .string()
+          .trim()
+          .regex(
+            /^https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/\d+$/,
+            'Must be a valid GitHub PR URL (https://github.com/owner/repo/pull/N)'
+          ),
+      })
+    )
+    .mutation(async ({ input }) => {
+      const workspace = await workspaceDataService.findById(input.id);
+      if (!workspace) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: `Workspace not found: ${input.id}` });
+      }
+      const result = await prSnapshotService.attachAndRefreshPR(input.id, input.prUrl);
+      if (!result.success && result.reason === 'workspace_not_found') {
+        throw new TRPCError({ code: 'NOT_FOUND', message: `Workspace not found: ${input.id}` });
+      }
+      return workspaceDataService.findById(input.id);
     }),
 
   // Toggle workspace-level ratcheting

--- a/src/client/routes/projects/workspaces/workspace-detail-header.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-header.tsx
@@ -1,5 +1,5 @@
-import { Info, Pencil } from 'lucide-react';
-import { useRef, useState } from 'react';
+import { GitPullRequest, Info, Pencil } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import {
   HeaderLeftExtraSlot,
@@ -10,7 +10,15 @@ import {
 import { ProjectSelectorDropdown } from '@/client/components/project-selector';
 import { trpc } from '@/client/lib/trpc';
 import { Button } from '@/components/ui/button';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
 import { RunScriptButton, RunScriptPortBadge } from '@/components/workspace';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { cn } from '@/lib/utils';
@@ -60,6 +68,7 @@ export function WorkspaceDetailHeaderSlot({
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState(workspace.name);
   const [detailsOpen, setDetailsOpen] = useState(false);
+  const [attachPrOpen, setAttachPrOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const handleStartEdit = () => {
@@ -157,6 +166,17 @@ export function WorkspaceDetailHeaderSlot({
               >
                 <Info className="h-3 w-3" />
               </Button>
+              {!isArchived && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
+                  onClick={() => setAttachPrOpen(true)}
+                  aria-label={workspace.prUrl ? 'Edit associated PR' : 'Associate a PR'}
+                >
+                  <GitPullRequest className="h-3 w-3" />
+                </Button>
+              )}
             </div>
           )}
         </div>
@@ -218,7 +238,99 @@ export function WorkspaceDetailHeaderSlot({
         onOpenChange={setDetailsOpen}
         workspace={workspace}
       />
+      <AttachPrDialog
+        open={attachPrOpen}
+        onOpenChange={setAttachPrOpen}
+        workspaceId={workspaceId}
+        currentPrUrl={workspace.prUrl ?? undefined}
+      />
     </>
+  );
+}
+
+function AttachPrDialog({
+  open,
+  onOpenChange,
+  workspaceId,
+  currentPrUrl,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  workspaceId: string;
+  currentPrUrl?: string;
+}) {
+  const utils = trpc.useUtils();
+  const [value, setValue] = useState(currentPrUrl ?? '');
+  const [error, setError] = useState<string | null>(null);
+
+  const attachPrMutation = trpc.workspace.attachPR.useMutation({
+    onSuccess: async () => {
+      await utils.workspace.get.invalidate({ id: workspaceId });
+      onOpenChange(false);
+      toast.success('PR associated successfully');
+    },
+    onError: (err) => {
+      setError(err.message);
+    },
+  });
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) {
+      setValue(currentPrUrl ?? '');
+      setError(null);
+    }
+    onOpenChange(next);
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    attachPrMutation.mutate({ id: workspaceId, prUrl: value.trim() });
+  };
+
+  // Sync input value when dialog opens
+  useEffect(() => {
+    if (open) {
+      setValue(currentPrUrl ?? '');
+      setError(null);
+    }
+  }, [open, currentPrUrl]);
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md" aria-describedby="attach-pr-description">
+        <DialogHeader>
+          <DialogTitle>{currentPrUrl ? 'Edit associated PR' : 'Associate a PR'}</DialogTitle>
+          <DialogDescription id="attach-pr-description">
+            Enter the GitHub PR URL to link it to this workspace. The ratchet will use this PR to
+            monitor CI and review status.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1.5">
+            <Input
+              type="url"
+              placeholder="https://github.com/owner/repo/pull/123"
+              value={value}
+              onChange={(e) => {
+                setValue(e.target.value);
+                setError(null);
+              }}
+              autoFocus
+            />
+            {error && <p className="text-xs text-destructive">{error}</p>}
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => handleOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!value.trim() || attachPrMutation.isPending}>
+              {attachPrMutation.isPending ? 'Saving…' : 'Save'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
   );
 }
 


### PR DESCRIPTION
## Summary

- Adds a `GitPullRequest` icon button to the workspace name hover cluster (alongside the existing rename and info buttons), hidden until mouseover and hidden when workspace is archived
- Clicking opens a dialog to enter or replace the PR URL — pre-filled with the existing URL when one is already set
- New `workspace.attachPR` tRPC mutation validates the URL format, calls `prSnapshotService.attachAndRefreshPR()` to fetch full PR state from GitHub, and updates the workspace atomically

Fixes the case where the `pr-detection.interceptor` misses the PR URL during a session (e.g. buffered output, regex miss), leaving `prUrl` null and breaking the ratchet.

## Test plan

- [ ] `pnpm typecheck` — passes
- [ ] `pnpm check:fix` — no new errors
- [ ] Hover over workspace name in header → three icons appear (pencil, info, PR)
- [ ] Click PR icon on a workspace with no PR → dialog title says "Associate a PR", input is empty
- [ ] Enter a valid GitHub PR URL → saves, toast shows "PR associated successfully", PR chip appears in header
- [ ] Click PR icon on a workspace with an existing PR → dialog title says "Edit associated PR", input pre-filled
- [ ] Enter an invalid URL → error message shown inline
- [ ] Cancel → dialog closes, no changes made
- [ ] Archived workspace → PR button does not appear