### PR TITLE
Allow archiving workspaces in PROVISIONING state

### DIFF
--- a/docs/design/archive-provisioning-workspace.md
+++ b/docs/design/archive-provisioning-workspace.md
@@ -1,0 +1,91 @@
+# Archive Workspace from PROVISIONING State
+
+## Problem Statement
+
+When a workspace gets stuck or encounters an error during `PROVISIONING`, users cannot archive it. The state machine (`state-machine.service.ts`) only permits `READY` and `FAILED` to transition to `ARCHIVING`:
+
+```ts
+PROVISIONING: ['READY', 'FAILED'],  // no ARCHIVING allowed
+```
+
+This causes `archiveWorkspace()` in `workspace-archive.orchestrator.ts` to throw:
+
+```
+Cannot archive workspace from status: PROVISIONING
+```
+
+There is a "stale PROVISIONING" recovery mechanism (10-minute threshold) that transitions stuck workspaces to `FAILED` on restart, but users cannot manually trigger cleanup mid-session. This is a problem when provisioning hangs or errors occur during workspace initialization.
+
+## What Happens During Provisioning
+
+The `initializeWorkspaceWorktree()` function runs several side-effectful operations in sequence:
+
+1. Creates a git worktree
+2. Loads `factory-factory.json` config
+3. Creates a default terminal
+4. Starts the agent session (fire-and-forget)
+5. Executes startup script pipeline
+6. Transitions to `READY` or `FAILED`
+
+If a user archives mid-provisioning, these may be partially complete -- some resources may exist, some may not.
+
+## Potential Solutions
+
+### Option A: Add `PROVISIONING -> ARCHIVING` to the state machine
+
+Add the transition directly. The archive orchestrator already handles missing resources gracefully (it stops sessions, terminals, run scripts, cleans up worktree). The main risk is a race condition: the provisioning process continues running concurrently and may re-transition to `READY` or `FAILED` after archive starts.
+
+**Pros:** Minimal code change, reuses existing archive logic
+**Cons:** Race condition between provisioning coroutine and archive; provisioning could undo partial cleanup or cause double-transitions
+
+### Option B: Force-transition to `FAILED` first, then archive
+
+When archive is requested from `PROVISIONING`, first force the workspace to `FAILED` (canceling/ignoring the in-progress provisioning), then run the normal archive flow. This respects the existing state machine.
+
+**Pros:** Clean separation of concerns, no new state transitions needed, existing archive path handles everything
+**Cons:** Requires a mechanism to signal the provisioning process to abort; if provisioning is fire-and-forget, it may still complete and fight the FAILED state
+
+### Option C: New `FORCE_ARCHIVE` escape hatch
+
+Add a separate `forceArchiveWorkspace()` that bypasses state validation entirely, runs full cleanup, and marks `ARCHIVED`. Only exposed via a separate "Force Archive" UI action.
+
+**Pros:** Doesn't touch the state machine; explicit user intent
+**Cons:** Code duplication, harder to maintain, bypassing the state machine could hide bugs
+
+### Option D: Extend `ARCHIVING` rollback to include `PROVISIONING`
+
+The current rollback in `archiveWorkspace()` records the pre-archive status to roll back to on failure. Allow `ARCHIVING` to record `PROVISIONING` as its source, and add `ARCHIVING -> PROVISIONING` as a valid rollback transition.
+
+**Pros:** Most state-machine-correct
+**Cons:** Complex; provisioning state is not safely resumable after partial archive cleanup
+
+## Chosen Solution: Hybrid of A and B
+
+We chose a hybrid approach that adds `PROVISIONING -> ARCHIVING` as a valid state transition (Option A) while also addressing the race condition with the provisioning coroutine (the key concern from Option B).
+
+### Key Design Decisions
+
+1. **Direct `PROVISIONING -> ARCHIVING` transition**: The state machine now allows archiving directly from `PROVISIONING`, keeping the user-facing behavior simple (normal "Archive" button works).
+
+2. **Atomic CAS-based `markFailedIfProvisioning`**: A new state machine method uses compare-and-swap to transition `PROVISIONING -> FAILED` only if the workspace is still in `PROVISIONING` state. The init orchestrator's failure handler uses this instead of `markFailed`, so if archive has already moved the workspace to `ARCHIVING`, the provisioning coroutine stands down rather than fighting the archive.
+
+3. **Rollback to `FAILED` on archive failure**: If archive was triggered from `PROVISIONING` and the archive itself fails, the workspace rolls back to `FAILED` (not `PROVISIONING`), since provisioning cannot be safely resumed after partial cleanup.
+
+4. **Best-effort cleanup**: The archive process cleans up whatever resources exist (sessions, terminals, run scripts, worktree) and silently handles missing ones. This is acceptable since archiving from `PROVISIONING` is a rare recovery path.
+
+### Race Condition Analysis
+
+The critical race is between the archive request and the in-flight provisioning coroutine:
+
+1. Archive atomically transitions `PROVISIONING -> ARCHIVING` via CAS
+2. Provisioning coroutine tries `markReady` -- reads `ARCHIVING`, `ARCHIVING -> READY` is invalid, throws
+3. Provisioning catch block calls `markFailedIfProvisioning` -- CAS against `PROVISIONING` fails (status is `ARCHIVING`), returns `false`
+4. Provisioning stands down, archive completes cleanup
+
+This eliminates the window where the provisioning coroutine could revert an in-progress archive by calling `markFailed` on an `ARCHIVING` workspace (since `ARCHIVING -> FAILED` is a valid rollback transition).
+
+### Files Changed
+
+- `state-machine.service.ts`: Added `ARCHIVING` to `PROVISIONING` valid transitions, expanded `ArchivingSourceStatus` type, added `markFailedIfProvisioning()` method
+- `workspace-archive.orchestrator.ts`: Updated rollback to use `FAILED` when source was `PROVISIONING`
+- `workspace-init.orchestrator.ts`: `handleWorkspaceInitFailure` uses `markFailedIfProvisioning` with early return on `false`

