### PR TITLE
Fix Codex tool call transcript rendering

### DIFF
--- a/src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.test.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.test.ts
@@ -2883,7 +2883,7 @@ describe('CodexAppServerAcpAdapter', () => {
     expect(mcpByThread.get('thread_restore')).toEqual(previousConfig);
   });
 
-  it('builds tool call state for file, MCP, web search, and unknown types', () => {
+  it('builds tool call state for file, MCP, web search, Codex function calls, and unknown types', () => {
     const { connection } = createMockConnection();
     const { client: codexClient } = createMockCodexClient();
     const adapter = new CodexAppServerAcpAdapter(connection as AgentSideConnection, codexClient);
@@ -2933,6 +2933,38 @@ describe('CodexAppServerAcpAdapter', () => {
       'turn_web'
     ) as { title: string };
 
+    const functionCall = (
+      adapter as unknown as {
+        buildToolCallState: (session: unknown, item: unknown, turnId: string) => unknown;
+      }
+    ).buildToolCallState(
+      session,
+      {
+        type: 'function_call',
+        id: 'item_function',
+        name: 'exec_command',
+        call_id: 'call_function',
+        arguments: '{"cmd":"cat package.json","workdir":"/tmp/workspace"}',
+      },
+      'turn_function'
+    ) as { toolCallId: string; title: string; kind: string };
+
+    const customToolCall = (
+      adapter as unknown as {
+        buildToolCallState: (session: unknown, item: unknown, turnId: string) => unknown;
+      }
+    ).buildToolCallState(
+      session,
+      {
+        type: 'custom_tool_call',
+        id: 'item_custom',
+        name: 'apply_patch',
+        call_id: 'call_custom',
+        input: '*** Begin Patch\n*** End Patch\n',
+      },
+      'turn_custom'
+    ) as { toolCallId: string; title: string; kind: string };
+
     const unknown = (
       adapter as unknown as {
         buildToolCallState: (session: unknown, item: unknown, turnId: string) => unknown;
@@ -2950,6 +2982,12 @@ describe('CodexAppServerAcpAdapter', () => {
     expect(fileCall.locations).toEqual([{ path: 'src/app.ts' }]);
     expect(mcpCall.title).toBe('mcpToolCall:docs/search');
     expect(webCall.title).toBe('webSearch');
+    expect(functionCall.toolCallId).toBe('call_function');
+    expect(functionCall.title).toBe('Read package.json');
+    expect(functionCall.kind).toBe('read');
+    expect(customToolCall.toolCallId).toBe('call_custom');
+    expect(customToolCall.title).toBe('apply_patch');
+    expect(customToolCall.kind).toBe('execute');
     expect(unknown).toBeNull();
   });
 });

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.test.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.test.ts
@@ -2965,6 +2965,36 @@ describe('CodexAppServerAcpAdapter', () => {
       'turn_custom'
     ) as { toolCallId: string; title: string; kind: string };
 
+    const functionCallOutput = (
+      adapter as unknown as {
+        buildToolCallState: (session: unknown, item: unknown, turnId: string) => unknown;
+      }
+    ).buildToolCallState(
+      session,
+      {
+        type: 'function_call_output',
+        id: 'item_function_output',
+        call_id: 'call_function',
+        output: 'done',
+      },
+      'turn_function_output'
+    );
+
+    const customToolCallOutput = (
+      adapter as unknown as {
+        buildToolCallState: (session: unknown, item: unknown, turnId: string) => unknown;
+      }
+    ).buildToolCallState(
+      session,
+      {
+        type: 'custom_tool_call_output',
+        id: 'item_custom_output',
+        call_id: 'call_custom',
+        output: 'done',
+      },
+      'turn_custom_output'
+    );
+
     const unknown = (
       adapter as unknown as {
         buildToolCallState: (session: unknown, item: unknown, turnId: string) => unknown;
@@ -2988,6 +3018,8 @@ describe('CodexAppServerAcpAdapter', () => {
     expect(customToolCall.toolCallId).toBe('call_custom');
     expect(customToolCall.title).toBe('apply_patch');
     expect(customToolCall.kind).toBe('execute');
+    expect(functionCallOutput).toBeNull();
+    expect(customToolCallOutput).toBeNull();
     expect(unknown).toBeNull();
   });
 });

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.ts
@@ -737,10 +737,8 @@ export class CodexAppServerAcpAdapter implements Agent {
     const kindByType: Record<string, ToolCallState['kind']> = {
       commandExecution: 'execute',
       custom_tool_call: 'execute',
-      custom_tool_call_output: 'execute',
       fileChange: 'edit',
       function_call: 'execute',
-      function_call_output: 'execute',
       mcpToolCall: 'fetch',
       webSearch: 'search',
       plan: 'think',

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.ts
@@ -736,7 +736,11 @@ export class CodexAppServerAcpAdapter implements Agent {
   ): ToolCallState | null {
     const kindByType: Record<string, ToolCallState['kind']> = {
       commandExecution: 'execute',
+      custom_tool_call: 'execute',
+      custom_tool_call_output: 'execute',
       fileChange: 'edit',
+      function_call: 'execute',
+      function_call_output: 'execute',
       mcpToolCall: 'fetch',
       webSearch: 'search',
       plan: 'think',
@@ -747,37 +751,86 @@ export class CodexAppServerAcpAdapter implements Agent {
       return null;
     }
 
-    let title = item.type;
-    let kindToEmit = kind;
-    let locations: Array<{ path: string; line?: number | null }> = [];
-    if (item.type === 'commandExecution') {
-      const command = asString(item.command);
-      const cwd = asString(item.cwd) ?? session.cwd;
-      const parsed = resolveCommandDisplay({ command, cwd });
-      title = parsed.title;
-      kindToEmit = parsed.kind;
-      locations = parsed.locations;
-    } else if (item.type === 'fileChange') {
-      title = 'fileChange';
-      locations = extractLocations(item);
-    } else if (item.type === 'mcpToolCall') {
-      const server = asString(item.server) ?? 'mcp';
-      const tool = asString(item.tool) ?? 'tool';
-      title = `mcpToolCall:${server}/${tool}`;
-    } else if (item.type === 'webSearch') {
-      const query = asString(item.query);
-      title = query ? `webSearch:${query}` : 'webSearch';
-    }
+    const display = this.resolveToolCallDisplay(session, item, kind);
 
     return {
       toolCallId: resolveToolCallId({
         itemId: item.id,
         source: item,
       }),
-      kind: kindToEmit,
-      title,
-      locations,
+      kind: display.kind,
+      title: display.title,
+      locations: display.locations,
     };
+  }
+
+  private resolveToolCallDisplay(
+    session: AdapterSession,
+    item: { type: string; id: string } & Record<string, unknown>,
+    defaultKind: ToolCallState['kind']
+  ): Pick<ToolCallState, 'kind' | 'title' | 'locations'> {
+    if (item.type === 'commandExecution') {
+      return this.resolveCommandExecutionDisplay(session, item);
+    }
+    if (item.type === 'function_call' || item.type === 'custom_tool_call') {
+      return this.resolveCodexFunctionCallDisplay(session, item, defaultKind);
+    }
+    if (item.type === 'fileChange') {
+      return { title: 'fileChange', kind: defaultKind, locations: extractLocations(item) };
+    }
+    if (item.type === 'mcpToolCall') {
+      const server = asString(item.server) ?? 'mcp';
+      const tool = asString(item.tool) ?? 'tool';
+      return { title: `mcpToolCall:${server}/${tool}`, kind: defaultKind, locations: [] };
+    }
+    if (item.type === 'webSearch') {
+      const query = asString(item.query);
+      return {
+        title: query ? `webSearch:${query}` : 'webSearch',
+        kind: defaultKind,
+        locations: [],
+      };
+    }
+    return { title: item.type, kind: defaultKind, locations: [] };
+  }
+
+  private resolveCommandExecutionDisplay(
+    session: AdapterSession,
+    item: Record<string, unknown>
+  ): Pick<ToolCallState, 'kind' | 'title' | 'locations'> {
+    const command = asString(item.command);
+    const cwd = asString(item.cwd) ?? session.cwd;
+    return resolveCommandDisplay({ command, cwd });
+  }
+
+  private resolveCodexFunctionCallDisplay(
+    session: AdapterSession,
+    item: Record<string, unknown>,
+    defaultKind: ToolCallState['kind']
+  ): Pick<ToolCallState, 'kind' | 'title' | 'locations'> {
+    const title = asString(item.name) ?? asString(item.type) ?? 'function_call';
+    const rawArguments = item.arguments ?? item.input;
+    const parsedArguments =
+      typeof rawArguments === 'string' ? this.parseToolCallArguments(rawArguments) : null;
+    const command = asString(parsedArguments?.cmd);
+    if (!command) {
+      return { title, kind: defaultKind, locations: [] };
+    }
+
+    const cwd = asString(parsedArguments?.workdir) ?? session.cwd;
+    return resolveCommandDisplay({ command, cwd });
+  }
+
+  private parseToolCallArguments(rawArguments: string): Record<string, unknown> | null {
+    try {
+      const parsed = JSON.parse(rawArguments);
+      if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      return null;
+    }
+    return null;
   }
 
   private async handleCodexServerRequest(request: {

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.test.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.test.ts
@@ -106,4 +106,62 @@ describe('stream-event-handler', () => {
       })
     );
   });
+
+  it('recovers completed tool-like items that arrive without started state', async () => {
+    const session = createSession();
+    const emitSessionUpdate = vi.fn(async () => undefined);
+    const reportShapeDrift = vi.fn();
+    const toolState: ToolCallState = {
+      toolCallId: 'call_recovered',
+      kind: 'execute',
+      title: 'exec_command',
+      locations: [],
+    };
+
+    const handler = new CodexStreamEventHandler({
+      codex: { request: vi.fn() },
+      sessionIdByThreadId: new Map([['thread_1', 'sess_thread_1']]),
+      sessions: new Map([['sess_thread_1', session]]),
+      requireSession: vi.fn(),
+      emitSessionUpdate,
+      reportShapeDrift,
+      buildToolCallState: vi.fn(() => toolState),
+      emitReasoningThoughtChunkFromItem: vi.fn(async () => undefined),
+      shouldHoldTurnForPlanApproval: vi.fn(() => false),
+      holdTurnUntilPlanApprovalResolves: vi.fn(),
+      maybeRequestPlanApproval: vi.fn(async () => undefined),
+      hasPendingPlanApprovals: vi.fn(() => false),
+      settleTurn: vi.fn(),
+      emitTurnFailureMessage: vi.fn(async () => undefined),
+    });
+
+    await handler.handleCodexNotification({
+      method: 'item/completed',
+      params: {
+        threadId: 'thread_1',
+        turnId: 'turn_1',
+        item: {
+          type: 'function_call',
+          id: 'item_function',
+          status: 'completed',
+          name: 'exec_command',
+          call_id: 'call_recovered',
+        },
+      },
+    });
+
+    expect(emitSessionUpdate).toHaveBeenCalledWith(
+      'sess_thread_1',
+      expect.objectContaining({
+        sessionUpdate: 'tool_call',
+        toolCallId: 'call_recovered',
+        title: 'exec_command',
+        status: 'completed',
+      })
+    );
+    expect(reportShapeDrift).not.toHaveBeenCalledWith(
+      'item_completed_without_started_state',
+      expect.anything()
+    );
+  });
 });

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.ts
@@ -604,11 +604,7 @@ export class CodexStreamEventHandler {
 
     const existing = session.toolCallsByItemId.get(item.id);
     if (!existing) {
-      this.deps.reportShapeDrift('item_completed_without_started_state', {
-        turnId,
-        itemType: item.type,
-        itemId: item.id,
-      });
+      await this.handleCompletedItemWithoutStartedState(session, item, turnId);
       return;
     }
 
@@ -635,5 +631,32 @@ export class CodexStreamEventHandler {
     session.syntheticallyCompletedToolItemIds.delete(item.id);
 
     await this.deps.maybeRequestPlanApproval(session, item, turnId, existing);
+  }
+
+  private async handleCompletedItemWithoutStartedState(
+    session: AdapterSession,
+    item: { type: string; id: string } & Record<string, unknown>,
+    turnId: string
+  ): Promise<void> {
+    const recovered = this.deps.buildToolCallState(session, item, turnId);
+    if (recovered) {
+      await this.deps.emitSessionUpdate(session.sessionId, {
+        sessionUpdate: 'tool_call',
+        toolCallId: recovered.toolCallId,
+        status: toToolStatus(item.status) ?? 'completed',
+        kind: recovered.kind,
+        title: recovered.title,
+        ...(recovered.locations.length > 0 ? { locations: recovered.locations } : {}),
+        rawInput: item,
+        rawOutput: item,
+      });
+      return;
+    }
+
+    this.deps.reportShapeDrift('item_completed_without_started_state', {
+      turnId,
+      itemType: item.type,
+      itemId: item.id,
+    });
   }
 }

--- a/src/backend/services/session/service/data/codex-session-history-loader.service.test.ts
+++ b/src/backend/services/session/service/data/codex-session-history-loader.service.test.ts
@@ -125,6 +125,25 @@ describe('codexSessionHistoryLoaderService', () => {
             output: 'M package.json',
           },
         },
+        {
+          timestamp: '2026-02-14T00:00:06.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'custom_tool_call',
+            name: 'apply_patch',
+            call_id: 'call-2',
+            input: '*** Begin Patch\n*** Update File: package.json\n*** End Patch\n',
+          },
+        },
+        {
+          timestamp: '2026-02-14T00:00:07.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'custom_tool_call_output',
+            call_id: 'call-2',
+            output: 'Success. Updated files',
+          },
+        },
       ],
     });
 
@@ -162,6 +181,22 @@ describe('codexSessionHistoryLoaderService', () => {
         content: 'M package.json',
         timestamp: '2026-02-14T00:00:05.000Z',
         toolId: 'call-1',
+      },
+      {
+        type: 'tool_use',
+        content: '',
+        timestamp: '2026-02-14T00:00:06.000Z',
+        toolName: 'apply_patch',
+        toolId: 'call-2',
+        toolInput: {
+          rawArguments: '*** Begin Patch\n*** Update File: package.json\n*** End Patch\n',
+        },
+      },
+      {
+        type: 'tool_result',
+        content: 'Success. Updated files',
+        timestamp: '2026-02-14T00:00:07.000Z',
+        toolId: 'call-2',
       },
     ]);
   });

