### PR TITLE
Fix #1599: Restrict MCP PR creation detection

### DIFF
--- a/src/backend/interceptors/pr-detection.interceptor.test.ts
+++ b/src/backend/interceptors/pr-detection.interceptor.test.ts
@@ -181,6 +181,115 @@ describe('prDetectionInterceptor', () => {
     );
   });
 
+  it('detects PR URL from codex_apps MCP create_pull_request display tool names', async () => {
+    const event = createEvent({
+      toolName: 'mcpToolCall:codex_apps/create_pull_request',
+      input: {},
+      output: {
+        content: JSON.stringify({
+          structuredContent: {
+            url: 'https://github.com/purplefish-ai/factory-factory/pull/1584',
+          },
+        }),
+        isError: false,
+      },
+    });
+
+    await prDetectionInterceptor.onToolComplete!(event, context);
+
+    expect(mockAttachAndRefreshPR).toHaveBeenCalledWith(
+      'workspace-1',
+      'https://github.com/purplefish-ai/factory-factory/pull/1584'
+    );
+  });
+
+  it('detects PR URL from codex_apps MCP create_pull_request input fields', async () => {
+    const event = createEvent({
+      toolName: 'mcpToolCall',
+      input: {
+        type: 'mcpToolCall',
+        server: 'codex_apps',
+        tool: 'create_pull_request',
+      },
+      output: {
+        content: JSON.stringify({
+          structuredContent: {
+            url: 'https://github.com/purplefish-ai/factory-factory/pull/1585',
+          },
+        }),
+        isError: false,
+      },
+    });
+
+    await prDetectionInterceptor.onToolComplete!(event, context);
+
+    expect(mockAttachAndRefreshPR).toHaveBeenCalledWith(
+      'workspace-1',
+      'https://github.com/purplefish-ai/factory-factory/pull/1585'
+    );
+  });
+
+  it('does not detect create_pull_request from custom servers containing github', async () => {
+    const event = createEvent({
+      toolName: 'mcpToolCall:company_github/create_pull_request',
+      input: {
+        type: 'mcpToolCall',
+        server: 'company_github',
+        tool: 'create_pull_request',
+      },
+      output: {
+        content: JSON.stringify({
+          structuredContent: {
+            url: 'https://github.com/purplefish-ai/factory-factory/pull/1586',
+          },
+        }),
+        isError: false,
+      },
+    });
+
+    await prDetectionInterceptor.onToolComplete!(event, context);
+
+    expect(mockAttachAndRefreshPR).not.toHaveBeenCalled();
+  });
+
+  it('does not detect create_pull_request from display servers containing github', async () => {
+    const event = createEvent({
+      toolName: 'mcpToolCall:x_github/create_pull_request',
+      input: {},
+      output: {
+        content: JSON.stringify({
+          structuredContent: {
+            url: 'https://github.com/purplefish-ai/factory-factory/pull/1587',
+          },
+        }),
+        isError: false,
+      },
+    });
+
+    await prDetectionInterceptor.onToolComplete!(event, context);
+
+    expect(mockAttachAndRefreshPR).not.toHaveBeenCalled();
+  });
+
+  it('does not detect unrelated tool names ending in github_create_pull_request', async () => {
+    const event = createEvent({
+      toolName: 'company_github_create_pull_request',
+      input: {},
+      output: {
+        content: JSON.stringify({
+          structuredContent: {
+            url: 'https://github.com/purplefish-ai/factory-factory/pull/1588',
+          },
+        }),
+        isError: false,
+      },
+    });
+
+    await prDetectionInterceptor.onToolComplete!(event, context);
+
+    expect(mockAttachAndRefreshPR).not.toHaveBeenCalled();
+  });
+
   it('detects PR URL when command is provided as cmd', async () => {
     const event = createEvent({
       toolName: 'exec_command',

--- a/src/backend/interceptors/pr-detection.interceptor.ts
+++ b/src/backend/interceptors/pr-detection.interceptor.ts
@@ -15,6 +15,7 @@ const GH_PR_CREATE_REGEX = /\bgh\s+pr\s+create\b/;
 const GITHUB_PR_URL_REGEX = /https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/\d+/;
 const GITHUB_CREATE_PULL_REQUEST_TOOL = 'github_create_pull_request';
 const CREATE_PULL_REQUEST_TOOL = 'create_pull_request';
+const OFFICIAL_GITHUB_MCP_SERVERS = new Set(['github', 'codex_apps']);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -44,10 +45,6 @@ function extractCommand(event: ToolEvent): string | undefined {
   return directCommand ?? cmd ?? title;
 }
 
-function normalizeToolName(value: string): string {
-  return value.toLowerCase().replace(/[^a-z0-9]+/g, '');
-}
-
 function extractMcpToolNameFromDisplayName(toolName: string): string | undefined {
   const slashIndex = toolName.lastIndexOf('/');
   if (slashIndex === -1 || slashIndex === toolName.length - 1) {
@@ -70,6 +67,10 @@ function extractMcpServerNameFromDisplayName(toolName: string): string | undefin
   return toolName.slice(prefix.length, slashIndex);
 }
 
+function isOfficialGithubMcpServer(serverName: string): boolean {
+  return OFFICIAL_GITHUB_MCP_SERVERS.has(serverName.toLowerCase());
+}
+
 function isGithubCreatePullRequestTool(event: ToolEvent): boolean {
   const inputTool = extractInputValue(event.input, 'tool', isString, event.toolName, logger);
   if (inputTool === GITHUB_CREATE_PULL_REQUEST_TOOL) {
@@ -77,7 +78,11 @@ function isGithubCreatePullRequestTool(event: ToolEvent): boolean {
   }
 
   const inputServer = extractInputValue(event.input, 'server', isString, event.toolName, logger);
-  if (inputTool === CREATE_PULL_REQUEST_TOOL && inputServer?.toLowerCase().includes('github')) {
+  if (
+    inputTool === CREATE_PULL_REQUEST_TOOL &&
+    inputServer &&
+    isOfficialGithubMcpServer(inputServer)
+  ) {
     return true;
   }
 
@@ -89,13 +94,13 @@ function isGithubCreatePullRequestTool(event: ToolEvent): boolean {
   const displayServerName = extractMcpServerNameFromDisplayName(event.toolName);
   if (
     displayToolName === CREATE_PULL_REQUEST_TOOL &&
-    displayServerName?.toLowerCase().includes('github')
+    displayServerName &&
+    isOfficialGithubMcpServer(displayServerName)
   ) {
     return true;
   }
 
-  const normalizedToolName = normalizeToolName(event.toolName);
-  return normalizedToolName.endsWith(normalizeToolName(GITHUB_CREATE_PULL_REQUEST_TOOL));
+  return false;
 }
 
 function extractPrUrlFromEvent(event: ToolEvent): string | null {


### PR DESCRIPTION
## Summary
- Restricts MCP PR tracking to real GitHub create-PR tools.
- Prevents workspaces from attaching PRs referenced by non-creation tools.
- Adds regression coverage for custom server names and suffix-matching false positives.

## Changes
- **PR Detection**: Replace substring server checks with an exact official MCP server allowlist for `github` and `codex_apps`.
- **PR Detection**: Remove the permissive normalized suffix fallback that could classify unrelated tools as `github_create_pull_request`.
- **Tests**: Cover valid `codex_apps` create-PR detection plus the three false-positive vectors from #1599.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Manual testing: Verified full command chain `pnpm typecheck && pnpm check:fix && pnpm test && pnpm build`

Closes #1599

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrows PR auto-attachment conditions and adds tests; main impact is potentially missing PR detection for non-allowlisted MCP servers that previously matched loosely.
> 
> **Overview**
> Tightens PR auto-detection for MCP tool calls so the interceptor only treats `create_pull_request` as a PR-creation signal when it comes from an allowlisted official server (`github`, `codex_apps`), instead of any server name containing “github”.
> 
> Removes the permissive normalized-suffix fallback that could misclassify unrelated tool names as `github_create_pull_request`, and adds regression tests covering `codex_apps` detection plus multiple false-positive scenarios (custom server names, display names, and suffix-matching tool names).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c4ae0d7171efe22b457d71a5999ee6697a7dde4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->