### PR TITLE
feat: add time-of-day scheduling for periodic tasks

### DIFF
--- a/prisma/migrations/20260519122959_add_periodic_task_scheduled_time/migration.sql
+++ b/prisma/migrations/20260519122959_add_periodic_task_scheduled_time/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "PeriodicTask" ADD COLUMN "scheduledTime" TEXT;
+ALTER TABLE "PeriodicTask" ADD COLUMN "timezone" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -374,9 +374,11 @@ model PeriodicTask {
   projectId   String
   project     Project              @relation(fields: [projectId], references: [id])
 
-  name        String
-  prompt      String
-  cadence     PeriodicTaskCadence
+  name          String
+  prompt        String
+  cadence       PeriodicTaskCadence
+  scheduledTime String?
+  timezone      String?
 
   isEnabled   Boolean              @default(true)
   nextRunAt   DateTime

--- a/src/backend/services/periodic-task/resources/periodic-task.accessor.ts
+++ b/src/backend/services/periodic-task/resources/periodic-task.accessor.ts
@@ -66,7 +66,34 @@ function applyScheduledTime(date: Date, scheduledTime: string, timezone: string)
   }
   const offsetMs = offsetMinutes * 60_000;
 
-  return new Date(utcProbe.getTime() + offsetMs);
+  const candidate = new Date(utcProbe.getTime() + offsetMs);
+
+  // Validate the candidate's calendar day in the target timezone matches the
+  // intended day. Ambiguous offset boundaries (e.g. UTC-10 at morning hours
+  // where offsetMinutes lands exactly on -840) can cause an off-by-one-day
+  // error; correct by ±24h if needed.
+  const candidateParts = Object.fromEntries(
+    new Intl.DateTimeFormat('en-CA', {
+      timeZone: timezone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    })
+      .formatToParts(candidate)
+      .map(({ type, value }) => [type, value])
+  );
+
+  const intendedDate = `${dateParts.year}-${dateParts.month}-${dateParts.day}`;
+  const candidateDate = `${candidateParts.year}-${candidateParts.month}-${candidateParts.day}`;
+
+  if (candidateDate < intendedDate) {
+    return new Date(candidate.getTime() + 24 * 60 * 60_000);
+  }
+  if (candidateDate > intendedDate) {
+    return new Date(candidate.getTime() - 24 * 60 * 60_000);
+  }
+
+  return candidate;
 }
 
 function computeNextRunAt(

--- a/src/backend/services/periodic-task/resources/periodic-task.accessor.ts
+++ b/src/backend/services/periodic-task/resources/periodic-task.accessor.ts
@@ -4,7 +4,68 @@ import type { PeriodicTaskCadence, PeriodicTaskExecutionStatus } from '@/shared/
 
 // ─── Cadence helpers ────────────────────────────────────────────────────────
 
-function computeNextRunAt(cadence: PeriodicTaskCadence, from: Date = new Date()): Date {
+const LONG_CADENCES = new Set<PeriodicTaskCadence>(['DAILY', 'WEEKLY', 'MONTHLY']);
+
+/**
+ * When a task has a scheduledTime + timezone, snap the computed next date to
+ * that clock time in the user's timezone. Uses the Intl API — no extra deps.
+ */
+function applyScheduledTime(date: Date, scheduledTime: string, timezone: string): Date {
+  const parts = scheduledTime.split(':').map(Number);
+  const hours = parts[0] ?? 0;
+  const minutes = parts[1] ?? 0;
+
+  // Get the calendar date (Y/M/D) in the target timezone.
+  const dateParts = Object.fromEntries(
+    new Intl.DateTimeFormat('en-CA', {
+      timeZone: timezone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    })
+      .formatToParts(date)
+      .map(({ type, value }) => [type, value])
+  );
+
+  // Build a UTC probe: treat the target local datetime as if it were UTC.
+  const utcProbe = new Date(
+    Date.UTC(
+      Number(dateParts.year),
+      Number(dateParts.month) - 1,
+      Number(dateParts.day),
+      hours,
+      minutes,
+      0
+    )
+  );
+
+  // Find what hour/minute utcProbe shows in the target timezone so we can
+  // compute the offset and correct back to true UTC.
+  const localTimeParts = Object.fromEntries(
+    new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    })
+      .formatToParts(utcProbe)
+      .map(({ type, value }) => [type, value])
+  );
+
+  const probeHour = Number(localTimeParts.hour) % 24; // guard against "24" at midnight
+  const probeMinute = Number(localTimeParts.minute);
+
+  const offsetMs = ((hours - probeHour) * 60 + (minutes - probeMinute)) * 60_000;
+
+  return new Date(utcProbe.getTime() + offsetMs);
+}
+
+function computeNextRunAt(
+  cadence: PeriodicTaskCadence,
+  from: Date = new Date(),
+  scheduledTime?: string | null,
+  timezone?: string | null
+): Date {
   const next = new Date(from);
   switch (cadence) {
     case 'EVERY_MINUTE':
@@ -29,6 +90,11 @@ function computeNextRunAt(cadence: PeriodicTaskCadence, from: Date = new Date())
       break;
     }
   }
