### PR TITLE
Fix ACP busy-turn retry loop after sleep

### DIFF
--- a/src/backend/services/session/service/chat/chat-message-handlers.service.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers.service.ts
@@ -12,6 +12,7 @@ import type { WebSocket } from 'ws';
 import { createLogger } from '@/backend/services/logger.service';
 import type { SessionInitPolicyBridge } from '@/backend/services/session/service/bridges';
 import { sessionDataService } from '@/backend/services/session/service/data/session-data.service';
+import { toErrorMessage } from '@/backend/services/session/service/lifecycle/session.error-message';
 import { sessionService } from '@/backend/services/session/service/lifecycle/session.service';
 import { sessionDomainService } from '@/backend/services/session/service/session-domain.service';
 import {
@@ -22,7 +23,6 @@ import {
   resolveSelectedModel,
 } from '@/shared/acp-protocol';
 import type { ChatMessageInput } from '@/shared/websocket';
-import { toErrorMessage } from '../lifecycle/session.error-message';
 import {
   processAttachmentsAndBuildContent,
   UnsupportedImageTypeError,

--- a/src/backend/services/session/service/chat/chat-message-handlers.service.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers.service.ts
@@ -22,6 +22,7 @@ import {
   resolveSelectedModel,
 } from '@/shared/acp-protocol';
 import type { ChatMessageInput } from '@/shared/websocket';
+import { toErrorMessage } from '../lifecycle/session.error-message';
 import {
   processAttachmentsAndBuildContent,
   UnsupportedImageTypeError,
@@ -365,17 +366,7 @@ class ChatMessageHandlerService {
   }
 
   private formatDispatchError(error: unknown): string {
-    if (error instanceof Error) {
-      return error.message;
-    }
-    if (error !== null && typeof error === 'object') {
-      try {
-        return JSON.stringify(error);
-      } catch {
-        return String(error);
-      }
-    }
-    return String(error);
+    return toErrorMessage(error);
   }
 
   /**

--- a/src/backend/services/session/service/lifecycle/session.error-message.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.error-message.test.ts
@@ -6,23 +6,31 @@ describe('toErrorMessage', () => {
     expect(toErrorMessage(new Error('boom'))).toBe('boom');
   });
 
-  it('stringifies non-null objects', () => {
-    expect(toErrorMessage({ reason: 'boom' })).toBe('{"reason":"boom"}');
+  it('summarizes structured non-null objects without stringifying them', () => {
+    expect(toErrorMessage({ reason: 'boom' })).toBe('boom');
+    expect(
+      toErrorMessage({
+        code: -32_600,
+        message: 'Invalid request',
+        data: { reason: 'A turn is already in progress for this session' },
+      })
+    ).toBe('code -32600: Invalid request: A turn is already in progress for this session');
   });
 
-  it('does not call JSON.stringify for null values', () => {
+  it('does not call JSON.stringify for null values or objects', () => {
     const originalStringify = JSON.stringify;
     const stringifySpy = vi
       .spyOn(JSON, 'stringify')
       .mockImplementation((...args: Parameters<typeof JSON.stringify>) => {
         const [value] = args;
-        if (value === null) {
-          throw new Error('null should not be stringified');
+        if (value === null || (typeof value === 'object' && value !== null)) {
+          throw new Error('objects should not be stringified');
         }
         return originalStringify(...args);
       });
 
     expect(toErrorMessage(null)).toBe('null');
+    expect(toErrorMessage({ reason: 'boom' })).toBe('boom');
     expect(stringifySpy).not.toHaveBeenCalled();
   });
 });

--- a/src/backend/services/session/service/lifecycle/session.error-message.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.error-message.test.ts
@@ -23,7 +23,7 @@ describe('toErrorMessage', () => {
       .spyOn(JSON, 'stringify')
       .mockImplementation((...args: Parameters<typeof JSON.stringify>) => {
         const [value] = args;
-        if (value === null || (typeof value === 'object' && value !== null)) {
+        if (value == null || typeof value === 'object') {
           throw new Error('objects should not be stringified');
         }
         return originalStringify(...args);

--- a/src/backend/services/session/service/lifecycle/session.error-message.ts
+++ b/src/backend/services/session/service/lifecycle/session.error-message.ts
@@ -1,9 +1,58 @@
+const MAX_ERROR_MESSAGE_LENGTH = 4000;
+
+function truncate(value: string): string {
+  if (value.length <= MAX_ERROR_MESSAGE_LENGTH) {
+    return value;
+  }
+  return `${value.slice(0, MAX_ERROR_MESSAGE_LENGTH)}... [truncated]`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function readErrorCode(value: Record<string, unknown>): string | number | null {
+  return typeof value.code === 'number' || typeof value.code === 'string' ? value.code : null;
+}
+
+function readErrorReason(value: Record<string, unknown>): string | null {
+  return readString(value.reason) ?? (isRecord(value.data) ? readString(value.data.reason) : null);
+}
+
+function summarizeErrorObject(error: Record<string, unknown>): string {
+  const message = readString(error.message);
+  const reason = readErrorReason(error);
+  const code = readErrorCode(error);
+
+  const parts: string[] = [];
+  if (code !== null) {
+    parts.push(`code ${code}`);
+  }
+  if (message) {
+    parts.push(message);
+  }
+  if (reason && reason !== message) {
+    parts.push(reason);
+  }
+
+  if (parts.length > 0) {
+    return truncate(parts.join(': '));
+  }
+
+  const keys = Object.keys(error).slice(0, 5);
+  return keys.length > 0 ? `Object(${keys.join(', ')})` : '[object Object]';
+}
+
 export function toErrorMessage(error: unknown): string {
   if (error instanceof Error) {
-    return error.message;
+    return truncate(error.message);
   }
-  if (error !== null && typeof error === 'object') {
-    return JSON.stringify(error);
+  if (isRecord(error)) {
+    return summarizeErrorObject(error);
   }
-  return String(error);
+  return truncate(String(error));
 }

--- a/src/backend/services/session/service/lifecycle/session.service.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.service.test.ts
@@ -1900,6 +1900,25 @@ describe('SessionService', () => {
     }
   });
 
+  it('schedules prompt-turn completion callbacks after non-busy prompt errors', async () => {
+    vi.useFakeTimers();
+    try {
+      const onPromptTurnComplete = vi.fn().mockResolvedValue(undefined);
+      sessionService.setPromptTurnCompleteHandler(onPromptTurnComplete);
+      vi.mocked(acpRuntimeManager.sendPrompt).mockRejectedValue(new Error('network blip'));
+
+      await expect(
+        sessionService.sendAcpMessage('session-1', [{ type: 'text', text: 'hello' }])
+      ).rejects.toThrow('network blip');
+
+      expect(onPromptTurnComplete).not.toHaveBeenCalled();
+      await vi.runOnlyPendingTimersAsync();
+      expect(onPromptTurnComplete).toHaveBeenCalledWith('session-1');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('cancels scheduled prompt-turn completion callback when session stops first', async () => {
     vi.useFakeTimers();
     try {

--- a/src/backend/services/session/service/lifecycle/session.service.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.service.test.ts
@@ -1876,6 +1876,30 @@ describe('SessionService', () => {
     }
   });
 
+  it('does not schedule prompt-turn completion callbacks after provider busy errors', async () => {
+    vi.useFakeTimers();
+    try {
+      const onPromptTurnComplete = vi.fn().mockResolvedValue(undefined);
+      sessionService.setPromptTurnCompleteHandler(onPromptTurnComplete);
+      vi.mocked(acpRuntimeManager.sendPrompt).mockRejectedValue({
+        code: -32_600,
+        message: 'Invalid request',
+        data: { reason: 'A turn is already in progress for this session' },
+      } as never);
+
+      await expect(
+        sessionService.sendAcpMessage('session-1', [{ type: 'text', text: 'hello' }])
+      ).rejects.toMatchObject({
+        data: { reason: 'A turn is already in progress for this session' },
+      });
+
+      await vi.runOnlyPendingTimersAsync();
+      expect(onPromptTurnComplete).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('cancels scheduled prompt-turn completion callback when session stops first', async () => {
     vi.useFakeTimers();
     try {

--- a/src/backend/services/session/service/lifecycle/session.service.ts
+++ b/src/backend/services/session/service/lifecycle/session.service.ts
@@ -32,6 +32,7 @@ import { SessionRetryService } from './session.retry.service';
 
 const logger = createLogger('session');
 const DEFAULT_USER_PROMPT_TIMEOUT_MS = 60 * 60 * 1000;
+const TURN_ALREADY_IN_PROGRESS_REASON = 'A turn is already in progress for this session';
 type SessionStartupModePreset = 'non_interactive' | 'plan';
 type PromptTurnCompleteHandler = (sessionId: string) => Promise<void> | void;
 
@@ -240,10 +241,18 @@ export class SessionService {
       return this.sendAcpMessage(sessionId, prompt, DEFAULT_USER_PROMPT_TIMEOUT_MS)
         .then(() => undefined)
         .catch((error) => {
-          logger.error('ACP prompt failed', {
-            sessionId,
-            error: toErrorMessage(error),
-          });
+          const errorMessage = toErrorMessage(error);
+          if (this.isTurnAlreadyInProgressError(error)) {
+            logger.debug('ACP prompt deferred because a turn is already in progress', {
+              sessionId,
+              error: errorMessage,
+            });
+          } else {
+            logger.error('ACP prompt failed', {
+              sessionId,
+              error: errorMessage,
+            });
+          }
           throw error;
         });
     }
@@ -348,6 +357,7 @@ export class SessionService {
     timeoutMs?: number
   ): Promise<string> {
     const workspaceId = this.acpEventProcessor.getWorkspaceId(sessionId);
+    let promptCompleted = false;
     // Scope orphan detection to each prompt turn.
     this.acpEventProcessor.beginPromptTurn(sessionId);
 
@@ -364,6 +374,7 @@ export class SessionService {
 
     try {
       const result = await this.runtimeManager.sendPrompt(sessionId, prompt, timeoutMs);
+      promptCompleted = true;
       this.acpEventProcessor.finalizeOrphanedToolCalls(
         sessionId,
         `stop_reason:${result.stopReason}`
@@ -389,8 +400,14 @@ export class SessionService {
       if (workspaceId && this.workspaceBridge) {
         this.workspaceBridge.markSessionIdle(workspaceId, sessionId);
       }
-      this.promptTurnCompletionService.schedule(sessionId);
+      if (promptCompleted) {
+        this.promptTurnCompletionService.schedule(sessionId);
+      }
     }
+  }
+
+  private isTurnAlreadyInProgressError(error: unknown): boolean {
+    return toErrorMessage(error).includes(TURN_ALREADY_IN_PROGRESS_REASON);
   }
 
   /**

--- a/src/backend/services/session/service/lifecycle/session.service.ts
+++ b/src/backend/services/session/service/lifecycle/session.service.ts
@@ -358,6 +358,8 @@ export class SessionService {
   ): Promise<string> {
     const workspaceId = this.acpEventProcessor.getWorkspaceId(sessionId);
     let promptCompleted = false;
+    let promptError: unknown;
+    let promptErrorSet = false;
     // Scope orphan detection to each prompt turn.
     this.acpEventProcessor.beginPromptTurn(sessionId);
 
@@ -387,6 +389,8 @@ export class SessionService {
       });
       return result.stopReason;
     } catch (error) {
+      promptError = error;
+      promptErrorSet = true;
       this.acpEventProcessor.finalizeOrphanedToolCalls(sessionId, 'prompt_error');
       this.sessionDomainService.setRuntimeSnapshot(sessionId, {
         phase: 'error',
@@ -400,7 +404,7 @@ export class SessionService {
       if (workspaceId && this.workspaceBridge) {
         this.workspaceBridge.markSessionIdle(workspaceId, sessionId);
       }
-      if (promptCompleted) {
+      if (promptCompleted || (promptErrorSet && !this.isTurnAlreadyInProgressError(promptError))) {
         this.promptTurnCompletionService.schedule(sessionId);
       }
     }


### PR DESCRIPTION
## Summary
- Prevent provider-busy ACP prompt rejections from scheduling prompt-turn completion callbacks, which stops the immediate retry loop after sleep/resume.
- Downgrade expected "turn already in progress" prompt rejections from error spam to debug logging.
- Replace unsafe arbitrary error-object stringification with bounded structured error summaries in session and chat dispatch paths.
- Add regression coverage for provider-busy prompt errors and safe error formatting.

## Tests
- pnpm vitest run src/backend/services/session/service/lifecycle/session.error-message.test.ts src/backend/services/session/service/lifecycle/session.service.test.ts src/backend/services/session/service/chat/chat-message-handlers.service.test.ts
- pnpm exec biome check src/backend/services/session/service/lifecycle/session.error-message.ts src/backend/services/session/service/lifecycle/session.error-message.test.ts src/backend/services/session/service/lifecycle/session.service.ts src/backend/services/session/service/lifecycle/session.service.test.ts src/backend/services/session/service/chat/chat-message-handlers.service.ts
- pnpm typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes prompt lifecycle behavior by skipping prompt-turn completion scheduling on provider "turn already in progress" rejections and alters error logging/formatting; could affect retry/completion flows and observability if the busy condition is misdetected.
> 
> **Overview**
> Prevents immediate retry loops after sleep/resume by **not scheduling prompt-turn completion callbacks** when an ACP prompt fails with the provider-busy "turn already in progress" error, while still scheduling completion for successful prompts and other failures.
> 
> Improves observability and safety by downgrading expected busy-turn prompt failures from `error` to `debug` logs, and by replacing unbounded `JSON.stringify` of arbitrary error objects with a **bounded, structured `toErrorMessage` summary** (used in both session and chat dispatch paths), with new tests covering busy-error behavior and error formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b31eff79294f0ddb3f345e8cfb99313905f6c64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->