### PR TITLE
Fix #1632: Stop waiting on signal-killed run scripts

### DIFF
--- a/src/backend/services/run-script/service/run-script-process-utils.ts
+++ b/src/backend/services/run-script/service/run-script-process-utils.ts
@@ -99,7 +99,7 @@ export async function waitForChildProcessExit(params: {
     return;
   }
 
-  if (childProcess.exitCode !== null) {
+  if (childProcess.exitCode !== null || childProcess.signalCode !== null) {
     return;
   }
 
@@ -142,7 +142,7 @@ export async function waitForChildProcessExit(params: {
     childProcess.once('exit', onExit);
     childProcess.once('error', onError);
 
-    if (childProcess.exitCode !== null) {
+    if (childProcess.exitCode !== null || childProcess.signalCode !== null) {
       cleanup();
       resolve();
     }

--- a/src/backend/services/run-script/service/run-script.service.test.ts
+++ b/src/backend/services/run-script/service/run-script.service.test.ts
@@ -85,6 +85,7 @@ import { RunScriptService } from './run-script.service';
 class FakeChildProcess extends EventEmitter {
   pid: number | undefined;
   exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
   killed = false;
   stdout = new EventEmitter();
   stderr = new EventEmitter();
@@ -784,11 +785,13 @@ describe('RunScriptService.stopRunScript', () => {
     const mockProcess: {
       pid: number;
       exitCode: number | null;
+      signalCode: NodeJS.Signals | null;
       once: (event: string, handler: (code: number | null, signal: string | null) => void) => void;
       off: (event: string, handler: (code: number | null, signal: string | null) => void) => void;
     } = {
       pid: 12_345,
       exitCode: null,
+      signalCode: null,
       once: vi.fn(
         (event: string, handler: (code: number | null, signal: string | null) => void) => {
           if (event === 'exit') {
@@ -1749,6 +1752,22 @@ describe('RunScriptService.waitForProcessExit', () => {
     await expect(service.waitForProcessExit('ws-1', childProcess, 12_345)).resolves.toBeUndefined();
   });
 
+  it('returns when process already has signalCode', async () => {
+    const service = new RunScriptService() as unknown as {
+      waitForProcessExit: (
+        workspaceId: string,
+        childProcess: FakeChildProcess | undefined,
+        pid: number | null
+      ) => Promise<void>;
+    };
+    const childProcess = new FakeChildProcess(12_345);
+    childProcess.signalCode = 'SIGTERM';
+    const onceSpy = vi.spyOn(childProcess, 'once');
+
+    await expect(service.waitForProcessExit('ws-1', childProcess, 12_345)).resolves.toBeUndefined();
+    expect(onceSpy).not.toHaveBeenCalled();
+  });
+
   it('returns when child process does not expose once/off', async () => {
     const service = new RunScriptService() as unknown as {
       waitForProcessExit: (
@@ -1808,6 +1827,25 @@ describe('RunScriptService.waitForProcessExit', () => {
     onceSpy.mockImplementation(((event: string, listener: (...args: unknown[]) => void) => {
       EventEmitter.prototype.once.call(childProcess, event, listener);
       childProcess.exitCode = 0;
+      return childProcess;
+    }) as typeof childProcess.once);
+
+    await expect(service.waitForProcessExit('ws-1', childProcess, 12_345)).resolves.toBeUndefined();
+  });
+
+  it('resolves immediately when signalCode flips after listeners are attached', async () => {
+    const service = new RunScriptService() as unknown as {
+      waitForProcessExit: (
+        workspaceId: string,
+        childProcess: FakeChildProcess | undefined,
+        pid: number | null
+      ) => Promise<void>;
+    };
+    const childProcess = new FakeChildProcess(12_345);
+    const onceSpy = vi.spyOn(childProcess, 'once');
+    onceSpy.mockImplementation(((event: string, listener: (...args: unknown[]) => void) => {
+      EventEmitter.prototype.once.call(childProcess, event, listener);
+      childProcess.signalCode = 'SIGTERM';
       return childProcess;
     }) as typeof childProcess.once);
 


### PR DESCRIPTION
## Summary
- Treat signal-terminated run-script child processes as already exited.
- Avoid the 10-second stop timeout when `exit` listeners are attached after signal termination.
- Add regression coverage for `signalCode` in both early-return and post-listener race paths.

## Changes
- **Run Script**: Checks `exitCode` or `signalCode` before waiting for child process exit.
- **Tests**: Extends fake child process coverage and verifies signal-killed processes resolve immediately.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: not run; backend process-state regression covered by unit tests

Closes #1632

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to stop-wait logic in run-script process utils with unit test coverage; no auth or data-path changes.
> 
> **Overview**
> Fixes run-script **stop** hanging up to 10s when a child was killed by signal but `exitCode` was still `null`.
> 
> `waitForChildProcessExit` in `run-script-process-utils.ts` now treats **`signalCode`** like a finished process—both on the initial check and again right after attaching `exit`/`error` listeners—so stop does not wait on an `exit` event that may never fire in that race.
> 
> Tests extend `FakeChildProcess` with `signalCode` and add cases for early return and post-listener `signalCode` updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecc08a854fd300250967d41c120935c54d8d86f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->