### PR TITLE
Fix duplicate linked issues in Todo

### DIFF
--- a/src/backend/trpc/github.router.test.ts
+++ b/src/backend/trpc/github.router.test.ts
@@ -9,6 +9,7 @@ const mockGithubCLIService = vi.hoisted(() => ({
 
 const mockWorkspaceDataService = vi.hoisted(() => ({
   findByIdWithProject: vi.fn(),
+  findByProjectId: vi.fn(),
 }));
 
 const mockProjectManagementService = vi.hoisted(() => ({
@@ -33,6 +34,7 @@ function createCaller() {
 describe('githubRouter', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockWorkspaceDataService.findByProjectId.mockResolvedValue([]);
   });
 
   it('checks health and project/repo availability', async () => {
@@ -102,6 +104,37 @@ describe('githubRouter', () => {
     await expect(caller.getIssue({ projectId: 'p1', issueNumber: 99 })).resolves.toEqual({
       issue: null,
       error: 'boom',
+    });
+  });
+
+  it('filters project issues that already have active workspaces', async () => {
+    const caller = createCaller();
+    mockGithubCLIService.checkHealth.mockResolvedValue({
+      isInstalled: true,
+      isAuthenticated: true,
+    });
+    mockProjectManagementService.findById.mockResolvedValue({
+      id: 'p1',
+      githubOwner: 'purplefish-ai',
+      githubRepo: 'factory-factory',
+    });
+    mockGithubCLIService.listIssues.mockResolvedValue([
+      { number: 55, title: 'Has workspace' },
+      { number: 56, title: 'No workspace' },
+      { number: 57, title: 'Archived workspace' },
+    ]);
+    mockWorkspaceDataService.findByProjectId.mockResolvedValue([
+      { githubIssueNumber: 55, status: 'READY' },
+      { githubIssueNumber: 57, status: 'ARCHIVED' },
+    ]);
+
+    await expect(caller.listIssuesForProject({ projectId: 'p1' })).resolves.toEqual({
+      issues: [
+        { number: 56, title: 'No workspace' },
+        { number: 57, title: 'Archived workspace' },
+      ],
+      health: { isInstalled: true, isAuthenticated: true },
+      error: null,
     });
   });
 });

--- a/src/backend/trpc/github.trpc.ts
+++ b/src/backend/trpc/github.trpc.ts
@@ -7,7 +7,33 @@
 import { z } from 'zod';
 import { githubCLIService } from '@/backend/services/github';
 import { projectManagementService, workspaceDataService } from '@/backend/services/workspace';
+import { WorkspaceStatus } from '@/shared/core';
 import { publicProcedure, router } from './trpc';
+
+function filterIssuesLinkedToActiveWorkspaces<TIssue extends { number: number }>(
+  issues: TIssue[],
+  workspaces: Array<{
+    githubIssueNumber: number | null;
+    status: WorkspaceStatus;
+  }>
+): TIssue[] {
+  const linkedIssueNumbers = new Set(
+    workspaces
+      .filter(
+        (workspace) =>
+          workspace.status !== WorkspaceStatus.ARCHIVING &&
+          workspace.status !== WorkspaceStatus.ARCHIVED
+      )
+      .map((workspace) => workspace.githubIssueNumber)
+      .filter((issueNumber): issueNumber is number => issueNumber !== null)
+  );
+
+  if (linkedIssueNumbers.size === 0) {
+    return issues;
+  }
+
+  return issues.filter((issue) => !linkedIssueNumbers.has(issue.number));
+}
 
 export const githubRouter = router({
   /**
@@ -108,10 +134,17 @@ export const githubRouter = router({
 
       try {
         // Only fetch issues assigned to the current user (@me)
-        const issues = await githubCLIService.listIssues(githubOwner, githubRepo, {
-          assignee: '@me',
-        });
-        return { issues, health, error: null };
+        const [issues, workspaces] = await Promise.all([
+          githubCLIService.listIssues(githubOwner, githubRepo, {
+            assignee: '@me',
+          }),
+          workspaceDataService.findByProjectId(input.projectId),
+        ]);
+        return {
+          issues: filterIssuesLinkedToActiveWorkspaces(issues, workspaces),
+          health,
+          error: null,
+        };
       } catch (err) {
         return {
           issues: [],

--- a/src/backend/trpc/github.trpc.ts
+++ b/src/backend/trpc/github.trpc.ts
@@ -7,33 +7,8 @@
 import { z } from 'zod';
 import { githubCLIService } from '@/backend/services/github';
 import { projectManagementService, workspaceDataService } from '@/backend/services/workspace';
-import { WorkspaceStatus } from '@/shared/core';
+import { filterIssuesLinkedToActiveWorkspaces } from './issue-filter';
 import { publicProcedure, router } from './trpc';
-
-function filterIssuesLinkedToActiveWorkspaces<TIssue extends { number: number }>(
-  issues: TIssue[],
-  workspaces: Array<{
-    githubIssueNumber: number | null;
-    status: WorkspaceStatus;
-  }>
-): TIssue[] {
-  const linkedIssueNumbers = new Set(
-    workspaces
-      .filter(
-        (workspace) =>
-          workspace.status !== WorkspaceStatus.ARCHIVING &&
-          workspace.status !== WorkspaceStatus.ARCHIVED
-      )
-      .map((workspace) => workspace.githubIssueNumber)
-      .filter((issueNumber): issueNumber is number => issueNumber !== null)
-  );
-
-  if (linkedIssueNumbers.size === 0) {
-    return issues;
-  }
-
-  return issues.filter((issue) => !linkedIssueNumbers.has(issue.number));
-}
 
 export const githubRouter = router({
   /**
@@ -141,7 +116,12 @@ export const githubRouter = router({
           workspaceDataService.findByProjectId(input.projectId),
         ]);
         return {
-          issues: filterIssuesLinkedToActiveWorkspaces(issues, workspaces),
+          issues: filterIssuesLinkedToActiveWorkspaces(
+            issues,
+            workspaces,
+            (workspace) => workspace.githubIssueNumber,
+            (issue) => issue.number
+          ),
           health,
           error: null,
         };

--- a/src/backend/trpc/issue-filter.ts
+++ b/src/backend/trpc/issue-filter.ts
@@ -1,0 +1,36 @@
+import { WorkspaceStatus } from '@/shared/core';
+
+type IssueKey = number | string;
+
+export function filterIssuesLinkedToActiveWorkspaces<
+  TIssue,
+  TWorkspace extends { status: WorkspaceStatus },
+  TIssueKey extends IssueKey,
+>(
+  issues: TIssue[],
+  workspaces: TWorkspace[],
+  getWorkspaceIssueKey: (workspace: TWorkspace) => TIssueKey | null | undefined,
+  getIssueKey: (issue: TIssue) => TIssueKey
+): TIssue[] {
+  const linkedIssueKeys = new Set<TIssueKey>();
+
+  for (const workspace of workspaces) {
+    if (
+      workspace.status === WorkspaceStatus.ARCHIVING ||
+      workspace.status === WorkspaceStatus.ARCHIVED
+    ) {
+      continue;
+    }
+
+    const issueKey = getWorkspaceIssueKey(workspace);
+    if (issueKey != null) {
+      linkedIssueKeys.add(issueKey);
+    }
+  }
+
+  if (linkedIssueKeys.size === 0) {
+    return issues;
+  }
+
+  return issues.filter((issue) => !linkedIssueKeys.has(getIssueKey(issue)));
+}

--- a/src/backend/trpc/linear.router.test.ts
+++ b/src/backend/trpc/linear.router.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockFindProjectById = vi.hoisted(() => vi.fn());
+const mockFindWorkspacesByProjectId = vi.hoisted(() => vi.fn());
 const mockValidateKeyAndListTeams = vi.hoisted(() => vi.fn());
 const mockListMyIssues = vi.hoisted(() => vi.fn());
 const mockGetIssue = vi.hoisted(() => vi.fn());
@@ -9,6 +10,9 @@ const mockDecrypt = vi.hoisted(() => vi.fn());
 vi.mock('@/backend/services/workspace', () => ({
   projectManagementService: {
     findById: (...args: unknown[]) => mockFindProjectById(...args),
+  },
+  workspaceDataService: {
+    findByProjectId: (...args: unknown[]) => mockFindWorkspacesByProjectId(...args),
   },
 }));
 
@@ -35,6 +39,7 @@ function createCaller() {
 describe('linearRouter', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockFindWorkspacesByProjectId.mockResolvedValue([]);
   });
 
   it('validates API key and lists teams', async () => {
@@ -87,6 +92,38 @@ describe('linearRouter', () => {
     await expect(caller.listIssuesForProject({ projectId: 'p1' })).resolves.toEqual({
       issues: [],
       error: 'linear down',
+    });
+  });
+
+  it('filters issues that already have active workspaces', async () => {
+    mockFindProjectById.mockResolvedValue({
+      issueTrackerConfig: {
+        linear: {
+          apiKey: 'encrypted-key',
+          teamId: 'team-1',
+          teamName: 'Core',
+          viewerName: 'Alice',
+        },
+      },
+    });
+    mockDecrypt.mockReturnValue('lin_api_decrypted');
+    mockListMyIssues.mockResolvedValueOnce([
+      { id: 'issue-1', identifier: 'FF-1' },
+      { id: 'issue-2', identifier: 'FF-2' },
+      { id: 'issue-3', identifier: 'FF-3' },
+    ]);
+    mockFindWorkspacesByProjectId.mockResolvedValue([
+      { linearIssueId: 'issue-1', status: 'READY' },
+      { linearIssueId: 'issue-3', status: 'ARCHIVED' },
+    ]);
+
+    const caller = createCaller();
+    await expect(caller.listIssuesForProject({ projectId: 'p1' })).resolves.toEqual({
+      issues: [
+        { id: 'issue-2', identifier: 'FF-2' },
+        { id: 'issue-3', identifier: 'FF-3' },
+      ],
+      error: null,
     });
   });
 

--- a/src/backend/trpc/linear.trpc.ts
+++ b/src/backend/trpc/linear.trpc.ts
@@ -2,8 +2,8 @@ import { z } from 'zod';
 import { cryptoService } from '@/backend/services/crypto.service';
 import { linearClientService } from '@/backend/services/linear';
 import { projectManagementService, workspaceDataService } from '@/backend/services/workspace';
-import { WorkspaceStatus } from '@/shared/core';
 import { IssueTrackerConfigSchema } from '@/shared/schemas/issue-tracker-config.schema';
+import { filterIssuesLinkedToActiveWorkspaces } from './issue-filter';
 import { publicProcedure, router } from './trpc';
 
 /** Look up a project's Linear config and decrypt the API key. Returns null if not configured. */
@@ -17,31 +17,6 @@ function getLinearConfig(project: { issueTrackerConfig: unknown }) {
     apiKey: cryptoService.decrypt(linear.apiKey),
     teamId: linear.teamId,
   };
-}
-
-function filterIssuesLinkedToActiveWorkspaces<TIssue extends { id: string }>(
-  issues: TIssue[],
-  workspaces: Array<{
-    linearIssueId: string | null;
-    status: WorkspaceStatus;
-  }>
-): TIssue[] {
-  const linkedIssueIds = new Set(
-    workspaces
-      .filter(
-        (workspace) =>
-          workspace.status !== WorkspaceStatus.ARCHIVING &&
-          workspace.status !== WorkspaceStatus.ARCHIVED
-      )
-      .map((workspace) => workspace.linearIssueId)
-      .filter((issueId): issueId is string => issueId !== null)
-  );
-
-  if (linkedIssueIds.size === 0) {
-    return issues;
-  }
-
-  return issues.filter((issue) => !linkedIssueIds.has(issue.id));
 }
 
 export const linearRouter = router({
@@ -71,7 +46,15 @@ export const linearRouter = router({
           linearClientService.listMyIssues(config.apiKey, config.teamId),
           workspaceDataService.findByProjectId(input.projectId),
         ]);
-        return { issues: filterIssuesLinkedToActiveWorkspaces(issues, workspaces), error: null };
+        return {
+          issues: filterIssuesLinkedToActiveWorkspaces(
+            issues,
+            workspaces,
+            (workspace) => workspace.linearIssueId,
+            (issue) => issue.id
+          ),
+          error: null,
+        };
       } catch (err) {
         return {
           issues: [],

--- a/src/backend/trpc/linear.trpc.ts
+++ b/src/backend/trpc/linear.trpc.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod';
 import { cryptoService } from '@/backend/services/crypto.service';
 import { linearClientService } from '@/backend/services/linear';
-import { projectManagementService } from '@/backend/services/workspace';
+import { projectManagementService, workspaceDataService } from '@/backend/services/workspace';
+import { WorkspaceStatus } from '@/shared/core';
 import { IssueTrackerConfigSchema } from '@/shared/schemas/issue-tracker-config.schema';
 import { publicProcedure, router } from './trpc';
 
@@ -16,6 +17,31 @@ function getLinearConfig(project: { issueTrackerConfig: unknown }) {
     apiKey: cryptoService.decrypt(linear.apiKey),
     teamId: linear.teamId,
   };
+}
+
+function filterIssuesLinkedToActiveWorkspaces<TIssue extends { id: string }>(
+  issues: TIssue[],
+  workspaces: Array<{
+    linearIssueId: string | null;
+    status: WorkspaceStatus;
+  }>
+): TIssue[] {
+  const linkedIssueIds = new Set(
+    workspaces
+      .filter(
+        (workspace) =>
+          workspace.status !== WorkspaceStatus.ARCHIVING &&
+          workspace.status !== WorkspaceStatus.ARCHIVED
+      )
+      .map((workspace) => workspace.linearIssueId)
+      .filter((issueId): issueId is string => issueId !== null)
+  );
+
+  if (linkedIssueIds.size === 0) {
+    return issues;
+  }
+
+  return issues.filter((issue) => !linkedIssueIds.has(issue.id));
 }
 
 export const linearRouter = router({
@@ -41,8 +67,11 @@ export const linearRouter = router({
       }
 
       try {
-        const issues = await linearClientService.listMyIssues(config.apiKey, config.teamId);
-        return { issues, error: null };
+        const [issues, workspaces] = await Promise.all([
+          linearClientService.listMyIssues(config.apiKey, config.teamId),
+          workspaceDataService.findByProjectId(input.projectId),
+        ]);
+        return { issues: filterIssuesLinkedToActiveWorkspaces(issues, workspaces), error: null };
       } catch (err) {
         return {
           issues: [],

--- a/src/client/hooks/use-sidebar-issues.ts
+++ b/src/client/hooks/use-sidebar-issues.ts
@@ -45,7 +45,7 @@ export function useSidebarIssues(
       return undefined;
     }
     if (!serverWorkspaces) {
-      return normalizedIssues;
+      return undefined;
     }
 
     if (isLinear) {


### PR DESCRIPTION
## Summary
- Prevent sidebar Todo issues from rendering before workspace summary data is available.
- Filter GitHub and Linear issue-list endpoints to exclude issues already linked to active workspaces.
- Add router coverage for GitHub and Linear linked-issue filtering.

## Verification
- pnpm vitest run src/backend/trpc/github.router.test.ts src/backend/trpc/linear.router.test.ts
- pnpm typecheck
- pnpm check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to issue-list responses and sidebar loading behavior; logic is covered by new router tests with no auth or data-model changes.
> 
> **Overview**
> Fixes **duplicate linked issues** in the sidebar Todo list by filtering on the server and avoiding a race where issues rendered before workspace data arrived.
> 
> **GitHub** and **Linear** `listIssuesForProject` now load project workspaces alongside issue lists and apply a shared **`filterIssuesLinkedToActiveWorkspaces`** helper. Issues tied to **active** workspaces are removed; issues linked only to **archiving/archived** workspaces stay visible so they can be picked again.
> 
> **`useSidebarIssues`** no longer returns normalized issues when `serverWorkspaces` is still undefined, so Todo does not briefly show issues that should be hidden.
> 
> Router tests cover the new filtering behavior for both providers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4260a97f1a14bc565d03b77d5de40c5f592da5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->