### PR TITLE
Fix npm publish release version output

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -81,7 +81,9 @@ jobs:
       - name: Compute release version
         if: ${{ matrix.node-version == '20' && github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true' }}
         id: release_version
-        run: echo "version=$(node -p \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Create and push tag
         if: ${{ matrix.node-version == '20' && github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true' }}


### PR DESCRIPTION
## Summary
- Convert the npm publish workflow's release version computation to a multiline shell block.
- Avoid the escaped-quote parsing issue that caused the post-publish tag/release step to fail.

## Testing
- Ran the release-version shell snippet locally and confirmed it writes `version=0.3.16`.
- Commit hook ran `pnpm typecheck`, dependency cruiser, and knip checks successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change; it just adjusts how the version string is written to `GITHUB_OUTPUT`, but could impact automated tagging/release steps if misformatted.
> 
> **Overview**
> Fixes the `npm-publish` GitHub Actions workflow’s “Compute release version” step by switching from a single-line `echo` with nested escaping to a multiline shell block that stores the package version in a variable and then writes it to `GITHUB_OUTPUT`.
> 
> This is intended to prevent quoting/parse issues that could break downstream tag creation and GitHub release steps after publishing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59b14512c525b0157f008a1758fa4f0d928c8bd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->