+
+  if (scheduledTime && timezone && LONG_CADENCES.has(cadence)) {
+    return applyScheduledTime(next, scheduledTime, timezone);
+  }
+
   return next;
 }
 
@@ -39,6 +105,8 @@ interface CreatePeriodicTaskInput {
   name: string;
   prompt: string;
   cadence: PeriodicTaskCadence;
+  scheduledTime?: string | null;
+  timezone?: string | null;
 }
 
 interface UpdatePeriodicTaskInput {
@@ -46,6 +114,8 @@ interface UpdatePeriodicTaskInput {
   prompt?: string;
   cadence?: PeriodicTaskCadence;
   isEnabled?: boolean;
+  scheduledTime?: string | null;
+  timezone?: string | null;
 }
 
 type PeriodicTaskWithExecutions = PeriodicTask & {
@@ -64,6 +134,8 @@ export const periodicTaskAccessor = {
         name: input.name,
         prompt: input.prompt,
         cadence: input.cadence,
+        scheduledTime: input.scheduledTime ?? null,
+        timezone: input.timezone ?? null,
         nextRunAt: new Date(), // Run immediately for first execution
       },
     });
@@ -95,9 +167,25 @@ export const periodicTaskAccessor = {
     if (input.isEnabled !== undefined) {
       data.isEnabled = input.isEnabled;
     }
-    if (input.cadence !== undefined) {
-      data.cadence = input.cadence;
-      data.nextRunAt = computeNextRunAt(input.cadence);
+
+    const needsNextRunAt =
+      input.cadence !== undefined ||
+      input.scheduledTime !== undefined ||
+      input.timezone !== undefined;
+
+    if (needsNextRunAt) {
+      const existing = await prisma.periodicTask.findUniqueOrThrow({ where: { id } });
+      const cadence = (input.cadence ?? existing.cadence) as PeriodicTaskCadence;
+      const scheduledTime =
+        input.scheduledTime !== undefined ? input.scheduledTime : existing.scheduledTime;
+      const timezone = input.timezone !== undefined ? input.timezone : existing.timezone;
+
+      Object.assign(data, {
+        ...(input.cadence !== undefined && { cadence: input.cadence }),
+        ...(input.scheduledTime !== undefined && { scheduledTime: input.scheduledTime }),
+        ...(input.timezone !== undefined && { timezone: input.timezone }),
+        nextRunAt: computeNextRunAt(cadence, new Date(), scheduledTime, timezone),
+      });
     }
 
     return await prisma.periodicTask.update({ where: { id }, data });
@@ -111,7 +199,12 @@ export const periodicTaskAccessor = {
     const data: Record<string, unknown> = { isEnabled: enabled };
     if (enabled) {
       const task = await prisma.periodicTask.findUniqueOrThrow({ where: { id } });
-      data.nextRunAt = computeNextRunAt(task.cadence as PeriodicTaskCadence);
+      data.nextRunAt = computeNextRunAt(
+        task.cadence as PeriodicTaskCadence,
+        new Date(),
+        task.scheduledTime,
+        task.timezone
+      );
     }
     return await prisma.periodicTask.update({ where: { id }, data });
   },
@@ -125,12 +218,17 @@ export const periodicTaskAccessor = {
     });
   },
 
