### PR TITLE
Clarify workspace runtime activity checks

### DIFF
--- a/src/backend/lib/session-summaries.ts
+++ b/src/backend/lib/session-summaries.ts
@@ -1,6 +1,10 @@
 import type { WorkspaceSessionSummary } from '@/backend/services/workspace-snapshot-store.service';
 import type { SessionStatus as DbSessionStatus } from '@/shared/core';
-import type { SessionRuntimeState } from '@/shared/session-runtime';
+import {
+  hasWorkingSessionSummary as hasWorkingRuntimeSessionSummary,
+  isSessionSummaryWorking as isRuntimeSessionSummaryWorking,
+  type SessionRuntimeState,
+} from '@/shared/session-runtime';
 
 interface SessionLike {
   id: string;
@@ -35,9 +39,9 @@ export function buildWorkspaceSessionSummaries(
 }
 
 export function isSessionSummaryWorking(summary: WorkspaceSessionSummary): boolean {
-  return summary.activity === 'WORKING' || summary.runtimePhase === 'running';
+  return isRuntimeSessionSummaryWorking(summary);
 }
 
 export function hasWorkingSessionSummary(summaries: WorkspaceSessionSummary[]): boolean {
-  return summaries.some((summary) => isSessionSummaryWorking(summary));
+  return hasWorkingRuntimeSessionSummary(summaries);
 }

--- a/src/client/routes/projects/workspaces/workspace-detail-container.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-container.tsx
@@ -11,7 +11,7 @@ import {
   resolveEffectiveSessionProvider,
   type SessionProviderValue,
 } from '@/lib/session-provider-selection';
-import type { SessionRuntimeState } from '@/shared/session-runtime';
+import { isSessionSummaryWorking, type SessionRuntimeState } from '@/shared/session-runtime';
 import { forgetResumeWorkspace } from './resume-workspace-storage';
 import { useSessionManagement, useWorkspaceData } from './use-workspace-detail';
 import {
@@ -20,6 +20,7 @@ import {
   useWorkspaceInitStatus,
 } from './use-workspace-detail-hooks';
 import type { ChatContentProps } from './workspace-detail-chat-content';
+import { hasUserMessageWithoutAgentMessage } from './workspace-detail-container.utils';
 import { WorkspaceDetailView } from './workspace-detail-view';
 
 function areRuntimeStatesEqual(
@@ -220,8 +221,7 @@ export function WorkspaceDetailContainer() {
     selectedDbSessionId !== null &&
     (sessionStatus.phase === 'loading' || sessionStatus.phase === 'ready') &&
     processStatus.state === 'unknown' &&
-    messages.some((message) => message.source === 'user') &&
-    !messages.some((message) => message.source === 'agent');
+    hasUserMessageWithoutAgentMessage(messages);
 
   const [liveSessionRuntimeById, setLiveSessionRuntimeById] = useState<
     Map<string, SessionRuntimeState>
@@ -271,9 +271,7 @@ export function WorkspaceDetailContainer() {
   );
   const workspaceRunning = useMemo(
     () =>
-      Array.from(sessionSummariesById.values()).some(
-        (summary) => summary.activity === 'WORKING' || summary.runtimePhase === 'running'
-      ),
+      Array.from(sessionSummariesById.values()).some((summary) => isSessionSummaryWorking(summary)),
     [sessionSummariesById]
   );
 

--- a/src/client/routes/projects/workspaces/workspace-detail-container.utils.test.ts
+++ b/src/client/routes/projects/workspaces/workspace-detail-container.utils.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { hasUserMessageWithoutAgentMessage } from './workspace-detail-container.utils';
+
+describe('workspace detail container utils', () => {
+  it('returns true when the transcript has a user message and no agent message', () => {
+    expect(hasUserMessageWithoutAgentMessage([{ source: 'user' }])).toBe(true);
+  });
+
+  it('returns false when the transcript has no user message', () => {
+    expect(hasUserMessageWithoutAgentMessage([])).toBe(false);
+  });
+
+  it('returns false when any agent message is present', () => {
+    expect(hasUserMessageWithoutAgentMessage([{ source: 'user' }, { source: 'agent' }])).toBe(
+      false
+    );
+  });
+
+  it('stops scanning once an agent message makes the result false', () => {
+    const laterMessage = {
+      get source(): 'user' | 'agent' {
+        throw new Error('later messages should not be inspected');
+      },
+    };
+
+    expect(hasUserMessageWithoutAgentMessage([{ source: 'agent' }, laterMessage])).toBe(false);
+  });
+});

--- a/src/client/routes/projects/workspaces/workspace-detail-container.utils.ts
+++ b/src/client/routes/projects/workspaces/workspace-detail-container.utils.ts
@@ -1,0 +1,18 @@
+import type { ChatMessage } from '@/lib/chat-protocol';
+
+type MessageSourceOnly = Pick<ChatMessage, 'source'>;
+
+export function hasUserMessageWithoutAgentMessage(messages: readonly MessageSourceOnly[]): boolean {
+  let hasUserMessage = false;
+
+  for (const message of messages) {
+    if (message.source === 'agent') {
+      return false;
+    }
+    if (message.source === 'user') {
+      hasUserMessage = true;
+    }
+  }
+
+  return hasUserMessage;
+}

--- a/src/components/workspace/session-tab-runtime.ts
+++ b/src/components/workspace/session-tab-runtime.ts
@@ -8,7 +8,11 @@ import {
   XCircle,
 } from 'lucide-react';
 import type { SessionStatus as DbSessionStatus } from '@/shared/core';
-import { getSessionSummaryErrorMessage, type SessionSummary } from '@/shared/session-runtime';
+import {
+  getSessionSummaryErrorMessage,
+  isSessionSummaryWorking,
+  type SessionSummary,
+} from '@/shared/session-runtime';
 
 export type WorkspaceSessionRuntimeSummary = SessionSummary;
 
@@ -168,7 +172,7 @@ export function deriveSessionTabRuntime(
     };
   }
 
-  if (summary.activity === 'WORKING' || summary.runtimePhase === 'running') {
+  if (isSessionSummaryWorking(summary)) {
     return {
       color: 'text-brand',
       pulse: true,

--- a/src/shared/session-runtime.test.ts
+++ b/src/shared/session-runtime.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
   getSessionRuntimeErrorMessage,
   getSessionSummaryErrorMessage,
+  hasWorkingSessionSummary,
+  isSessionSummaryWorking,
   type SessionRuntimeLastExit,
   type SessionRuntimePhase,
 } from './session-runtime';
@@ -69,4 +71,27 @@ describe('session runtime error message helpers', () => {
       ).toBe(testCase.expected);
     });
   }
+});
+
+describe('session runtime working helpers', () => {
+  it('treats activity WORKING as working even when lifecycle phase has not caught up', () => {
+    expect(isSessionSummaryWorking({ activity: 'WORKING', runtimePhase: 'idle' })).toBe(true);
+  });
+
+  it('treats runtime phase running as working even when activity has not caught up', () => {
+    expect(isSessionSummaryWorking({ activity: 'IDLE', runtimePhase: 'running' })).toBe(true);
+  });
+
+  it('treats idle activity and idle phase as not working', () => {
+    expect(isSessionSummaryWorking({ activity: 'IDLE', runtimePhase: 'idle' })).toBe(false);
+  });
+
+  it('detects any working summary in a list', () => {
+    expect(
+      hasWorkingSessionSummary([
+        { activity: 'IDLE', runtimePhase: 'idle' },
+        { activity: 'IDLE', runtimePhase: 'running' },
+      ])
+    ).toBe(true);
+  });
 });

--- a/src/shared/session-runtime.ts
+++ b/src/shared/session-runtime.ts
@@ -95,6 +95,20 @@ export function getSessionRuntimeErrorMessage(
   return resolveSessionRuntimeErrorMessage(runtime.phase, runtime.errorMessage, runtime.lastExit);
 }
 
+export function isSessionSummaryWorking(
+  summary: Pick<SessionSummary, 'activity' | 'runtimePhase'>
+): boolean {
+  // activity tracks prompt/work-in-flight state; runtimePhase tracks process lifecycle.
+  // Persisted or merged snapshots can briefly expose only one of these signals.
+  return summary.activity === 'WORKING' || summary.runtimePhase === 'running';
+}
+
+export function hasWorkingSessionSummary(
+  summaries: Pick<SessionSummary, 'activity' | 'runtimePhase'>[]
+): boolean {
+  return summaries.some((summary) => isSessionSummaryWorking(summary));
+}
+
 export function findWorkspaceSessionRuntimeError(
   summaries: SessionSummary[] | undefined
 ): { sessionId: string; message: string } | null {


### PR DESCRIPTION
## Summary
- Replace the workspace issue auto-start transcript check with a single-pass helper and tests.
- Move the runtime activity/phase working-state rule into a shared helper with documentation explaining why both signals are considered.
- Reuse the shared working-state helper in workspace detail, session tab runtime display, and backend session summary code.

## Tests
- pnpm vitest run src/client/routes/projects/workspaces/workspace-detail-container.utils.test.ts src/shared/session-runtime.test.ts src/components/workspace/session-tab-runtime.test.ts
- pnpm typecheck
- pnpm check:fix (completed with pre-existing unrelated noImgElement warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes “working” detection and the issue auto-start transcript check; behavior should be equivalent but could affect UI/backend running indicators if the helper semantics are wrong.
> 
> **Overview**
> Consolidates the definition of when a session/workspace is considered *working* by introducing shared helpers in `src/shared/session-runtime.ts` and updating the backend (`session-summaries.ts`) and UI (`workspace-detail-container.tsx`, `session-tab-runtime.ts`) to use them instead of duplicating inline checks.
> 
> Refactors the GitHub-issue auto-start “transcript has user but no agent message” condition into a single-pass utility `hasUserMessageWithoutAgentMessage` with new Vitest coverage, and adds tests for the new shared working-state helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed3d3fcb769124f800bbfd3fa9af71b1b1b4da9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->