### PR TITLE
Fix #1630: clean up timed-out ACP prompts

### DIFF
--- a/src/backend/services/session/service/acp/acp-runtime-manager.test.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-manager.test.ts
@@ -73,7 +73,7 @@ vi.mock('@/backend/services/logger.service', () => ({
 import type { AcpEventCallback } from './acp-client-handler';
 import { AcpClientHandler } from './acp-client-handler';
 import type { AcpRuntimeEventHandlers } from './acp-runtime-manager';
-import { AcpRuntimeManager } from './acp-runtime-manager';
+import { AcpRuntimeManager, PromptTimeoutError } from './acp-runtime-manager';
 import type { AcpClientOptions } from './types';
 
 // ---- Helpers ----
@@ -1183,6 +1183,84 @@ describe('AcpRuntimeManager', () => {
         manager.sendPrompt('session-1', [{ type: 'text', text: 'Hello' }])
       ).rejects.toThrow('prompt failed');
       expect(handle.isPromptInFlight).toBe(false);
+    });
+
+    it('keeps prompt marked in flight while cancelling after prompt timeout', async () => {
+      setupSuccessfulSpawn();
+      mockPrompt.mockReturnValue(new Promise(() => undefined));
+      mockCancel.mockResolvedValue(undefined);
+
+      const handle = await manager.getOrCreateClient(
+        'session-1',
+        defaultOptions(),
+        defaultHandlers(),
+        defaultContext()
+      );
+
+      vi.useFakeTimers();
+
+      try {
+        const promptPromise = manager.sendPrompt(
+          'session-1',
+          [{ type: 'text', text: 'Hello' }],
+          100
+        );
+        const promptRejection = promptPromise.catch((error: unknown) => error);
+
+        await vi.advanceTimersByTimeAsync(100);
+
+        await expect(promptRejection).resolves.toBeInstanceOf(PromptTimeoutError);
+        expect(mockCancel).toHaveBeenCalledWith({
+          sessionId: 'provider-session-123',
+        });
+        expect(handle.isPromptInFlight).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('stops the client when prompt timeout cancellation hangs', async () => {
+      const child = setupSuccessfulSpawn();
+      mockPrompt.mockReturnValue(new Promise(() => undefined));
+      mockCancel.mockReturnValue(new Promise(() => undefined));
+
+      const handle = await manager.getOrCreateClient(
+        'session-1',
+        defaultOptions(),
+        defaultHandlers(),
+        defaultContext()
+      );
+      child.kill = vi.fn((signal?: string) => {
+        if (signal === 'SIGTERM') {
+          child.killed = true;
+          child.exitCode = 0;
+          child.emit('exit', 0, null);
+        }
+        return true;
+      });
+
+      vi.useFakeTimers();
+
+      try {
+        const promptPromise = manager.sendPrompt(
+          'session-1',
+          [{ type: 'text', text: 'Hello' }],
+          100
+        );
+        const promptRejection = promptPromise.catch((error: unknown) => error);
+
+        await vi.advanceTimersByTimeAsync(100);
+        expect(mockCancel).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(5000);
+
+        await expect(promptRejection).resolves.toBeInstanceOf(PromptTimeoutError);
+        expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+        expect(manager.getClient('session-1')).toBeUndefined();
+        expect(handle.isPromptInFlight).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('throws if no session found', async () => {

--- a/src/backend/services/session/service/acp/acp-runtime-manager.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-manager.ts
@@ -671,10 +671,10 @@ export class AcpRuntimeManager {
       handle.isPromptInFlight = false;
       return { stopReason: result.stopReason };
     } catch (error) {
-      handle.isPromptInFlight = false;
       if (error instanceof PromptTimeoutError) {
         await this.escalatePromptTimeout(sessionId, timeoutMs);
       }
+      handle.isPromptInFlight = false;
       throw error;
     }
   }
@@ -692,6 +692,7 @@ export class AcpRuntimeManager {
       ]);
       if (!cancelled) {
         logger.warn('Cancel timed out after prompt timeout, stopping client', { sessionId });
+        this.clearPromptInFlight(sessionId);
         await this.stopClient(sessionId).catch(() => {
           // Best-effort cleanup
         });
@@ -699,9 +700,17 @@ export class AcpRuntimeManager {
     } catch {
       // Cancel failed — stop the client forcibly
       logger.warn('Cancel failed after timeout, stopping client', { sessionId });
+      this.clearPromptInFlight(sessionId);
       await this.stopClient(sessionId).catch(() => {
         // Best-effort cleanup
       });
+    }
+  }
+
+  private clearPromptInFlight(sessionId: string): void {
+    const handle = this.sessions.get(sessionId);
+    if (handle) {
+      handle.isPromptInFlight = false;
     }
   }
 


### PR DESCRIPTION
## Summary
- Fixes ACP prompt timeout escalation so timed-out turns are cancelled while still marked in flight.
- Ensures a hanging timeout cancel can fall back to stopping the ACP client.
- Adds regression coverage for cancel-on-timeout and cancel-hang cleanup.

## Changes
- **ACP runtime**: Move `isPromptInFlight` cleanup until after timeout escalation so `cancelPrompt()` sends ACP cancel.
- **ACP runtime**: Clear the in-flight flag before fallback `stopClient()` when timeout cancellation hangs or fails, avoiding a second hung cancel during process termination.
- **Tests**: Cover prompt timeout cancellation and client stop fallback for hanging cancels.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Guardrails pass (`pnpm check:fix`)
- [ ] Manual testing: Not applicable; backend runtime regression covered by unit tests.

Closes #1630

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session lifecycle and subprocess teardown on timeouts in the ACP runtime; scope is narrow and covered by new unit tests.
> 
> **Overview**
> Fixes **ACP prompt timeout** handling so timed-out turns are actually cancelled on the wire and the session can recover when cancel never completes.
> 
> On `PromptTimeoutError`, **`isPromptInFlight` is no longer cleared before** `escalatePromptTimeout`, so `cancelPrompt()` still sees an in-flight prompt and issues **`connection.cancel`**. The flag is cleared only after escalation finishes (or via a new **`clearPromptInFlight`** helper when cancel hangs or fails and the runtime falls back to **`stopClient`**, avoiding a second stuck cancel during SIGTERM).
> 
> Unit tests cover timeout → cancel, and timeout → hung cancel → client stop with the in-flight flag cleared.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 976cb75c6a8566c84a90d3555cb8e5241b0dcbc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->