### PR TITLE
Back off busy ACP chat dispatches

### DIFF
--- a/src/backend/orchestration/domain-bridges.orchestrator.test.ts
+++ b/src/backend/orchestration/domain-bridges.orchestrator.test.ts
@@ -328,7 +328,9 @@ describe('configureDomainBridges', () => {
 
       expect(onPromptTurnComplete).toBeTypeOf('function');
       await onPromptTurnComplete?.('s1');
-      expect(chatMessageHandlerService.tryDispatchNextMessage).toHaveBeenCalledWith('s1');
+      expect(chatMessageHandlerService.tryDispatchNextMessage).toHaveBeenCalledWith('s1', {
+        bypassTurnInProgressBackoff: true,
+      });
     });
   });
 

--- a/src/backend/orchestration/domain-bridges.orchestrator.ts
+++ b/src/backend/orchestration/domain-bridges.orchestrator.ts
@@ -227,7 +227,9 @@ export function configureDomainBridges(services: Partial<BridgeServices> = {}): 
     },
   });
   sessionService.setPromptTurnCompleteHandler((sessionId) =>
-    chatMessageHandlerService.tryDispatchNextMessage(sessionId)
+    chatMessageHandlerService.tryDispatchNextMessage(sessionId, {
+      bypassTurnInProgressBackoff: true,
+    })
   );
 
   // === Run-script domain bridges ===

--- a/src/backend/services/session/service/chat/chat-message-handlers.service.test.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers.service.test.ts
@@ -177,6 +177,40 @@ describe('chatMessageHandlerService.tryDispatchNextMessage', () => {
     }
   });
 
