### PR TITLE
Fix #1624: Prevent concurrent auto-iteration resume loops

### DIFF
--- a/src/backend/services/auto-iteration/service/auto-iteration.service.test.ts
+++ b/src/backend/services/auto-iteration/service/auto-iteration.service.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { createLogger } from '@/backend/services/logger.service';
+import { AutoIterationStatus } from '@/shared/core';
+import { AutoIterationService } from './auto-iteration.service';
+import type { RunningLoop } from './auto-iteration-loop-state';
+import { createInitialRunningLoop } from './auto-iteration-loop-state';
+import type {
+  AutoIterationLogbookBridge,
+  AutoIterationSessionBridge,
+  AutoIterationWorkspaceBridge,
+} from './bridges';
+
+type Logger = ReturnType<typeof createLogger>;
+type AutoIterationServiceInternals = {
+  loops: Map<string, RunningLoop>;
+  runLoop(loop: RunningLoop, worktreePath: string): Promise<void>;
+};
+
+const config = {
+  testCommand: 'pnpm test',
+  targetDescription: 'Improve tests',
+  maxIterations: 5,
+  testTimeoutSeconds: 60,
+  sessionRecycleInterval: 3,
+};
+
+function createLoggerMock(): Logger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  } as unknown as Logger;
+}
+
+function createWorkspaceBridge(): AutoIterationWorkspaceBridge {
+  return {
+    getWorktreePath: vi.fn().mockResolvedValue('/tmp/worktree'),
+    updateAutoIterationStatus: vi.fn().mockResolvedValue(undefined),
+    updateAutoIterationProgress: vi.fn().mockResolvedValue(undefined),
+    updateAutoIterationSessionId: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createSessionBridge(): AutoIterationSessionBridge {
+  return {
+    startSession: vi.fn().mockResolvedValue('session-1'),
+    sendPrompt: vi.fn().mockResolvedValue(undefined),
+    waitForIdle: vi.fn().mockResolvedValue(undefined),
+    stopSession: vi.fn().mockResolvedValue(undefined),
+    getLastAssistantMessage: vi.fn().mockResolvedValue('assistant response'),
+    recycleSession: vi.fn().mockResolvedValue('session-2'),
+  };
+}
+
+function createLogbookBridge(): AutoIterationLogbookBridge {
+  return {
+    initialize: vi.fn().mockResolvedValue(undefined),
+    appendEntry: vi.fn().mockResolvedValue(undefined),
+    read: vi.fn().mockResolvedValue(null),
+    readStrategyFile: vi.fn().mockResolvedValue(null),
+    writeStrategyFile: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createPausedLoop(workspaceId: string): RunningLoop {
+  const loop = createInitialRunningLoop(workspaceId, config);
+  loop.sessionId = 'session-1';
+  loop.pauseRequested = true;
+  loop.loopPromise = Promise.resolve();
+  return loop;
+}
+
+describe('AutoIterationService resume', () => {
+  let service: AutoIterationService;
+  let serviceInternals: AutoIterationServiceInternals;
+  let workspaceBridge: AutoIterationWorkspaceBridge;
+
+  beforeEach(() => {
+    service = new AutoIterationService(createLoggerMock());
+    serviceInternals = service as unknown as AutoIterationServiceInternals;
+    workspaceBridge = createWorkspaceBridge();
+    service.configure(createSessionBridge(), workspaceBridge, createLogbookBridge());
+  });
+
+  it('starts only one run loop for concurrent resume calls', async () => {
+    const loop = createPausedLoop('ws-1');
+    serviceInternals.loops.set('ws-1', loop);
+
+    let releaseStatusUpdate = (): void => undefined;
+    vi.mocked(workspaceBridge.updateAutoIterationStatus).mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseStatusUpdate = resolve;
+        })
+    );
+
+    const runLoop = vi
+      .spyOn(serviceInternals, 'runLoop')
+      .mockImplementation(() => new Promise<void>(() => undefined));
+
+    const firstResume = service.resume('ws-1');
+    await vi.waitFor(() => {
+      expect(workspaceBridge.updateAutoIterationStatus).toHaveBeenCalledTimes(1);
+    });
+
+    const secondResume = service.resume('ws-1');
+    releaseStatusUpdate();
+
+    await Promise.all([firstResume, secondResume]);
+
+    expect(workspaceBridge.updateAutoIterationStatus).toHaveBeenCalledWith(
+      'ws-1',
+      AutoIterationStatus.RUNNING
+    );
+    expect(workspaceBridge.updateAutoIterationStatus).toHaveBeenCalledTimes(1);
+    expect(workspaceBridge.getWorktreePath).toHaveBeenCalledTimes(1);
+    expect(runLoop).toHaveBeenCalledTimes(1);
+    expect(loop.loopPromise).not.toBeNull();
+  });
+
+  it('releases the resume sentinel if restarting the loop fails', async () => {
+    const loop = createPausedLoop('ws-1');
+    serviceInternals.loops.set('ws-1', loop);
+
+    const startupError = new Error('status update failed');
+    let rejectStatusUpdate = (_error: Error): void => undefined;
+    vi.mocked(workspaceBridge.updateAutoIterationStatus)
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((_resolve, reject) => {
+            rejectStatusUpdate = reject;
+          })
+      )
+      .mockResolvedValueOnce(undefined);
+
+    const runLoop = vi
+      .spyOn(serviceInternals, 'runLoop')
+      .mockImplementation(() => new Promise<void>(() => undefined));
+
+    const firstResume = service.resume('ws-1');
+    await vi.waitFor(() => {
+      expect(workspaceBridge.updateAutoIterationStatus).toHaveBeenCalledTimes(1);
+    });
+
+    const secondResume = service.resume('ws-1');
+    rejectStatusUpdate(startupError);
+
+    await expect(firstResume).rejects.toThrow('status update failed');
+    await secondResume;
+
+    expect(workspaceBridge.updateAutoIterationStatus).toHaveBeenCalledTimes(2);
+    expect(workspaceBridge.getWorktreePath).toHaveBeenCalledTimes(1);
+    expect(runLoop).toHaveBeenCalledTimes(1);
+    expect(loop.loopPromise).not.toBeNull();
+  });
+});

