### PR TITLE
Persist CLI setup banner dismissal

### DIFF
--- a/src/client/components/cli-health-banner.test.tsx
+++ b/src/client/components/cli-health-banner.test.tsx
@@ -1,6 +1,36 @@
 import { renderToStaticMarkup } from 'react-dom/server';
-import { describe, expect, it, vi } from 'vitest';
-import { CLIHealthBannerContent, collectIssues } from './cli-health-banner';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  CLIHealthBannerContent,
+  collectIssues,
+  forgetDismissedCLIHealthWarning,
+  getCLIHealthWarningFingerprint,
+  isCLIHealthWarningDismissed,
+  readDismissedCLIHealthWarningFingerprint,
+  rememberDismissedCLIHealthWarning,
+} from './cli-health-banner';
+
+const mockStorage = new Map<string, string>();
+
+const mockLocalStorage = {
+  getItem: vi.fn((key: string) => mockStorage.get(key) ?? null),
+  setItem: vi.fn((key: string, value: string) => {
+    mockStorage.set(key, value);
+  }),
+  removeItem: vi.fn((key: string) => {
+    mockStorage.delete(key);
+  }),
+  clear: vi.fn(() => {
+    mockStorage.clear();
+  }),
+  get length() {
+    return mockStorage.size;
+  },
+  key: vi.fn((index: number) => {
+    const keys = Array.from(mockStorage.keys());
+    return keys[index] ?? null;
+  }),
+};
 
 describe('collectIssues', () => {
   it('collects outdated and missing CLI issues', () => {
@@ -49,6 +79,116 @@ describe('collectIssues', () => {
     });
 
     expect(issues).toHaveLength(0);
+  });
+});
+
+describe('CLI health warning dismissal storage', () => {
+  beforeEach(() => {
+    mockStorage.clear();
+    vi.clearAllMocks();
+    vi.stubGlobal('localStorage', mockLocalStorage);
+    vi.stubGlobal('window', { localStorage: mockLocalStorage });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    mockStorage.clear();
+  });
+
+  it('remembers a dismissed warning for the same warning fingerprint', () => {
+    const issues = collectIssues({
+      claude: { isInstalled: true },
+      codex: { isInstalled: true, isAuthenticated: true },
+      github: { isInstalled: false, isAuthenticated: false },
+    });
+    const fingerprint = getCLIHealthWarningFingerprint(issues);
+
+    rememberDismissedCLIHealthWarning(fingerprint);
+
+    expect(isCLIHealthWarningDismissed(fingerprint)).toBe(true);
+  });
+
+  it('does not reuse dismissal when the latest version changes', () => {
+    const dismissedIssues = collectIssues({
+      claude: {
+        isInstalled: true,
+        isOutdated: true,
+        version: '0.1.0',
+        latestVersion: '0.2.0',
+      },
+      codex: { isInstalled: true, isAuthenticated: true },
+      github: { isInstalled: true, isAuthenticated: true },
+    });
+    const updatedIssues = collectIssues({
+      claude: {
+        isInstalled: true,
+        isOutdated: true,
+        version: '0.1.0',
+        latestVersion: '0.3.0',
+      },
+      codex: { isInstalled: true, isAuthenticated: true },
+      github: { isInstalled: true, isAuthenticated: true },
+    });
+
+    rememberDismissedCLIHealthWarning(getCLIHealthWarningFingerprint(dismissedIssues));
+
+    expect(isCLIHealthWarningDismissed(getCLIHealthWarningFingerprint(updatedIssues))).toBe(false);
+  });
+
+  it('does not reuse dismissal when the issue set changes', () => {
+    const dismissedIssues = collectIssues({
+      claude: { isInstalled: true },
+      codex: { isInstalled: true, isAuthenticated: true },
+      github: { isInstalled: false, isAuthenticated: false },
+    });
+    const updatedIssues = collectIssues({
+      claude: {
+        isInstalled: true,
+        isOutdated: true,
+        version: '0.1.0',
+        latestVersion: '0.2.0',
+      },
+      codex: { isInstalled: true, isAuthenticated: true },
+      github: { isInstalled: false, isAuthenticated: false },
+    });
+
+    rememberDismissedCLIHealthWarning(getCLIHealthWarningFingerprint(dismissedIssues));
+
+    expect(isCLIHealthWarningDismissed(getCLIHealthWarningFingerprint(updatedIssues))).toBe(false);
+  });
+
+  it('forgets a dismissed warning after warnings clear', () => {
+    const issues = collectIssues({
+      claude: { isInstalled: true },
+      codex: { isInstalled: true, isAuthenticated: true },
+      github: { isInstalled: false, isAuthenticated: false },
+    });
+
+    rememberDismissedCLIHealthWarning(getCLIHealthWarningFingerprint(issues));
+    forgetDismissedCLIHealthWarning();
+
+    expect(readDismissedCLIHealthWarningFingerprint()).toBeNull();
+  });
+
+  it('ignores localStorage failures', () => {
+    vi.stubGlobal('window', {
+      localStorage: {
+        getItem: vi.fn(() => {
+          throw new Error('blocked');
+        }),
+        setItem: vi.fn(() => {
+          throw new Error('blocked');
+        }),
+        removeItem: vi.fn(() => {
+          throw new Error('blocked');
+        }),
+      },
+    });
+
+    expect(readDismissedCLIHealthWarningFingerprint()).toBeNull();
+    expect(() => rememberDismissedCLIHealthWarning('fingerprint')).not.toThrow();
+    expect(() => forgetDismissedCLIHealthWarning()).not.toThrow();
+    expect(isCLIHealthWarningDismissed('fingerprint')).toBe(false);
   });
 });
 

