### PR TITLE
Prepare 0.3.19 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to Factory Factory will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.19] - 2026-05-20
+
+### Changed
+
+- Add Prisma generated drift guardrail (#1614)
+- Require workspace field ownership policies (#1617)
+- Extract runtime orchestration collaborators (#1616)
+
+### Fixed
+
+- Hide periodic task workspace controls (#1612)
+- Fix monthly periodic task timezone scheduling (#1609)
+- Fix PR detection MCP false positives (#1608)
+- Fix plan approval prompt autofocus (#1607)
+- Fix ratchet active session cleanup (#1606)
+- Preserve monthly periodic task day (#1610)
+- Recover stuck periodic task executions (#1613)
+- Fix periodic task DST scheduling (#1611)
+
+### Documentation
+
+- Add time-of-day scheduling to Periodic Tasks feature note in AGENTS.md (#1615)
+
 ## [0.3.18] - 2026-05-20
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "factory-factory",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "description": "Workspace-based coding environment for running multiple Claude Code and Codex sessions in parallel",
   "private": false,
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump Factory Factory from 0.3.18 to 0.3.19
- Add the 0.3.19 changelog entry covering fixes and guardrails merged since 0.3.18

## Tests
- `pnpm check`
- pre-commit: `pnpm typecheck`, `pnpm deps:check`, `pnpm knip`

Notes: `pnpm check` completed successfully with existing Biome `<img>` warnings. The local Codex schema drift check skipped strict enforcement because the local Codex CLI is newer than the pinned CI version; CI enforces the pinned version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: version bump and changelog entry updates with no runtime code changes.
> 
> **Overview**
> Prepares the `0.3.19` patch release by bumping the npm package version from `0.3.18` to `0.3.19`.
> 
> Adds a new `CHANGELOG.md` entry for `0.3.19`, summarizing the included guardrails, periodic task fixes, and documentation updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bc8d6c956fbec340cbdf43b9c5946a96afbd737. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->