### PR TITLE
Detect PRs created through GitHub MCP

### DIFF
--- a/src/backend/interceptors/pr-detection.interceptor.test.ts
+++ b/src/backend/interceptors/pr-detection.interceptor.test.ts
@@ -107,6 +107,80 @@ describe('prDetectionInterceptor', () => {
     );
   });
 
+  it('detects PR URL from GitHub MCP create_pull_request results', async () => {
+    const event = createEvent({
+      toolName: 'mcpToolCall:codex_apps/github_create_pull_request',
+      input: {
+        type: 'mcpToolCall',
+        id: 'call_oensfoBCcJ33zeogkYFUkfw4',
+        server: 'codex_apps',
+        tool: 'github_create_pull_request',
+        arguments: {
+          repository_full_name: 'purplefish-ai/factory-factory',
+          base_branch: 'main',
+          head_branch: 'fix-npm-publish-release-version-output',
+          title: 'Fix npm publish release version output',
+        },
+      },
+      output: {
+        content: JSON.stringify({
+          type: 'mcpToolCall',
+          id: 'call_oensfoBCcJ33zeogkYFUkfw4',
+          server: 'codex_apps',
+          tool: 'github_create_pull_request',
+          status: 'completed',
+          result: {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  url: 'https://github.com/purplefish-ai/factory-factory/pull/1581',
+                  number: 1581,
+                  state: 'open',
+                  display_url: 'https://github.com/purplefish-ai/factory-factory/pull/1581',
+                }),
+              },
+            ],
+            structuredContent: {
+              url: 'https://github.com/purplefish-ai/factory-factory/pull/1581',
+              number: 1581,
+            },
+          },
+        }),
+        isError: false,
+      },
+    });
+
+    await prDetectionInterceptor.onToolComplete!(event, context);
+
+    expect(mockAttachAndRefreshPR).toHaveBeenCalledWith(
+      'workspace-1',
+      'https://github.com/purplefish-ai/factory-factory/pull/1581'
+    );
+  });
+
+  it('detects PR URL from GitHub MCP create_pull_request display tool names', async () => {
+    const event = createEvent({
+      toolName: 'mcpToolCall:github/create_pull_request',
+      input: {},
+      output: {
+        content: JSON.stringify({
+          structuredContent: {
+            url: 'https://github.com/purplefish-ai/factory-factory/pull/1582',
+          },
+        }),
+        isError: false,
+      },
+    });
+
+    await prDetectionInterceptor.onToolComplete!(event, context);
+
+    expect(mockAttachAndRefreshPR).toHaveBeenCalledWith(
+      'workspace-1',
+      'https://github.com/purplefish-ai/factory-factory/pull/1582'
+    );
+  });
+
   it('detects PR URL when command is provided as cmd', async () => {
     const event = createEvent({
       toolName: 'exec_command',
@@ -171,6 +245,29 @@ describe('prDetectionInterceptor', () => {
       output: {
         content: 'error: remote: Repository not found.',
         isError: true,
+      },
+    });
+
+    await prDetectionInterceptor.onToolComplete!(event, context);
+
+    expect(mockAttachAndRefreshPR).not.toHaveBeenCalled();
+  });
+
+  it('does not attach arbitrary PR URLs from non-create MCP tools', async () => {
+    const event = createEvent({
+      toolName: 'mcpToolCall:codex_apps/github_fetch_pull_request',
+      input: {
+        type: 'mcpToolCall',
+        server: 'codex_apps',
+        tool: 'github_fetch_pull_request',
+      },
+      output: {
+        content: JSON.stringify({
+          structuredContent: {
+            url: 'https://github.com/purplefish-ai/factory-factory/pull/1583',
+          },
+        }),
+        isError: false,
       },
     });
 

--- a/src/backend/interceptors/pr-detection.interceptor.ts
+++ b/src/backend/interceptors/pr-detection.interceptor.ts
@@ -13,6 +13,8 @@ import type { InterceptorContext, ToolEvent, ToolInterceptor } from './types';
 const logger = createLogger('pr-detection');
 const GH_PR_CREATE_REGEX = /\bgh\s+pr\s+create\b/;
 const GITHUB_PR_URL_REGEX = /https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/\d+/;
+const GITHUB_CREATE_PULL_REQUEST_TOOL = 'github_create_pull_request';
+const CREATE_PULL_REQUEST_TOOL = 'create_pull_request';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -40,6 +42,60 @@ function extractCommand(event: ToolEvent): string | undefined {
   }
 
   return directCommand ?? cmd ?? title;
+}
+
+function normalizeToolName(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+function extractMcpToolNameFromDisplayName(toolName: string): string | undefined {
+  const slashIndex = toolName.lastIndexOf('/');
+  if (slashIndex === -1 || slashIndex === toolName.length - 1) {
+    return undefined;
+  }
+  return toolName.slice(slashIndex + 1);
+}
+
+function extractMcpServerNameFromDisplayName(toolName: string): string | undefined {
+  const prefix = 'mcpToolCall:';
+  if (!toolName.startsWith(prefix)) {
+    return undefined;
+  }
+
+  const slashIndex = toolName.indexOf('/', prefix.length);
+  if (slashIndex === -1) {
+    return undefined;
+  }
+
+  return toolName.slice(prefix.length, slashIndex);
+}
+
+function isGithubCreatePullRequestTool(event: ToolEvent): boolean {
+  const inputTool = extractInputValue(event.input, 'tool', isString, event.toolName, logger);
+  if (inputTool === GITHUB_CREATE_PULL_REQUEST_TOOL) {
+    return true;
+  }
+
+  const inputServer = extractInputValue(event.input, 'server', isString, event.toolName, logger);
+  if (inputTool === CREATE_PULL_REQUEST_TOOL && inputServer?.toLowerCase().includes('github')) {
+    return true;
+  }
+
+  const displayToolName = extractMcpToolNameFromDisplayName(event.toolName) ?? event.toolName;
+  if (displayToolName === GITHUB_CREATE_PULL_REQUEST_TOOL) {
+    return true;
+  }
+
+  const displayServerName = extractMcpServerNameFromDisplayName(event.toolName);
+  if (
+    displayToolName === CREATE_PULL_REQUEST_TOOL &&
+    displayServerName?.toLowerCase().includes('github')
+  ) {
+    return true;
+  }
+
+  const normalizedToolName = normalizeToolName(event.toolName);
+  return normalizedToolName.endsWith(normalizeToolName(GITHUB_CREATE_PULL_REQUEST_TOOL));
 }
 
 function extractPrUrlFromEvent(event: ToolEvent): string | null {
@@ -97,7 +153,9 @@ export const prDetectionInterceptor: ToolInterceptor = {
     // non-zero (e.g. "A pull request for branch 'x' already exists") while still
     // printing the PR URL in its output. We only bail if no URL is found.
     const command = extractCommand(event);
-    if (!(command && GH_PR_CREATE_REGEX.test(command))) {
+    const isGhPrCreate = command ? GH_PR_CREATE_REGEX.test(command) : false;
+    const isMcpPrCreate = isGithubCreatePullRequestTool(event);
+    if (!(isGhPrCreate || isMcpPrCreate)) {
       return;
     }
 


### PR DESCRIPTION
## Summary
- Detect PRs created through GitHub MCP tool calls in the PR detection interceptor.
- Support both `github_create_pull_request` and GitHub-scoped `create_pull_request` tool names while preserving the existing `gh pr create` path.
- Add regression coverage for completed MCP result payloads and non-create MCP tools containing PR URLs.

## Testing
- `pnpm vitest run src/backend/interceptors/pr-detection.interceptor.test.ts`
- `pnpm typecheck`
- Commit hook ran `biome check --write`, `pnpm typecheck`, dependency cruiser, and `knip` successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands PR auto-attachment triggers beyond `gh pr create` to include MCP tool calls; incorrect tool-name matching could cause missed or unintended PR attachments, though mitigated by create-only checks and tests.
> 
> **Overview**
> The PR detection interceptor now treats GitHub MCP `create_pull_request` tool calls (including `github_create_pull_request` and GitHub-scoped `create_pull_request`, plus display-name variants) as PR-creation events, not just `gh pr create` commands.
> 
> It adds tool-name normalization/parsing to reliably identify those MCP calls, and expands tests to cover MCP result payloads and to ensure PR URLs from *non-create* MCP tools are ignored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f546eb2f0fcebb64101212b3b107642a08ffa89e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->