-  async markDispatched(id: string, cadence: PeriodicTaskCadence): Promise<void> {
+  async markDispatched(
+    id: string,
+    cadence: PeriodicTaskCadence,
+    scheduledTime: string | null,
+    timezone: string | null
+  ): Promise<void> {
     await prisma.periodicTask.update({
       where: { id },
       data: {
         lastRunAt: new Date(),
-        nextRunAt: computeNextRunAt(cadence),
+        nextRunAt: computeNextRunAt(cadence, new Date(), scheduledTime, timezone),
       },
     });
   },

--- a/src/backend/services/periodic-task/resources/periodic-task.accessor.ts
+++ b/src/backend/services/periodic-task/resources/periodic-task.accessor.ts
@@ -55,7 +55,15 @@ function applyScheduledTime(date: Date, scheduledTime: string, timezone: string)
   const probeHour = Number(localTimeParts.hour) % 24; // guard against "24" at midnight
   const probeMinute = Number(localTimeParts.minute);
 
-  const offsetMs = ((hours - probeHour) * 60 + (minutes - probeMinute)) * 60_000;
+  let offsetMinutes = (hours - probeHour) * 60 + (minutes - probeMinute);
+  // Normalize: timezone offsets are always within [-12h, +14h]
+  if (offsetMinutes < -12 * 60) {
+    offsetMinutes += 24 * 60;
+  }
+  if (offsetMinutes > 14 * 60) {
+    offsetMinutes -= 24 * 60;
+  }
+  const offsetMs = offsetMinutes * 60_000;
 
   return new Date(utcProbe.getTime() + offsetMs);
 }

--- a/src/backend/services/periodic-task/resources/periodic-task.accessor.ts
+++ b/src/backend/services/periodic-task/resources/periodic-task.accessor.ts
@@ -56,11 +56,12 @@ function applyScheduledTime(date: Date, scheduledTime: string, timezone: string)
   const probeMinute = Number(localTimeParts.minute);
 
   let offsetMinutes = (hours - probeHour) * 60 + (minutes - probeMinute);
