### PR TITLE
Guard Prisma generated imports

### DIFF
--- a/scripts/check-service-registry.ts
+++ b/scripts/check-service-registry.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import ts from 'typescript';
 
@@ -11,6 +11,14 @@ import {
 const rootDir = process.cwd();
 const servicesRoot = path.join(rootDir, 'src/backend/services');
 const schemaPath = path.join(rootDir, 'prisma/schema.prisma');
+const prismaGeneratedRoot = path.join(rootDir, 'prisma/generated');
+const publicPrismaGeneratedSpecifiers = new Set([
+  '@prisma-gen/browser',
+  '@prisma-gen/client',
+  '@prisma-gen/commonInputTypes',
+  '@prisma-gen/enums',
+  '@prisma-gen/models',
+]);
 const infraServiceFileNames = new Set(
   readdirSync(servicesRoot, { withFileTypes: true })
     .filter(
@@ -25,22 +33,21 @@ function readPrismaModelNames(schemaFilePath: string): Set<string> {
   return new Set(Array.from(modelNameMatches, (match) => match[1]));
 }
 
-function listTypeScriptFiles(dirPath: string): string[] {
+function listTypeScriptFiles(dirPath: string, includeTests = false): string[] {
   const entries = readdirSync(dirPath, { withFileTypes: true });
   const filePaths: string[] = [];
 
   for (const entry of entries) {
     const entryPath = path.join(dirPath, entry.name);
     if (entry.isDirectory()) {
-      filePaths.push(...listTypeScriptFiles(entryPath));
+      filePaths.push(...listTypeScriptFiles(entryPath, includeTests));
       continue;
     }
 
     if (
       entry.isFile() &&
       (entry.name.endsWith('.ts') || entry.name.endsWith('.tsx')) &&
-      !entry.name.endsWith('.test.ts') &&
-      !entry.name.endsWith('.test.tsx')
+      (includeTests || !(entry.name.endsWith('.test.ts') || entry.name.endsWith('.test.tsx')))
     ) {
       filePaths.push(entryPath);
     }
@@ -62,6 +69,13 @@ function collectModuleSpecifiers(filePath: string): string[] {
         ts.isStringLiteral(moduleSpecifier) &&
         moduleSpecifier.text.length > 0
       ) {
+        moduleSpecifiers.push(moduleSpecifier.text);
+      }
+    }
+
+    if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+      const [moduleSpecifier] = node.arguments;
+      if (moduleSpecifier && ts.isStringLiteral(moduleSpecifier)) {
         moduleSpecifiers.push(moduleSpecifier.text);
       }
     }
@@ -259,6 +273,69 @@ function checkCrossServiceImports(errors: string[]): void {
   }
 }
 
+function isInsideDirectory(filePath: string, directoryPath: string): boolean {
+  const relativePath = path.relative(directoryPath, filePath);
+  return (
+    relativePath.length === 0 || !(relativePath.startsWith('..') || path.isAbsolute(relativePath))
+  );
+}
+
+function checkPrismaGeneratedImport(
+  filePath: string,
+  relativePath: string,
+  moduleSpecifier: string,
+  errors: string[]
+): void {
+  if (moduleSpecifier.startsWith('@prisma-gen/')) {
+    if (!publicPrismaGeneratedSpecifiers.has(moduleSpecifier)) {
+      errors.push(
+        `${relativePath} imports "${moduleSpecifier}", but generated Prisma imports must use public @prisma-gen entrypoints: ${Array.from(publicPrismaGeneratedSpecifiers).join(', ')}.`
+      );
+    }
+    return;
+  }
+
+  if (moduleSpecifier === 'prisma/generated' || moduleSpecifier.startsWith('prisma/generated/')) {
+    errors.push(
+      `${relativePath} imports "${moduleSpecifier}" directly. Use a public @prisma-gen/* entrypoint instead.`
+    );
+    return;
+  }
+
+  if (!moduleSpecifier.startsWith('.')) {
+    return;
+  }
+
+  const resolvedImportPath = path.resolve(path.dirname(filePath), moduleSpecifier);
+  if (isInsideDirectory(resolvedImportPath, prismaGeneratedRoot)) {
+    errors.push(
+      `${relativePath} imports "${moduleSpecifier}" from prisma/generated directly. Use a public @prisma-gen/* entrypoint instead.`
+    );
+  }
+}
+
+function checkPrismaGeneratedImports(errors: string[]): void {
+  const codeRoots = ['src', 'scripts', 'electron', 'packages'];
+
+  for (const codeRoot of codeRoots) {
+    const absoluteCodeRoot = path.join(rootDir, codeRoot);
+    if (!existsSync(absoluteCodeRoot)) {
+      continue;
+    }
+
+    for (const filePath of listTypeScriptFiles(absoluteCodeRoot, true)) {
+      if (isInsideDirectory(filePath, prismaGeneratedRoot)) {
+        continue;
+      }
+
+      const relativePath = getRelativeServiceFilePath(filePath);
+      for (const moduleSpecifier of collectModuleSpecifiers(filePath)) {
+        checkPrismaGeneratedImport(filePath, relativePath, moduleSpecifier, errors);
+      }
+    }
+  }
+}
+
 function checkRegistryModelList(errors: string[]): void {
   const schemaModelNames = readPrismaModelNames(schemaPath);
 
@@ -287,6 +364,7 @@ function main(): void {
   checkRegistryModelList(errors);
   checkDependencyGraph(errors);
   checkCrossServiceImports(errors);
+  checkPrismaGeneratedImports(errors);
 
   if (errors.length > 0) {
     const output = [


### PR DESCRIPTION
## Summary
- Enforce public `@prisma-gen/*` entrypoints in the service registry check.
- Reject direct imports into `prisma/generated/`, including generated internals and relative paths.
- Extend module specifier collection to include dynamic imports and co-located tests for this generated-import boundary.

## Validation
- `pnpm check:service-registry`
- `pnpm check:ownership`
- `pnpm check`
- Commit hook: `pnpm typecheck`, `pnpm deps:check`, `pnpm knip`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low runtime risk since changes are limited to a repo check script, but it may cause CI/commit hooks to fail until any direct `prisma/generated` imports are migrated to the approved `@prisma-gen/*` entrypoints.
> 
> **Overview**
> Strengthens `check:service-registry` by adding validation that **all Prisma generated code is imported only via approved public `@prisma-gen/*` entrypoints**, rejecting any direct `prisma/generated` (including subpaths) or relative-path access into that directory.
> 
> The check now scans across `src`, `scripts`, `electron`, and `packages`, includes test files, and also detects `import()` dynamic module specifiers to close gaps in import discovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04a52ca6d7427001084fa90c5f928de471772e40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->