### PR TITLE
Fix rewind capability checks in chat actions

### DIFF
--- a/src/components/chat/use-chat-actions.ts
+++ b/src/components/chat/use-chat-actions.ts
@@ -506,10 +506,9 @@ export function useChatActions(options: UseChatActionsOptions): UseChatActionsRe
   );
 
   // Rewind files actions
-  const rewindEnabled = stateRef.current.chatCapabilities.rewind.enabled;
   const startRewindPreview = useCallback(
     (userMessageUuid: string) => {
-      if (!rewindEnabled) {
+      if (!stateRef.current.chatCapabilities.rewind.enabled) {
         return;
       }
 
@@ -533,11 +532,11 @@ export function useChatActions(options: UseChatActionsOptions): UseChatActionsRe
         payload: { error: 'Rewind is not supported in ACP runtime.', requestNonce },
       });
     },
-    [dispatch, rewindEnabled, rewindTimeoutRef]
+    [dispatch, stateRef, rewindTimeoutRef]
   );
 
   const confirmRewind = useCallback(() => {
-    if (!rewindEnabled) {
+    if (!stateRef.current.chatCapabilities.rewind.enabled) {
       return;
     }
 
@@ -562,7 +561,7 @@ export function useChatActions(options: UseChatActionsOptions): UseChatActionsRe
         requestNonce: rewindPreview.requestNonce,
       },
     });
-  }, [dispatch, rewindEnabled, stateRef, rewindTimeoutRef]);
+  }, [dispatch, stateRef, rewindTimeoutRef]);
 
   const cancelRewind = useCallback(() => {
     // Clear the timeout when canceling


### PR DESCRIPTION
## Summary
- Read rewind capability from stateRef inside rewind action callbacks.
- Keep startRewindPreview and confirmRewind aligned with current chat capabilities without stale closure risk.

## Tests
- pnpm typecheck
- Commit hook checks: Biome, Prisma schema drift, dependency boundaries, knip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral fix in chat rewind guards only; no auth, data, or API surface changes.
> 
> **Overview**
> **Rewind gating** in `startRewindPreview` and `confirmRewind` no longer uses a render-time `rewindEnabled` snapshot. Both callbacks now read `stateRef.current.chatCapabilities.rewind.enabled` when they run, so capability changes after mount are respected.
> 
> **Hook deps** for those callbacks drop `rewindEnabled` and keep `stateRef`, matching the ref-based pattern used elsewhere in this hook and avoiding stale closure behavior on the guard checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0d720fa48f55f34d3f476adb2c560667ac18d46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->