### PR TITLE
Fix Dependabot dependency alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "tree-kill": "^1.2.2",
     "tw-animate-css": "^1.4.0",
     "vaul": "^1.1.2",
-    "ws": "^8.19.0",
+    "ws": "^8.20.1",
     "zod": "^4.3.6"
   },
   "lint-staged": {
@@ -200,7 +200,7 @@
       "app-builder-lib>minimatch": ">=10.2.1",
       "fast-uri": "3.1.2",
       "brace-expansion@^1": "1.1.13",
-      "brace-expansion@^5": "5.0.5",
+      "brace-expansion@^5": "5.0.6",
       "braces": ">=3.0.3",
       "filelist>minimatch": ">=10.2.1",
       "follow-redirects": "1.16.0",
@@ -218,7 +218,8 @@
       "serialize-javascript": "7.0.5",
       "smol-toml": "1.6.1",
       "dompurify": "3.4.0",
-      "qs": ">=6.14.2",
+      "qs": "6.15.2",
+      "tmp": "0.2.6",
       "form-data": ">=2.5.4",
       "tough-cookie": ">=4.1.3",
       "uuid": "14.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ overrides:
   app-builder-lib>minimatch: '>=10.2.1'
   fast-uri: 3.1.2
   brace-expansion@^1: 1.1.13
-  brace-expansion@^5: 5.0.5
+  brace-expansion@^5: 5.0.6
   braces: '>=3.0.3'
   filelist>minimatch: '>=10.2.1'
   follow-redirects: 1.16.0
@@ -31,7 +31,8 @@ overrides:
   serialize-javascript: 7.0.5
   smol-toml: 1.6.1
   dompurify: 3.4.0
-  qs: '>=6.14.2'
+  qs: 6.15.2
+  tmp: 0.2.6
   form-data: '>=2.5.4'
   tough-cookie: '>=4.1.3'
   uuid: 14.0.0
@@ -289,8 +290,8 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ws:
-        specifier: ^8.19.0
-        version: 8.19.0
+        specifier: ^8.20.1
+        version: 8.21.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -3185,8 +3186,8 @@ packages:
   brace-expansion@1.1.13:
     resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -5552,8 +5553,8 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  qs@6.15.0:
-    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   queue-lit@1.5.2:
@@ -6241,8 +6242,8 @@ packages:
   tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
 
-  tmp@0.2.5:
-    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+  tmp@0.2.6:
+    resolution: {integrity: sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==}
     engines: {node: '>=14.14'}
 
   to-regex-range@5.0.1:
@@ -6604,8 +6605,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.19.0:
-    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -9448,7 +9449,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.0
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -9462,7 +9463,7 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -10471,7 +10472,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.0
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -11781,11 +11782,11 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:
@@ -11793,7 +11794,7 @@ snapshots:
 
   minimatch@9.0.8:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimist@1.2.8: {}
 
@@ -12279,7 +12280,7 @@ snapshots:
       pngjs: 5.0.0
       yargs: 15.4.1
 
-  qs@6.15.0:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -12902,7 +12903,7 @@ snapshots:
       recast: 0.23.11
       semver: 7.7.4
       use-sync-external-store: 1.6.0(react@19.2.4)
-      ws: 8.19.0
+      ws: 8.21.0
     transitivePeerDependencies:
       - '@testing-library/dom'
       - bufferutil
@@ -12997,7 +12998,7 @@ snapshots:
       formidable: 3.5.4
       methods: 1.1.2
       mime: 2.6.0
-      qs: 6.15.0
+      qs: 6.15.2
     transitivePeerDependencies:
       - supports-color
 
@@ -13099,9 +13100,9 @@ snapshots:
 
   tmp-promise@3.0.3:
     dependencies:
-      tmp: 0.2.5
+      tmp: 0.2.6
 
-  tmp@0.2.5: {}
+  tmp@0.2.6: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -13465,7 +13466,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.19.0: {}
+  ws@8.21.0: {}
 
   wsl-utils@0.1.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Bump `ws` to a patched 8.x release to address the direct Dependabot alert.
- Pin transitive `qs` and `tmp` via pnpm overrides at patched versions.
- Bump `brace-expansion@^5` override to clear the remaining local audit advisory.

## Verification
- `pnpm audit --audit-level low`
- `pnpm check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and lockfile-only changes with no runtime code edits; risk is limited to patch-level behavior in WebSocket and common HTTP/query utilities.
> 
> **Overview**
> Addresses Dependabot dependency alerts by updating **direct** and **transitive** packages, with matching lockfile changes only—no application source changes.
> 
> The direct dependency **`ws`** is bumped from `^8.19.0` to `^8.20.1` (lock resolves to **8.21.0**), covering the flagged WebSocket client/server package used by the backend transport layer.
> 
> **pnpm overrides** are tightened so transitive packages resolve to patched versions: **`qs`** moves from a minimum range (`>=6.14.2`) to a pinned **6.15.2** (affects Express/body-parser/superagent paths in the lockfile), **`tmp`** is newly pinned to **0.2.6** (replacing **0.2.5** under `tmp-promise`), and **`brace-expansion@^5`** is bumped from **5.0.5** to **5.0.6** for minimatch-related advisories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d11595cbca4b10673f7310da7761adf94b3d285b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->