### PR TITLE
Fix plan approval scrolling

### DIFF
--- a/src/client/routes/projects/workspaces/workspace-detail-chat-content.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-chat-content.tsx
@@ -291,12 +291,13 @@ export const ChatContent = memo(function ChatContent(props: ChatContentProps) {
         </div>
       )}
 
-      <div className="z-20 border-t bg-background pb-safe">
+      <div className="z-20 flex max-h-full min-h-0 flex-col border-t bg-background pb-safe">
         <PermissionPrompt
           permission={
             props.pendingRequest.type === 'permission' ? props.pendingRequest.request : null
           }
           onApprove={props.approvePermission}
+          className="min-h-0 shrink overflow-y-auto"
         />
         <QuestionPrompt
           question={props.pendingRequest.type === 'question' ? props.pendingRequest.request : null}
@@ -304,6 +305,7 @@ export const ChatContent = memo(function ChatContent(props: ChatContentProps) {
         />
 
         <ChatInput
+          className="shrink-0"
           onSend={props.sendMessage}
           onStop={props.stopChat}
           disabled={!props.connected || loadingSession}

--- a/src/components/chat/permission-prompt.test.tsx
+++ b/src/components/chat/permission-prompt.test.tsx
@@ -48,6 +48,10 @@ describe('PermissionPrompt', () => {
     expect(container.textContent).toContain('Approve and switch to Default');
     expect(container.textContent).toContain('Keep planning');
 
+    const planPrompt = container.querySelector('[aria-label="Plan approval request"]');
+    expect(planPrompt?.className).toContain('min-h-0');
+    expect(planPrompt?.className).toContain('overflow-y-auto');
+
     const renderedMarkdown = container.querySelector('.prose');
     expect(renderedMarkdown?.className).toContain('overflow-hidden');
 

--- a/src/components/chat/permission-prompt.tsx
+++ b/src/components/chat/permission-prompt.tsx
@@ -16,6 +16,7 @@ import { type PlanViewMode, usePlanViewMode } from './plan-view-preference';
 interface PermissionPromptProps {
   permission: PermissionRequest | null;
   onApprove: (requestId: string, allow: boolean, optionId?: string) => void;
+  className?: string;
 }
 
 interface PermissionOption {
@@ -33,6 +34,7 @@ interface PermissionDecisionActionsProps {
 interface PermissionDecisionCardProps extends PermissionDecisionActionsProps {
   toolName: string;
   children: React.ReactNode;
+  className?: string;
 }
 
 // =============================================================================
@@ -124,11 +126,13 @@ function PermissionDecisionCard({
   onAllow,
   onDeny,
   children,
+  className,
 }: PermissionDecisionCardProps) {
   return (
     <PromptCard
       icon={<Terminal className="h-5 w-5 text-muted-foreground" aria-hidden="true" />}
       label={`Permission request for ${toolName}`}
+      className={className}
       actions={
         <PermissionDecisionActions
           allowButtonRef={allowButtonRef}
@@ -230,21 +234,10 @@ function PlanViewToggle({ value, onChange }: PlanViewToggleProps) {
  * Specialized prompt for approving plans in ExitPlanMode.
  * Displays the plan content with expand/collapse functionality.
  */
-function PlanApprovalPrompt({ permission, onApprove }: PermissionPromptProps) {
+function PlanApprovalPrompt({ permission, onApprove, className }: PermissionPromptProps) {
   const firstActionButtonRef = useRef<HTMLButtonElement>(null);
   const [expanded, setExpanded] = useState(true);
   const [viewMode, setViewMode] = usePlanViewMode();
-  const permissionRequestId = permission?.requestId;
-
-  useEffect(() => {
-    if (!permissionRequestId) {
-      return;
-    }
-    const timeoutId = setTimeout(() => {
-      firstActionButtonRef.current?.focus();
-    }, 100);
-    return () => clearTimeout(timeoutId);
-  }, [permissionRequestId]);
 
   if (!permission) {
     return null;
@@ -272,7 +265,11 @@ function PlanApprovalPrompt({ permission, onApprove }: PermissionPromptProps) {
   };
 
   return (
-    <div className="border-b bg-muted/50 p-3" role="alertdialog" aria-label="Plan approval request">
+    <div
+      className={cn('min-h-0 overflow-y-auto border-b bg-muted/50 p-3', className)}
+      role="alertdialog"
+      aria-label="Plan approval request"
+    >
       <div className="min-w-0 space-y-3">
         {/* Header */}
         <div className="flex flex-wrap items-start justify-between gap-2">
@@ -351,7 +348,7 @@ function PlanApprovalPrompt({ permission, onApprove }: PermissionPromptProps) {
  * Renders distinct buttons for each permission option (allow once, allow always,
  * reject once, reject always) instead of the binary Allow/Deny UI.
  */
-function AcpPermissionPrompt({ permission, onApprove }: PermissionPromptProps) {
+function AcpPermissionPrompt({ permission, onApprove, className }: PermissionPromptProps) {
   const firstButtonRef = useRef<HTMLButtonElement>(null);
   const permissionRequestId = permission?.requestId;
 
@@ -383,6 +380,7 @@ function AcpPermissionPrompt({ permission, onApprove }: PermissionPromptProps) {
     <PromptCard
       icon={<Terminal className="h-5 w-5 text-muted-foreground" aria-hidden="true" />}
       label={`Permission request for ${toolName}`}
+      className={className}
       actions={
         <div className="flex flex-wrap gap-2">
           {[...allowOptions, ...rejectOptions].map((option, index) => {
@@ -423,7 +421,7 @@ function AcpPermissionPrompt({ permission, onApprove }: PermissionPromptProps) {
  * For ExitPlanMode requests, shows a specialized plan approval view.
  * For ACP requests with acpOptions, shows multi-option permission buttons.
  */
-export function PermissionPrompt({ permission, onApprove }: PermissionPromptProps) {
+export function PermissionPrompt({ permission, onApprove, className }: PermissionPromptProps) {
   const allowButtonRef = useRef<HTMLButtonElement>(null);
   const permissionRequestId =
     permission?.toolName === 'ExitPlanMode' ? undefined : permission?.requestId;
@@ -435,12 +433,16 @@ export function PermissionPrompt({ permission, onApprove }: PermissionPromptProp
 
   // ExitPlanMode always uses plan-specific view so plan content is visible.
   if (permission.toolName === 'ExitPlanMode') {
-    return <PlanApprovalPrompt permission={permission} onApprove={onApprove} />;
+    return (
+      <PlanApprovalPrompt permission={permission} onApprove={onApprove} className={className} />
+    );
   }
 
   // ACP multi-option permissions
   if (permission.acpOptions && permission.acpOptions.length > 0) {
-    return <AcpPermissionPrompt permission={permission} onApprove={onApprove} />;
+    return (
+      <AcpPermissionPrompt permission={permission} onApprove={onApprove} className={className} />
+    );
   }
 
   const { requestId, toolName, toolInput } = permission;
@@ -460,6 +462,7 @@ export function PermissionPrompt({ permission, onApprove }: PermissionPromptProp
       allowButtonRef={allowButtonRef}
       onAllow={handleAllow}
       onDeny={handleDeny}
+      className={className}
     >
       <div className="text-sm font-medium">Permission: {toolName}</div>
       <div className="text-xs text-muted-foreground mt-1 font-mono truncate" title={inputPreview}>
@@ -473,7 +476,11 @@ export function PermissionPrompt({ permission, onApprove }: PermissionPromptProp
  * Expanded inline prompt with full tool input details.
  * Use when more context is needed before approval.
  */
-export function PermissionPromptExpanded({ permission, onApprove }: PermissionPromptProps) {
+export function PermissionPromptExpanded({
+  permission,
+  onApprove,
+  className,
+}: PermissionPromptProps) {
   const allowButtonRef = useRef<HTMLButtonElement>(null);
   useAutoFocusPermissionButton(allowButtonRef, permission?.requestId);
 
@@ -497,6 +504,7 @@ export function PermissionPromptExpanded({ permission, onApprove }: PermissionPr
       allowButtonRef={allowButtonRef}
       onAllow={handleAllow}
       onDeny={handleDeny}
+      className={className}
     >
       <div className="space-y-2">
         <div className="text-sm font-medium">Permission: {toolName}</div>

--- a/src/components/chat/permission-prompt.tsx
+++ b/src/components/chat/permission-prompt.tsx
@@ -235,7 +235,6 @@ function PlanViewToggle({ value, onChange }: PlanViewToggleProps) {
  * Displays the plan content with expand/collapse functionality.
  */
 function PlanApprovalPrompt({ permission, onApprove, className }: PermissionPromptProps) {
-  const firstActionButtonRef = useRef<HTMLButtonElement>(null);
   const [expanded, setExpanded] = useState(true);
   const [viewMode, setViewMode] = usePlanViewMode();
 
@@ -316,13 +315,12 @@ function PlanApprovalPrompt({ permission, onApprove, className }: PermissionProm
 
         {/* Actions */}
         <div className="flex flex-wrap justify-end gap-2">
-          {options.map((option, index) => {
+          {options.map((option) => {
             const style = getPermissionOptionStyle(option.kind);
             const Icon = style.icon;
             return (
               <Button
                 key={option.optionId}
-                ref={index === 0 ? firstActionButtonRef : undefined}
                 variant={style.variant}
                 size="sm"
                 onClick={() => handleOptionClick(option)}


### PR DESCRIPTION
## Summary
- Constrain the bottom chat composer so plan approvals shrink inside the available workspace pane instead of clipping off the top.
- Make the plan approval prompt scrollable and remove autofocus that could pull the visible area down to the action buttons.
- Add regression coverage for the plan approval scroll-safe classes.

## Tests
- pnpm exec vitest run src/components/chat/permission-prompt.test.tsx
- pnpm typecheck
- pnpm exec biome check --write src/client/routes/projects/workspaces/workspace-detail-chat-content.tsx src/components/chat/permission-prompt.tsx src/components/chat/permission-prompt.test.tsx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/layout change that adjusts flex/overflow styling and removes plan-approval autofocus; main risk is minor regression in prompt sizing/scroll behavior across chat surfaces.
> 
> **Overview**
> Fixes plan approval prompts getting clipped in the workspace chat composer by turning the bottom composer area into a constrained flex column and making `PermissionPrompt` shrink/scroll within available space.
> 
> Updates `PermissionPrompt` to accept a passthrough `className` and applies scroll-safe classes to the ExitPlanMode plan approval container; also removes the plan approval action-button autofocus that could yank the viewport. Adds a regression test asserting the new scroll/height classes on the plan approval prompt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77f6b77b70b9f975c8182a614e3f6d4c0e42f15d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->