### PR TITLE
Fix #1604: Restore plan approval autofocus

### DIFF
--- a/src/components/chat/permission-prompt.test.tsx
+++ b/src/components/chat/permission-prompt.test.tsx
@@ -15,6 +15,7 @@ function findButtonByText(container: HTMLElement, text: string): HTMLButtonEleme
 }
 
 afterEach(() => {
+  vi.useRealTimers();
   document.body.innerHTML = '';
 });
 
@@ -108,6 +109,38 @@ describe('PermissionPrompt', () => {
     expect(longLabelButton?.className).toContain('max-w-full');
     const promptLayout = container.querySelector('[role="alertdialog"] > div');
     expect(promptLayout?.className).toContain('flex-col');
+
+    root.unmount();
+  });
+
+  it('focuses the first plan approval action after render', async () => {
+    vi.useFakeTimers();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const onApprove = vi.fn();
+
+    const permission: PermissionRequest = {
+      requestId: 'req-plan-focus-1',
+      toolName: 'ExitPlanMode',
+      toolInput: {
+        plan: 'Focus the first plan action.',
+      },
+      timestamp: '2026-05-20T00:00:00.000Z',
+      planContent: 'Focus the first plan action.',
+      acpOptions: [
+        { optionId: 'plan', name: 'Keep planning', kind: 'reject_once' },
+        { optionId: 'default', name: 'Approve Plan', kind: 'allow_once' },
+      ],
+    };
+
+    flushSync(() => {
+      root.render(createElement(PermissionPrompt, { permission, onApprove }));
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(document.activeElement).toBe(findButtonByText(container, 'Approve Plan'));
 
     root.unmount();
   });

--- a/src/components/chat/permission-prompt.tsx
+++ b/src/components/chat/permission-prompt.tsx
@@ -235,8 +235,12 @@ function PlanViewToggle({ value, onChange }: PlanViewToggleProps) {
  * Displays the plan content with expand/collapse functionality.
  */
 function PlanApprovalPrompt({ permission, onApprove, className }: PermissionPromptProps) {
+  const firstActionButtonRef = useRef<HTMLButtonElement>(null);
   const [expanded, setExpanded] = useState(true);
   const [viewMode, setViewMode] = usePlanViewMode();
+  const permissionRequestId = permission?.requestId;
+
+  useAutoFocusPermissionButton(firstActionButtonRef, permissionRequestId);
 
   if (!permission) {
     return null;
@@ -315,12 +319,13 @@ function PlanApprovalPrompt({ permission, onApprove, className }: PermissionProm
 
         {/* Actions */}
         <div className="flex flex-wrap justify-end gap-2">
-          {options.map((option) => {
+          {options.map((option, index) => {
             const style = getPermissionOptionStyle(option.kind);
             const Icon = style.icon;
             return (
               <Button
                 key={option.optionId}
+                ref={index === 0 ? firstActionButtonRef : undefined}
                 variant={style.variant}
                 size="sm"
                 onClick={() => handleOptionClick(option)}


### PR DESCRIPTION
## Summary
- Restores autofocus for `ExitPlanMode` plan approval prompts.
- Adds regression coverage for focusing the first rendered plan action.

## Changes
- **PlanApprovalPrompt**: Reintroduced a first-action button ref and reused the existing delayed permission autofocus hook.
- **Tests**: Verifies plan approval actions sort allow options first and focus the first rendered action after render.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not run; focus-only regression is covered by jsdom autofocus test.

Closes #1604

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change: adds focus management to the plan-approval button and a regression test; main risk is minor focus/timing differences in the prompt.
> 
> **Overview**
> Restores autofocus behavior for `ExitPlanMode` plan approval prompts by wiring the existing delayed autofocus hook to the *first rendered* plan action button (via a new ref on the first option).
> 
> Adds a regression test that uses fake timers to assert focus lands on the first allow/approval action after render, and ensures timers are reset between tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28a35db72e9123622fbcd370638c3cf19a9f5135. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->