### PR TITLE
Fix #1625: Reuse ACP permission bridges

### DIFF
--- a/src/backend/services/session/service/lifecycle/session.permission.service.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.permission.service.test.ts
@@ -40,6 +40,53 @@ describe('SessionPermissionService', () => {
     });
   });
 
+  it('reuses the existing ACP permission bridge for repeated session setup', () => {
+    const service = createService();
+
+    const firstBridge = service.createPermissionBridge('session-1');
+    const secondBridge = service.createPermissionBridge('session-1');
+
+    expect(secondBridge).toBe(firstBridge);
+  });
+
+  it('keeps pending ACP permissions reachable when bridge creation is repeated', async () => {
+    const service = createService();
+    const bridge = service.createPermissionBridge('session-1');
+
+    const responsePromise = bridge.waitForUserResponse(
+      'req-1',
+      unsafeCoerce({
+        toolCall: {
+          toolCallId: 'tool-1',
+          title: 'Command',
+          rawInput: { command: 'pwd' },
+        },
+        options: [{ optionId: 'allow_once', name: 'Allow once', kind: 'allow_once' }],
+      })
+    );
+
+    service.createPermissionBridge('session-1');
+
+    expect(service.respondToPermission('session-1', 'req-1', 'allow_once')).toBe(true);
+    expect(bridge.hasPending('req-1')).toBe(false);
+    await expect(responsePromise).resolves.toMatchObject({
+      outcome: {
+        outcome: 'selected',
+        optionId: 'allow_once',
+      },
+    });
+  });
+
+  it('creates a fresh ACP permission bridge after session cancellation clears one', () => {
+    const service = createService();
+    const firstBridge = service.createPermissionBridge('session-1');
+
+    service.cancelPendingRequests('session-1');
+
+    const secondBridge = service.createPermissionBridge('session-1');
+    expect(secondBridge).not.toBe(firstBridge);
+  });
+
   it('cancels pending permissions and clears the bridge for the session', async () => {
     const service = createService();
     const bridge = service.createPermissionBridge('session-1');

--- a/src/backend/services/session/service/lifecycle/session.permission.service.ts
+++ b/src/backend/services/session/service/lifecycle/session.permission.service.ts
@@ -21,6 +21,11 @@ export class SessionPermissionService {
   }
 
   createPermissionBridge(sessionId: string): AcpPermissionBridge {
+    const existing = this.acpPermissionBridges.get(sessionId);
+    if (existing) {
+      return existing;
+    }
+
     const bridge = new AcpPermissionBridge();
     this.acpPermissionBridges.set(sessionId, bridge);
     return bridge;


### PR DESCRIPTION
## Summary
- Reuses the existing ACP permission bridge when session setup runs more than once.
- Preserves pending ACP permission requests so frontend responses resolve against the bridge used by the running client.
- Adds regression coverage for duplicate bridge creation and cancellation cleanup.

## Changes
- **Session lifecycle**: Made `createPermissionBridge` idempotent per live session.
- **Tests**: Added coverage for bridge reuse, duplicate creation with a pending request, and fresh bridge creation after cancellation.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not run; backend lifecycle regression is covered by unit tests.

Closes #1625

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session permission routing for ACP tool approvals; the change is small and regression-tested but affects interactive permission resolution.
> 
> **Overview**
> **`SessionPermissionService.createPermissionBridge`** is now **idempotent per session**: if a bridge already exists for that session id, the service returns it instead of creating a new one.
> 
> This fixes a lifecycle bug where **repeated session setup** could register a second bridge while the ACP client still held pending permission requests on the first. Frontend **`respondToPermission`** calls would then hit the wrong bridge and fail to resolve in-flight prompts.
> 
> **`cancelPendingRequests`** behavior is unchanged—it still cancels and removes the bridge—so the next **`createPermissionBridge`** after cancellation allocates a **new** instance. Unit tests cover bridge reuse, pending resolution after duplicate creation, and fresh bridge after cancel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e409f8a197aab0fb1f23b72f34ae9d12b16e878e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->