### PR TITLE
Fix #1628: Restart Electron backend after stop failure

### DIFF
--- a/electron/main/server-manager.test.ts
+++ b/electron/main/server-manager.test.ts
@@ -245,4 +245,29 @@ describe('ServerManager lifecycle locking', () => {
     expect(createServer).toHaveBeenCalledTimes(1);
     expect(runMigrations).toHaveBeenCalledTimes(1);
   });
+
+  it('clears cached server state when stop fails so the next start creates a new server', async () => {
+    const manager = new ServerManager();
+    const stopError = new Error('cleanup failed after server closed');
+    const firstServer = {
+      start: vi.fn().mockResolvedValue('http://localhost:8001'),
+      stop: vi.fn().mockRejectedValue(stopError),
+    };
+    const secondServer = {
+      start: vi.fn().mockResolvedValue('http://localhost:8002'),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const createServer = vi.fn().mockReturnValueOnce(firstServer).mockReturnValueOnce(secondServer);
+    mockServerManagerImports(manager, createServer);
+
+    const firstUrl = await manager.start();
+    await expect(manager.stop()).rejects.toThrow(stopError);
+    const secondUrl = await manager.start();
+
+    expect(firstUrl).toBe('http://localhost:8001');
+    expect(secondUrl).toBe('http://localhost:8002');
+    expect(createServer).toHaveBeenCalledTimes(2);
+    expect(firstServer.stop).toHaveBeenCalledTimes(1);
+    expect(secondServer.start).toHaveBeenCalledTimes(1);
+  });
 });

--- a/electron/main/server-manager.ts
+++ b/electron/main/server-manager.ts
@@ -135,9 +135,12 @@ export class ServerManager {
 
       const serverInstance = this.serverInstance;
       console.log('[electron] Stopping backend server...');
-      await serverInstance.stop();
-      this.serverInstance = null;
-      this.serverUrl = null;
+      try {
+        await serverInstance.stop();
+      } finally {
+        this.serverInstance = null;
+        this.serverUrl = null;
+      }
       console.log('[electron] Backend server stopped');
     });
   }


### PR DESCRIPTION
## Summary
- Clear Electron backend server cache even when shutdown throws.
- Add regression coverage for restart after a failed stop.

## Changes
- **Electron server lifecycle**: Move `serverInstance` and `serverUrl` clearing into a `finally` block during `ServerManager.stop()`.
- **Tests**: Verify that a failed stop rejects but leaves the manager restartable instead of returning a stale cached URL.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Formatting/lint fixes checked (`pnpm check:fix`)
- [ ] Manual testing: Not run; change is covered by focused Electron lifecycle regression test.

Closes #1628

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to Electron main-process server lifecycle with focused regression coverage; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes Electron backend restart after a failed shutdown by always clearing **`ServerManager`**’s cached **`serverInstance`** and **`serverUrl`** in a **`finally`** block, while still rejecting when **`stop()`** throws.
> 
> Adds a lifecycle regression test that expects a failed **`stop()`** to be followed by a fresh **`createServer`** on the next **`start()`**, instead of reusing a stale cached URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eb9828591ad28f2fdb619173018c5da0c1e4193. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->