### PR TITLE
Fix startup reconciliation errors after unclean shutdown

### DIFF
--- a/src/backend/db.ts
+++ b/src/backend/db.ts
@@ -38,8 +38,14 @@ function createPrismaClient(): PrismaClient {
   // Create Prisma adapter with SQLite configuration
   // Note: The adapter expects a raw file path, not a file: URL
   // (getDatabaseUrl() with file: prefix is for Prisma CLI configuration)
+  //
+  // timeout: busy_timeout in ms — how long better-sqlite3 waits for a write
+  // lock before throwing SQLITE_BUSY. Without this, a brief lock held during
+  // WAL recovery or by another process causes an immediate "Operation has
+  // timed out" error and corrupts the shared Prisma connection state.
   const adapter = new PrismaBetterSqlite3({
     url: databasePath,
+    timeout: 5000,
   });
 
   return new PrismaClient({ adapter });

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -277,6 +277,15 @@ export function createServer(requestedPort?: number, appContext?: AppContext): S
       await task();
     } catch (error) {
       logger.error(errorMessage, toError(error));
+      // A failed write can corrupt the shared Prisma connection's internal
+      // transaction state (e.g., better-sqlite3 commits synchronously while
+      // Prisma's async timeout fires a rollback against an already-committed
+      // tx). Disconnect so the next task gets a clean connection.
+      try {
+        await prisma.$disconnect();
+      } catch {
+        // Ignore disconnect errors during recovery
+      }
     }
   };
 
@@ -347,16 +356,25 @@ export function createServer(requestedPort?: number, appContext?: AppContext): S
       }
 
       const runStartupReconciliation = async (): Promise<void> => {
-        await runStartupTask('Failed to cleanup orphan sessions on startup', () =>
-          reconciliationService.cleanupOrphans()
-        );
+        // Enable WAL journal mode so readers don't block writers and vice versa,
+        // reducing SQLITE_BUSY errors when a previous unclean shutdown left a
+        // WAL/journal file being recovered.
+        await runStartupTask('Failed to configure SQLite WAL mode on startup', async () => {
+          await prisma.$queryRawUnsafe('PRAGMA journal_mode=WAL');
+        });
 
         // Reset agent sessions that were persisted as RUNNING by a prior process.
         // Live ACP runtimes are in-memory only, so after a backend restart these
         // records must not drive workspace "Working" state.
+        // Run BEFORE cleanupOrphans: this is a fast single updateMany and should
+        // not be blocked by the per-row loop that is prone to lock contention.
         await runStartupTask('Failed to recover stale agent sessions on startup', async () => {
           await sessionService.recoverStaleSessionStates();
         });
+
+        await runStartupTask('Failed to cleanup orphan sessions on startup', () =>
+          reconciliationService.cleanupOrphans()
+        );
 
         // Reconcile workspaces that may have been left in inconsistent states
         // (e.g., stuck in PROVISIONING due to server crash)

--- a/src/backend/services/ratchet/service/reconciliation.service.ts
+++ b/src/backend/services/ratchet/service/reconciliation.service.ts
@@ -151,19 +151,16 @@ class ReconciliationService {
     // Terminal sessions are still PID-tracked and may become orphaned.
     const terminalSessionsWithPid = await terminalSessionAccessor.findWithPid();
 
-    for (const session of terminalSessionsWithPid) {
-      if (session.pid) {
-        const isRunning = this.isProcessRunning(session.pid);
-        if (!isRunning) {
-          await terminalSessionAccessor.update(session.id, {
-            status: SessionStatus.IDLE,
-            pid: null,
-          });
-          logger.info('Marked orphaned terminal session as idle', {
-            sessionId: session.id,
-          });
-        }
-      }
+    const orphanIds = terminalSessionsWithPid
+      .filter((s) => s.pid != null && !this.isProcessRunning(s.pid))
+      .map((s) => s.id);
+
+    if (orphanIds.length > 0) {
+      await terminalSessionAccessor.updateManyByIds(orphanIds, {
+        status: SessionStatus.IDLE,
+        pid: null,
+      });
+      logger.info('Marked orphaned terminal sessions as idle', { count: orphanIds.length });
     }
   }
 

--- a/src/backend/services/terminal/resources/terminal-session.accessor.ts
+++ b/src/backend/services/terminal/resources/terminal-session.accessor.ts
@@ -81,6 +81,15 @@ class TerminalSessionAccessor {
     });
   }
 
+  updateManyByIds(ids: string[], data: UpdateTerminalSessionInput): Promise<number> {
+    return prisma.terminalSession
+      .updateMany({
+        where: { id: { in: ids } },
+        data,
+      })
+      .then((r) => r.count);
+  }
+
   delete(id: string): Promise<TerminalSession> {
     return prisma.terminalSession.delete({
       where: { id },


### PR DESCRIPTION
## Summary

After merging #1574, two errors still fired on every server startup:

- `terminalSession.update()` → **"Operation has timed out"** (`cleanupOrphans`)
- `agentSession.updateMany()` → **"Transaction already closed"** (`recoverStaleSessionStates`)

The first error occurs because `better-sqlite3` throws `SQLITE_BUSY` immediately when a write lock is held (e.g., SQLite recovering a leftover WAL/journal after an unclean shutdown). The second is always a cascade: a failed write in `cleanupOrphans` corrupts the shared Prisma connection's internal transaction state, causing every subsequent startup write to fail with "Transaction already closed".

## Changes

- **`src/backend/db.ts`**: Add `timeout: 5000` to the adapter config — `better-sqlite3`'s busy timeout; waits up to 5 s for a write lock rather than throwing immediately
- **`src/backend/server.ts`**:
  - Add `PRAGMA journal_mode=WAL` as the first startup task, reducing lock contention on startup
  - Add `prisma.$disconnect()` in `runStartupTask`'s error handler to recycle a corrupted connection before the next task runs
  - Move `recoverStaleSessionStates` before `cleanupOrphans` so the fast `updateMany` completes before the per-row loop that is prone to contention
- **`src/backend/services/terminal/resources/terminal-session.accessor.ts`**: Add `updateManyByIds` method
- **`src/backend/services/ratchet/service/reconciliation.service.ts`**: Batch orphan cleanup into a single `updateMany`, shrinking the write-lock window from O(n) to O(1)

## Test plan

- [ ] Simulate unclean shutdown (kill -9 server while sessions are active), restart, confirm no startup reconciliation errors in logs
- [ ] Confirm workspace creation succeeds after restart with orphaned terminal sessions
- [ ] `pnpm test`
- [ ] `pnpm typecheck`
- [ ] `pnpm check:fix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
