### PR TITLE
Add refresh button to Changes tab

### DIFF
--- a/src/components/workspace/right-panel.tsx
+++ b/src/components/workspace/right-panel.tsx
@@ -130,6 +130,7 @@ function TopPanelArea({
   isAutoIteration,
   periodicTaskId,
 }: TopPanelAreaProps) {
+  const utils = trpc.useUtils();
   const showChanges = activeTopTab === 'changes';
   const showFiles = activeTopTab === 'files';
   const showTasks = activeTopTab === 'tasks';
@@ -154,6 +155,30 @@ function TopPanelArea({
           isActive={showChanges}
           onSelect={() => onTopTabChange('changes')}
         />
+        {showChanges && (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={() => {
+                    void utils.workspace.getGitStatus.invalidate({ workspaceId });
+                    void utils.workspace.getDiffVsMain.invalidate({ workspaceId });
+                    void utils.workspace.getUnpushedFiles.invalidate({ workspaceId });
+                    void utils.workspace.getFileDiff.invalidate({ workspaceId });
+                  }}
+                  className="h-6 w-6 flex-shrink-0 flex items-center justify-center rounded-md transition-colors text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+                  aria-label="Refresh changes"
+                >
+                  <RefreshCw className="h-3 w-3" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Refresh changes</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )}
         <TabButton
           label="Files"
           icon={<Files className="h-3.5 w-3.5" />}


### PR DESCRIPTION
## Summary
- Adds a small refresh icon button next to the "Changes" tab that appears when the tab is active
- Clicking it immediately invalidates all git change queries (`getGitStatus`, `getDiffVsMain`, `getUnpushedFiles`) and any open diff tabs (`getFileDiff`) for the current workspace
- Eliminates the need to switch tabs to force a data refresh

## Test plan
- [ ] Open a workspace and navigate to the Changes tab
- [ ] Verify the refresh icon (↻) appears next to the "Changes" tab label
- [ ] Make a change in the workspace repo, click refresh, and confirm the file list updates immediately
- [ ] Open a file diff tab, make a change to that file, click refresh, and confirm the diff view updates
- [ ] Switch to a different tab (e.g. Files) and verify the refresh button disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)