--- a/src/backend/orchestration/workspace-archive.orchestrator.test.ts
+++ b/src/backend/orchestration/workspace-archive.orchestrator.test.ts
@@ -284,6 +284,49 @@ describe('archiveWorkspace', () => {
       await expect(archiveWorkspace(workspace, defaultOptions)).rejects.toThrow();
       expect(workspaceStateMachine.transition).toHaveBeenCalledWith('ws-1', 'FAILED');
     });
+
+    it('rolls back to FAILED (not PROVISIONING) when archive from PROVISIONING fails', async () => {
+      vi.mocked(workspaceStateMachine.startArchivingWithSourceStatus).mockResolvedValue(
+        unsafeCoerce({
+          workspace: { id: 'ws-1', status: 'ARCHIVING' },
+          previousStatus: 'PROVISIONING',
+        })
+      );
+      vi.mocked(worktreeLifecycleService.cleanupWorkspaceWorktree).mockRejectedValue(
+        new Error('cleanup failed')
+      );
+      const workspace = makeWorkspace({ status: 'PROVISIONING' as never });
+
+      await expect(archiveWorkspace(workspace, defaultOptions)).rejects.toThrow();
+      expect(workspaceStateMachine.transition).toHaveBeenCalledWith('ws-1', 'FAILED');
+    });
+  });
+
+  describe('archiving from PROVISIONING state', () => {
+    it('archives successfully when workspace is in PROVISIONING state', async () => {
+      vi.mocked(workspaceStateMachine.startArchivingWithSourceStatus).mockResolvedValue(
+        unsafeCoerce({
+          workspace: { id: 'ws-1', status: 'ARCHIVING' },
+          previousStatus: 'PROVISIONING',
+        })
+      );
+      const workspace = makeWorkspace({ status: 'PROVISIONING' as never });
+
+      await archiveWorkspace(workspace, defaultOptions);
+
+      expect(workspaceStateMachine.startArchivingWithSourceStatus).toHaveBeenCalledWith('ws-1');
+      expect(workspaceStateMachine.markArchived).toHaveBeenCalledWith('ws-1');
+    });
+
+    it('checks transition from PROVISIONING to ARCHIVING', async () => {
+      const workspace = makeWorkspace({ status: 'PROVISIONING' as never });
+      await archiveWorkspace(workspace, defaultOptions);
+
+      expect(workspaceStateMachine.isValidTransition).toHaveBeenCalledWith(
+        'PROVISIONING',
+        'ARCHIVING'
+      );
+    });
   });
 
   describe('GitHub issue comment on archive', () => {

--- a/src/backend/orchestration/workspace-archive.orchestrator.ts
+++ b/src/backend/orchestration/workspace-archive.orchestrator.ts
@@ -162,12 +162,15 @@ export async function archiveWorkspace(
   try {
     return await completeArchive(workspace, options, services);
   } catch (error) {
+    // If archive was triggered from PROVISIONING, we cannot resume provisioning,
+    // so roll back to FAILED instead (ARCHIVING → PROVISIONING is not a valid transition).
+    const rollbackStatus = statusBeforeArchive === 'PROVISIONING' ? 'FAILED' : statusBeforeArchive;
     try {
-      await workspaceStateMachine.transition(workspace.id, statusBeforeArchive);
+      await workspaceStateMachine.transition(workspace.id, rollbackStatus);
     } catch (rollbackError) {
       logger.error('Failed to rollback workspace status after archive failure', {
         workspaceId: workspace.id,
-        rollbackTo: statusBeforeArchive,
+        rollbackTo: rollbackStatus,
         error: rollbackError instanceof Error ? rollbackError.message : String(rollbackError),
       });
     }

--- a/src/backend/orchestration/workspace-init.orchestrator.test.ts
+++ b/src/backend/orchestration/workspace-init.orchestrator.test.ts
@@ -53,6 +53,7 @@ vi.mock('@/backend/services/workspace', () => ({
   workspaceStateMachine: {
     startProvisioning: vi.fn(),
     markFailed: vi.fn(),
+    markFailedIfProvisioning: vi.fn(),
     markReady: vi.fn(),
     markReadyWithWarning: vi.fn(),
   },
@@ -198,6 +199,7 @@ function setupHappyPath(overrides = {}) {
   vi.mocked(workspaceStateMachine.markReady).mockResolvedValue(unsafeCoerce(workspace));
   vi.mocked(workspaceStateMachine.markReadyWithWarning).mockResolvedValue(unsafeCoerce(workspace));
   vi.mocked(workspaceStateMachine.markFailed).mockResolvedValue(unsafeCoerce(workspace));
+  vi.mocked(workspaceStateMachine.markFailedIfProvisioning).mockResolvedValue(true);
   vi.mocked(githubCLIService.getAuthenticatedUsername).mockResolvedValue('testuser');
   vi.mocked(agentSessionAccessor.findByWorkspaceId).mockResolvedValue([]);
   vi.mocked(sessionService.stopWorkspaceSessions).mockResolvedValue(undefined as never);
@@ -248,13 +250,13 @@ describe('initializeWorkspaceWorktree', () => {
     it('marks failed when workspace has no project', async () => {
       vi.mocked(workspaceStateMachine.startProvisioning).mockResolvedValue(unsafeCoerce({}));
       vi.mocked(workspaceAccessor.findByIdWithProject).mockResolvedValue(null);
-      vi.mocked(workspaceStateMachine.markFailed).mockResolvedValue(unsafeCoerce({}));
+      vi.mocked(workspaceStateMachine.markFailedIfProvisioning).mockResolvedValue(true);
       vi.mocked(sessionService.stopWorkspaceSessions).mockResolvedValue(undefined as never);
       vi.mocked(worktreeLifecycleService.clearInitMode).mockResolvedValue(undefined);
 
       await initializeWorkspaceWorktree(WORKSPACE_ID);
 
-      expect(workspaceStateMachine.markFailed).toHaveBeenCalledWith(
+      expect(workspaceStateMachine.markFailedIfProvisioning).toHaveBeenCalledWith(
         WORKSPACE_ID,
         'Workspace project not found'
       );
@@ -265,13 +267,13 @@ describe('initializeWorkspaceWorktree', () => {
       vi.mocked(workspaceAccessor.findByIdWithProject).mockResolvedValue(
         unsafeCoerce({ id: WORKSPACE_ID, project: null })
       );
-      vi.mocked(workspaceStateMachine.markFailed).mockResolvedValue(unsafeCoerce({}));
+      vi.mocked(workspaceStateMachine.markFailedIfProvisioning).mockResolvedValue(true);
       vi.mocked(sessionService.stopWorkspaceSessions).mockResolvedValue(undefined as never);
       vi.mocked(worktreeLifecycleService.clearInitMode).mockResolvedValue(undefined);
 
       await initializeWorkspaceWorktree(WORKSPACE_ID);
 
-      expect(workspaceStateMachine.markFailed).toHaveBeenCalledWith(
+      expect(workspaceStateMachine.markFailedIfProvisioning).toHaveBeenCalledWith(
         WORKSPACE_ID,
         'Workspace project not found'
       );
@@ -1093,7 +1095,7 @@ describe('initializeWorkspaceWorktree', () => {
 
       await initializeWorkspaceWorktree(WORKSPACE_ID);
 
-      expect(workspaceStateMachine.markFailed).toHaveBeenCalledWith(
+      expect(workspaceStateMachine.markFailedIfProvisioning).toHaveBeenCalledWith(
         WORKSPACE_ID,
         'git worktree add failed'
       );
@@ -1120,7 +1122,7 @@ describe('initializeWorkspaceWorktree', () => {
       // Should not throw
       await initializeWorkspaceWorktree(WORKSPACE_ID);
 
-      expect(workspaceStateMachine.markFailed).toHaveBeenCalled();
+      expect(workspaceStateMachine.markFailedIfProvisioning).toHaveBeenCalled();
     });
 
     it('does not clear init mode when worktree was never created', async () => {
@@ -1182,7 +1184,7 @@ describe('initializeWorkspaceWorktree', () => {
 
       await initializeWorkspaceWorktree(WORKSPACE_ID);
 
-      expect(workspaceStateMachine.markFailed).toHaveBeenCalledWith(
+      expect(workspaceStateMachine.markFailedIfProvisioning).toHaveBeenCalledWith(
         WORKSPACE_ID,
         'db update error'
       );
@@ -1198,7 +1200,7 @@ describe('initializeWorkspaceWorktree', () => {
 
       await initializeWorkspaceWorktree(WORKSPACE_ID);
 
-      expect(workspaceStateMachine.markFailed).toHaveBeenCalledWith(
+      expect(workspaceStateMachine.markFailedIfProvisioning).toHaveBeenCalledWith(
         WORKSPACE_ID,
         'db update error'
       );
@@ -1230,7 +1232,10 @@ describe('initializeWorkspaceWorktree', () => {
       expect(sessionService.stopWorkspaceSessions).toHaveBeenCalledWith(WORKSPACE_ID);
       expect(terminalService.destroyTerminal).toHaveBeenCalledWith(WORKSPACE_ID, 'term-default');
       expect(sessionDataService.clearTerminalPid).toHaveBeenCalledWith('term-default');
-      expect(workspaceStateMachine.markFailed).toHaveBeenCalledWith(WORKSPACE_ID, 'script boom');
+      expect(workspaceStateMachine.markFailedIfProvisioning).toHaveBeenCalledWith(
+        WORKSPACE_ID,
+        'script boom'
+      );
     });
 
     it('does not destroy an existing terminal after init failure', async () => {
@@ -1248,7 +1253,10 @@ describe('initializeWorkspaceWorktree', () => {
       expect(terminalService.createTerminal).not.toHaveBeenCalled();
       expect(terminalService.destroyTerminal).not.toHaveBeenCalled();
       expect(sessionDataService.clearTerminalPid).not.toHaveBeenCalled();
-      expect(workspaceStateMachine.markFailed).toHaveBeenCalledWith(WORKSPACE_ID, 'script boom');
+      expect(workspaceStateMachine.markFailedIfProvisioning).toHaveBeenCalledWith(
+        WORKSPACE_ID,
+        'script boom'
+      );
     });
   });
 

--- a/src/backend/orchestration/workspace-init.orchestrator.ts
+++ b/src/backend/orchestration/workspace-init.orchestrator.ts
@@ -135,6 +135,27 @@ async function readFactoryConfigSafe(
   }
 }
 
+async function cleanupAutoCreatedTerminal(workspaceId: string, terminalId: string): Promise<void> {
+  try {
+    terminalService.destroyTerminal(workspaceId, terminalId);
+  } catch (destroyError) {
+    logger.warn('Failed to destroy default terminal after init failure', {
+      workspaceId,
+      terminalId,
+      error: destroyError instanceof Error ? destroyError.message : String(destroyError),
+    });
+  }
+  try {
+    await sessionDataService.clearTerminalPid(terminalId);
+  } catch (clearPidError) {
+    logger.warn('Failed to clear default terminal PID after init failure', {
+      workspaceId,
+      terminalId,
+      error: clearPidError instanceof Error ? clearPidError.message : String(clearPidError),
+    });
+  }
+}
+
 async function handleWorkspaceInitFailure(
   workspaceId: string,
   error: Error,
@@ -142,32 +163,34 @@ async function handleWorkspaceInitFailure(
   unregisteredWorktreeCleanupCandidate?: UnregisteredWorktreeCleanupCandidate
 ): Promise<void> {
   logger.error('Failed to initialize workspace worktree', error, { workspaceId });
-  await workspaceStateMachine.markFailed(workspaceId, error.message);
+
+  // Always clean up unregistered worktrees: the archive handler only cleans up worktrees
+  // recorded on the workspace record (worktreePath), so a worktree created but not yet
+  // registered would be orphaned on disk.
   if (unregisteredWorktreeCleanupCandidate) {
     await cleanupUnregisteredWorktreeAfterInitFailure(
       workspaceId,
       unregisteredWorktreeCleanupCandidate
     );
   }
+
+  // Use a conditional CAS transition so we don't fight an archive request that may have
+  // already moved this workspace out of PROVISIONING (e.g. user triggered archive while
+  // provisioning was in progress). If the workspace is no longer PROVISIONING, the archive
+  // handler owns cleanup and we should stand down.
+  const transitioned = await workspaceStateMachine.markFailedIfProvisioning(
+    workspaceId,
+    error.message
+  );
+  if (!transitioned) {
+    logger.info(
+      'Workspace no longer in PROVISIONING state during init failure handler, skipping cleanup',
+      { workspaceId }
+    );
+    return;
+  }
   if (autoCreatedTerminalId) {
-    try {
-      terminalService.destroyTerminal(workspaceId, autoCreatedTerminalId);
-    } catch (destroyError) {
-      logger.warn('Failed to destroy default terminal after init failure', {
-        workspaceId,
-        terminalId: autoCreatedTerminalId,
-        error: destroyError instanceof Error ? destroyError.message : String(destroyError),
-      });
-    }
-    try {
-      await sessionDataService.clearTerminalPid(autoCreatedTerminalId);
-    } catch (clearPidError) {
-      logger.warn('Failed to clear default terminal PID after init failure', {
-        workspaceId,
-        terminalId: autoCreatedTerminalId,
-        error: clearPidError instanceof Error ? clearPidError.message : String(clearPidError),
-      });
-    }
+    await cleanupAutoCreatedTerminal(workspaceId, autoCreatedTerminalId);
   }
   try {
     await sessionService.stopWorkspaceSessions(workspaceId);

--- a/src/backend/services/workspace/service/lifecycle/state-machine.service.test.ts
+++ b/src/backend/services/workspace/service/lifecycle/state-machine.service.test.ts
@@ -548,13 +548,17 @@ describe('WorkspaceStateMachineService', () => {
       );
     });
 
-    it('should throw error when trying to start archiving from PROVISIONING', async () => {
+    it('should allow starting archiving from PROVISIONING', async () => {
       const workspace = { id: 'ws-1', status: 'PROVISIONING' };
-      mockFindUnique.mockResolvedValue(workspace);
+      const updatedWorkspace = { ...workspace, status: 'ARCHIVING' };
 
-      await expect(workspaceStateMachine.startArchiving('ws-1')).rejects.toThrow(
-        WorkspaceStateMachineError
-      );
+      mockFindUnique.mockResolvedValue(workspace);
+      mockUpdateMany.mockResolvedValue({ count: 1 });
+      mockFindUniqueOrThrow.mockResolvedValue(updatedWorkspace);
+
+      const result = await workspaceStateMachine.startArchiving('ws-1');
+
+      expect(result.status).toBe('ARCHIVING');
     });
   });
 
@@ -587,6 +591,20 @@ describe('WorkspaceStateMachineService', () => {
       expect(result.workspace.status).toBe('ARCHIVING');
     });
 
+    it('should return previous PROVISIONING status when starting archiving', async () => {
+      const workspace = { id: 'ws-1', status: 'PROVISIONING' };
+      const updatedWorkspace = { ...workspace, status: 'ARCHIVING' };
+
+      mockFindUnique.mockResolvedValue(workspace);
+      mockUpdateMany.mockResolvedValue({ count: 1 });
+      mockFindUniqueOrThrow.mockResolvedValue(updatedWorkspace);
+
+      const result = await workspaceStateMachine.startArchivingWithSourceStatus('ws-1');
+
+      expect(result.previousStatus).toBe('PROVISIONING');
+      expect(result.workspace.status).toBe('ARCHIVING');
+    });
+
     it('should fail when status changes during start archiving CAS', async () => {
       const workspace = { id: 'ws-1', status: 'READY' };
 
@@ -595,6 +613,42 @@ describe('WorkspaceStateMachineService', () => {
 
       await expect(workspaceStateMachine.startArchivingWithSourceStatus('ws-1')).rejects.toThrow(
         /Transition failed: status changed by another process/
+      );
+    });
+  });
+
+  describe('markFailedIfProvisioning', () => {
+    it('transitions to FAILED and returns true when workspace is PROVISIONING', async () => {
+      mockUpdateMany.mockResolvedValue({ count: 1 });
+
+      const result = await workspaceStateMachine.markFailedIfProvisioning('ws-1', 'init error');
+
+      expect(result).toBe(true);
+      expect(mockUpdateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ id: 'ws-1', status: 'PROVISIONING' }),
+          data: expect.objectContaining({ status: 'FAILED', initErrorMessage: 'init error' }),
+        })
+      );
+    });
+
+    it('returns false without transitioning when workspace is no longer PROVISIONING', async () => {
+      mockUpdateMany.mockResolvedValue({ count: 0 });
+
+      const result = await workspaceStateMachine.markFailedIfProvisioning('ws-1', 'init error');
+
+      expect(result).toBe(false);
+    });
+
+    it('sets initErrorMessage to null when no error message provided', async () => {
+      mockUpdateMany.mockResolvedValue({ count: 1 });
+
+      await workspaceStateMachine.markFailedIfProvisioning('ws-1');
+
+      expect(mockUpdateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ initErrorMessage: null }),
+        })
       );
     });
   });

--- a/src/backend/services/workspace/service/lifecycle/state-machine.service.ts
+++ b/src/backend/services/workspace/service/lifecycle/state-machine.service.ts
@@ -14,6 +14,7 @@
  *   READY → PROVISIONING (retry setup script when workspace is READY+warning)
  *   READY → ARCHIVING → ARCHIVED
  *   FAILED → ARCHIVING → ARCHIVED
+ *   PROVISIONING → ARCHIVING → ARCHIVED (user-initiated archive during provisioning)
  *   ARCHIVING → READY/FAILED (rollback on archive failure)
  */
 
@@ -30,7 +31,7 @@ const logger = createLogger('workspace-state-machine');
  */
 const VALID_TRANSITIONS: Record<WorkspaceStatus, WorkspaceStatus[]> = {
   NEW: ['PROVISIONING'],
-  PROVISIONING: ['READY', 'FAILED'],
+  PROVISIONING: ['READY', 'FAILED', 'ARCHIVING'],
   READY: ['ARCHIVING', 'PROVISIONING'],
   FAILED: ['PROVISIONING', 'NEW', 'ARCHIVING'],
   ARCHIVING: ['READY', 'FAILED', 'ARCHIVED'],
@@ -79,7 +80,7 @@ export interface StartProvisioningOptions {
   maxRetries?: number;
 }
 
-type ArchivingSourceStatus = Extract<WorkspaceStatus, 'READY' | 'FAILED'>;
+type ArchivingSourceStatus = Extract<WorkspaceStatus, 'READY' | 'FAILED' | 'PROVISIONING'>;
 
 export interface StartArchivingResult {
   workspace: Workspace;
@@ -288,6 +289,40 @@ class WorkspaceStateMachineService extends EventEmitter {
   }
 
   /**
+   * Conditionally mark workspace as FAILED only if it is still in PROVISIONING state.
+   * Returns true if the transition was applied, false if the workspace has already moved on
+   * (e.g. an archive request took over mid-provisioning).
+   * Uses an atomic CAS so it is safe to call concurrently with archive.
+   */
+  async markFailedIfProvisioning(workspaceId: string, errorMessage?: string): Promise<boolean> {
+    const now = new Date();
+    const result = await workspaceAccessor.transitionWithCas(workspaceId, 'PROVISIONING', {
+      status: 'FAILED',
+      initCompletedAt: now,
+      initErrorMessage: errorMessage ?? null,
+    });
+
+    if (result.count > 0) {
+      this.emit(WORKSPACE_STATE_CHANGED, {
+        workspaceId,
+        fromStatus: 'PROVISIONING',
+        toStatus: 'FAILED',
+      } satisfies WorkspaceStateChangedEvent);
+      logger.debug('Workspace status transitioned', {
+        workspaceId,
+        from: 'PROVISIONING',
+        to: 'FAILED',
+      });
+      return true;
+    }
+
+    logger.debug('markFailedIfProvisioning: workspace no longer in PROVISIONING state', {
+      workspaceId,
+    });
+    return false;
+  }
+
+  /**
    * Mark a workspace as archiving.
    * Can only begin archiving from READY or FAILED status.
    */
@@ -300,7 +335,9 @@ class WorkspaceStateMachineService extends EventEmitter {
 
     const currentStatus = workspace.status;
 
-    if (!(currentStatus === 'READY' || currentStatus === 'FAILED')) {
+    if (
+      !(currentStatus === 'READY' || currentStatus === 'FAILED' || currentStatus === 'PROVISIONING')
+    ) {
       throw new WorkspaceStateMachineError(
         workspaceId,
         currentStatus,

--- a/src/backend/services/workspace/service/worktree/worktree-init.test.ts
+++ b/src/backend/services/workspace/service/worktree/worktree-init.test.ts
@@ -33,6 +33,7 @@ const mocks = vi.hoisted(() => ({
   markReady: vi.fn(),
   markReadyWithWarning: vi.fn(),
   markFailed: vi.fn(),
+  markFailedIfProvisioning: vi.fn(),
   getInitMode: vi.fn(),
   clearInitMode: vi.fn(),
   assertWorktreePathSafe: vi.fn(),
@@ -45,6 +46,7 @@ vi.mock('@/backend/services/workspace', () => ({
     markReady: mocks.markReady,
     markReadyWithWarning: mocks.markReadyWithWarning,
     markFailed: mocks.markFailed,
+    markFailedIfProvisioning: mocks.markFailedIfProvisioning,
   },
   worktreeLifecycleService: {
     getInitMode: mocks.getInitMode,
@@ -178,6 +180,7 @@ describe('initializeWorkspaceWorktree orchestrator', () => {
     });
     mocks.getTerminalsForWorkspace.mockReturnValue([]);
     mocks.onExit.mockImplementation(() => vi.fn());
+    mocks.markFailedIfProvisioning.mockResolvedValue(true);
     mocks.getInitMode.mockResolvedValue(undefined);
     mocks.clearInitMode.mockResolvedValue(undefined);
   });
@@ -313,7 +316,7 @@ describe('initializeWorkspaceWorktree orchestrator', () => {
     expect(mocks.stopWorkspaceSessions).toHaveBeenCalledWith('workspace-1');
     expect(mocks.destroyTerminal).toHaveBeenCalledWith('workspace-1', 'term-default');
     expect(mocks.clearTerminalPid).toHaveBeenCalledWith('term-default');
-    expect(mocks.markFailed).toHaveBeenCalled();
+    expect(mocks.markFailedIfProvisioning).toHaveBeenCalled();
   });
 
   it('continues session normally when startup script reports failure (non-blocking)', async () => {


### PR DESCRIPTION
## Summary
- Allow archiving workspaces in `PROVISIONING` state by adding `PROVISIONING → ARCHIVING` as a valid state transition
- Add race-safe `markFailedIfProvisioning` CAS method so the init orchestrator stands down when archive takes over mid-provisioning
- On archive failure rollback, target `FAILED` (not `PROVISIONING`) since provisioning cannot be safely resumed after partial cleanup
- Clean up unregistered worktrees even when archive takes over, preventing orphaned worktrees on disk

## Design doc
See `docs/design/archive-provisioning-workspace.md` for problem statement, alternatives considered, and race condition analysis.

## Test plan
- [x] Existing state machine tests updated — PROVISIONING can now transition to ARCHIVING
- [x] New tests for `markFailedIfProvisioning` (CAS success, CAS miss, null error message)
- [x] New tests for archive from PROVISIONING (happy path, rollback to FAILED)
- [x] Init orchestrator tests updated to assert `markFailedIfProvisioning` usage
- [x] All 3039 tests pass, typecheck clean, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
