### PR TITLE
Fix new project header navigation

### DIFF
--- a/src/client/hooks/use-app-navigation-data.ts
+++ b/src/client/hooks/use-app-navigation-data.ts
@@ -1,4 +1,13 @@
-import { useEffect, useRef, useState } from 'react';
+import {
+  createContext,
+  createElement,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { useLocation } from 'react-router';
 import { toast } from 'sonner';
 import { useProjectSnapshotSync } from '@/client/hooks/use-project-snapshot-sync';
@@ -8,17 +17,22 @@ import { trpc } from '@/client/lib/trpc';
 
 const SELECTED_PROJECT_KEY = 'factoryfactory_selected_project_slug';
 
-function getProjectSlugFromPath(pathname: string): string | null {
+export function getProjectSlugFromPath(pathname: string): string | null {
   const match = pathname.match(/^\/projects\/([^/]+)/);
-  return match ? (match[1] as string) : null;
+  const slug = match?.[1];
+  return slug && slug !== 'new' ? slug : null;
+}
+
+function persistSelectedProjectSlug(slug: string) {
+  localStorage.setItem(SELECTED_PROJECT_KEY, slug);
 }
 
 function getInitialProjectSlug(): string {
-  const slugFromPath = getProjectSlugFromPath(window.location.pathname);
-  if (slugFromPath && slugFromPath !== 'new') {
-    return slugFromPath;
-  }
-  return localStorage.getItem(SELECTED_PROJECT_KEY) || '';
+  return (
+    getProjectSlugFromPath(window.location.pathname) ??
+    localStorage.getItem(SELECTED_PROJECT_KEY) ??
+    ''
+  );
 }
 
 /**
@@ -45,35 +59,34 @@ function useProjectSlugSync(
   pathname: string,
   projects: Array<{ id: string; slug: string; name: string }> | undefined,
   selectedProjectSlug: string,
-  setSelectedProjectSlug: (slug: string) => void
+  selectProjectSlug: (slug: string) => void
 ) {
   useEffect(() => {
     const slugFromPath = getProjectSlugFromPath(pathname);
-    const hasValidSlugInPath = slugFromPath && slugFromPath !== 'new';
-
-    if (hasValidSlugInPath) {
-      setSelectedProjectSlug(slugFromPath);
-      localStorage.setItem(SELECTED_PROJECT_KEY, slugFromPath);
+    if (slugFromPath) {
+      selectProjectSlug(slugFromPath);
     } else {
       const stored = localStorage.getItem(SELECTED_PROJECT_KEY);
       if (stored) {
-        setSelectedProjectSlug(stored);
+        selectProjectSlug(stored);
       }
     }
-  }, [pathname, setSelectedProjectSlug]);
+  }, [pathname, selectProjectSlug]);
 
-  // Select first project if none selected
   useEffect(() => {
-    if (!projects || projects.length === 0 || selectedProjectSlug) {
+    if (!projects || projects.length === 0 || getProjectSlugFromPath(pathname)) {
+      return;
+    }
+
+    if (selectedProjectSlug && projects.some((project) => project.slug === selectedProjectSlug)) {
       return;
     }
 
     const firstSlug = projects[0]?.slug;
     if (firstSlug) {
-      setSelectedProjectSlug(firstSlug);
-      localStorage.setItem(SELECTED_PROJECT_KEY, firstSlug);
+      selectProjectSlug(firstSlug);
     }
-  }, [projects, selectedProjectSlug, setSelectedProjectSlug]);
+  }, [pathname, projects, selectedProjectSlug, selectProjectSlug]);
 }
 
 /**
@@ -86,6 +99,10 @@ export function useAppNavigationData() {
   const { setProjectContext } = useProjectContext();
 
   const { data: projects } = trpc.project.list.useQuery({ isArchived: false });
+  const selectProjectSlug = useCallback((slug: string) => {
+    setSelectedProjectSlug(slug);
+    persistSelectedProjectSlug(slug);
+  }, []);
 
   const selectedProject = projects?.find((p) => p.slug === selectedProjectSlug);
   const selectedProjectId = selectedProject?.id;
@@ -111,8 +128,8 @@ export function useAppNavigationData() {
   // Track workspaces that need user attention
   const { needsAttention, clearAttention } = useWorkspaceAttention();
 
-  // Sync slug from URL
-  useProjectSlugSync(pathname, projects, selectedProjectSlug, setSelectedProjectSlug);
+  // Sync slug from URL/localStorage and keep stale selections from surviving project changes.
+  useProjectSlugSync(pathname, projects, selectedProjectSlug, selectProjectSlug);
 
   // Set project context for tRPC headers
   useEffect(() => {
@@ -138,6 +155,7 @@ export function useAppNavigationData() {
   return {
     projects,
     selectedProjectSlug,
+    selectProjectSlug,
     selectedProjectId,
     issueProvider,
     serverWorkspaces,
@@ -146,4 +164,26 @@ export function useAppNavigationData() {
     clearAttention,
     currentWorkspaceId,
   };
+}
+
+export type AppNavigationData = ReturnType<typeof useAppNavigationData>;
+
+const AppNavigationDataContext = createContext<AppNavigationData | null>(null);
+
+export function AppNavigationDataProvider({
+  children,
+  value,
+}: {
+  children?: ReactNode;
+  value: AppNavigationData;
+}) {
+  return createElement(AppNavigationDataContext.Provider, { value }, children);
+}
+
+export function useAppNavigationDataContext() {
+  const context = useContext(AppNavigationDataContext);
+  if (!context) {
+    throw new Error('useAppNavigationDataContext must be used within AppNavigationDataProvider');
+  }
+  return context;
 }

--- a/src/client/hooks/use-project-header-navigation.ts
+++ b/src/client/hooks/use-project-header-navigation.ts
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+import { trpc } from '@/client/lib/trpc';
+
+const SELECTED_PROJECT_KEY = 'factoryfactory_selected_project_slug';
+
+function getProjectSlugFromPath(pathname: string): string | null {
+  const match = pathname.match(/^\/projects\/([^/]+)/);
+  const slug = match?.[1];
+  return slug && slug !== 'new' ? slug : null;
+}
+
+function getInitialProjectSlug(): string {
+  return (
+    getProjectSlugFromPath(window.location.pathname) ??
+    localStorage.getItem(SELECTED_PROJECT_KEY) ??
+    ''
+  );
+}
+
+export function useProjectHeaderNavigation() {
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
+  const [selectedProjectSlug, setSelectedProjectSlug] = useState(getInitialProjectSlug);
+  const { data: projects } = trpc.project.list.useQuery({ isArchived: false });
+  const currentProjectSlug = getProjectSlugFromPath(pathname) ?? selectedProjectSlug;
+
+  useEffect(() => {
+    const slugFromPath = getProjectSlugFromPath(pathname);
+    if (slugFromPath) {
+      setSelectedProjectSlug(slugFromPath);
+      localStorage.setItem(SELECTED_PROJECT_KEY, slugFromPath);
+      return;
+    }
+
+    const stored = localStorage.getItem(SELECTED_PROJECT_KEY);
+    if (stored) {
+      setSelectedProjectSlug(stored);
+    }
+  }, [pathname]);
+
+  useEffect(() => {
+    if (!projects || projects.length === 0) {
+      return;
+    }
+
+    if (selectedProjectSlug && projects.some((project) => project.slug === selectedProjectSlug)) {
+      return;
+    }
+
+    const firstSlug = projects[0]?.slug;
+    if (firstSlug) {
+      setSelectedProjectSlug(firstSlug);
+      localStorage.setItem(SELECTED_PROJECT_KEY, firstSlug);
+    }
+  }, [projects, selectedProjectSlug]);
+
+  const navigateToProject = useCallback(
+    (slug: string) => {
+      localStorage.setItem(SELECTED_PROJECT_KEY, slug);
+      setSelectedProjectSlug(slug);
+      void navigate(`/projects/${slug}/workspaces`);
+    },
+    [navigate]
+  );
+
+  const handleProjectChange = useCallback(
+    (value: string) => {
+      if (value === '__manage__') {
+        void navigate('/projects');
+        return;
+      }
+      if (value === '__create__') {
+        void navigate('/projects/new');
+        return;
+      }
+      navigateToProject(value);
+    },
+    [navigate, navigateToProject]
+  );
+
+  const handleCurrentProjectSelect = useCallback(() => {
+    if (!currentProjectSlug) {
+      return;
+    }
+    navigateToProject(currentProjectSlug);
+  }, [currentProjectSlug, navigateToProject]);
+
+  return {
+    selectedProjectSlug: currentProjectSlug,
+    projects,
+    handleProjectChange,
+    handleCurrentProjectSelect,
+  };
+}

--- a/src/client/hooks/use-project-header-navigation.ts
+++ b/src/client/hooks/use-project-header-navigation.ts
@@ -1,67 +1,22 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback } from 'react';
 import { useLocation, useNavigate } from 'react-router';
-import { trpc } from '@/client/lib/trpc';
-
-const SELECTED_PROJECT_KEY = 'factoryfactory_selected_project_slug';
-
-function getProjectSlugFromPath(pathname: string): string | null {
-  const match = pathname.match(/^\/projects\/([^/]+)/);
-  const slug = match?.[1];
-  return slug && slug !== 'new' ? slug : null;
-}
-
-function getInitialProjectSlug(): string {
-  return (
-    getProjectSlugFromPath(window.location.pathname) ??
-    localStorage.getItem(SELECTED_PROJECT_KEY) ??
-    ''
-  );
-}
+import {
+  getProjectSlugFromPath,
+  useAppNavigationDataContext,
+} from '@/client/hooks/use-app-navigation-data';
 
 export function useProjectHeaderNavigation() {
   const { pathname } = useLocation();
   const navigate = useNavigate();
-  const [selectedProjectSlug, setSelectedProjectSlug] = useState(getInitialProjectSlug);
-  const { data: projects } = trpc.project.list.useQuery({ isArchived: false });
+  const { projects, selectedProjectSlug, selectProjectSlug } = useAppNavigationDataContext();
   const currentProjectSlug = getProjectSlugFromPath(pathname) ?? selectedProjectSlug;
-
-  useEffect(() => {
-    const slugFromPath = getProjectSlugFromPath(pathname);
-    if (slugFromPath) {
-      setSelectedProjectSlug(slugFromPath);
-      localStorage.setItem(SELECTED_PROJECT_KEY, slugFromPath);
-      return;
-    }
-
-    const stored = localStorage.getItem(SELECTED_PROJECT_KEY);
-    if (stored) {
-      setSelectedProjectSlug(stored);
-    }
-  }, [pathname]);
-
-  useEffect(() => {
-    if (!projects || projects.length === 0) {
-      return;
-    }
-
-    if (selectedProjectSlug && projects.some((project) => project.slug === selectedProjectSlug)) {
-      return;
-    }
-
-    const firstSlug = projects[0]?.slug;
-    if (firstSlug) {
-      setSelectedProjectSlug(firstSlug);
-      localStorage.setItem(SELECTED_PROJECT_KEY, firstSlug);
-    }
-  }, [projects, selectedProjectSlug]);
 
   const navigateToProject = useCallback(
     (slug: string) => {
-      localStorage.setItem(SELECTED_PROJECT_KEY, slug);
-      setSelectedProjectSlug(slug);
+      selectProjectSlug(slug);
       void navigate(`/projects/${slug}/workspaces`);
     },
-    [navigate]
+    [navigate, selectProjectSlug]
   );
 
   const handleProjectChange = useCallback(

--- a/src/client/routes/projects/new.test.tsx
+++ b/src/client/routes/projects/new.test.tsx
@@ -4,10 +4,15 @@ import { createElement, type ReactNode } from 'react';
 import { flushSync } from 'react-dom';
 import { createRoot } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  type AppNavigationData,
+  AppNavigationDataProvider,
+} from '@/client/hooks/use-app-navigation-data';
 import NewProjectPage from './new';
 
 const navigateMock = vi.fn();
 const useAppHeaderMock = vi.fn();
+const selectProjectSlugMock = vi.fn();
 const projects = [
   { id: 'project-1', slug: 'alpha', name: 'Alpha' },
   { id: 'project-2', slug: 'beta', name: 'Beta' },
@@ -136,9 +141,27 @@ function renderPage() {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const root = createRoot(container);
+  const navigationData = {
+    projects,
+    selectedProjectSlug: 'beta',
+    selectProjectSlug: selectProjectSlugMock,
+    selectedProjectId: 'project-2',
+    issueProvider: 'GITHUB',
+    serverWorkspaces: undefined,
+    reviewCount: 0,
+    needsAttention: () => false,
+    clearAttention: vi.fn(),
+    currentWorkspaceId: undefined,
+  } as unknown as AppNavigationData;
 
   flushSync(() => {
-    root.render(createElement(NewProjectPage));
+    root.render(
+      createElement(
+        AppNavigationDataProvider,
+        { value: navigationData },
+        createElement(NewProjectPage)
+      )
+    );
   });
 
   return { container, root };
@@ -153,6 +176,7 @@ beforeEach(() => {
   localStorage.setItem('factoryfactory_selected_project_slug', 'beta');
   navigateMock.mockClear();
   useAppHeaderMock.mockClear();
+  selectProjectSlugMock.mockClear();
 });
 
 afterEach(() => {

--- a/src/client/routes/projects/new.test.tsx
+++ b/src/client/routes/projects/new.test.tsx
@@ -1,0 +1,189 @@
+// @vitest-environment jsdom
+
+import { createElement, type ReactNode } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import NewProjectPage from './new';
+
+const navigateMock = vi.fn();
+const useAppHeaderMock = vi.fn();
+const projects = [
+  { id: 'project-1', slug: 'alpha', name: 'Alpha' },
+  { id: 'project-2', slug: 'beta', name: 'Beta' },
+];
+
+vi.mock('react-router', () => ({
+  Link: ({ children, to }: { children: ReactNode; to: string }) =>
+    createElement('a', { href: to }, children),
+  useLocation: () => ({ pathname: '/projects/new' }),
+  useNavigate: () => navigateMock,
+}));
+
+vi.mock('@/client/components/app-header-context', () => ({
+  HeaderLeftStartSlot: ({ children }: { children: ReactNode }) =>
+    createElement('div', { 'data-testid': 'header-left-start' }, children),
+  useAppHeader: (input: unknown) => useAppHeaderMock(input),
+}));
+
+vi.mock('@/client/components/logo', () => ({
+  Logo: () => createElement('div', null, 'Logo'),
+}));
+
+vi.mock('@/client/components/project-selector', () => ({
+  ProjectSelectorDropdown: ({
+    selectedProjectSlug,
+    onCurrentProjectSelect,
+    projects,
+  }: {
+    selectedProjectSlug: string;
+    onCurrentProjectSelect?: () => void;
+    projects: Array<{ slug: string; name: string }> | undefined;
+  }) => {
+    const selectedProject = projects?.find((project) => project.slug === selectedProjectSlug);
+    return createElement(
+      'button',
+      { onClick: onCurrentProjectSelect, type: 'button' },
+      selectedProject?.name ?? 'Select a project'
+    );
+  },
+}));
+
+vi.mock('@/components/data-import/data-import-button', () => ({
+  DataImportButton: ({ children }: { children: ReactNode }) =>
+    createElement('button', null, children),
+}));
+
+vi.mock('@/components/project/github-url-form', () => ({
+  GithubUrlForm: ({ footerActions }: { footerActions?: ReactNode }) =>
+    createElement('div', null, 'GitHub URL Form', footerActions),
+}));
+
+vi.mock('@/components/project/onboarding-cli-health', () => ({
+  OnboardingCliHealth: () => createElement('div', null, 'CLI Health'),
+}));
+
+vi.mock('@/components/project/project-repo-form', () => ({
+  ProjectRepoForm: ({ footerActions }: { footerActions?: ReactNode }) =>
+    createElement('div', null, 'Project Repo Form', footerActions),
+}));
+
+vi.mock('@/components/project/setup-terminal-modal', () => ({
+  SetupTerminalModal: () => null,
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children }: { children: ReactNode }) => createElement('div', null, children),
+}));
+
+vi.mock('@/components/ui/card', () => ({
+  Card: ({ children }: { children: ReactNode }) => createElement('div', null, children),
+  CardContent: ({ children }: { children: ReactNode }) => createElement('div', null, children),
+  CardDescription: ({ children }: { children: ReactNode }) => createElement('div', null, children),
+  CardHeader: ({ children }: { children: ReactNode }) => createElement('div', null, children),
+  CardTitle: ({ children }: { children: ReactNode }) => createElement('div', null, children),
+}));
+
+vi.mock('@/components/ui/tabs', () => ({
+  Tabs: ({ children }: { children: ReactNode }) => createElement('div', null, children),
+  TabsContent: ({ children }: { children: ReactNode }) => createElement('div', null, children),
+  TabsList: ({ children }: { children: ReactNode }) => createElement('div', null, children),
+  TabsTrigger: ({ children }: { children: ReactNode }) =>
+    createElement('button', { type: 'button' }, children),
+}));
+
+vi.mock('@/client/lib/trpc', () => ({
+  trpc: {
+    useUtils: () => ({
+      project: { list: { invalidate: vi.fn() } },
+      admin: { checkCLIHealth: { invalidate: vi.fn() } },
+    }),
+    project: {
+      list: { useQuery: () => ({ data: projects }) },
+      checkFactoryConfig: { useQuery: () => ({ data: { exists: false } }) },
+      checkGithubAuth: { useQuery: () => ({ data: null, isLoading: false, refetch: vi.fn() }) },
+      create: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      createFromGithub: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+    },
+  },
+}));
+
+function createStorageStub(): Storage {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(key: string) {
+      return store.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    setItem(key: string, value: string) {
+      store.set(key, value);
+    },
+  };
+}
+
+function renderPage() {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  flushSync(() => {
+    root.render(createElement(NewProjectPage));
+  });
+
+  return { container, root };
+}
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    writable: true,
+    value: createStorageStub(),
+  });
+  localStorage.setItem('factoryfactory_selected_project_slug', 'beta');
+  navigateMock.mockClear();
+  useAppHeaderMock.mockClear();
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  localStorage.clear();
+});
+
+describe('NewProjectPage navigation', () => {
+  it('keeps the selected project in the header and navigates to its board', () => {
+    const { container, root } = renderPage();
+
+    expect(useAppHeaderMock).toHaveBeenCalledWith({ title: '' });
+    const headerProject = container.querySelector('[data-testid="header-left-start"] button');
+    expect(headerProject?.textContent).toBe('Beta');
+
+    flushSync(() => {
+      headerProject?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(navigateMock).toHaveBeenCalledWith('/projects/beta/workspaces');
+    root.unmount();
+  });
+
+  it('does not render a generic projects back link on the add project page', () => {
+    const { container, root } = renderPage();
+
+    expect(container.querySelector('a[href="/projects"]')).toBeNull();
+    expect(container.querySelector('a[href="/projects/beta/workspaces"]')?.textContent).toContain(
+      'Cancel'
+    );
+
+    root.unmount();
+  });
+});

--- a/src/client/routes/projects/new.tsx
+++ b/src/client/routes/projects/new.tsx
@@ -1,8 +1,9 @@
-import { ArrowLeftIcon } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate } from 'react-router';
-import { useAppHeader } from '@/client/components/app-header-context';
+import { HeaderLeftStartSlot, useAppHeader } from '@/client/components/app-header-context';
 import { Logo } from '@/client/components/logo';
+import { ProjectSelectorDropdown } from '@/client/components/project-selector';
+import { useProjectHeaderNavigation } from '@/client/hooks/use-project-header-navigation';
 import { trpc } from '@/client/lib/trpc';
 import { DataImportButton } from '@/components/data-import/data-import-button';
 import { GithubUrlForm } from '@/components/project/github-url-form';
@@ -32,10 +33,10 @@ function parseGithubUrl(url: string): { owner: string; repo: string } | null {
 }
 
 export default function NewProjectPage() {
-  useAppHeader({ title: 'New Project' });
-
   const navigate = useNavigate();
   const [source, setSource] = useState<ProjectSource>('github');
+  const { selectedProjectSlug, projects, handleProjectChange, handleCurrentProjectSelect } =
+    useProjectHeaderNavigation();
 
   // Local path state
   const [repoPath, setRepoPath] = useState('');
@@ -101,8 +102,13 @@ export default function NewProjectPage() {
     }
   };
 
-  const { data: projects } = trpc.project.list.useQuery({ isArchived: false });
   const hasExistingProjects = projects && projects.length > 0;
+  const selectedProject = projects?.find((project) => project.slug === selectedProjectSlug);
+  const selectedProjectHref = selectedProject
+    ? `/projects/${selectedProject.slug}/workspaces`
+    : '/projects';
+
+  useAppHeader({ title: hasExistingProjects ? '' : 'New Project' });
 
   const utils = trpc.useUtils();
 
@@ -289,12 +295,18 @@ export default function NewProjectPage() {
   // Normal view when projects already exist
   return (
     <div className="mx-auto max-w-2xl space-y-4 p-3 md:p-6">
-      <div className="flex items-center gap-2 md:gap-4">
-        <Button variant="ghost" size="icon" asChild>
-          <Link to="/projects">
-            <ArrowLeftIcon className="h-5 w-5" />
-          </Link>
-        </Button>
+      <HeaderLeftStartSlot>
+        <ProjectSelectorDropdown
+          selectedProjectSlug={selectedProjectSlug}
+          onProjectChange={handleProjectChange}
+          onCurrentProjectSelect={handleCurrentProjectSelect}
+          projects={projects}
+          showLeadingSlash
+          triggerId="new-project-header-project-select"
+        />
+      </HeaderLeftStartSlot>
+
+      <div>
         <div>
           <h1 className="text-2xl font-bold">Add Project</h1>
           <p className="text-muted-foreground mt-1">
@@ -325,7 +337,7 @@ export default function NewProjectPage() {
                 idPrefix="new"
                 footerActions={
                   <Button variant="secondary" asChild>
-                    <Link to="/projects">Cancel</Link>
+                    <Link to={selectedProjectHref}>Cancel</Link>
                   </Button>
                 }
               />
@@ -336,7 +348,7 @@ export default function NewProjectPage() {
                 idPrefix="new-gh"
                 footerActions={
                   <Button variant="secondary" asChild>
-                    <Link to="/projects">Cancel</Link>
+                    <Link to={selectedProjectHref}>Cancel</Link>
                   </Button>
                 }
               />

--- a/src/client/routes/projects/workspaces/use-workspace-project-navigation.ts
+++ b/src/client/routes/projects/workspaces/use-workspace-project-navigation.ts
@@ -1,33 +1,13 @@
-import { useCallback } from 'react';
-import { useNavigate, useParams } from 'react-router';
-import { trpc } from '@/client/lib/trpc';
+import { useProjectHeaderNavigation } from '@/client/hooks/use-project-header-navigation';
 
 export function useWorkspaceProjectNavigation() {
-  const { slug = '' } = useParams<{ slug: string }>();
-  const navigate = useNavigate();
-  const { data: projects } = trpc.project.list.useQuery({ isArchived: false });
+  const { selectedProjectSlug, projects, handleProjectChange, handleCurrentProjectSelect } =
+    useProjectHeaderNavigation();
 
-  const handleProjectChange = useCallback(
-    (value: string) => {
-      if (value === '__manage__') {
-        void navigate('/projects');
-        return;
-      }
-      if (value === '__create__') {
-        void navigate('/projects/new');
-        return;
-      }
-      void navigate(`/projects/${value}/workspaces`);
-    },
-    [navigate]
-  );
-
-  const handleCurrentProjectSelect = useCallback(() => {
-    if (!slug) {
-      return;
-    }
-    void navigate(`/projects/${slug}/workspaces`);
-  }, [navigate, slug]);
-
-  return { slug, projects, handleProjectChange, handleCurrentProjectSelect };
+  return {
+    slug: selectedProjectSlug,
+    projects,
+    handleProjectChange,
+    handleCurrentProjectSelect,
+  };
 }

--- a/src/components/layout/resizable-layout.tsx
+++ b/src/components/layout/resizable-layout.tsx
@@ -2,7 +2,10 @@ import type { ReactNode } from 'react';
 import { AppHeader } from '@/client/components/app-header';
 import { AppHeaderProvider } from '@/client/components/app-header-context';
 import { AppSidebar } from '@/client/components/app-sidebar';
-import { useAppNavigationData } from '@/client/hooks/use-app-navigation-data';
+import {
+  AppNavigationDataProvider,
+  useAppNavigationData,
+} from '@/client/hooks/use-app-navigation-data';
 import { useRouteSidebarState } from '@/client/hooks/use-sidebar-default-open';
 import { SidebarProvider } from '@/components/ui/sidebar';
 import { TooltipProvider } from '@/components/ui/tooltip';
@@ -25,15 +28,17 @@ export function AppLayout({ children, className }: AppLayoutProps) {
           onOpenChange={setSidebarOpen}
           className="flex-1 flex-col min-h-0"
         >
-          <AppHeaderProvider>
-            <AppHeader />
-            <div className="flex flex-1 min-h-0 overflow-hidden">
-              <AppSidebar navData={navData} />
-              <main className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-background">
-                {children}
-              </main>
-            </div>
-          </AppHeaderProvider>
+          <AppNavigationDataProvider value={navData}>
+            <AppHeaderProvider>
+              <AppHeader />
+              <div className="flex flex-1 min-h-0 overflow-hidden">
+                <AppSidebar navData={navData} />
+                <main className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-background">
+                  {children}
+                </main>
+              </div>
+            </AppHeaderProvider>
+          </AppNavigationDataProvider>
         </SidebarProvider>
       </TooltipProvider>
     </div>


### PR DESCRIPTION
## Summary
- Keep the current project selector visible in the header on the Add Project page when projects already exist.
- Make the current project segment navigate back to that project workspace board.
- Remove the in-page back button and route Cancel back to the selected project board.
- Share project header navigation logic between workspace routes and the new-project route.

## Tests
- pnpm exec vitest run src/client/routes/projects/new.test.tsx
- pnpm exec biome check src/client/hooks/use-project-header-navigation.ts src/client/routes/projects/workspaces/use-workspace-project-navigation.ts src/client/routes/projects/new.tsx src/client/routes/projects/new.test.tsx
- pnpm typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes global project-selection syncing (URL/localStorage/first-project fallback) and introduces a new navigation context/provider; mistakes could send users to the wrong project or persist stale selections.
> 
> **Overview**
> **Project selection + header navigation is refactored and reused across routes.** `use-app-navigation-data` now exposes `selectProjectSlug`, persists selection via a helper, tightens slug parsing (ignores `/projects/new`), and avoids keeping an invalid/stale slug when the project list changes.
> 
> **Adds a shared hook for header project switching.** New `useProjectHeaderNavigation` reads navigation state from a new `AppNavigationDataProvider` (wired into `AppLayout`) and standardizes handling for switching projects, creating/managing projects, and clicking the current project name.
> 
> **Updates `/projects/new` UX when projects already exist.** Removes the in-page back button, injects the `ProjectSelectorDropdown` into the header left slot, sets the header title to blank in this mode, and routes `Cancel` back to the currently selected project’s workspaces (or `/projects` if none). Includes a new Vitest coverage for the header selector behavior and cancel link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af9e2eb20993c59a22fd31e697b2720001b7170d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->