### PR TITLE
Fix #1633: Dispatch queued messages after init retry

### DIFF
--- a/src/backend/orchestration/workspace-init.orchestrator.ts
+++ b/src/backend/orchestration/workspace-init.orchestrator.ts
@@ -383,7 +383,7 @@ async function startDefaultAgentSession(workspaceId: string): Promise<string | n
   }
 }
 
-async function retryQueuedDispatchAfterWorkspaceReady(
+export async function retryQueuedDispatchAfterWorkspaceReady(
   workspaceId: string,
   startedSessionId: string | null
 ): Promise<void> {

--- a/src/backend/trpc/workspace/init.router.test.ts
+++ b/src/backend/trpc/workspace/init.router.test.ts
@@ -10,6 +10,7 @@ const mockGetInitMode = vi.hoisted(() => vi.fn());
 const mockSetInitMode = vi.hoisted(() => vi.fn());
 const mockGetWorkspaceInitPolicy = vi.hoisted(() => vi.fn());
 const mockInitializeWorkspaceWorktree = vi.hoisted(() => vi.fn());
+const mockRetryQueuedDispatchAfterWorkspaceReady = vi.hoisted(() => vi.fn());
 const mockExecuteStartupScriptPipeline = vi.hoisted(() => vi.fn());
 const mockReadConfig = vi.hoisted(() => vi.fn());
 
@@ -38,6 +39,8 @@ vi.mock('@/backend/services/workspace', () => ({
 
 vi.mock('@/backend/orchestration/workspace-init.orchestrator', () => ({
   initializeWorkspaceWorktree: (...args: unknown[]) => mockInitializeWorkspaceWorktree(...args),
+  retryQueuedDispatchAfterWorkspaceReady: (...args: unknown[]) =>
+    mockRetryQueuedDispatchAfterWorkspaceReady(...args),
 }));
 
 vi.mock('@/backend/orchestration/workspace-init-script-pipeline', () => ({
@@ -69,6 +72,7 @@ describe('workspaceInitRouter', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockInitializeWorkspaceWorktree.mockResolvedValue(undefined);
+    mockRetryQueuedDispatchAfterWorkspaceReady.mockResolvedValue(undefined);
     mockRunStartupScript.mockResolvedValue({ success: true });
   });
 
@@ -235,6 +239,14 @@ describe('workspaceInitRouter', () => {
         worktreePath: '/tmp/w3',
       })
     );
+    expect(mockRetryQueuedDispatchAfterWorkspaceReady).toHaveBeenCalledWith('w3', null);
+    const pipelineCallOrder = mockExecuteStartupScriptPipeline.mock.invocationCallOrder[0];
+    const retryDispatchCallOrder =
+      mockRetryQueuedDispatchAfterWorkspaceReady.mock.invocationCallOrder[0];
+    if (pipelineCallOrder === undefined || retryDispatchCallOrder === undefined) {
+      throw new Error('Expected startup pipeline and queued dispatch to be called');
+    }
+    expect(pipelineCallOrder).toBeLessThan(retryDispatchCallOrder);
   });
 
   it('throws TOO_MANY_REQUESTS when READY+warning retry exceeds max retries', async () => {

--- a/src/backend/trpc/workspace/init.trpc.ts
+++ b/src/backend/trpc/workspace/init.trpc.ts
@@ -2,7 +2,10 @@ import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 import { toError } from '@/backend/lib/error-utils';
 import type { WorkspaceWithProject } from '@/backend/orchestration/types';
-import { initializeWorkspaceWorktree } from '@/backend/orchestration/workspace-init.orchestrator';
+import {
+  initializeWorkspaceWorktree,
+  retryQueuedDispatchAfterWorkspaceReady,
+} from '@/backend/orchestration/workspace-init.orchestrator';
 import { executeStartupScriptPipeline } from '@/backend/orchestration/workspace-init-script-pipeline';
 import { FactoryConfigService } from '@/backend/services/factory-config.service';
 import { createLogger } from '@/backend/services/logger.service';
@@ -158,6 +161,8 @@ export const workspaceInitRouter = router({
           worktreePath,
           factoryConfig,
         });
+
+        await retryQueuedDispatchAfterWorkspaceReady(workspace.id, null);
 
         return workspaceDataService.findById(input.id);
       }


### PR DESCRIPTION
## Summary
- Dispatches queued chat messages after READY+warning workspace init retries complete
- Reuses the existing post-init queued dispatch helper for this retry path
- Adds router coverage to lock dispatch sequencing after the startup pipeline

## Changes
- **Workspace init retry**: Calls `retryQueuedDispatchAfterWorkspaceReady(workspace.id, null)` after `executeStartupScriptPipeline` completes for READY+warning retries.
- **Workspace init orchestrator**: Exports the queued dispatch helper for reuse by the retry mutation.
- **Tests**: Verifies READY+warning retry dispatches queued messages after the startup pipeline finishes.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Reproduce a READY+warning retry, send chat while retry is PROVISIONING, and confirm it auto-dispatches after READY

Closes #1633

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted sequencing change on an existing dispatch helper with test coverage; no new auth or data paths.
> 
> **Overview**
> **READY+warning init retries** now flush the session message queue after the startup script pipeline finishes, matching behavior from the main init orchestrator path.
> 
> The `retryInit` mutation calls **`retryQueuedDispatchAfterWorkspaceReady(workspace.id, null)`** immediately after **`executeStartupScriptPipeline`** for workspaces that are READY but still carry a setup warning. That helper is **exported** from the workspace init orchestrator so the tRPC layer can reuse it (with `null` session id so dispatch targets an existing RUNNING or IDLE session).
> 
> Tests assert the helper is invoked for this retry path and that it runs **after** the startup pipeline completes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 114506c6878eb86864e16783f9308b1fc42840a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->