### PR TITLE
Fix stale workspace working state after restart

### DIFF
--- a/src/backend/lib/workspace-derived-state.test.ts
+++ b/src/backend/lib/workspace-derived-state.test.ts
@@ -6,10 +6,10 @@ import {
 } from './workspace-derived-state';
 
 describe('assembleWorkspaceDerivedState', () => {
-  it('uses effective working state from session OR flow', () => {
-    const computeKanbanColumn = vi.fn(() => KanbanColumn.WORKING);
+  it('uses live session activity, not PR flow activity, for workspace working state', () => {
+    const computeKanbanColumn = vi.fn(() => KanbanColumn.WAITING);
     const deriveSidebarStatus = vi.fn(() => ({
-      activityState: 'WORKING' as const,
+      activityState: 'IDLE' as const,
       ciState: 'NONE' as const,
     }));
 
@@ -33,18 +33,19 @@ describe('assembleWorkspaceDerivedState', () => {
       }
     );
 
-    expect(result.isWorking).toBe(true);
+    expect(result.isWorking).toBe(false);
     expect(computeKanbanColumn).toHaveBeenCalledWith(
       expect.objectContaining({
         lifecycle: WorkspaceStatus.READY,
-        isWorking: true,
+        isWorking: false,
       })
     );
     expect(deriveSidebarStatus).toHaveBeenCalledWith(
       expect.objectContaining({
-        isWorking: true,
+        isWorking: false,
       })
     );
+    expect(result.flowPhase).toBe('NO_PR');
   });
 
   it('maps flow fields and computed values into canonical derived shape', () => {
@@ -67,17 +68,46 @@ describe('assembleWorkspaceDerivedState', () => {
       },
       {
         computeKanbanColumn: () => KanbanColumn.WORKING,
-        deriveSidebarStatus: () => ({ activityState: 'WORKING', ciState: 'RUNNING' }),
+        deriveSidebarStatus: () => ({ activityState: 'IDLE', ciState: 'RUNNING' }),
       }
     );
 
     expect(result).toEqual({
-      isWorking: true,
+      isWorking: false,
       kanbanColumn: KanbanColumn.WORKING,
-      sidebarStatus: { activityState: 'WORKING', ciState: 'RUNNING' },
+      sidebarStatus: { activityState: 'IDLE', ciState: 'RUNNING' },
       ratchetButtonAnimated: true,
       flowPhase: 'CI_WAIT',
       ciObservation: 'CHECKS_PENDING',
     });
+  });
+
+  it('marks the workspace working when a session is actively working', () => {
+    const computeKanbanColumn = vi.fn(() => KanbanColumn.WORKING);
+    const deriveSidebarStatus = vi.fn(() => ({
+      activityState: 'WORKING' as const,
+      ciState: 'NONE' as const,
+    }));
+
+    const result = assembleWorkspaceDerivedState(
+      {
+        lifecycle: WorkspaceStatus.READY,
+        prUrl: null,
+        prState: PRState.NONE,
+        prCiStatus: 'UNKNOWN',
+        ratchetState: RatchetState.IDLE,
+        hasHadSessions: true,
+        sessionIsWorking: true,
+        flowState: DEFAULT_WORKSPACE_DERIVED_FLOW_STATE,
+      },
+      {
+        computeKanbanColumn,
+        deriveSidebarStatus,
+      }
+    );
+
+    expect(result.isWorking).toBe(true);
+    expect(computeKanbanColumn).toHaveBeenCalledWith(expect.objectContaining({ isWorking: true }));
+    expect(deriveSidebarStatus).toHaveBeenCalledWith(expect.objectContaining({ isWorking: true }));
   });
 });

--- a/src/backend/lib/workspace-derived-state.ts
+++ b/src/backend/lib/workspace-derived-state.ts
@@ -59,7 +59,7 @@ export function assembleWorkspaceDerivedState(
   input: WorkspaceDerivedStateInput,
   fns: WorkspaceDerivedStateFns
 ): WorkspaceDerivedState {
-  const isWorking = input.sessionIsWorking || input.flowState.isWorking;
+  const isWorking = input.sessionIsWorking;
 
   return {
     isWorking,

--- a/src/backend/orchestration/snapshot-reconciliation.orchestrator.test.ts
+++ b/src/backend/orchestration/snapshot-reconciliation.orchestrator.test.ts
@@ -670,6 +670,43 @@ describe('SnapshotReconciliationService', () => {
       expect(upsertFields.isWorking).toBe(true);
     });
 
+    it('does not treat stale persisted RUNNING sessions as working after restart', async () => {
+      const ws = createMockWorkspace({
+        id: 'ws-1',
+        worktreePath: null,
+        agentSessions: [
+          {
+            id: 'cs-stale',
+            name: 'Stale Chat',
+            workflow: 'followup',
+            model: 'claude-sonnet',
+            status: 'RUNNING',
+            updatedAt: new Date('2026-01-03T15:00:00.000Z'),
+          },
+        ],
+      });
+      mockFindAllNonArchived.mockResolvedValue([ws]);
+      vi.mocked(bridges.session.getRuntimeSnapshot).mockReturnValue({
+        phase: 'idle',
+        processState: 'stopped',
+        activity: 'IDLE',
+        updatedAt: '2026-01-03T15:00:00.000Z',
+      });
+
+      await service.reconcile();
+
+      const upsertFields = mockUpsert.mock.calls[0]![1] as SnapshotUpdateInput;
+      expect(upsertFields.sessionSummaries).toEqual([
+        expect.objectContaining({
+          sessionId: 'cs-stale',
+          persistedStatus: 'RUNNING',
+          runtimePhase: 'idle',
+          activity: 'IDLE',
+        }),
+      ]);
+      expect(upsertFields.isWorking).toBe(false);
+    });
+
     it('returns ReconciliationResult with correct counts', async () => {
       const ws1 = createMockWorkspace({
         id: 'ws-1',

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -397,13 +397,13 @@ export function createServer(requestedPort?: number, appContext?: AppContext): S
 
             await runStartupReconciliation();
 
-            configureSnapshotReconciliation(context.services);
-
             if (startupFailed) {
               return;
             }
 
             server.listen(actualPort, REQUESTED_HOST, async () => {
+              configureSnapshotReconciliation(context.services);
+
               logger.info('Backend server started', {
                 port: actualPort,
                 environment: configService.getEnvironment(),

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -351,6 +351,13 @@ export function createServer(requestedPort?: number, appContext?: AppContext): S
           reconciliationService.cleanupOrphans()
         );
 
+        // Reset agent sessions that were persisted as RUNNING by a prior process.
+        // Live ACP runtimes are in-memory only, so after a backend restart these
+        // records must not drive workspace "Working" state.
+        await runStartupTask('Failed to recover stale agent sessions on startup', async () => {
+          await sessionService.recoverStaleSessionStates();
+        });
+
         // Reconcile workspaces that may have been left in inconsistent states
         // (e.g., stuck in PROVISIONING due to server crash)
         await runStartupTask('Failed to reconcile workspaces on startup', () =>
@@ -376,45 +383,60 @@ export function createServer(requestedPort?: number, appContext?: AppContext): S
       };
 
       return new Promise((resolve, reject) => {
-        server.listen(actualPort, REQUESTED_HOST, async () => {
-          logger.info('Backend server started', {
-            port: actualPort,
-            environment: configService.getEnvironment(),
-          });
-          if (configService.isRunScriptProxyEnabled()) {
-            process.stdout.write(`BACKEND_PORT:${actualPort}\n`);
-          }
-
-          configureDomainBridges(context.services);
-          configureEventCollector(context.services);
-          configureSnapshotReconciliation(context.services);
-
-          await runStartupReconciliation();
-
-          sessionFileLogger.cleanupOldLogs();
-          acpTraceLogger.cleanupOldLogs();
-          await startInterceptors();
-          reconciliationService.startPeriodicCleanup();
-          rateLimiter.start();
-          schedulerService.start();
-          ratchetService.start();
-
-          logger.info('Server endpoints available', {
-            server: `http://${ENDPOINT_HOST}:${actualPort}`,
-            health: `http://${ENDPOINT_HOST}:${actualPort}/health`,
-            healthAll: `http://${ENDPOINT_HOST}:${actualPort}/health/all`,
-            trpc: `http://${ENDPOINT_HOST}:${actualPort}/api/trpc`,
-            wsChat: `ws://${ENDPOINT_HOST}:${actualPort}/chat`,
-            wsTerminal: `ws://${ENDPOINT_HOST}:${actualPort}/terminal`,
-            wsSnapshots: `ws://${ENDPOINT_HOST}:${actualPort}/snapshots`,
-          });
-
-          resolve(`http://${ENDPOINT_HOST}:${actualPort}`);
-        });
-
-        server.on('error', (error) => {
+        let startupFailed = false;
+        const onServerError = (error: Error) => {
+          startupFailed = true;
           reject(error);
-        });
+        };
+        server.once('error', onServerError);
+
+        void (async () => {
+          try {
+            configureDomainBridges(context.services);
+            configureEventCollector(context.services);
+
+            await runStartupReconciliation();
+
+            configureSnapshotReconciliation(context.services);
+
+            if (startupFailed) {
+              return;
+            }
+
+            server.listen(actualPort, REQUESTED_HOST, async () => {
+              logger.info('Backend server started', {
+                port: actualPort,
+                environment: configService.getEnvironment(),
+              });
+              if (configService.isRunScriptProxyEnabled()) {
+                process.stdout.write(`BACKEND_PORT:${actualPort}\n`);
+              }
+
+              sessionFileLogger.cleanupOldLogs();
+              acpTraceLogger.cleanupOldLogs();
+              await startInterceptors();
+              reconciliationService.startPeriodicCleanup();
+              rateLimiter.start();
+              schedulerService.start();
+              ratchetService.start();
+
+              logger.info('Server endpoints available', {
+                server: `http://${ENDPOINT_HOST}:${actualPort}`,
+                health: `http://${ENDPOINT_HOST}:${actualPort}/health`,
+                healthAll: `http://${ENDPOINT_HOST}:${actualPort}/health/all`,
+                trpc: `http://${ENDPOINT_HOST}:${actualPort}/api/trpc`,
+                wsChat: `ws://${ENDPOINT_HOST}:${actualPort}/chat`,
+                wsTerminal: `ws://${ENDPOINT_HOST}:${actualPort}/terminal`,
+                wsSnapshots: `ws://${ENDPOINT_HOST}:${actualPort}/snapshots`,
+              });
+
+              resolve(`http://${ENDPOINT_HOST}:${actualPort}`);
+            });
+          } catch (error) {
+            server.off('error', onServerError);
+            reject(error);
+          }
+        })();
       });
     },
 

--- a/src/backend/server.upgrade.test.ts
+++ b/src/backend/server.upgrade.test.ts
@@ -459,6 +459,7 @@ describe('server websocket upgrade routing', () => {
     httpServer.emit('error', new Error('listen failed'));
 
     await expect(startPromise).rejects.toThrow('listen failed');
+    expect(configureSnapshotReconciliation).not.toHaveBeenCalled();
   });
 
   it('runs cleanup fan-out when server stops', async () => {

--- a/src/backend/server.upgrade.test.ts
+++ b/src/backend/server.upgrade.test.ts
@@ -165,6 +165,7 @@ function createTestHarness(options: TestHarnessOptions = {}) {
     },
     sessionService: {
       stopAllClients: vi.fn(async () => undefined),
+      recoverStaleSessionStates: vi.fn(async () => 0),
     },
     terminalService: {
       cleanup: vi.fn(),
@@ -369,6 +370,7 @@ describe('server websocket upgrade routing', () => {
     expect(configureEventCollector).toHaveBeenCalledWith(harness.context.services);
     expect(configureSnapshotReconciliation).toHaveBeenCalledWith(harness.context.services);
     expect(reconciliationService.cleanupOrphans).toHaveBeenCalledOnce();
+    expect(harness.services.sessionService.recoverStaleSessionStates).toHaveBeenCalledOnce();
     expect(reconciliationService.reconcile).toHaveBeenCalledOnce();
     expect(runScriptStateMachine.recoverStaleStates).toHaveBeenCalledOnce();
     expect(recoverStaleArchivingWorkspaces).toHaveBeenCalledWith(harness.context.services);
@@ -376,9 +378,13 @@ describe('server websocket upgrade routing', () => {
       .invocationCallOrder[0];
     const archiveRecoveryOrder = vi.mocked(recoverStaleArchivingWorkspaces).mock
       .invocationCallOrder[0];
+    const snapshotReconciliationOrder = vi.mocked(configureSnapshotReconciliation).mock
+      .invocationCallOrder[0];
     expect(runScriptRecoveryOrder).toBeDefined();
     expect(archiveRecoveryOrder).toBeDefined();
+    expect(snapshotReconciliationOrder).toBeDefined();
     expect(runScriptRecoveryOrder ?? 0).toBeLessThan(archiveRecoveryOrder ?? 0);
+    expect(archiveRecoveryOrder ?? 0).toBeLessThan(snapshotReconciliationOrder ?? 0);
     expect(startInterceptors).toHaveBeenCalledOnce();
     expect(reconciliationService.startPeriodicCleanup).toHaveBeenCalledOnce();
     expect(harness.services.rateLimiter.start).toHaveBeenCalledOnce();
@@ -401,8 +407,12 @@ describe('server websocket upgrade routing', () => {
   });
 
   it('logs startup reconciliation failures and continues starting', async () => {
+    const harness = createTestHarness({ requestedPortResult: 0 });
     vi.mocked(reconciliationService.cleanupOrphans).mockRejectedValueOnce(
       new Error('cleanup failed')
+    );
+    vi.mocked(harness.services.sessionService.recoverStaleSessionStates).mockRejectedValueOnce(
+      new Error('session recovery failed')
     );
     vi.mocked(reconciliationService.reconcile).mockRejectedValueOnce(new Error('reconcile failed'));
     vi.mocked(runScriptStateMachine.recoverStaleStates).mockRejectedValueOnce(
@@ -412,12 +422,15 @@ describe('server websocket upgrade routing', () => {
       new Error('archive recovery failed')
     );
 
-    const harness = createTestHarness({ requestedPortResult: 0 });
     const server = createTestServer(harness.context, 0);
 
     await expect(server.start()).resolves.toBe('http://localhost:0');
     expect(harness.logger.error).toHaveBeenCalledWith(
       'Failed to cleanup orphan sessions on startup',
+      expect.any(Object)
+    );
+    expect(harness.logger.error).toHaveBeenCalledWith(
+      'Failed to recover stale agent sessions on startup',
       expect.any(Object)
     );
     expect(harness.logger.error).toHaveBeenCalledWith(

--- a/src/backend/services/session/resources/agent-session.accessor.test.ts
+++ b/src/backend/services/session/resources/agent-session.accessor.test.ts
@@ -8,6 +8,7 @@ const mockFindUnique = vi.fn();
 const mockFindMany = vi.fn();
 const mockCount = vi.fn();
 const mockUpdate = vi.fn();
+const mockUpdateMany = vi.fn();
 const mockDelete = vi.fn();
 const mockUserSettingsGet = vi.fn();
 
@@ -19,6 +20,7 @@ vi.mock('@/backend/db', () => ({
       findMany: (...args: unknown[]) => mockFindMany(...args),
       count: (...args: unknown[]) => mockCount(...args),
       update: (...args: unknown[]) => mockUpdate(...args),
+      updateMany: (...args: unknown[]) => mockUpdateMany(...args),
       delete: (...args: unknown[]) => mockDelete(...args),
     },
     $transaction: vi.fn(),
@@ -201,6 +203,22 @@ describe('agentSessionAccessor', () => {
         providerProcessPid: { not: null },
       },
       orderBy: { updatedAt: 'desc' },
+    });
+  });
+
+  it('recoverStaleRunning marks persisted running sessions idle and clears pids', async () => {
+    mockUpdateMany.mockResolvedValue({ count: 2 });
+
+    await expect(agentSessionAccessor.recoverStaleRunning()).resolves.toBe(2);
+
+    expect(mockUpdateMany).toHaveBeenCalledWith({
+      where: {
+        status: SessionStatus.RUNNING,
+      },
+      data: {
+        status: SessionStatus.IDLE,
+        providerProcessPid: null,
+      },
     });
   });
 });

--- a/src/backend/services/session/resources/agent-session.accessor.ts
+++ b/src/backend/services/session/resources/agent-session.accessor.ts
@@ -65,6 +65,7 @@ export interface AgentSessionAccessor {
   update(id: string, data: UpdateAgentSessionInput): Promise<AgentSessionRecord>;
   delete(id: string): Promise<AgentSessionRecord>;
   findWithPid(): Promise<AgentSessionRecord[]>;
+  recoverStaleRunning(): Promise<number>;
   acquireFixerSession(input: AcquireFixerAgentSessionInput): Promise<FixerAgentSessionAcquisition>;
 }
 
@@ -178,6 +179,20 @@ class PrismaAgentSessionAccessor implements AgentSessionAccessor {
       },
       orderBy: { updatedAt: 'desc' },
     });
+  }
+
+  async recoverStaleRunning(): Promise<number> {
+    const result = await prisma.agentSession.updateMany({
+      where: {
+        status: SessionStatus.RUNNING,
+      },
+      data: {
+        status: SessionStatus.IDLE,
+        providerProcessPid: null,
+      },
+    });
+
+    return result.count;
   }
 
   acquireFixerSession(input: AcquireFixerAgentSessionInput): Promise<FixerAgentSessionAcquisition> {

--- a/src/backend/services/session/service/lifecycle/session.repository.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.repository.test.ts
@@ -28,6 +28,7 @@ describe('SessionRepository', () => {
     findByWorkspaceId: vi.fn<() => Promise<AgentSessionRecord[]>>(),
     update: vi.fn<() => Promise<AgentSessionRecord>>(),
     delete: vi.fn<() => Promise<AgentSessionRecord>>(),
+    recoverStaleRunning: vi.fn<() => Promise<number>>(),
   };
 
   const workspaces = {
@@ -84,5 +85,13 @@ describe('SessionRepository', () => {
       /immutable/
     );
     expect(sessions.update).not.toHaveBeenCalled();
+  });
+
+  it('delegates stale running session recovery to the session accessor', async () => {
+    sessions.recoverStaleRunning.mockResolvedValue(3);
+
+    await expect(repository.recoverStaleRunningSessions()).resolves.toBe(3);
+
+    expect(sessions.recoverStaleRunning).toHaveBeenCalledOnce();
   });
 });

--- a/src/backend/services/session/service/lifecycle/session.repository.ts
+++ b/src/backend/services/session/service/lifecycle/session.repository.ts
@@ -23,6 +23,7 @@ type SessionAccessor = {
     >
   ): Promise<AgentSessionRecord>;
   delete(id: string): Promise<AgentSessionRecord>;
+  recoverStaleRunning(): Promise<number>;
 };
 
 type WorkspaceAccessor = {
@@ -111,6 +112,10 @@ export class SessionRepository {
 
   deleteSession(sessionId: string): Promise<AgentSessionRecord> {
     return this.sessions.delete(sessionId);
+  }
+
+  recoverStaleRunningSessions(): Promise<number> {
+    return this.sessions.recoverStaleRunning();
   }
 }
 

--- a/src/backend/services/session/service/lifecycle/session.service.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.service.test.ts
@@ -69,6 +69,7 @@ vi.mock('./session.repository', () => ({
     markWorkspaceHasHadSessions: vi.fn(),
     updateSession: vi.fn(),
     deleteSession: vi.fn(),
+    recoverStaleRunningSessions: vi.fn(),
   },
 }));
 

--- a/src/backend/services/session/service/lifecycle/session.service.ts
+++ b/src/backend/services/session/service/lifecycle/session.service.ts
@@ -168,6 +168,16 @@ export class SessionService {
     await this.lifecycleService.stopWorkspaceSessions(workspaceId);
   }
 
+  async recoverStaleSessionStates(): Promise<number> {
+    const recoveredCount = await this.repository.recoverStaleRunningSessions();
+    if (recoveredCount > 0) {
+      logger.info('Recovered stale agent session states on startup', {
+        recoveredCount,
+      });
+    }
+    return recoveredCount;
+  }
+
   getOrCreateSessionClient(
     sessionId: string,
     options?: {

--- a/src/backend/services/workspace-snapshot-store.service.test.ts
+++ b/src/backend/services/workspace-snapshot-store.service.test.ts
@@ -412,7 +412,7 @@ describe('WorkspaceSnapshotStore', () => {
       expect(entry!.sidebarStatus.ciState).toBe('RUNNING');
     });
 
-    it('kanbanColumn reflects isWorking from flow state', () => {
+    it('kanbanColumn does not treat PR flow as live agent work', () => {
       store.upsert(
         'ws-1',
         makeUpdate({
@@ -424,10 +424,10 @@ describe('WorkspaceSnapshotStore', () => {
       );
 
       const entry = store.getByWorkspaceId('ws-1');
-      // Flow state returns isWorking=true (prUrl set + PENDING)
-      // Effective isWorking = session(false) OR flow(true) = true
-      expect(entry!.isWorking).toBe(true);
-      expect(entry!.kanbanColumn).toBe('WORKING');
+      expect(entry!.flowPhase).toBe('CI_WAIT');
+      expect(entry!.isWorking).toBe(false);
+      expect(entry!.sidebarStatus.activityState).toBe('IDLE');
+      expect(entry!.kanbanColumn).toBe('WAITING');
     });
 
     it('does not latch flow-derived isWorking across PR-only updates', () => {
@@ -442,12 +442,12 @@ describe('WorkspaceSnapshotStore', () => {
         100
       );
 
-      // Initial effective isWorking is true because flow is active.
-      expect(store.getByWorkspaceId('ws-1')!.isWorking).toBe(true);
+      // PR flow can be active without making the workspace look like an agent is working.
+      expect(store.getByWorkspaceId('ws-1')!.isWorking).toBe(false);
 
       store.upsert('ws-1', { prCiStatus: 'SUCCESS' }, 'test', 200);
 
-      // Session signal remains false, so effective isWorking should clear.
+      // Session signal remains false, so visible isWorking should stay clear.
       const entry = store.getByWorkspaceId('ws-1');
       expect(entry!.isWorking).toBe(false);
       expect(entry!.sidebarStatus.activityState).toBe('IDLE');
@@ -470,13 +470,11 @@ describe('WorkspaceSnapshotStore', () => {
       expect(entry!.ratchetButtonAnimated).toBe(true);
     });
 
-    it('derived state uses effective isWorking (session OR flow)', () => {
+    it('derived state uses session activity for visible working state', () => {
       // isWorking=true from session, prUrl=null so flow isWorking=false
-      // Effective isWorking should be true (session OR flow)
       store.upsert('ws-1', makeUpdate({ isWorking: true, prUrl: null }), 'test', 100);
 
       const entry = store.getByWorkspaceId('ws-1');
-      // sidebarStatus should reflect effective isWorking=true
       expect(entry!.sidebarStatus.activityState).toBe('WORKING');
     });
 

--- a/src/backend/services/workspace/service/query/workspace-query.service.test.ts
+++ b/src/backend/services/workspace/service/query/workspace-query.service.test.ts
@@ -364,7 +364,7 @@ describe('WorkspaceQueryService', () => {
     mockDeriveWorkspaceRuntimeState.mockReturnValue({
       sessionIds: ['s-eq'],
       isSessionWorking: false,
-      isWorking: flowState.isWorking,
+      isWorking: false,
       flowState,
     });
 

--- a/src/backend/services/workspace/service/state/kanban-state.ts
+++ b/src/backend/services/workspace/service/state/kanban-state.ts
@@ -3,7 +3,6 @@ import { createLogger } from '@/backend/services/logger.service';
 import { workspaceAccessor } from '@/backend/services/workspace/resources/workspace.accessor';
 import type { WorkspaceSessionBridge } from '@/backend/services/workspace/service/bridges';
 import { KanbanColumn, PRState, RatchetState, WorkspaceStatus } from '@/shared/core';
-import { deriveWorkspaceFlowStateFromWorkspace } from './flow-state';
 import { deriveWorkspaceRuntimeState } from './workspace-runtime-state';
 
 const logger = createLogger('kanban-state');
@@ -175,12 +174,12 @@ class KanbanStateService {
       return;
     }
 
-    const flowState = deriveWorkspaceFlowStateFromWorkspace(workspace);
-
-    // For cached column, include flow-state working but not in-memory session activity.
+    // Cached columns cannot know in-memory session activity. Do not treat PR/CI
+    // flow progress as live agent work, or restarted processes can remain in
+    // the Working column without an active prompt.
     const cachedColumn = computeKanbanColumn({
       lifecycle: workspace.status,
-      isWorking: flowState.isWorking,
+      isWorking: false,
       prState: workspace.prState,
       ratchetState: workspace.ratchetState,
       hasHadSessions: workspace.hasHadSessions,

--- a/src/backend/services/workspace/service/state/workspace-runtime-state.ts
+++ b/src/backend/services/workspace/service/state/workspace-runtime-state.ts
@@ -27,6 +27,6 @@ export function deriveWorkspaceRuntimeState(
     sessionIds,
     isSessionWorking,
     flowState,
-    isWorking: isSessionWorking || flowState.isWorking,
+    isWorking: isSessionWorking,
   };
 }


### PR DESCRIPTION
## Summary
- Recover stale persisted RUNNING agent sessions on backend startup so restarted app instances do not show workspaces as actively working.
- Base workspace working state and pulsing indicators on live session activity only, while preserving PR/CI/ratchet flow metadata.
- Seed snapshot reconciliation after startup recovery so reconnecting clients receive corrected workspace state.

## Tests
- pnpm vitest run src/backend/server.upgrade.test.ts src/backend/services/session/resources/agent-session.accessor.test.ts src/backend/services/session/service/lifecycle/session.repository.test.ts src/backend/lib/workspace-derived-state.test.ts src/backend/services/workspace-snapshot-store.service.test.ts src/backend/services/workspace/service/query/workspace-query.service.test.ts src/backend/services/workspace/service/state/kanban-state.test.ts src/backend/orchestration/snapshot-reconciliation.orchestrator.test.ts
- pnpm typecheck
- pnpm check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how workspace `isWorking` is derived and adds startup recovery that mutates persisted session state; mistakes could hide real activity or incorrectly mark sessions idle after restart.
> 
> **Overview**
> Workspace *working* state is now derived **only from live session activity** (not PR/CI flow), so PR progress no longer drives `isWorking`, sidebar activity, or cached kanban columns.
> 
> On backend startup, a new recovery step resets any persisted `RUNNING` agent sessions to `IDLE` (clearing stored PIDs) before reconciliation, and server startup ordering is adjusted so snapshot reconciliation is configured only after successful startup tasks.
> 
> Tests are updated/added across derived state, snapshot reconciliation, server startup, and session persistence to cover stale-`RUNNING` recovery and the new `isWorking` semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfaba1d6cbbaaed97e97cc851868a858ec344278. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->