### PR TITLE
Persist init warning dismissal

### DIFF
--- a/src/client/routes/projects/workspaces/setup-warning-storage.test.ts
+++ b/src/client/routes/projects/workspaces/setup-warning-storage.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  forgetSetupWarningDismissed,
+  isSetupWarningDismissed,
+  rememberSetupWarningDismissed,
+} from './setup-warning-storage';
+
+const mockStorage = new Map<string, string>();
+
+const mockLocalStorage = {
+  getItem: vi.fn((key: string) => mockStorage.get(key) ?? null),
+  setItem: vi.fn((key: string, value: string) => mockStorage.set(key, value)),
+  removeItem: vi.fn((key: string) => mockStorage.delete(key)),
+  clear: vi.fn(() => mockStorage.clear()),
+  get length() {
+    return mockStorage.size;
+  },
+  key: vi.fn((index: number) => {
+    const keys = Array.from(mockStorage.keys());
+    return keys[index] ?? null;
+  }),
+};
+
+describe('setup-warning-storage', () => {
+  beforeEach(() => {
+    mockStorage.clear();
+    vi.clearAllMocks();
+    vi.stubGlobal('localStorage', mockLocalStorage);
+    vi.stubGlobal('window', { localStorage: mockLocalStorage });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    mockStorage.clear();
+  });
+
+  it('remembers a dismissed setup warning for the same workspace and error', () => {
+    rememberSetupWarningDismissed('ws-1', 'npm install failed');
+
+    expect(isSetupWarningDismissed('ws-1', 'npm install failed')).toBe(true);
+  });
+
+  it('does not reuse dismissal for a different error message', () => {
+    rememberSetupWarningDismissed('ws-1', 'npm install failed');
+
+    expect(isSetupWarningDismissed('ws-1', 'pnpm install failed')).toBe(false);
+  });
+
+  it('does not reuse dismissal for a different workspace', () => {
+    rememberSetupWarningDismissed('ws-1', 'npm install failed');
+
+    expect(isSetupWarningDismissed('ws-2', 'npm install failed')).toBe(false);
+  });
+
+  it('forgets dismissal when the setup warning clears', () => {
+    rememberSetupWarningDismissed('ws-1', 'npm install failed');
+
+    forgetSetupWarningDismissed('ws-1');
+
+    expect(isSetupWarningDismissed('ws-1', 'npm install failed')).toBe(false);
+  });
+});

--- a/src/client/routes/projects/workspaces/setup-warning-storage.ts
+++ b/src/client/routes/projects/workspaces/setup-warning-storage.ts
@@ -1,0 +1,55 @@
+const SETUP_WARNING_DISMISSED_PREFIX = 'ff_setup_warning_dismissed:';
+
+function getStorage(): Storage | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function getSetupWarningDismissedKey(workspaceId: string): string {
+  return `${SETUP_WARNING_DISMISSED_PREFIX}${workspaceId}`;
+}
+
+export function isSetupWarningDismissed(
+  workspaceId: string,
+  initErrorMessage: string | null
+): boolean {
+  if (!initErrorMessage) {
+    return false;
+  }
+
+  try {
+    return getStorage()?.getItem(getSetupWarningDismissedKey(workspaceId)) === initErrorMessage;
+  } catch {
+    return false;
+  }
+}
+
+export function rememberSetupWarningDismissed(
+  workspaceId: string,
+  initErrorMessage: string | null
+) {
+  if (!initErrorMessage) {
+    return;
+  }
+
+  try {
+    getStorage()?.setItem(getSetupWarningDismissedKey(workspaceId), initErrorMessage);
+  } catch {
+    // Non-blocking: ignore localStorage failures.
+  }
+}
+
+export function forgetSetupWarningDismissed(workspaceId: string) {
+  try {
+    getStorage()?.removeItem(getSetupWarningDismissedKey(workspaceId));
+  } catch {
+    // Non-blocking: ignore localStorage failures.
+  }
+}

--- a/src/client/routes/projects/workspaces/use-workspace-detail-hooks.ts
+++ b/src/client/routes/projects/workspaces/use-workspace-detail-hooks.ts
@@ -2,6 +2,11 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { trpc } from '@/client/lib/trpc';
 