+  it('lets prompt-turn completion bypass a pending active-turn backoff', async () => {
+    vi.useFakeTimers();
+    try {
+      const client = {
+        isCompactingActive: vi.fn().mockReturnValue(false),
+        startCompaction: vi.fn(),
+        endCompaction: vi.fn(),
+        setMaxThinkingTokens: vi.fn().mockResolvedValue(undefined),
+      };
+      mockSessionService.getSessionClient.mockReturnValue(client);
+      mockSessionService.sendSessionMessage
+        .mockRejectedValueOnce({
+          code: -32_600,
+          message: 'Invalid request',
+          data: { reason: 'A turn is already in progress for this session' },
+        })
+        .mockResolvedValueOnce(undefined);
+
+      await chatMessageHandlerService.tryDispatchNextMessage('s1');
+      expect(mockSessionService.sendSessionMessage).toHaveBeenCalledTimes(1);
+
+      await chatMessageHandlerService.tryDispatchNextMessage('s1', {
+        bypassTurnInProgressBackoff: true,
+      });
+      expect(mockSessionService.sendSessionMessage).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(mockSessionService.sendSessionMessage).toHaveBeenCalledTimes(2);
+    } finally {
+      chatMessageHandlerService.resetDispatchState('s1');
+      vi.useRealTimers();
+    }
+  });
+
   it('marks runtime as error when auto-start cannot run because client creator is missing', async () => {
     mockSessionService.getSessionClient.mockReturnValue(undefined);
     mockSessionService.isSessionRunning.mockReturnValue(false);

--- a/src/backend/services/session/service/chat/chat-message-handlers.service.test.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers.service.test.ts
@@ -63,6 +63,7 @@ describe('chatMessageHandlerService.tryDispatchNextMessage', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    chatMessageHandlerService.resetDispatchState('s1');
     // Configure the init policy bridge (replaces direct import of getWorkspaceInitPolicy)
     chatMessageHandlerService.configure({
       initPolicy: {
@@ -136,6 +137,44 @@ describe('chatMessageHandlerService.tryDispatchNextMessage', () => {
     });
     expect(mockSessionDomainService.markIdle).not.toHaveBeenCalled();
     expect(mockSessionDomainService.requeueFront).toHaveBeenCalledWith('s1', queuedMessage);
+  });
+
+  it('backs off instead of immediately retrying when ACP reports an active turn', async () => {
+    vi.useFakeTimers();
+    try {
+      const client = {
+        isCompactingActive: vi.fn().mockReturnValue(false),
+        startCompaction: vi.fn(),
+        endCompaction: vi.fn(),
+        setMaxThinkingTokens: vi.fn().mockResolvedValue(undefined),
+      };
+      mockSessionService.getSessionClient.mockReturnValue(client);
+      mockSessionService.sendSessionMessage
+        .mockRejectedValueOnce({
+          code: -32_600,
+          message: 'Invalid request',
+          data: { reason: 'A turn is already in progress for this session' },
+        })
+        .mockResolvedValueOnce(undefined);
+
+      await chatMessageHandlerService.tryDispatchNextMessage('s1');
+
+      expect(mockSessionDomainService.markRunning).toHaveBeenCalledWith('s1');
+      expect(mockSessionDomainService.markIdle).not.toHaveBeenCalled();
+      expect(mockSessionDomainService.requeueFront).toHaveBeenCalledWith('s1', queuedMessage);
+      expect(mockSessionService.sendSessionMessage).toHaveBeenCalledTimes(1);
+
+      await chatMessageHandlerService.tryDispatchNextMessage('s1');
+      expect(mockSessionService.sendSessionMessage).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1000);
+      await vi.waitFor(() => {
+        expect(mockSessionService.sendSessionMessage).toHaveBeenCalledTimes(2);
+      });
+    } finally {
+      chatMessageHandlerService.resetDispatchState('s1');
+      vi.useRealTimers();
+    }
   });
 
   it('marks runtime as error when auto-start cannot run because client creator is missing', async () => {

--- a/src/backend/services/session/service/chat/chat-message-handlers.service.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers.service.ts
@@ -31,6 +31,8 @@ import { createChatMessageHandlerRegistry } from './chat-message-handlers/regist
 import type { ClientCreator } from './chat-message-handlers/types';
 
 const logger = createLogger('chat-message-handlers');
+const TURN_IN_PROGRESS_RETRY_BASE_MS = 1000;
+const TURN_IN_PROGRESS_RETRY_MAX_MS = 30_000;
 
 // ============================================================================
 // Types
@@ -82,6 +84,9 @@ class ChatMessageHandlerService {
   private dispatchInProgress = new Map<string, number>();
   /** Monotonic token to invalidate stale dispatch completions. */
   private nextDispatchToken = 1;
+  /** Retry timers for provider-side busy responses that are not reflected locally yet. */
+  private turnInProgressRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private turnInProgressRetryAttempts = new Map<string, number>();
 
   /** Client creator function - injected to avoid circular dependencies */
   private clientCreator: ClientCreator | null = null;
@@ -132,6 +137,7 @@ class ChatMessageHandlerService {
 
   resetDispatchState(sessionId: string): void {
     this.dispatchInProgress.delete(sessionId);
+    this.clearTurnInProgressRetry(sessionId);
   }
 
   private isDispatchInProgress(dbSessionId: string): boolean {
@@ -167,6 +173,10 @@ class ChatMessageHandlerService {
    * to dispatch, so a page refresh during auto-start won't lose it.
    */
   async tryDispatchNextMessage(dbSessionId: string): Promise<void> {
+    if (this.turnInProgressRetryTimers.has(dbSessionId)) {
+      return;
+    }
+
     // Guard against concurrent dispatch calls for the same session
     if (this.isDispatchInProgress(dbSessionId)) {
       return;
@@ -178,6 +188,7 @@ class ChatMessageHandlerService {
       // Peek first — message stays in queue (visible in snapshots during auto-start).
       const peeked = sessionDomainService.peekNextMessage(dbSessionId);
       if (!peeked) {
+        this.turnInProgressRetryAttempts.delete(dbSessionId);
         return;
       }
 
@@ -200,6 +211,7 @@ class ChatMessageHandlerService {
 
       try {
         await this.dispatchMessage(dbSessionId, msg, clientResult.client);
+        this.turnInProgressRetryAttempts.delete(dbSessionId);
       } catch (error) {
         this.handleDispatchError(dbSessionId, msg, error);
       }
@@ -274,13 +286,31 @@ class ChatMessageHandlerService {
       });
       return;
     }
+
+    if (this.isTurnAlreadyInProgressError(error)) {
+      logger.warn('[Chat WS] ACP turn already in progress, retrying queued message later', {
+        dbSessionId,
+        messageId: msg.id,
+        error: this.formatDispatchError(error),
+      });
+      sessionDomainService.removeTranscriptMessageById(dbSessionId, msg.id, {
+        emitSnapshot: false,
+      });
+      if (sessionService.isSessionRunning(dbSessionId)) {
+        sessionDomainService.markRunning(dbSessionId);
+      }
+      sessionDomainService.requeueFront(dbSessionId, msg);
+      this.scheduleTurnInProgressRetry(dbSessionId);
+      return;
+    }
+
     // Transient errors: dispatch can fail after we pessimistically committed the
     // user message to transcript for refresh safety. Roll it back before
     // re-queueing so clients do not see the same message as both queued and committed.
     logger.error('[Chat WS] Failed to dispatch message, re-queueing', {
       dbSessionId,
       messageId: msg.id,
-      error: error instanceof Error ? error.message : String(error),
+      error: this.formatDispatchError(error),
     });
     sessionDomainService.removeTranscriptMessageById(dbSessionId, msg.id, {
       emitSnapshot: false,
@@ -291,6 +321,53 @@ class ChatMessageHandlerService {
       sessionDomainService.markIdle(dbSessionId, 'alive');
     }
     sessionDomainService.requeueFront(dbSessionId, msg);
+  }
+
+  private scheduleTurnInProgressRetry(dbSessionId: string): void {
+    if (this.turnInProgressRetryTimers.has(dbSessionId)) {
+      return;
+    }
+
+    const attempts = this.turnInProgressRetryAttempts.get(dbSessionId) ?? 0;
+    const delayMs = Math.min(
+      TURN_IN_PROGRESS_RETRY_BASE_MS * 2 ** attempts,
+      TURN_IN_PROGRESS_RETRY_MAX_MS
+    );
+    this.turnInProgressRetryAttempts.set(dbSessionId, attempts + 1);
+
+    const timer = setTimeout(() => {
+      this.turnInProgressRetryTimers.delete(dbSessionId);
+      void this.tryDispatchNextMessage(dbSessionId);
+    }, delayMs);
+    this.turnInProgressRetryTimers.set(dbSessionId, timer);
+  }
+
+  private clearTurnInProgressRetry(dbSessionId: string): void {
+    const timer = this.turnInProgressRetryTimers.get(dbSessionId);
+    if (timer) {
+      clearTimeout(timer);
+      this.turnInProgressRetryTimers.delete(dbSessionId);
+    }
+    this.turnInProgressRetryAttempts.delete(dbSessionId);
+  }
+
+  private isTurnAlreadyInProgressError(error: unknown): boolean {
+    const message = this.formatDispatchError(error);
+    return message.includes('A turn is already in progress for this session');
+  }
+
+  private formatDispatchError(error: unknown): string {
+    if (error instanceof Error) {
+      return error.message;
+    }
+    if (error !== null && typeof error === 'object') {
+      try {
+        return JSON.stringify(error);
+      } catch {
+        return String(error);
+      }
+    }
+    return String(error);
   }
 
   /**

--- a/src/backend/services/session/service/chat/chat-message-handlers.service.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers.service.ts
@@ -55,6 +55,10 @@ type DispatchGateResult =
   | { policy: 'manual_resume' }
   | { policy: 'blocked'; permanent: boolean; reason: string | null };
 
+type DispatchOptions = {
+  bypassTurnInProgressBackoff?: boolean;
+};
+
 function isClaudeCompactionClient(value: unknown): value is ClaudeCompactionClient {
   if (!value || typeof value !== 'object') {
     return false;
@@ -172,9 +176,13 @@ class ChatMessageHandlerService {
    * The message stays in the queue (visible in snapshots) until we're ready
    * to dispatch, so a page refresh during auto-start won't lose it.
    */
-  async tryDispatchNextMessage(dbSessionId: string): Promise<void> {
+  async tryDispatchNextMessage(dbSessionId: string, options: DispatchOptions = {}): Promise<void> {
     if (this.turnInProgressRetryTimers.has(dbSessionId)) {
-      return;
+      if (options.bypassTurnInProgressBackoff) {
+        this.clearTurnInProgressRetry(dbSessionId);
+      } else {
+        return;
+      }
     }
 
     // Guard against concurrent dispatch calls for the same session


### PR DESCRIPTION
## Summary
- Add a per-session backoff for ACP "turn already in progress" dispatch failures.
- Keep the queued message requeued without marking the session idle for provider-side busy responses.
- Improve dispatch error formatting for object-shaped ACP errors.

## Tests
- pnpm vitest run src/backend/services/session/service/chat/chat-message-handlers.service.test.ts
- pnpm typecheck
- pnpm exec biome check --write src/backend/services/session/service/chat/chat-message-handlers.service.ts src/backend/services/session/service/chat/chat-message-handlers.service.test.ts
- Commit hook: biome check --write, pnpm typecheck, depcruise, knip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core chat dispatch error-handling and adds timer-based retry state per session, which could affect message delivery order and runtime state transitions if mis-triggered or not cleared correctly.
> 
> **Overview**
> Adds per-session exponential backoff when ACP rejects a dispatch with "A turn is already in progress for this session": the message is re-queued, the session is kept `running` (not `idle`), and `tryDispatchNextMessage` is suppressed until a scheduled retry fires.
> 
> Also improves dispatch error logging by stringifying object-shaped ACP errors, and extends tests to cover the new backoff behavior plus ensuring `resetDispatchState` clears retry state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46e0dac4dfcc7632b96a13a051cd89503ca7cbb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->