### PR TITLE
Fix chat test message ID lookup

### DIFF
--- a/src/components/chat/use-chat-state.integration.test.tsx
+++ b/src/components/chat/use-chat-state.integration.test.tsx
@@ -75,7 +75,8 @@ function createAttachment(): MessageAttachment {
 }
 
 function getSentMessageId(send: ReturnType<typeof vi.fn>): string {
-  const message = send.mock.calls[0]?.[0];
+  const lastCall = send.mock.calls.at(-1);
+  const message = lastCall?.[0];
   if (typeof message !== 'object' || message === null || !('id' in message)) {
     throw new Error('Expected queued message with an id');
   }


### PR DESCRIPTION
## Summary
- Update `getSentMessageId` in the chat state integration test to read the most recent `send` mock call.
- Avoid using a stale queued message ID if multiple send calls are recorded.

## Tests
- `pnpm test src/components/chat/use-chat-state.integration.test.tsx`
- pre-commit hook: `pnpm typecheck`
- pre-commit hook: dependency checks via `depcruise` and `knip`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production behavior impact.
> 
> **Overview**
> Updates **`getSentMessageId`** in the chat state integration test so it reads the **last** `send` mock invocation instead of the first.
> 
> That keeps rejected-message recovery tests aligned with the message id from the most recent send when the mock records multiple calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d275690675c2efea5a0280e1036f33e1e43be0cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->