--- a/src/backend/services/auto-iteration/service/auto-iteration.service.ts
+++ b/src/backend/services/auto-iteration/service/auto-iteration.service.ts
@@ -228,23 +228,32 @@ export class AutoIterationService {
 
     loop.pauseRequested = false;
 
-    // Set a sentinel promise synchronously to prevent concurrent resume() calls from
-    // both passing the swap-check guard — mirrors how start() uses a synchronous map insertion.
-    // A second concurrent resume() will see loopPromise changed and bail out at the swap-check.
-    const sentinel = Promise.resolve();
+    // Set a pending sentinel synchronously so concurrent resume() calls wait until
+    // this call has swapped in the real runLoop promise or reset after failure.
+    let releaseSentinel = (): void => undefined;
+    const sentinel = new Promise<void>((resolve) => {
+      releaseSentinel = resolve;
+    });
     loop.loopPromise = sentinel;
 
-    await this.workspace.updateAutoIterationStatus(workspaceId, AutoIterationStatus.RUNNING);
+    try {
+      await this.workspace.updateAutoIterationStatus(workspaceId, AutoIterationStatus.RUNNING);
 
-    const worktreePath = await this.workspace.getWorktreePath(workspaceId);
-    loop.loopPromise = this.runLoop(loop, worktreePath).catch((err) => {
-      this.logger.error('Auto-iteration loop failed on resume', {
-        workspaceId,
-        error: String(err),
+      const worktreePath = await this.workspace.getWorktreePath(workspaceId);
+      loop.loopPromise = this.runLoop(loop, worktreePath).catch((err) => {
+        this.logger.error('Auto-iteration loop failed on resume', {
+          workspaceId,
+          error: String(err),
+        });
+        void this.workspace.updateAutoIterationStatus(workspaceId, AutoIterationStatus.FAILED);
+        this.loops.delete(workspaceId);
       });
-      void this.workspace.updateAutoIterationStatus(workspaceId, AutoIterationStatus.FAILED);
-      this.loops.delete(workspaceId);
-    });
+    } catch (err) {
+      loop.loopPromise = null;
+      throw err;
+    } finally {
+      releaseSentinel();
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
- Fixes the auto-iteration `resume()` sentinel so concurrent resume calls cannot start multiple loops for one workspace.
- Adds service-level race tests for concurrent resume and resume startup failure recovery.

## Changes
- **Auto-iteration service**: Replaced the already-resolved resume sentinel with a pending sentinel that releases only after the real loop promise is installed or startup failure resets state.
- **Tests**: Added focused Vitest coverage proving concurrent resume calls start one loop and that a failed restart does not leave future resume calls blocked.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; backend race condition covered by unit tests.

Closes #1624

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches orchestration concurrency for auto-iteration resume; wrong sentinel behavior could block resumes or still double-start loops, but scope is limited to resume() and is covered by new unit tests.
> 
> **Overview**
> Fixes a race in **`resume()`** where an immediately-resolved sentinel let two concurrent resumes both restart **`runLoop`** for the same workspace.
> 
> **`resume()`** now installs a **pending** sentinel on **`loopPromise`** so overlapping callers block until startup finishes. Startup (status → RUNNING, worktree path, **`runLoop`**) runs inside **try/catch/finally**: failures clear **`loopPromise`** and rethrow; **finally** always releases the sentinel so a failed restart does not wedge later resumes.
> 
> New Vitest coverage asserts one loop for concurrent resumes and that a failed status update allows a follow-up resume to retry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a09b902e2e5cd72c1425376fd22f01e0c5e92337. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->