### PR TITLE
Fix #1636: Recover validation-failed chat messages

### DIFF
--- a/src/backend/services/session/service/chat/chat-message-handlers/handlers/queue-message.handler.test.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers/handlers/queue-message.handler.test.ts
@@ -20,7 +20,7 @@ describe('createQueueMessageHandler', () => {
     vi.clearAllMocks();
   });
 
-  it('rejects empty queue messages', async () => {
+  it('emits rejected state for empty queue messages with an id', async () => {
     const ws = { send: vi.fn() };
     const handler = createQueueMessageHandler({
       getClientCreator: () => null,
@@ -35,9 +35,13 @@ describe('createQueueMessageHandler', () => {
       message: { type: 'queue_message', id: 'msg-1', text: '   ', attachments: [] } as never,
     });
 
-    expect(ws.send).toHaveBeenCalledWith(
-      JSON.stringify({ type: 'error', message: 'Empty message' })
-    );
+    expect(ws.send).not.toHaveBeenCalled();
+    expect(mocks.emitDelta).toHaveBeenCalledWith('session-1', {
+      type: 'message_state_changed',
+      id: 'msg-1',
+      newState: MessageState.REJECTED,
+      errorMessage: 'Empty message',
+    });
     expect(mocks.enqueue).not.toHaveBeenCalled();
   });
 
@@ -62,7 +66,7 @@ describe('createQueueMessageHandler', () => {
     expect(mocks.enqueue).not.toHaveBeenCalled();
   });
 
-  it('rejects queue messages with invalid attachments', async () => {
+  it('emits rejected state for queue messages with invalid attachments', async () => {
     const ws = { send: vi.fn() };
     const tryDispatchNextMessage = vi.fn();
     const handler = createQueueMessageHandler({
@@ -91,11 +95,14 @@ describe('createQueueMessageHandler', () => {
       } as never,
     });
 
-    expect(ws.send).toHaveBeenCalledWith(
-      JSON.stringify({ type: 'error', message: 'Attachment "broken.png" has invalid image data' })
-    );
+    expect(ws.send).not.toHaveBeenCalled();
+    expect(mocks.emitDelta).toHaveBeenCalledWith('session-1', {
+      type: 'message_state_changed',
+      id: 'msg-1',
+      newState: MessageState.REJECTED,
+      errorMessage: 'Attachment "broken.png" has invalid image data',
+    });
     expect(mocks.enqueue).not.toHaveBeenCalled();
-    expect(mocks.emitDelta).not.toHaveBeenCalled();
     expect(tryDispatchNextMessage).not.toHaveBeenCalled();
   });
 

--- a/src/backend/services/session/service/chat/chat-message-handlers/handlers/queue-message.handler.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers/handlers/queue-message.handler.ts
@@ -62,6 +62,11 @@ export function createQueueMessageHandler(
     const text = message.text?.trim();
     const validationError = validateQueueMessageInput(message, text);
     if (validationError) {
+      if (message.id) {
+        emitRejectedMessageState(sessionId, message.id, validationError);
+        return;
+      }
+
       ws.send(JSON.stringify({ type: 'error', message: validationError }));
       return;
     }


### PR DESCRIPTION
## Summary
- Emit `REJECTED` message state for queue-message validation failures that include a message id.
- Preserve the WebSocket error fallback for malformed messages that cannot be tied to a pending message.
- Update queue-message handler tests for invalid attachment recovery behavior.

## Changes
- **Session chat queue**: Validation failures now use the same rejected-state recovery path as enqueue failures when a recoverable `message.id` is present.
- **Tests**: Updated empty-message and invalid-attachment validation cases to assert `MessageState.REJECTED` emission and no enqueue/dispatch.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not run; server-side behavior is covered by focused handler tests and full automated verification.

Closes #1636

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to session chat queue validation handling with matching unit tests; no auth, persistence, or dispatch logic beyond error reporting.
> 
> **Overview**
> Queue-message **validation failures** (empty text, bad attachments) now follow the same **recovery path as enqueue failures**: when the client sends a **`message.id`**, the handler emits a **`message_state_changed`** delta with **`MessageState.REJECTED`** and the validation **`errorMessage`**, instead of only pushing a WebSocket **`error`** frame.
> 
> Messages **without an id** still get the WebSocket error fallback (e.g. missing id), since there is no pending message to update.
> 
> Handler tests were updated so empty-message and invalid-attachment cases assert **`emitDelta` / REJECTED** and no **`ws.send`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdc0d297fb3258344463a5a524e5fc4ce9026e2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->