### PR TITLE
Fix session restart after stop

### DIFF
--- a/src/backend/services/session/service/lifecycle/session.service.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.service.test.ts
@@ -751,6 +751,35 @@ describe('SessionService', () => {
     expect(acpRuntimeManager.sendPrompt).toHaveBeenCalledTimes(1);
   });
 
+  it('does not queue restarted prompts behind an unresolved stopped prompt', async () => {
+    const firstPrompt = createDeferred<{ stopReason: string }>();
+    vi.mocked(acpRuntimeManager.isStopInProgress).mockReturnValue(false);
+    vi.mocked(acpRuntimeManager.sendPrompt)
+      .mockReturnValueOnce(firstPrompt.promise as never)
+      .mockResolvedValueOnce({ stopReason: 'end_turn' });
+    vi.mocked(acpRuntimeManager.stopClient).mockResolvedValue();
+    vi.mocked(sessionRepository.updateSession).mockResolvedValue({} as never);
+
+    const firstSend = sessionService.sendAcpMessage('session-restarted-after-stop', [
+      { type: 'text', text: 'first' },
+    ]);
+    await Promise.resolve();
+    expect(acpRuntimeManager.sendPrompt).toHaveBeenCalledTimes(1);
+
+    await sessionService.stopSession('session-restarted-after-stop');
+
+    const restartedSend = sessionService.sendAcpMessage('session-restarted-after-stop', [
+      { type: 'text', text: 'after restart' },
+    ]);
+    await Promise.resolve();
+
+    expect(acpRuntimeManager.sendPrompt).toHaveBeenCalledTimes(2);
+    await expect(restartedSend).resolves.toBe('end_turn');
+
+    firstPrompt.resolve({ stopReason: 'end_turn' });
+    await expect(firstSend).resolves.toBe('end_turn');
+  });
+
   it('rejects queued ACP prompts during unexpected runtime exit', async () => {
     const session = unsafeCoerce<
       NonNullable<Awaited<ReturnType<typeof sessionRepository.getSessionById>>>
@@ -928,7 +957,7 @@ describe('SessionService', () => {
     expect(pendingToolCalls.has('session-runtime-exit')).toBe(false);
   });
 
-  it('keeps active ACP prompt serialization during manual stop', async () => {
+  it('drops active ACP prompt serialization during manual stop', async () => {
     const firstPrompt = createDeferred<{ stopReason: string }>();
     const thirdPrompt = createDeferred<{ stopReason: string }>();
     vi.mocked(acpRuntimeManager.isStopInProgress).mockReturnValue(false);
@@ -958,15 +987,13 @@ describe('SessionService', () => {
       { type: 'text', text: 'third' },
     ]);
     await Promise.resolve();
-    expect(acpRuntimeManager.sendPrompt).toHaveBeenCalledTimes(1);
+    expect(acpRuntimeManager.sendPrompt).toHaveBeenCalledTimes(2);
+
+    thirdPrompt.resolve({ stopReason: 'end_turn' });
+    await expect(thirdSend).resolves.toBe('end_turn');
 
     firstPrompt.resolve({ stopReason: 'end_turn' });
     await expect(firstSend).resolves.toBe('end_turn');
-    await Promise.resolve();
-
-    expect(acpRuntimeManager.sendPrompt).toHaveBeenCalledTimes(2);
-    thirdPrompt.resolve({ stopReason: 'end_turn' });
-    await expect(thirdSend).resolves.toBe('end_turn');
   });
 
   it('clears in-memory session state after manual stop when no clients are connected', async () => {

--- a/src/backend/services/session/service/lifecycle/session.service.ts
+++ b/src/backend/services/session/service/lifecycle/session.service.ts
@@ -316,7 +316,10 @@ export class SessionService {
       return;
     }
     limiter.clearQueue();
-    this.deleteAcpPromptLimiterIfDrained(sessionId, limiter);
+    // A stop can kill the ACP process while the active prompt promise never
+    // settles. Drop the limiter so a later restart is not queued behind that
+    // stale in-flight turn.
+    this.acpPromptLimiters.delete(sessionId);
   }
 
   private deleteAcpPromptLimiterIfDrained(sessionId: string, limiter: LimitFunction): void {


### PR DESCRIPTION
## Summary

- Fix session restart after stop by dropping the stale per-session ACP prompt limiter during stop cleanup.
- Prevent a restarted prompt from queueing behind an unresolved prompt promise from a killed ACP process.
- Add regression coverage for restart after an unresolved stopped prompt and update the manual-stop serialization expectation.

## Log Investigation

- The affected workspace session stopped at 2026-05-14T19:52:19Z after SIGTERM timed out and SIGKILL was used.
- The restart at 2026-05-14T20:02:09Z successfully spawned and resumed the ACP process, but never logged `Session started`, showing it blocked after client creation while sending the initial prompt.

## Tests

- `pnpm vitest run src/backend/services/session/service/lifecycle/session.service.test.ts`
- `pnpm typecheck`
- Commit hook also ran Biome, dependency-cruiser, and knip.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ACP prompt serialization behavior during `stopSession` by dropping the per-session limiter even if an in-flight prompt never settles, which could affect prompt ordering/concurrency around stop/restart paths.
> 
> **Overview**
> Fixes a restart-after-stop deadlock by changing `SessionService.clearQueuedAcpPrompts` to **delete** the per-session ACP prompt limiter after clearing its queue, instead of waiting for the limiter to fully drain (which may never happen if the ACP process was killed mid-prompt).
> 
> Adds regression coverage ensuring a prompt sent after restart is not queued behind an unresolved pre-stop prompt, and updates the manual-stop test to expect serialization to be dropped for new prompts while the original in-flight prompt remains unresolved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0eb42b8d32f3a0c3f28b60608334ede64d7c8bfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->