### PR TITLE
Update changelog for latest changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix ACP prompt timeout cleanup (#1657)
 - Validate websocket origins (#1658)
 - Fix duplicate linked issues in Todo (#1659)
+- Fix Codex tool call transcript rendering (#1664)
 
 ### Security
 
@@ -47,6 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update Prisma workflow guidance for generated-output guardrail (#1621)
 - Add runScriptPostRunCommand to state-ownership-matrix (#1620)
 - Correct stale periodic task recovery notes (#1619)
+- Fix stale docs after initScriptPid addition (#1663)
+- Correct WebSocket origin validation coverage in CONCERNS.md (#1661)
+- Update WebSocket origin check and CLI structure docs (#1662)
 
 ## [0.3.19] - 2026-05-20
 


### PR DESCRIPTION
## Summary
- Add the latest fix and documentation updates to the existing 0.3.20 changelog section
- Keep the version unchanged because no release has been cut yet

## Tests
- commit hook: typecheck/dependency checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edits with no runtime or behavioral changes.
> 
> **Overview**
> Extends the unreleased **0.3.20** section in `CHANGELOG.md` with four bullets that were missing from the release notes.
> 
> Under **Fixed**, it records **Codex tool call transcript rendering** (#1664). Under **Documentation**, it adds entries for docs aligned with **`initScriptPid`**, **WebSocket origin validation** in `CONCERNS.md`, and **WebSocket origin / CLI structure** updates (#1661–#1663). The version stays **0.3.20** because no release has been cut yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b03afcaa9a5b8994d8a859a5040c9e97cd8587eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->