### PR TITLE
Prepare 0.3.20 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ All notable changes to Factory Factory will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.20] - 2026-05-29
+
+### Added
+
+- Add default provider effort settings (#1651)
+
+### Changed
+
+- Emit rejected state for validation failures (#1637)
+- Track startup script PID during provisioning (#1640)
+- Refactor single writer test fixtures (#1649)
+- Scope untracked Prisma drift files (#1648)
+- Harden rejected chat recovery (#1656)
+
+### Fixed
+
+- Fix ACP permission bridge reuse (#1639)
+- Treat blank optional env vars as unset (#1638)
+- Respect empty initial session prompts (#1647)
+- Fix auto-iteration resume race (#1650)
+- Prevent rejected chat recovery session leak (#1641)
+- Preserve completed session status on stop (#1645)
+- Clean up failed session starts (#1644)
+- Reject malformed attachment dispatches (#1643)
+- Prevent stale lock cleanup from deleting valid locks (#1642)
+- Fix Electron server restart after stop failure (#1653)
+- Fix queued dispatch after init retry (#1655)
+- Fix signal-killed run script wait (#1654)
+- Fix ACP prompt timeout cleanup (#1657)
+- Validate websocket origins (#1658)
+- Fix duplicate linked issues in Todo (#1659)
+
+### Security
+
+- Fix Dependabot dependency alerts (#1652)
+- Fix CodeQL findings in websocket tests (#1646)
+
+### Documentation
+
+- Update Prisma workflow guidance for generated-output guardrail (#1621)
+- Add runScriptPostRunCommand to state-ownership-matrix (#1620)
+- Correct stale periodic task recovery notes (#1619)
+
 ## [0.3.19] - 2026-05-20
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "factory-factory",
-  "version": "0.3.19",
+  "version": "0.3.20",
   "description": "Workspace-based coding environment for running multiple Claude Code and Codex sessions in parallel",
   "private": false,
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump package version to 0.3.20
- add 0.3.20 changelog entries from commits since v0.3.19

## Tests
- pnpm typecheck
- pnpm check

Notes: `pnpm check` completed successfully with existing Biome `<img>` warnings and skipped local Codex schema drift enforcement because the local Codex CLI is 0.135.0 while CI uses the pinned 0.101.0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release bookkeeping only (version and CHANGELOG); no runtime or application code changes in the PR diff.
> 
> **Overview**
> Prepares the **0.3.20** patch release by bumping `package.json` from **0.3.19** to **0.3.20** and adding a new **Keep a Changelog** section dated 2026-05-29.
> 
> The changelog entry aggregates work since v0.3.19: default provider effort settings; validation/rejected-state and rejected-chat recovery hardening; ACP/session lifecycle fixes (permission bridge, prompt timeouts, init retry dispatch, failed starts, stop/status preservation); websocket origin validation; Electron restart and run-script wait fixes; security/doc updates from merged PRs. **No application source changes** are included in this diff—only release metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 377d1bf388ffc7f479fb5dd7bf7c955b26f26210. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->