### PR TITLE
Prepare 0.3.18 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to Factory Factory will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.18] - 2026-05-20
+
+### Added
+
+- Add time-of-day scheduling for periodic tasks (#1597)
+
+### Changed
+
+- Persist CLI setup banner dismissal (#1590)
+- Guard Prisma generated imports (#1589)
+- Add missing guardrails to standard checks (#1588)
+- Validate auto-iteration JSON at runtime boundaries (#1593)
+- Split large orchestration and runtime modules (#1592)
+
+### Fixed
+
+- Fix ACP busy-turn retry loop after sleep (#1587)
+- Fix plan approval scrolling (#1591)
+
+### Documentation
+
+- Map existing codebase (#1586)
+- Fix stale pnpm check references after guardrail consolidation (#1596)
+- Update stale large-module file reference in CONCERNS.md (#1595)
+- Document @prisma-gen/* public entrypoint restriction in CONVENTIONS (#1594)
+
 ## [0.3.17] - 2026-05-14
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "factory-factory",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "Workspace-based coding environment for running multiple Claude Code and Codex sessions in parallel",
   "private": false,
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump root package version to 0.3.18
- Add the 0.3.18 changelog entry for changes since v0.3.17

## Tests
- pnpm check
- pre-commit hook: pnpm typecheck, deps:check, knip

Notes: `pnpm check` reported existing Biome `<img>` warnings and skipped the local Codex schema drift check because the local Codex CLI is newer than the pinned CI version. `knip` reported existing configuration hints.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a release bookkeeping change (version bump and changelog entry) with no functional code modifications.
> 
> **Overview**
> Prepares the `0.3.18` patch release by bumping the root `package.json` version from `0.3.17` to `0.3.18`.
> 
> Adds a `CHANGELOG.md` entry for `0.3.18` summarizing the included additions, changes, fixes, and documentation updates shipped in this release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5368507f409c0f66c88017f6c2a625f65e4c3daf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->