### PR TITLE
Fix ratchet active session cleanup

### DIFF
--- a/src/backend/services/ratchet/service/ratchet.service.test.ts
+++ b/src/backend/services/ratchet/service/ratchet.service.test.ts
@@ -777,6 +777,60 @@ describe('ratchet service (state-change + idle dispatch)', () => {
     expect(mockSnapshotBridge.recordReviewCheck).not.toHaveBeenCalled();
   });
 
+  it('cleans up completed ratchet sessions before skipping clean PRs', async () => {
+    const workspace = {
+      id: 'ws-clean-active',
+      prUrl: 'https://github.com/example/repo/pull/13',
+      prNumber: 13,
+      prState: 'OPEN',
+      prCiStatus: CIStatus.SUCCESS,
+      ratchetEnabled: true,
+      ratchetState: RatchetState.READY,
+      ratchetActiveSessionId: 'ratchet-session',
+      ratchetLastCiRunId: 'clean-snapshot',
+      prReviewLastCheckedAt: new Date('2026-01-01T00:00:00Z'),
+    };
+    const prStateInfo = {
+      ciStatus: CIStatus.SUCCESS,
+      snapshotKey: 'clean-snapshot',
+      hasChangesRequested: false,
+      latestReviewActivityAtMs: null,
+      statusCheckRollup: null,
+      prState: 'OPEN',
+      prNumber: 13,
+      reviewComments: [],
+    };
+
+    vi.mocked(agentSessionAccessor.findById).mockResolvedValue({
+      id: 'ratchet-session',
+      provider: 'CLAUDE',
+      status: SessionStatus.RUNNING,
+    } as never);
+    vi.mocked(mockSessionBridge.isSessionRunning).mockReturnValue(true);
+    vi.mocked(mockSessionBridge.isSessionWorking).mockReturnValue(false);
+    vi.mocked(mockSessionBridge.stopSession).mockResolvedValue();
+    vi.mocked(workspaceAccessor.update).mockResolvedValue({} as never);
+
+    const result = await unsafeCoerce<{
+      collectRatchetingActivityChecks: (
+        workspaceArg: typeof workspace,
+        prStateInfoArg: typeof prStateInfo,
+        isCleanPrWithNoNewReviewActivity: boolean,
+        hasStateChangedSinceLastDispatch: boolean
+      ) => Promise<unknown>;
+    }>(ratchetService).collectRatchetingActivityChecks(workspace, prStateInfo, true, false);
+
+    expect(result).toEqual({
+      activeRatchetSession: null,
+      hasOtherActiveSession: false,
+    });
+    expect(workspaceAccessor.update).toHaveBeenCalledWith(workspace.id, {
+      ratchetActiveSessionId: null,
+    });
+    expect(mockSessionBridge.stopSession).toHaveBeenCalledWith('ratchet-session');
+    expect(agentSessionAccessor.findByWorkspaceId).not.toHaveBeenCalled();
+  });
+
   it('decides to trigger fixer when context is actionable', () => {
     const decision = unsafeCoerce<{
       decideRatchetAction: (context: unknown) => { type: string };

--- a/src/backend/services/ratchet/service/ratchet.service.ts
+++ b/src/backend/services/ratchet/service/ratchet.service.ts
@@ -666,21 +666,27 @@ class RatchetService extends EventEmitter {
     activeRatchetSession: RatchetAction | null;
     hasOtherActiveSession: boolean;
   }> {
-    if (
-      !workspace.ratchetEnabled ||
-      prStateInfo.prState !== 'OPEN' ||
-      isCleanPrWithNoNewReviewActivity
-    ) {
+    if (!workspace.ratchetEnabled || prStateInfo.prState !== 'OPEN') {
       return {
         activeRatchetSession: null,
         hasOtherActiveSession: false,
       };
     }
 
-    const activeRatchetSession = await this.getActiveRatchetSession(workspace);
-    if (activeRatchetSession) {
+    let activeRatchetSession: RatchetAction | null = null;
+    if (workspace.ratchetActiveSessionId) {
+      activeRatchetSession = await this.getActiveRatchetSession(workspace);
+      if (activeRatchetSession) {
+        return {
+          activeRatchetSession,
+          hasOtherActiveSession: false,
+        };
+      }
+    }
+
+    if (isCleanPrWithNoNewReviewActivity) {
       return {
-        activeRatchetSession,
+        activeRatchetSession: null,
         hasOtherActiveSession: false,
       };
     }
@@ -730,6 +736,10 @@ class RatchetService extends EventEmitter {
       };
     }
 
+    if (context.activeRatchetSession) {
+      return { type: 'RETURN_ACTION', action: context.activeRatchetSession };
+    }
+
     if (context.isCleanPrWithNoNewReviewActivity) {
       return {
         type: 'RETURN_ACTION',
@@ -742,10 +752,6 @@ class RatchetService extends EventEmitter {
         type: 'RETURN_ACTION',
         action: { type: 'WAITING', reason: 'No CI failures or PR review comments to address' },
       };
-    }
-
-    if (context.activeRatchetSession) {
-      return { type: 'RETURN_ACTION', action: context.activeRatchetSession };
     }
 
     if (!context.hasStateChangedSinceLastDispatch) {


### PR DESCRIPTION
## Summary

- Fix ratchet active-session cleanup when a PR becomes clean while a ratchet session is still recorded.
- Reconcile any existing `ratchetActiveSessionId` before skipping clean PRs.
- Add regression coverage for clean PRs with completed ratchet sessions.

## Verification

- `pnpm vitest run src/backend/services/ratchet/service/ratchet.service.test.ts`
- `pnpm typecheck`
- `pnpm check`

Note: `pnpm check` completed successfully and reported existing unrelated Biome `<img>` performance warnings in UI files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ratchet dispatch/decision flow to always reconcile and potentially stop a recorded `ratchetActiveSessionId` before early-returning on clean PRs; mistakes could cause missed dispatches or unnecessary session stops.
> 
> **Overview**
> Fixes a ratchet edge case where a PR becoming clean could cause the service to skip processing while a stale `ratchetActiveSessionId` was still recorded.
> 
> `collectRatchetingActivityChecks` now checks/cleans up an existing active ratchet session **before** applying the “clean PR” early return, and `decideRatchetAction` is reordered to always return an active session action ahead of the clean-PR wait state. Adds a regression test ensuring completed sessions are stopped and `ratchetActiveSessionId` is cleared even when the PR is clean.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1cff034eb7480d4daaeac6bbf91e3ba612c55f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->