--- a/src/backend/services/session/service/data/codex-session-history-loader.service.ts
+++ b/src/backend/services/session/service/data/codex-session-history-loader.service.ts
@@ -237,7 +237,7 @@ function parseFunctionCallResponseItem(
       timestamp,
       toolName,
       toolId,
-      toolInput: normalizeCodexFunctionArgs(payload.arguments),
+      toolInput: normalizeCodexFunctionArgs(payload.arguments ?? payload.input),
     },
   ];
 }
@@ -270,11 +270,11 @@ function parseCodexResponseItemMessages(
   }
 
   const payloadType = entry.payload.type;
-  if (payloadType === 'function_call') {
+  if (payloadType === 'function_call' || payloadType === 'custom_tool_call') {
     return parseFunctionCallResponseItem(entry.payload, timestamp);
   }
 
-  if (payloadType === 'function_call_output') {
+  if (payloadType === 'function_call_output' || payloadType === 'custom_tool_call_output') {
     return parseFunctionCallOutputResponseItem(entry.payload, timestamp);
   }
 


### PR DESCRIPTION
## Summary
- Render Codex `function_call` and `custom_tool_call` items as transcript tool calls in the app-server ACP adapter.
- Recover completed tool-like items when a matching `item/started` update was missed.
- Hydrate custom tool calls from Codex JSONL history so reloads show the same tool activity.

## Validation
- `pnpm vitest run src/backend/services/session/service/data/codex-session-history-loader.service.test.ts src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.test.ts src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.test.ts`
- `pnpm exec biome check src/backend/services/session/service/data/codex-session-history-loader.service.ts src/backend/services/session/service/data/codex-session-history-loader.service.test.ts src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.ts src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.test.ts src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.ts src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.test.ts`
- `pnpm typecheck`
- Pre-commit hook: `biome check --write`, typecheck, Prisma drift check, dependency cruise, and knip completed successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Session transcript and history display only; no auth, persistence, or payment paths. Behavior is covered by targeted unit tests.
> 
> **Overview**
> Fixes **Codex tool call transcript rendering** by teaching the app-server ACP adapter and session history loader to handle Codex’s `function_call` / `custom_tool_call` items (and their output-only siblings).
> 
> The adapter now maps those item types to transcript tool calls, refactors display resolution into helpers, and parses JSON `arguments` or raw `input` so exec-style calls get the same titles/kinds/locations as `commandExecution` (e.g. `Read package.json`). Output-only types stay non-renderable (`null`).
> 
> When **`item/completed`** arrives without a prior **`item/started`**, the stream handler **recovers** a completed tool call via `buildToolCallState` instead of only reporting shape drift.
> 
> The Codex JSONL history loader treats **`custom_tool_call`** / **`custom_tool_call_output`** like function calls and normalizes args from **`arguments ?? input`**, so reloads show the same tool activity as live streams.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b04e3e25d5e54844a29008679142c83e359e858c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->