### PR TITLE
Fix #1635: Harden rejected chat recovery

### DIFF
--- a/src/components/chat/use-chat-state.integration.test.tsx
+++ b/src/components/chat/use-chat-state.integration.test.tsx
@@ -15,7 +15,7 @@ Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
 });
 
 interface ChatStateHarnessProps {
-  dbSessionId: string;
+  dbSessionId: string | null;
   send: (message: unknown) => boolean;
   chatRef: { current: UseChatStateReturn | null };
 }
@@ -25,13 +25,13 @@ function ChatStateHarness({ dbSessionId, send, chatRef }: ChatStateHarnessProps)
   return null;
 }
 
-function renderChatState(initialSessionId: string, send = vi.fn(() => true)) {
+function renderChatState(initialSessionId: string | null, send = vi.fn(() => true)) {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const root: Root = createRoot(container);
   const chatRef = { current: null as UseChatStateReturn | null };
 
-  const render = (dbSessionId: string) => {
+  const render = (dbSessionId: string | null) => {
     root.render(createElement(ChatStateHarness, { dbSessionId, send, chatRef }));
   };
 
@@ -42,7 +42,7 @@ function renderChatState(initialSessionId: string, send = vi.fn(() => true)) {
   return {
     chatRef,
     send,
-    rerenderSession: (dbSessionId: string) => {
+    rerenderSession: (dbSessionId: string | null) => {
       render(dbSessionId);
     },
     cleanup: () => {
@@ -168,6 +168,43 @@ describe('useChatState rejected message recovery', () => {
     expect(harness.chatRef.current?.inputAttachments).toEqual([]);
     expect(sessionStorage.getItem('chat-draft-session-B') ?? '').not.toContain('sensitive data');
     expect(sessionStorage.getItem('chat-attachments-session-B') ?? '').not.toContain('secret.txt');
+
+    harness.cleanup();
+  });
+
+  it('does not recover rejected message content without a captured source session', async () => {
+    const harness = renderChatState(null);
+    await flushEffects();
+
+    flushSync(() => {
+      harness.chatRef.current?.setInputAttachments([createAttachment()]);
+    });
+
+    await flushEffects();
+
+    flushSync(() => {
+      harness.chatRef.current?.sendMessage('sensitive data');
+    });
+
+    const messageId = getSentMessageId(harness.send);
+    flushSync(() => {
+      harness.chatRef.current?.dispatch({
+        type: 'MESSAGE_STATE_CHANGED',
+        payload: {
+          id: messageId,
+          newState: MessageState.REJECTED,
+          errorMessage: 'Rejected',
+        },
+      });
+    });
+
+    await flushEffects();
+    await flushDraftDebounce();
+
+    expect(harness.chatRef.current?.inputDraft).toBe('');
+    expect(harness.chatRef.current?.inputAttachments).toEqual([]);
+    expect(sessionStorage.getItem('chat-draft-null')).toBeNull();
+    expect(sessionStorage.getItem('chat-attachments-null')).toBeNull();
 
     harness.cleanup();
   });

--- a/src/components/chat/use-chat-state.ts
+++ b/src/components/chat/use-chat-state.ts
@@ -187,7 +187,7 @@ export function useChatState(options: UseChatStateOptions): UseChatStateReturn {
   useEffect(() => {
     if (state.lastRejectedMessage) {
       const { text, attachments, sessionId } = state.lastRejectedMessage;
-      if (sessionId && sessionId !== dbSessionIdRef.current) {
+      if (!sessionId || sessionId !== dbSessionIdRef.current) {
         dispatch({ type: 'CLEAR_REJECTED_MESSAGE' });
         return;
       }


### PR DESCRIPTION
## Summary
- Harden rejected message recovery so messages without a captured source session are cleared instead of recovered into the active session.
- Add integration coverage for missing-source-session rejected messages.

## Changes
- **Chat state**: Require rejected recovery content to have a session id matching the active session before restoring draft text or attachments.
- **Tests**: Extend `useChatState` integration coverage to verify sessionless rejected content is not restored or persisted.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not run; state-only persistence behavior is covered by integration tests.

Closes #1635

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes client-side handling of rejected messages and session-scoped draft persistence, which could affect retry UX but reduces cross-session data leakage risk.
> 
> **Overview**
> **Rejected message recovery** now only restores draft text and attachments when the rejected payload’s `sessionId` matches the active session. If there is **no** captured source session or it differs from the current session, the hook clears `lastRejectedMessage` instead of repopulating the input—closing a path where sensitive content could appear in the wrong session.
> 
> Integration tests were updated to allow `dbSessionId: null` in the harness and to assert that a rejection with no source session leaves the draft empty, attachments cleared, and nothing written to session storage under `chat-draft-null` / `chat-attachments-null`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 423eb45388b599f6e3b7fc52ebcc447a573b619f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->