### PR TITLE
Sync export data schema provider enums

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,7 +27,10 @@ export {
   PRState,
   RatchetState,
   RunScriptStatus,
+  SessionPermissionPreset,
+  SessionProvider,
   SessionStatus,
   WorkspaceCreationSource,
+  WorkspaceProviderSelection,
   WorkspaceStatus,
 } from './types/index.js';

--- a/packages/core/src/types/enums.ts
+++ b/packages/core/src/types/enums.ts
@@ -17,6 +17,28 @@ export const SessionStatus = {
 } as const;
 export type SessionStatus = (typeof SessionStatus)[keyof typeof SessionStatus];
 
+export const SessionProvider = {
+  CLAUDE: 'CLAUDE',
+  CODEX: 'CODEX',
+} as const;
+export type SessionProvider = (typeof SessionProvider)[keyof typeof SessionProvider];
+
+export const SessionPermissionPreset = {
+  STRICT: 'STRICT',
+  RELAXED: 'RELAXED',
+  YOLO: 'YOLO',
+} as const;
+export type SessionPermissionPreset =
+  (typeof SessionPermissionPreset)[keyof typeof SessionPermissionPreset];
+
+export const WorkspaceProviderSelection = {
+  WORKSPACE_DEFAULT: 'WORKSPACE_DEFAULT',
+  CLAUDE: 'CLAUDE',
+  CODEX: 'CODEX',
+} as const;
+export type WorkspaceProviderSelection =
+  (typeof WorkspaceProviderSelection)[keyof typeof WorkspaceProviderSelection];
+
 export const PRState = {
   NONE: 'NONE',
   DRAFT: 'DRAFT',

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -5,7 +5,10 @@ export {
   PRState,
   RatchetState,
   RunScriptStatus,
+  SessionPermissionPreset,
+  SessionProvider,
   SessionStatus,
   WorkspaceCreationSource,
+  WorkspaceProviderSelection,
   WorkspaceStatus,
 } from './enums.js';

--- a/src/shared/core/enums.drift.test.ts
+++ b/src/shared/core/enums.drift.test.ts
@@ -5,8 +5,11 @@ import {
   PRState as PackagePRState,
   RatchetState as PackageRatchetState,
   RunScriptStatus as PackageRunScriptStatus,
+  SessionPermissionPreset as PackageSessionPermissionPreset,
+  SessionProvider as PackageSessionProvider,
   SessionStatus as PackageSessionStatus,
   WorkspaceCreationSource as PackageWorkspaceCreationSource,
+  WorkspaceProviderSelection as PackageWorkspaceProviderSelection,
   WorkspaceStatus as PackageWorkspaceStatus,
 } from '@factory-factory/core-types/enums';
 import { describe, expect, it } from 'vitest';
@@ -17,14 +20,20 @@ import {
   PRState,
   RatchetState,
   RunScriptStatus,
+  SessionPermissionPreset,
+  SessionProvider,
   SessionStatus,
   WorkspaceCreationSource,
+  WorkspaceProviderSelection,
   WorkspaceStatus,
 } from './enums';
 
 type SharedEnums = {
   WorkspaceStatus: Record<string, string>;
   SessionStatus: Record<string, string>;
+  SessionProvider: Record<string, string>;
+  SessionPermissionPreset: Record<string, string>;
+  WorkspaceProviderSelection: Record<string, string>;
   PRState: Record<string, string>;
   CIStatus: Record<string, string>;
   KanbanColumn: Record<string, string>;
@@ -37,6 +46,9 @@ type SharedEnums = {
 const appEnums: SharedEnums = {
   WorkspaceStatus,
   SessionStatus,
+  SessionProvider,
+  SessionPermissionPreset,
+  WorkspaceProviderSelection,
   PRState,
   CIStatus,
   KanbanColumn,
@@ -51,6 +63,9 @@ describe('core enum drift guard', () => {
     const packageEnums: SharedEnums = {
       WorkspaceStatus: PackageWorkspaceStatus,
       SessionStatus: PackageSessionStatus,
+      SessionProvider: PackageSessionProvider,
+      SessionPermissionPreset: PackageSessionPermissionPreset,
+      WorkspaceProviderSelection: PackageWorkspaceProviderSelection,
       PRState: PackagePRState,
       CIStatus: PackageCIStatus,
       KanbanColumn: PackageKanbanColumn,

--- a/src/shared/core/enums.ts
+++ b/src/shared/core/enums.ts
@@ -17,6 +17,28 @@ export const SessionStatus = {
 } as const;
 export type SessionStatus = (typeof SessionStatus)[keyof typeof SessionStatus];
 
+export const SessionProvider = {
+  CLAUDE: 'CLAUDE',
+  CODEX: 'CODEX',
+} as const;
+export type SessionProvider = (typeof SessionProvider)[keyof typeof SessionProvider];
+
+export const SessionPermissionPreset = {
+  STRICT: 'STRICT',
+  RELAXED: 'RELAXED',
+  YOLO: 'YOLO',
+} as const;
+export type SessionPermissionPreset =
+  (typeof SessionPermissionPreset)[keyof typeof SessionPermissionPreset];
+
+export const WorkspaceProviderSelection = {
+  WORKSPACE_DEFAULT: 'WORKSPACE_DEFAULT',
+  CLAUDE: 'CLAUDE',
+  CODEX: 'CODEX',
+} as const;
+export type WorkspaceProviderSelection =
+  (typeof WorkspaceProviderSelection)[keyof typeof WorkspaceProviderSelection];
+
 export const PRState = {
   NONE: 'NONE',
   DRAFT: 'DRAFT',

--- a/src/shared/core/index.ts
+++ b/src/shared/core/index.ts
@@ -16,9 +16,12 @@ export {
   PRState,
   RatchetState,
   RunScriptStatus,
+  SessionPermissionPreset,
+  SessionProvider,
   SessionStatus,
   WorkspaceCreationSource,
   WorkspaceMode,
+  WorkspaceProviderSelection,
   WorkspaceStatus,
 } from './enums.js';
 

--- a/src/shared/schemas/export-data.schema.ts
+++ b/src/shared/schemas/export-data.schema.ts
@@ -16,9 +16,12 @@ import {
   PRState as CorePRState,
   RatchetState as CoreRatchetState,
   RunScriptStatus as CoreRunScriptStatus,
+  SessionPermissionPreset as CoreSessionPermissionPreset,
+  SessionProvider as CoreSessionProvider,
   SessionStatus as CoreSessionStatus,
   WorkspaceCreationSource as CoreWorkspaceCreationSource,
   WorkspaceMode as CoreWorkspaceMode,
+  WorkspaceProviderSelection as CoreWorkspaceProviderSelection,
   WorkspaceStatus as CoreWorkspaceStatus,
 } from '@/shared/core';
 import { autoIterationConfigSchema } from './auto-iteration.schema';
@@ -38,9 +41,9 @@ const CIStatus = z.enum(enumValues(CoreCIStatus));
 const KanbanColumn = z.enum(enumValues(CoreKanbanColumn));
 const RatchetState = z.enum(enumValues(CoreRatchetState));
 const SessionStatus = z.enum(enumValues(CoreSessionStatus));
-const SessionProvider = z.enum(['CLAUDE', 'CODEX']);
-const SessionPermissionPreset = z.enum(['STRICT', 'RELAXED', 'YOLO']);
-const WorkspaceProviderSelection = z.enum(['WORKSPACE_DEFAULT', 'CLAUDE', 'CODEX']);
+const SessionProvider = z.enum(enumValues(CoreSessionProvider));
+const SessionPermissionPreset = z.enum(enumValues(CoreSessionPermissionPreset));
+const WorkspaceProviderSelection = z.enum(enumValues(CoreWorkspaceProviderSelection));
 
 const exportedProjectSchema = z.object({
   id: z.string(),


### PR DESCRIPTION
## Summary

- Adds browser-safe core enum constants for session providers, permission presets, and workspace provider selections.
- Exports those enums from both the app shared core barrel and the core package type surfaces.
- Updates export/import data validation to derive these Zod enums from shared core values instead of hardcoded arrays.
- Extends the shared/core drift guard to include the newly shared enums.

## Validation

- pnpm exec vitest run src/shared/schemas/export-data.schema.test.ts src/shared/core/enums.drift.test.ts
- pnpm typecheck
- commit hook: biome check --write, typecheck, dependency cruiser, knip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Enum value sets are unchanged; this is a source-of-truth refactor with drift-test coverage and no runtime behavior change beyond validation staying aligned with core.
> 
> **Overview**
> Introduces shared **`SessionProvider`**, **`SessionPermissionPreset`**, and **`WorkspaceProviderSelection`** enum constants in `@factory-factory/core` and the app **`shared/core`** mirror, and re-exports them from the public type barrels.
> 
> **Export/import validation** in `export-data.schema.ts` now builds the related Zod enums via `enumValues(...)` from shared core instead of inline string arrays, matching the pattern used for other core enums.
> 
> The **core enum drift test** is extended so app and package copies of these three enums stay in sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39b6dd5b9769699ababa47317e78223445c7ee8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->