+import {
+  forgetSetupWarningDismissed,
+  isSetupWarningDismissed,
+  rememberSetupWarningDismissed,
+} from './setup-warning-storage';
 import type { useWorkspaceData } from './use-workspace-detail';
 
 export function useWorkspaceInitStatus(
@@ -60,17 +65,31 @@ export function useWorkspaceInitStatus(
   const isScriptFailed =
     (status === 'FAILED' && hasWorktreePath) || (status === 'READY' && !!initErrorMessage);
 
-  // Ephemeral dismiss state — resets when the error message changes (e.g. after a retry).
+  // Persisted per workspace/error so navigating away and back does not resurface dismissed warnings.
   const [setupWarningDismissed, setSetupWarningDismissed] = useState(false);
-  const prevErrorMessageRef = useRef<string | null>(null);
   useEffect(() => {
-    if (initErrorMessage !== prevErrorMessageRef.current) {
-      setSetupWarningDismissed(false);
-      prevErrorMessageRef.current = initErrorMessage;
+    if (!workspaceInitStatus) {
+      return;
     }
-  }, [initErrorMessage]);
 
-  const dismissSetupWarning = useCallback(() => setSetupWarningDismissed(true), []);
+    if (!initErrorMessage) {
+      forgetSetupWarningDismissed(workspaceId);
+      setSetupWarningDismissed(false);
+      return;
+    }
+
+    if (workspaceInitStatus.chatBanner?.showDismiss !== true) {
+      setSetupWarningDismissed(false);
+      return;
+    }
+
+    setSetupWarningDismissed(isSetupWarningDismissed(workspaceId, initErrorMessage));
+  }, [workspaceId, workspaceInitStatus, initErrorMessage]);
+
+  const dismissSetupWarning = useCallback(() => {
+    rememberSetupWarningDismissed(workspaceId, initErrorMessage);
+    setSetupWarningDismissed(true);
+  }, [workspaceId, initErrorMessage]);
 
   return {
     workspaceInitStatus,

--- a/src/client/routes/projects/workspaces/workspace-detail-container.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-container.tsx
@@ -338,6 +338,10 @@ export function WorkspaceDetailContainer() {
   );
 
   const chatTabId = selectedDbSessionId ? `chat-${selectedDbSessionId}` : null;
+  const initBanner =
+    setupWarningDismissed && workspaceInitStatus?.chatBanner?.showDismiss
+      ? null
+      : (workspaceInitStatus?.chatBanner ?? null);
 
   const { persistCurrent: persistChatScroll } = usePersistentScroll({
     tabId: chatTabId,
@@ -413,7 +417,7 @@ export function WorkspaceDetailContainer() {
     acpConfigOptions,
     setConfigOption,
     autoStartPending: isIssueAutoStartPending,
-    initBanner: workspaceInitStatus?.chatBanner ?? null,
+    initBanner,
   };
 
   return (


### PR DESCRIPTION
## Summary
- persist dismissed READY+warning init-script banners per workspace and exact error message
- reset dismissal when the warning clears or when a new error appears
- hide the chat init warning when the dismissible header warning has already been dismissed

## Tests
- pnpm vitest run src/client/routes/projects/workspaces/setup-warning-storage.test.ts src/client/routes/projects/workspaces/use-workspace-detail-hooks.test.ts
- pnpm exec biome check src/client/routes/projects/workspaces/setup-warning-storage.ts src/client/routes/projects/workspaces/setup-warning-storage.test.ts src/client/routes/projects/workspaces/use-workspace-detail-hooks.ts src/client/routes/projects/workspaces/workspace-detail-container.tsx
- pnpm typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-state change that only affects whether init warning banners reappear; failures degrade gracefully if `localStorage` is unavailable.
> 
> **Overview**
> Persists dismissal of the workspace init *READY-with-warning* banner in `localStorage`, keyed by workspace id and the exact `initErrorMessage`, so dismissed warnings don’t reappear after navigation.
> 
> Resets the persisted dismissal when the warning clears or when the banner is not dismissible, and hides the chat `initBanner` when the corresponding dismissible header warning has already been dismissed. Adds unit tests for the new storage helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bbc5bc047c25c31c148cf607b97e39dcf219563. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->