### PR TITLE
Handle wrapped base64 attachments

### DIFF
--- a/src/backend/services/session/service/chat/chat-message-handlers/attachment-processing.test.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers/attachment-processing.test.ts
@@ -95,6 +95,13 @@ describe('validateAttachment', () => {
     expect(() => validateAttachment(attachment)).not.toThrow();
   });
 
+  it('should accept image attachment with line-wrapped base64 data', () => {
+    const attachment = createImageAttachment({
+      data: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ\r\nAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==\n',
+    });
+    expect(() => validateAttachment(attachment)).not.toThrow();
+  });
+
   it('should throw a permanent error for unsupported image media types', () => {
     const attachment = createImageAttachment({ type: 'image/bmp' });
     expect(() => validateAttachment(attachment)).toThrow(UnsupportedImageTypeError);
@@ -310,6 +317,21 @@ describe('buildContentArray', () => {
     });
     expect(result[2]).toMatchObject({
       source: { media_type: 'image/webp' },
+    });
+  });
+
+  it('should strip base64 line endings from image content data', () => {
+    const imageAttachments = [
+      createImageAttachment({
+        data: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ\r\nAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==\n',
+      }),
+    ];
+    const result = buildContentArray('', imageAttachments);
+
+    expect(result[0]).toMatchObject({
+      source: {
+        data: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+      },
     });
   });
 });

--- a/src/backend/services/session/service/chat/chat-message-handlers/attachment-processing.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers/attachment-processing.ts
@@ -8,7 +8,7 @@
 import { createLogger } from '@/backend/services/logger.service';
 import type { AgentContentItem } from '@/shared/acp-protocol';
 import type { MessageAttachment } from '@/shared/acp-protocol/protocol';
-import { resolveAttachmentContentType } from './attachment-utils';
+import { resolveAttachmentContentType, stripBase64LineEndings } from './attachment-utils';
 
 const logger = createLogger('attachment-processing');
 
@@ -63,8 +63,10 @@ function validateAttachmentHasData(attachment: MessageAttachment): void {
  * @throws PermanentAttachmentError if attachment has invalid base64 data
  */
 function validateImageBase64(attachment: MessageAttachment): void {
+  const normalizedData = stripBase64LineEndings(attachment.data);
+
   // Basic base64 check - alphanumeric, +, /, =
-  if (!/^[A-Za-z0-9+/=]+$/.test(attachment.data)) {
+  if (!(normalizedData && /^[A-Za-z0-9+/=]+$/.test(normalizedData))) {
     logger.error('[Chat WS] Invalid base64 data in attachment', {
       attachmentId: attachment.id,
     });
@@ -193,7 +195,7 @@ export function buildContentArray(
       source: {
         type: 'base64',
         media_type: attachment.type as SupportedImageMediaType,
-        data: attachment.data,
+        data: stripBase64LineEndings(attachment.data),
       },
     };
     content.push(imageContent);

--- a/src/backend/services/session/service/chat/chat-message-handlers/attachment-utils.test.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers/attachment-utils.test.ts
@@ -53,4 +53,12 @@ describe('resolveAttachmentContentType', () => {
       resolveAttachmentContentType(createAttachment({ type: '', name: 'blob', data: 'SGVsbG8=' }))
     ).toBe('image');
   });
+
+  it('defaults to image for line-wrapped base64-like data when type is unknown', () => {
+    expect(
+      resolveAttachmentContentType(
+        createAttachment({ type: '', name: 'blob', data: 'SGVs\r\nbG8=\n' })
+      )
+    ).toBe('image');
+  });
 });

--- a/src/backend/services/session/service/chat/chat-message-handlers/attachment-utils.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers/attachment-utils.ts
@@ -3,8 +3,21 @@ import type { MessageAttachment } from '@/shared/acp-protocol';
 const PASTED_TEXT_NAME = /^Pasted text\b/i;
 const BASE64_REGEX = /^[A-Za-z0-9+/=]+$/;
 
+export function stripBase64LineEndings(data: string): string {
+  return data.replace(/[\r\n]/g, '');
+}
+
 function looksLikeBase64(data: string): boolean {
-  return BASE64_REGEX.test(data);
+  const normalizedData = stripBase64LineEndings(data);
+  if (!normalizedData) {
+    return false;
+  }
+
+  if (normalizedData !== data && normalizedData.length % 4 !== 0) {
+    return false;
+  }
+
+  return BASE64_REGEX.test(normalizedData);
 }
 
 function isNameLikelyText(name: string): boolean {


### PR DESCRIPTION
## Summary

- Normalize image attachment base64 by stripping CR/LF line endings before validation and dispatch.
- Reuse the same normalization in fallback attachment type detection so wrapped base64 without an explicit content type is still treated as an image.
- Add regression tests for LF/CRLF-wrapped base64 and normalized image payload output.

## Tests

- `pnpm test src/backend/services/session/service/chat/chat-message-handlers/attachment-processing.test.ts src/backend/services/session/service/chat/chat-message-handlers/attachment-utils.test.ts`
- `pnpm typecheck`
- `pnpm check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized attachment helper changes with added tests; no auth or broader chat pipeline refactors.
> 
> **Overview**
> Fixes chat image attachments whose base64 payload includes **CR/LF line breaks** (common in MIME or copy-paste), which previously failed validation or were misclassified as text.
> 
> Adds **`stripBase64LineEndings`** in `attachment-utils` and applies it when validating image base64, when building Claude image content, and in **`looksLikeBase64`** so wrapped payloads without a MIME type still resolve as images. Wrapped data that would be invalid after stripping (e.g. wrong length mod 4) is not treated as base64.
> 
> Regression tests cover CRLF/LF-wrapped validation, normalized outbound image `data`, and type resolution for wrapped blobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 627a0cb123536d2e0ea1983a629e4306f15c6324. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->