--- a/src/client/components/cli-health-banner.tsx
+++ b/src/client/components/cli-health-banner.tsx
@@ -4,6 +4,8 @@ import { toast } from 'sonner';
 import { trpc } from '@/client/lib/trpc';
 import { Button } from '@/components/ui/button';
 
+const CLI_HEALTH_WARNING_DISMISSED_KEY = 'ff_cli_health_warning_dismissed';
+
 interface HealthIssue {
   title: string;
   description: string;
@@ -69,6 +71,58 @@ export function collectIssues(health: CliHealthForBanner): HealthIssue[] {
   }
 
   return issues;
+}
+
+function getStorage(): Storage | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function getCLIHealthWarningFingerprint(issues: HealthIssue[]): string {
+  return JSON.stringify(
+    issues.map((issue) => ({
+      title: issue.title,
+      description: issue.description,
+      link: issue.link ?? null,
+      linkLabel: issue.linkLabel ?? null,
+      upgradeProvider: issue.upgradeProvider ?? null,
+    }))
+  );
+}
+
+export function readDismissedCLIHealthWarningFingerprint(): string | null {
+  try {
+    return getStorage()?.getItem(CLI_HEALTH_WARNING_DISMISSED_KEY) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function isCLIHealthWarningDismissed(fingerprint: string): boolean {
+  return readDismissedCLIHealthWarningFingerprint() === fingerprint;
+}
+
+export function rememberDismissedCLIHealthWarning(fingerprint: string) {
+  try {
+    getStorage()?.setItem(CLI_HEALTH_WARNING_DISMISSED_KEY, fingerprint);
+  } catch {
+    // Non-blocking: ignore localStorage failures.
+  }
+}
+
+export function forgetDismissedCLIHealthWarning() {
+  try {
+    getStorage()?.removeItem(CLI_HEALTH_WARNING_DISMISSED_KEY);
+  } catch {
+    // Non-blocking: ignore localStorage failures.
+  }
 }
 
 function renderIssueActions(
@@ -208,10 +262,12 @@ export function CLIHealthBannerContent({
 
 /**
  * Banner that displays warnings when CLI dependencies are not properly installed.
- * Shows on app launch and can be dismissed (but will reappear on next launch if issues persist).
+ * Shows on app launch and can be dismissed until the warning content changes.
  */
 export function CLIHealthBanner() {
-  const [dismissed, setDismissed] = useState(false);
+  const [dismissedFingerprint, setDismissedFingerprint] = useState(() =>
+    readDismissedCLIHealthWarningFingerprint()
+  );
   const utils = trpc.useUtils();
   const upgradeProviderCli = trpc.admin.upgradeProviderCLI.useMutation({
     onSuccess: (result) => {
@@ -239,22 +295,27 @@ export function CLIHealthBanner() {
     }
   );
 
-  const issueCount = health ? collectIssues(health).length : 0;
+  const issues = health ? collectIssues(health) : [];
+  const warningFingerprint = issues.length > 0 ? getCLIHealthWarningFingerprint(issues) : null;
 
-  // Reset dismissed state when health issues appear (or change).
   useEffect(() => {
-    if (issueCount > 0) {
-      setDismissed(false);
+    if (health && issues.length === 0) {
+      forgetDismissedCLIHealthWarning();
+      if (dismissedFingerprint !== null) {
+        setDismissedFingerprint(null);
+      }
     }
-  }, [issueCount]);
+  }, [dismissedFingerprint, health, issues.length]);
 
-  if (isLoading || dismissed || !health) {
+  if (isLoading || !health) {
     return null;
   }
 
-  const issues = collectIssues(health);
-
-  if (issues.length === 0) {
+  if (
+    !warningFingerprint ||
+    dismissedFingerprint === warningFingerprint ||
+    isCLIHealthWarningDismissed(warningFingerprint)
+  ) {
     return null;
   }
 
@@ -264,7 +325,10 @@ export function CLIHealthBanner() {
       isRefetching={isRefetching}
       isUpgrading={upgradeProviderCli.isPending}
       onRecheck={() => refetch()}
-      onDismiss={() => setDismissed(true)}
+      onDismiss={() => {
+        rememberDismissedCLIHealthWarning(warningFingerprint);
+        setDismissedFingerprint(warningFingerprint);
+      }}
       onUpgrade={(provider) => upgradeProviderCli.mutate({ provider })}
     />
   );


### PR DESCRIPTION
## Summary
- Persist dismissal of the global CLI setup warning using a stable fingerprint of the rendered warning contents.
- Resurface the banner when the warning changes, including new CLI latest-version text or a changed issue set.
- Clear the saved dismissal once CLI health warnings are resolved.

## Tests
- pnpm test src/client/components/cli-health-banner.test.tsx
- pnpm typecheck
- pnpm exec biome check src/client/components/cli-health-banner.tsx src/client/components/cli-health-banner.test.tsx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/state change confined to the CLI health banner, with defensive handling for SSR and `localStorage` failures. Main risk is incorrect fingerprinting causing the banner to hide or reappear unexpectedly.
> 
> **Overview**
> **Persisted dismissal for the CLI health banner.** Dismissals are now stored in `localStorage` keyed by a stable fingerprint of the current `issues`, so the banner stays hidden across reloads *until the warning content changes*.
> 
> The banner now clears the saved dismissal once CLI health issues resolve, and adds tests covering fingerprint stability, change detection (issue set/version text), and safe behavior when `localStorage` is unavailable/throws.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da3ba4daf09e03e4a861d93a1a35aff52771a2c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->