-  // Normalize: timezone offsets are always within [-12h, +14h]
-  if (offsetMinutes < -12 * 60) {
+  // offsetMinutes is the negation of the timezone offset, so valid range is
+  // [-14h, +12h] (i.e. UTC+14 → −840 min, UTC−12 → +720 min).
+  if (offsetMinutes < -14 * 60) {
     offsetMinutes += 24 * 60;
   }
-  if (offsetMinutes > 14 * 60) {
+  if (offsetMinutes > 12 * 60) {
     offsetMinutes -= 24 * 60;
   }
   const offsetMs = offsetMinutes * 60_000;

--- a/src/backend/services/periodic-task/service/periodic-task.service.ts
+++ b/src/backend/services/periodic-task/service/periodic-task.service.ts
@@ -122,7 +122,9 @@ export class PeriodicTaskService {
           task.projectId,
           task.name,
           task.prompt,
-          task.cadence as PeriodicTaskCadence
+          task.cadence as PeriodicTaskCadence,
+          task.scheduledTime,
+          task.timezone
         );
       } catch (error) {
         this.logger.error('Failed to dispatch periodic task', {
@@ -138,7 +140,9 @@ export class PeriodicTaskService {
     projectId: string,
     name: string,
     prompt: string,
-    cadence: PeriodicTaskCadence
+    cadence: PeriodicTaskCadence,
+    scheduledTime: string | null,
+    timezone: string | null
   ): Promise<void> {
     if (!this.workspaceBridge) {
       this.logger.warn('Periodic task service not configured — skipping dispatch');
@@ -149,7 +153,7 @@ export class PeriodicTaskService {
 
     // Advance nextRunAt first so a crash after this point won't re-dispatch
     // the same due window on the next poll (at worst we miss one run).
-    await periodicTaskAccessor.markDispatched(taskId, cadence);
+    await periodicTaskAccessor.markDispatched(taskId, cadence, scheduledTime, timezone);
 
     const result = await this.workspaceBridge.createWorkspaceForTask({
       projectId,

--- a/src/backend/trpc/periodic-task.trpc.ts
+++ b/src/backend/trpc/periodic-task.trpc.ts
@@ -3,6 +3,28 @@ import { z } from 'zod';
 import { periodicTaskAccessor } from '@/backend/services/periodic-task';
 import { publicProcedure, router } from './trpc';
 
+const scheduledTimeSchema = z
+  .string()
+  .regex(/^([01]\d|2[0-3]):[0-5]\d$/, 'Must be a valid HH:MM time (00:00–23:59)')
+  .nullable()
+  .optional();
+
+const timezoneSchema = z
+  .string()
+  .refine(
+    (tz) => {
+      try {
+        Intl.DateTimeFormat(undefined, { timeZone: tz });
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    { message: 'Must be a valid IANA timezone (e.g. America/New_York)' }
+  )
+  .nullable()
+  .optional();
+
 export const periodicTaskRouter = router({
   list: publicProcedure.input(z.object({ projectId: z.string() })).query(({ input }) => {
     return periodicTaskAccessor.listByProject(input.projectId);
@@ -23,12 +45,8 @@ export const periodicTaskRouter = router({
         name: z.string().min(1),
         prompt: z.string().min(1),
         cadence: z.enum(['EVERY_MINUTE', 'EVERY_FIVE_MINUTES', 'DAILY', 'WEEKLY', 'MONTHLY']),
-        scheduledTime: z
-          .string()
-          .regex(/^\d{2}:\d{2}$/)
-          .nullable()
-          .optional(),
-        timezone: z.string().nullable().optional(),
+        scheduledTime: scheduledTimeSchema,
+        timezone: timezoneSchema,
       })
     )
     .mutation(({ input }) => {
@@ -44,12 +62,8 @@ export const periodicTaskRouter = router({
         cadence: z
           .enum(['EVERY_MINUTE', 'EVERY_FIVE_MINUTES', 'DAILY', 'WEEKLY', 'MONTHLY'])
           .optional(),
-        scheduledTime: z
-          .string()
-          .regex(/^\d{2}:\d{2}$/)
-          .nullable()
-          .optional(),
-        timezone: z.string().nullable().optional(),
+        scheduledTime: scheduledTimeSchema,
+        timezone: timezoneSchema,
       })
     )
     .mutation(({ input }) => {

--- a/src/backend/trpc/periodic-task.trpc.ts
+++ b/src/backend/trpc/periodic-task.trpc.ts
@@ -23,6 +23,12 @@ export const periodicTaskRouter = router({
         name: z.string().min(1),
         prompt: z.string().min(1),
         cadence: z.enum(['EVERY_MINUTE', 'EVERY_FIVE_MINUTES', 'DAILY', 'WEEKLY', 'MONTHLY']),
+        scheduledTime: z
+          .string()
+          .regex(/^\d{2}:\d{2}$/)
+          .nullable()
+          .optional(),
+        timezone: z.string().nullable().optional(),
       })
     )
     .mutation(({ input }) => {
@@ -38,6 +44,12 @@ export const periodicTaskRouter = router({
         cadence: z
           .enum(['EVERY_MINUTE', 'EVERY_FIVE_MINUTES', 'DAILY', 'WEEKLY', 'MONTHLY'])
           .optional(),
+        scheduledTime: z
+          .string()
+          .regex(/^\d{2}:\d{2}$/)
+          .nullable()
+          .optional(),
+        timezone: z.string().nullable().optional(),
       })
     )
     .mutation(({ input }) => {

--- a/src/client/components/kanban/inline-workspace-form.tsx
+++ b/src/client/components/kanban/inline-workspace-form.tsx
@@ -160,6 +160,8 @@ function ModeConfigPanel({
   mode,
   cadence,
   setCadence,
+  scheduledTime,
+  setScheduledTime,
   isCreating,
   testCommand,
   setTestCommand,
@@ -177,6 +179,8 @@ function ModeConfigPanel({
   mode: 'STANDARD' | 'AUTO_ITERATION' | 'PERIODIC_TASK';
   cadence: 'EVERY_MINUTE' | 'EVERY_FIVE_MINUTES' | 'DAILY' | 'WEEKLY' | 'MONTHLY';
   setCadence: (v: 'EVERY_MINUTE' | 'EVERY_FIVE_MINUTES' | 'DAILY' | 'WEEKLY' | 'MONTHLY') => void;
+  scheduledTime: string;
+  setScheduledTime: (v: string) => void;
   isCreating: boolean;
   testCommand: string;
   setTestCommand: (v: string) => void;
@@ -193,7 +197,13 @@ function ModeConfigPanel({
 }) {
   if (mode === 'PERIODIC_TASK') {
     return (
-      <PeriodicTaskConfigPanel cadence={cadence} setCadence={setCadence} isCreating={isCreating} />
+      <PeriodicTaskConfigPanel
+        cadence={cadence}
+        setCadence={setCadence}
+        scheduledTime={scheduledTime}
+        setScheduledTime={setScheduledTime}
+        isCreating={isCreating}
+      />
     );
   }
   if (mode === 'AUTO_ITERATION') {
@@ -288,12 +298,17 @@ function ModeConfigPanel({
 function PeriodicTaskConfigPanel({
   cadence,
   setCadence,
+  scheduledTime,
+  setScheduledTime,
   isCreating,
 }: {
   cadence: 'EVERY_MINUTE' | 'EVERY_FIVE_MINUTES' | 'DAILY' | 'WEEKLY' | 'MONTHLY';
   setCadence: (v: 'EVERY_MINUTE' | 'EVERY_FIVE_MINUTES' | 'DAILY' | 'WEEKLY' | 'MONTHLY') => void;
+  scheduledTime: string;
+  setScheduledTime: (v: string) => void;
   isCreating: boolean;
 }) {
+  const isLongCadence = cadence === 'DAILY' || cadence === 'WEEKLY' || cadence === 'MONTHLY';
   return (
     <div className="space-y-2 rounded-md border border-dashed border-primary/40 bg-primary/5 p-3">
       <div className="flex items-center gap-1.5 text-xs font-medium text-primary">
@@ -321,8 +336,21 @@ function PeriodicTaskConfigPanel({
           </SelectContent>
         </Select>
       </div>
+      {isLongCadence && (
+        <div className="space-y-1.5">
+          <Label className="text-xs text-muted-foreground">Run time (optional)</Label>
+          <Input
+            type="time"
+            className="h-7 text-xs"
+            value={scheduledTime}
+            onChange={(e) => setScheduledTime(e.target.value)}
+            disabled={isCreating}
+          />
+        </div>
+      )}
       <p className="text-[10px] text-muted-foreground">
         Creates a new workspace on this schedule. The first run starts immediately.
+        {isLongCadence && scheduledTime ? ' Subsequent runs will use the time above.' : ''}
       </p>
     </div>
   );
@@ -355,6 +383,7 @@ export function InlineWorkspaceForm({
   const [cadence, setCadence] = useState<
     'EVERY_MINUTE' | 'EVERY_FIVE_MINUTES' | 'DAILY' | 'WEEKLY' | 'MONTHLY'
   >('DAILY');
+  const [scheduledTime, setScheduledTime] = useState('');
   const [testCommand, setTestCommand] = useState('');
   const [targetDescription, setTargetDescription] = useState('');
   const [maxIterations, setMaxIterations] = useState(25);
@@ -496,7 +525,16 @@ export function InlineWorkspaceForm({
       return;
     }
     const name = generateWorkspaceNameFromPrompt(trimmedPrompt, availableWorkspaceNames);
-    createPeriodicTaskMutation.mutate({ projectId, name, prompt: trimmedPrompt, cadence });
+    const isLongCadence = cadence === 'DAILY' || cadence === 'WEEKLY' || cadence === 'MONTHLY';
+    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    createPeriodicTaskMutation.mutate({
+      projectId,
+      name,
+      prompt: trimmedPrompt,
+      cadence,
+      scheduledTime: isLongCadence && scheduledTime ? scheduledTime : null,
+      timezone: isLongCadence && scheduledTime ? timezone : null,
+    });
   };
 
   const launchWorkspace = (trimmedPrompt: string, launchMode: 'STANDARD' | 'AUTO_ITERATION') => {
@@ -601,6 +639,8 @@ export function InlineWorkspaceForm({
           mode={mode}
           cadence={cadence}
           setCadence={setCadence}
+          scheduledTime={scheduledTime}
+          setScheduledTime={setScheduledTime}
           isCreating={isCreating}
           testCommand={testCommand}
           setTestCommand={setTestCommand}

--- a/src/client/routes/admin/PeriodicTasksSection.tsx
+++ b/src/client/routes/admin/PeriodicTasksSection.tsx
@@ -203,6 +203,17 @@ function ExecutionStatusBadge({ status }: { status: string }) {
 
 const LONG_CADENCES = new Set(['DAILY', 'WEEKLY', 'MONTHLY']);
 
+function resolveTimezone(
+  scheduledTime: string,
+  prevScheduledTime: string | null,
+  prevTimezone: string | null
+): string {
+  if (scheduledTime !== prevScheduledTime || !prevTimezone) {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  }
+  return prevTimezone;
+}
+
 function formatScheduledTime(scheduledTime: string, timezone: string): string {
   const parts = scheduledTime.split(':').map(Number);
   const hours = parts[0] ?? 0;
@@ -265,7 +276,9 @@ function PeriodicTaskRow({
   const handleSave = () => {
     const hasSchedule = LONG_CADENCES.has(editCadence) && !!editScheduledTime;
     const newScheduledTime = hasSchedule ? editScheduledTime : null;
-    const newTimezone = hasSchedule ? Intl.DateTimeFormat().resolvedOptions().timeZone : null;
+    const newTimezone = hasSchedule
+      ? resolveTimezone(editScheduledTime, task.scheduledTime, task.timezone)
+      : null;
     onUpdate({
       name: editName !== task.name ? editName : undefined,
       prompt: editPrompt !== task.prompt ? editPrompt : undefined,

--- a/src/client/routes/admin/PeriodicTasksSection.tsx
+++ b/src/client/routes/admin/PeriodicTasksSection.tsx
@@ -218,14 +218,19 @@ function formatScheduledTime(scheduledTime: string, timezone: string): string {
   const parts = scheduledTime.split(':').map(Number);
   const hours = parts[0] ?? 0;
   const minutes = parts[1] ?? 0;
-  const probe = new Date();
-  probe.setHours(hours, minutes, 0, 0);
-  const timePart = probe.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+  // Use UTC so the displayed clock time matches the stored scheduledTime
+  // regardless of the browser's local timezone.
+  const displayProbe = new Date(Date.UTC(2000, 0, 1, hours, minutes, 0, 0));
+  const timePart = displayProbe.toLocaleTimeString([], {
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZone: 'UTC',
+  });
   const tzShort = new Intl.DateTimeFormat('en-US', {
     timeZone: timezone,
     timeZoneName: 'short',
   })
-    .formatToParts(probe)
+    .formatToParts(displayProbe)
     .find((p) => p.type === 'timeZoneName')?.value;
   return tzShort ? `${timePart} (${tzShort})` : timePart;
 }

--- a/src/client/routes/admin/PeriodicTasksSection.tsx
+++ b/src/client/routes/admin/PeriodicTasksSection.tsx
@@ -201,6 +201,24 @@ function ExecutionStatusBadge({ status }: { status: string }) {
   );
 }
 
+const LONG_CADENCES = new Set(['DAILY', 'WEEKLY', 'MONTHLY']);
+
+function formatScheduledTime(scheduledTime: string, timezone: string): string {
+  const parts = scheduledTime.split(':').map(Number);
+  const hours = parts[0] ?? 0;
+  const minutes = parts[1] ?? 0;
+  const probe = new Date();
+  probe.setHours(hours, minutes, 0, 0);
+  const timePart = probe.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+  const tzShort = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    timeZoneName: 'short',
+  })
+    .formatToParts(probe)
+    .find((p) => p.type === 'timeZoneName')?.value;
+  return tzShort ? `${timePart} (${tzShort})` : timePart;
+}
+
 function PeriodicTaskRow({
   task,
   onToggle,
@@ -216,6 +234,8 @@ function PeriodicTaskRow({
     isEnabled: boolean;
     nextRunAt: Date;
     lastRunAt: Date | null;
+    scheduledTime: string | null;
+    timezone: string | null;
     executions: Array<{
       id: string;
       status: string;
@@ -226,20 +246,32 @@ function PeriodicTaskRow({
   };
   onToggle: (enabled: boolean) => void;
   onDelete: () => void;
-  onUpdate: (data: { name?: string; prompt?: string; cadence?: PeriodicTaskCadence }) => void;
+  onUpdate: (data: {
+    name?: string;
+    prompt?: string;
+    cadence?: PeriodicTaskCadence;
+    scheduledTime?: string | null;
+    timezone?: string | null;
+  }) => void;
   isUpdating: boolean;
 }) {
   const [editing, setEditing] = useState(false);
   const [editName, setEditName] = useState(task.name);
   const [editPrompt, setEditPrompt] = useState(task.prompt);
   const [editCadence, setEditCadence] = useState(task.cadence);
+  const [editScheduledTime, setEditScheduledTime] = useState(task.scheduledTime ?? '');
   const [showExecutions, setShowExecutions] = useState(false);
 
   const handleSave = () => {
+    const hasSchedule = LONG_CADENCES.has(editCadence) && !!editScheduledTime;
+    const newScheduledTime = hasSchedule ? editScheduledTime : null;
+    const newTimezone = hasSchedule ? Intl.DateTimeFormat().resolvedOptions().timeZone : null;
     onUpdate({
       name: editName !== task.name ? editName : undefined,
       prompt: editPrompt !== task.prompt ? editPrompt : undefined,
       cadence: editCadence !== task.cadence ? (editCadence as PeriodicTaskCadence) : undefined,
+      scheduledTime: newScheduledTime !== task.scheduledTime ? newScheduledTime : undefined,
+      timezone: newTimezone !== task.timezone ? newTimezone : undefined,
     });
     setEditing(false);
   };
@@ -258,6 +290,7 @@ function PeriodicTaskRow({
     setEditName(task.name);
     setEditPrompt(task.prompt);
     setEditCadence(task.cadence);
+    setEditScheduledTime(task.scheduledTime ?? '');
     setEditing(!editing);
   };
 
@@ -298,6 +331,9 @@ function PeriodicTaskRow({
         <span title={new Date(task.nextRunAt).toLocaleString()}>
           Next run: {formatRelativeTime(new Date(task.nextRunAt))}
         </span>
+        {LONG_CADENCES.has(task.cadence) && task.scheduledTime && task.timezone && (
+          <span>at {formatScheduledTime(task.scheduledTime, task.timezone)}</span>
+        )}
         {latestExecution && <ExecutionStatusBadge status={latestExecution.status} />}
       </div>
 
@@ -334,6 +370,17 @@ function PeriodicTaskRow({
               </SelectContent>
             </Select>
           </div>
+          {LONG_CADENCES.has(editCadence) && (
+            <div className="space-y-1">
+              <Label className="text-xs">Run time (optional)</Label>
+              <Input
+                type="time"
+                className="h-7 text-xs"
+                value={editScheduledTime}
+                onChange={(e) => setEditScheduledTime(e.target.value)}
+              />
+            </div>
+          )}
           <div className="flex justify-end gap-2">
             <Button
               variant="ghost"


### PR DESCRIPTION
## Summary

- Daily/weekly/monthly periodic tasks can now be configured to run at a specific time of day in the user's browser timezone
- Previously, tasks always ran N hours after their last execution (drift from creation time)
- First run still fires immediately on task creation; subsequent runs use the scheduled time

## Changes

**Schema**: Added `scheduledTime` (`"HH:MM"`) and `timezone` (IANA string) nullable fields to `PeriodicTask`. Includes migration.

**Backend** (`periodic-task.accessor.ts`): `computeNextRunAt` now accepts optional `scheduledTime` and `timezone`. For DAILY/WEEKLY/MONTHLY cadences, it snaps the computed next date to the configured clock time using the `Intl` API — DST-aware, no new dependencies. `markDispatched`, `update`, and `toggleEnabled` all thread the new fields through.

**TRPC** (`periodic-task.trpc.ts`): `create` and `update` accept optional `scheduledTime` (validated as `HH:MM`) and `timezone`.

**Create form** (`inline-workspace-form.tsx`): Shows a time picker under the cadence selector for daily+ cadences. Browser timezone is detected automatically at submit time via `Intl.DateTimeFormat().resolvedOptions().timeZone`.

**Settings page** (`PeriodicTasksSection.tsx`): Display mode shows "at 9:00 AM (ET)" alongside the next run time. Edit mode includes the same time picker.

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm check` passes (no new errors)
- [ ] Create a daily periodic task with a scheduled time — verify `nextRunAt` is set to tomorrow at that time in the correct timezone
- [ ] Edit the scheduled time — verify `nextRunAt` updates accordingly
- [ ] Create a task with EVERY_MINUTE cadence — verify no time picker appears and `scheduledTime` is null
- [ ] Toggle a task off and on — verify `nextRunAt` respects the scheduled time when re-enabled