### PR TITLE
Simplify issue intake launch flow

### DIFF
--- a/src/backend/services/workspace/service/lifecycle/creation.service.test.ts
+++ b/src/backend/services/workspace/service/lifecycle/creation.service.test.ts
@@ -473,6 +473,24 @@ describe('WorkspaceCreationService', () => {
           })
         );
       });
+
+      it('persists selected provider for GitHub issue workspaces', async () => {
+        const source: WorkspaceCreationSource = {
+          type: 'GITHUB_ISSUE',
+          projectId: 'proj-1',
+          issueNumber: 42,
+          issueUrl: 'https://github.com/org/repo/issues/42',
+          provider: 'CODEX',
+        };
+
+        await service.create(source);
+
+        expect(workspaceAccessorModule.workspaceAccessor.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            defaultSessionProvider: 'CODEX',
+          })
+        );
+      });
     });
 
     describe('LINEAR_ISSUE source', () => {
@@ -543,6 +561,25 @@ describe('WorkspaceCreationService', () => {
               issueUrl: 'https://linear.app/team/issue/ENG-42',
               startupModePreset: 'plan',
             },
+          })
+        );
+      });
+
+      it('persists selected provider for Linear issue workspaces', async () => {
+        const source: WorkspaceCreationSource = {
+          type: 'LINEAR_ISSUE',
+          projectId: 'proj-1',
+          issueId: 'linear-uuid-123',
+          issueIdentifier: 'ENG-42',
+          issueUrl: 'https://linear.app/team/issue/ENG-42',
+          provider: 'CODEX',
+        };
+
+        await service.create(source);
+
+        expect(workspaceAccessorModule.workspaceAccessor.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            defaultSessionProvider: 'CODEX',
           })
         );
       });

--- a/src/backend/services/workspace/service/lifecycle/creation.service.ts
+++ b/src/backend/services/workspace/service/lifecycle/creation.service.ts
@@ -48,6 +48,7 @@ export type WorkspaceCreationSource =
       description?: string;
       ratchetEnabled?: boolean;
       startupModePreset?: 'non_interactive' | 'plan';
+      provider?: SessionProvider;
     }
   | {
       type: 'LINEAR_ISSUE';
@@ -59,6 +60,7 @@ export type WorkspaceCreationSource =
       description?: string;
       ratchetEnabled?: boolean;
       startupModePreset?: 'non_interactive' | 'plan';
+      provider?: SessionProvider;
     };
 
 /**
@@ -81,6 +83,7 @@ type PreparedWorkspaceCreation = {
     linearIssueUrl?: string;
     creationSource: 'MANUAL' | 'RESUME_BRANCH' | 'GITHUB_ISSUE' | 'LINEAR_ISSUE' | 'PERIODIC_TASK';
     creationMetadata?: Prisma.InputJsonValue;
+    defaultSessionProvider?: Prisma.WorkspaceCreateInput['defaultSessionProvider'];
     mode?: 'STANDARD' | 'AUTO_ITERATION';
     autoIterationConfig?: Prisma.InputJsonValue;
   };
@@ -256,6 +259,7 @@ export class WorkspaceCreationService {
         description: source.description,
         githubIssueNumber: source.issueNumber,
         githubIssueUrl: source.issueUrl,
+        defaultSessionProvider: source.provider,
         creationSource: 'GITHUB_ISSUE',
         creationMetadata: metadata as Prisma.InputJsonValue,
       },
@@ -282,6 +286,7 @@ export class WorkspaceCreationService {
         linearIssueId: source.issueId,
         linearIssueIdentifier: source.issueIdentifier,
         linearIssueUrl: source.issueUrl,
+        defaultSessionProvider: source.provider,
         creationSource: 'LINEAR_ISSUE',
         creationMetadata: metadata as Prisma.InputJsonValue,
       },

--- a/src/backend/trpc/workspace.router.test.ts
+++ b/src/backend/trpc/workspace.router.test.ts
@@ -341,6 +341,27 @@ describe('workspaceRouter', () => {
     );
   });
 
+  it('passes provider through GitHub issue workspace creation', async () => {
+    const { caller } = createCaller();
+    mockWorkspaceCreationCreate.mockResolvedValue({ id: 'w-created' });
+
+    await caller.create({
+      type: 'GITHUB_ISSUE',
+      projectId: 'p1',
+      issueNumber: 42,
+      issueUrl: 'https://github.com/org/repo/issues/42',
+      provider: 'CODEX',
+    });
+
+    expect(mockResolveProviderForWorkspaceCreation).toHaveBeenCalledWith('CODEX');
+    expect(mockWorkspaceCreationCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'GITHUB_ISSUE',
+        provider: 'CODEX',
+      })
+    );
+  });
+
   it('passes startup mode preset through Linear issue workspace creation', async () => {
     const { caller } = createCaller();
     mockWorkspaceCreationCreate.mockResolvedValue({ id: 'w-created' });
@@ -358,6 +379,28 @@ describe('workspaceRouter', () => {
       expect.objectContaining({
         type: 'LINEAR_ISSUE',
         startupModePreset: 'plan',
+      })
+    );
+  });
+
+  it('passes provider through Linear issue workspace creation', async () => {
+    const { caller } = createCaller();
+    mockWorkspaceCreationCreate.mockResolvedValue({ id: 'w-created' });
+
+    await caller.create({
+      type: 'LINEAR_ISSUE',
+      projectId: 'p1',
+      issueId: 'linear-42',
+      issueIdentifier: 'ENG-42',
+      issueUrl: 'https://linear.app/org/issue/ENG-42',
+      provider: 'CODEX',
+    });
+
+    expect(mockResolveProviderForWorkspaceCreation).toHaveBeenCalledWith('CODEX');
+    expect(mockWorkspaceCreationCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'LINEAR_ISSUE',
+        provider: 'CODEX',
       })
     );
   });

--- a/src/backend/trpc/workspace.trpc.ts
+++ b/src/backend/trpc/workspace.trpc.ts
@@ -89,6 +89,7 @@ const workspaceCreationSourceSchema = z.discriminatedUnion('type', [
     description: z.string().optional(),
     ratchetEnabled: z.boolean().optional(),
     startupModePreset: z.enum(['non_interactive', 'plan']).optional(),
+    provider: z.nativeEnum(SessionProvider).optional(),
   }),
   z.object({
     type: z.literal('LINEAR_ISSUE'),
@@ -100,6 +101,7 @@ const workspaceCreationSourceSchema = z.discriminatedUnion('type', [
     description: z.string().optional(),
     ratchetEnabled: z.boolean().optional(),
     startupModePreset: z.enum(['non_interactive', 'plan']).optional(),
+    provider: z.nativeEnum(SessionProvider).optional(),
   }),
 ]);
 
@@ -194,7 +196,10 @@ export const workspaceRouter = router({
     const logger = getLogger(ctx);
     const { configService } = ctx.appContext.services;
     const maxSessionsPerWorkspace = configService.getMaxSessionsPerWorkspace();
-    const explicitProvider = input.type === 'MANUAL' ? input.provider : undefined;
+    const explicitProvider =
+      input.type === 'MANUAL' || input.type === 'GITHUB_ISSUE' || input.type === 'LINEAR_ISSUE'
+        ? input.provider
+        : undefined;
     let defaultSessionProvider: SessionProvider | undefined;
 
     // Workspace creation provisions a default session when session capacity is enabled.

--- a/src/client/components/kanban/issue-card.test.tsx
+++ b/src/client/components/kanban/issue-card.test.tsx
@@ -124,12 +124,27 @@ function renderCard(): { container: HTMLDivElement; root: Root } {
   return { container, root };
 }
 
+function openLaunchSheet(container: HTMLDivElement) {
+  const startButton = Array.from(container.querySelectorAll('button')).find((button) =>
+    button.textContent?.includes('Start')
+  );
+
+  if (!startButton) {
+    throw new Error('Start button not found');
+  }
+
+  flushSync(() => {
+    startButton.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+  });
+}
+
 beforeEach(() => {
   Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
     configurable: true,
     writable: true,
     value: true,
   });
+  mocks.createWorkspaceMutationOptions = undefined;
 });
 
 afterEach(() => {
@@ -138,8 +153,23 @@ afterEach(() => {
 });
 
 describe('IssueCard', () => {
+  it('mounts the issue launch sheet only after starting an issue', () => {
+    const { container, root } = renderCard();
+
+    expect(mocks.createWorkspaceMutationOptions).toBeUndefined();
+
+    openLaunchSheet(container);
+
+    expect(mocks.createWorkspaceMutationOptions).toBeDefined();
+
+    root.unmount();
+    container.remove();
+  });
+
   it('invalidates sidebar project summary after creating a workspace from an issue', () => {
     const { container, root } = renderCard();
+
+    openLaunchSheet(container);
 
     const mutationOptions = mocks.createWorkspaceMutationOptions as {
       onSuccess: (workspace: { id: string }) => void;
@@ -162,6 +192,8 @@ describe('IssueCard', () => {
 
   it('shows a toast when creating a workspace from an issue fails', () => {
     const { container, root } = renderCard();
+
+    openLaunchSheet(container);
 
     const mutationOptions = mocks.createWorkspaceMutationOptions as {
       onError: (error: Error) => void;

--- a/src/client/components/kanban/issue-card.test.tsx
+++ b/src/client/components/kanban/issue-card.test.tsx
@@ -18,8 +18,10 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('lucide-react', () => ({
   CircleDot: () => null,
+  ExternalLink: () => null,
   Play: () => null,
   User: () => null,
+  X: () => null,
 }));
 
 vi.mock('@/client/lib/workspace-cache-helpers', () => ({

--- a/src/client/components/kanban/issue-card.tsx
+++ b/src/client/components/kanban/issue-card.tsx
@@ -1,19 +1,9 @@
 import { CircleDot, Play, User } from 'lucide-react';
-import { useEffect, useState } from 'react';
-import { toast } from 'sonner';
+import { useState } from 'react';
 import type { NormalizedIssue } from '@/client/lib/issue-normalization';
-import { trpc } from '@/client/lib/trpc';
-import { createOptimisticWorkspaceCacheData } from '@/client/lib/workspace-cache-helpers';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { RatchetToggleButton } from '@/components/workspace';
+import { IssueLaunchSheet } from './issue-launch-sheet';
 
 interface IssueCardProps {
   issue: NormalizedIssue;
@@ -22,84 +12,12 @@ interface IssueCardProps {
 }
 
 export function IssueCard({ issue, projectId, onClick }: IssueCardProps) {
-  const utils = trpc.useUtils();
-  const { data: userSettings, isLoading: isLoadingSettings } = trpc.userSettings.get.useQuery();
-  const [ratchetEnabled, setRatchetEnabled] = useState(false);
-  const [startupModePreset, setStartupModePreset] = useState<'non_interactive' | 'plan'>(
-    'non_interactive'
-  );
-  const ratchetPreferenceKey = `kanban:issue-ratchet:${projectId}:${issue.id}`;
-
-  useEffect(() => {
-    if (userSettings?.ratchetEnabled === undefined) {
-      return;
-    }
-    try {
-      const savedPreference = window.localStorage.getItem(ratchetPreferenceKey);
-      if (savedPreference === 'true' || savedPreference === 'false') {
-        setRatchetEnabled(savedPreference === 'true');
-        return;
-      }
-    } catch {
-      // Ignore localStorage failures and fall back to admin default.
-    }
-    setRatchetEnabled(userSettings.ratchetEnabled);
-  }, [ratchetPreferenceKey, userSettings?.ratchetEnabled]);
-
-  const createWorkspaceMutation = trpc.workspace.create.useMutation({
-    onSuccess: (workspace) => {
-      // Optimistically populate the workspace detail query cache so the status
-      // is immediately visible when navigating to the detail page
-      utils.workspace.get.setData({ id: workspace.id }, (old) => {
-        // If there's already data (shouldn't happen for a new workspace), keep it
-        if (old) {
-          return old;
-        }
-
-        return createOptimisticWorkspaceCacheData(workspace);
-      });
-
-      // Invalidate workspace queries to refresh the board
-      utils.workspace.listWithKanbanState.invalidate({ projectId });
-      utils.workspace.getProjectSummaryState.invalidate({ projectId });
-    },
-    onError: (error) => {
-      toast.error(error.message || 'Failed to start workspace');
-    },
-  });
+  const [launchSheetOpen, setLaunchSheetOpen] = useState(false);
 
   const handleStart = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
-
-    if (issue.provider === 'linear' && issue.linearIssueId && issue.linearIssueIdentifier) {
-      createWorkspaceMutation.mutate({
-        type: 'LINEAR_ISSUE',
-        projectId,
-        issueId: issue.linearIssueId,
-        issueIdentifier: issue.linearIssueIdentifier,
-        issueUrl: issue.url,
-        name: issue.title,
-        ratchetEnabled,
-        startupModePreset,
-      });
-    } else if (issue.githubIssueNumber) {
-      createWorkspaceMutation.mutate({
-        type: 'GITHUB_ISSUE',
-        projectId,
-        issueNumber: issue.githubIssueNumber,
-        issueUrl: issue.url,
-        name: issue.title,
-        ratchetEnabled,
-        startupModePreset,
-      });
-    }
-  };
-
-  const handleOpenIssue = (e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    window.open(issue.url, '_blank', 'noopener,noreferrer');
+    setLaunchSheetOpen(true);
   };
 
   const handleCardClick = () => {
@@ -107,77 +25,46 @@ export function IssueCard({ issue, projectId, onClick }: IssueCardProps) {
   };
 
   return (
-    <Card
-      className="cursor-pointer hover:border-primary/50 transition-colors overflow-hidden border-dashed"
-      onClick={handleCardClick}
-    >
-      <CardHeader className="pb-3">
-        <CardTitle className="text-sm font-medium leading-tight line-clamp-2">
-          {issue.title}
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="pt-0">
-        <div className="flex items-center justify-between gap-2">
-          <div className="flex items-center gap-2 text-[11px] text-muted-foreground min-w-0">
-            <RatchetToggleButton
-              enabled={ratchetEnabled}
-              state="IDLE"
-              className="h-5 w-5 shrink-0"
-              stopPropagation
-              disabled={isLoadingSettings || createWorkspaceMutation.isPending}
-              onToggle={(enabled) => {
-                setRatchetEnabled(enabled);
-                try {
-                  window.localStorage.setItem(ratchetPreferenceKey, String(enabled));
-                } catch {
-                  // Ignore localStorage failures without interrupting the toggle.
-                }
-              }}
-            />
-            <button
-              type="button"
-              onClick={handleOpenIssue}
-              className="inline-flex items-center gap-1 hover:text-foreground shrink-0"
-            >
-              <CircleDot className="h-3 w-3 text-green-500" />
-              <span>{issue.displayId}</span>
-            </button>
-            <span className="inline-flex items-center gap-1 truncate">
-              <User className="h-3 w-3 shrink-0" />
-              {issue.author}
-            </span>
-          </div>
-          <div className="flex items-center gap-1 shrink-0">
-            <Select
-              value={startupModePreset}
-              onValueChange={(value) => setStartupModePreset(value as 'non_interactive' | 'plan')}
-              disabled={createWorkspaceMutation.isPending || isLoadingSettings}
-            >
-              <SelectTrigger
-                className="h-6 w-[92px] px-2 text-xs"
-                onClick={(e) => e.stopPropagation()}
-                onPointerDown={(e) => e.stopPropagation()}
-              >
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="non_interactive">Default</SelectItem>
-                <SelectItem value="plan">Planning</SelectItem>
-              </SelectContent>
-            </Select>
+    <>
+      <Card
+        className="cursor-pointer hover:border-primary/50 transition-colors overflow-hidden border-dashed"
+        onClick={handleCardClick}
+      >
+        <CardHeader className="pb-3">
+          <CardTitle className="text-sm font-medium leading-tight line-clamp-2">
+            {issue.title}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="pt-0">
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex items-center gap-2 text-[11px] text-muted-foreground min-w-0">
+              <span className="inline-flex items-center gap-1 shrink-0">
+                <CircleDot className="h-3 w-3 text-green-500" />
+                <span>{issue.displayId}</span>
+              </span>
+              <span className="inline-flex items-center gap-1 truncate">
+                <User className="h-3 w-3 shrink-0" />
+                {issue.author}
+              </span>
+            </div>
             <Button
               size="sm"
               variant="outline"
               className="h-6 px-2 text-xs shrink-0"
               onClick={handleStart}
-              disabled={createWorkspaceMutation.isPending || isLoadingSettings}
             >
               <Play className="h-3 w-3 mr-1" />
-              {createWorkspaceMutation.isPending ? '...' : 'Start'}
+              Start
             </Button>
           </div>
-        </div>
-      </CardContent>
-    </Card>
+        </CardContent>
+      </Card>
+      <IssueLaunchSheet
+        issue={issue}
+        projectId={projectId}
+        open={launchSheetOpen}
+        onOpenChange={setLaunchSheetOpen}
+      />
+    </>
   );
 }

--- a/src/client/components/kanban/issue-card.tsx
+++ b/src/client/components/kanban/issue-card.tsx
@@ -59,12 +59,14 @@ export function IssueCard({ issue, projectId, onClick }: IssueCardProps) {
           </div>
         </CardContent>
       </Card>
-      <IssueLaunchSheet
-        issue={issue}
-        projectId={projectId}
-        open={launchSheetOpen}
-        onOpenChange={setLaunchSheetOpen}
-      />
+      {launchSheetOpen ? (
+        <IssueLaunchSheet
+          issue={issue}
+          projectId={projectId}
+          open={launchSheetOpen}
+          onOpenChange={setLaunchSheetOpen}
+        />
+      ) : null}
     </>
   );
 }

--- a/src/client/components/kanban/issue-details-sheet.tsx
+++ b/src/client/components/kanban/issue-details-sheet.tsx
@@ -1,16 +1,9 @@
 import { CircleDot, ExternalLink, Play, User } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import type { NormalizedIssue } from '@/client/lib/issue-normalization';
 import { trpc } from '@/client/lib/trpc';
 import { Button } from '@/components/ui/button';
 import { MarkdownRenderer } from '@/components/ui/markdown';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
 import {
   Sheet,
   SheetContent,
@@ -19,7 +12,7 @@ import {
   SheetTitle,
 } from '@/components/ui/sheet';
 import { Skeleton } from '@/components/ui/skeleton';
-import { RatchetToggleButton } from '@/components/workspace';
+import { IssueLaunchSheet } from './issue-launch-sheet';
 
 interface IssueDetailsSheetProps {
   issue: NormalizedIssue | null;
@@ -65,12 +58,7 @@ function IssueDetailsContent({
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
-  const utils = trpc.useUtils();
-  const { data: userSettings, isLoading: isLoadingSettings } = trpc.userSettings.get.useQuery();
-  const [ratchetEnabled, setRatchetEnabled] = useState(false);
-  const [startupModePreset, setStartupModePreset] = useState<'non_interactive' | 'plan'>(
-    'non_interactive'
-  );
+  const [launchSheetOpen, setLaunchSheetOpen] = useState(false);
 
   const isGitHub = issue.provider === 'github';
   const isLinear = issue.provider === 'linear';
@@ -93,57 +81,6 @@ function IssueDetailsContent({
     ? linearDetailsData?.issue?.description
     : githubDetailsData?.issue?.body;
   const isLoadingDetails = isLinear ? isLoadingLinearDetails : isLoadingGithubDetails;
-
-  const ratchetPreferenceKey = `kanban:issue-ratchet:${projectId}:${issue.id}`;
-
-  useEffect(() => {
-    if (userSettings?.ratchetEnabled === undefined) {
-      return;
-    }
-    try {
-      const savedPreference = window.localStorage.getItem(ratchetPreferenceKey);
-      if (savedPreference === 'true' || savedPreference === 'false') {
-        setRatchetEnabled(savedPreference === 'true');
-        return;
-      }
-    } catch {
-      // Ignore localStorage failures and fall back to admin default.
-    }
-    setRatchetEnabled(userSettings.ratchetEnabled);
-  }, [ratchetPreferenceKey, userSettings?.ratchetEnabled]);
-
-  const createWorkspaceMutation = trpc.workspace.create.useMutation({
-    onSuccess: () => {
-      onOpenChange(false);
-      utils.workspace.listWithKanbanState.invalidate({ projectId });
-      utils.workspace.getProjectSummaryState.invalidate({ projectId });
-    },
-  });
-
-  const handleStart = () => {
-    if (issue.provider === 'linear' && issue.linearIssueId && issue.linearIssueIdentifier) {
-      createWorkspaceMutation.mutate({
-        type: 'LINEAR_ISSUE',
-        projectId,
-        issueId: issue.linearIssueId,
-        issueIdentifier: issue.linearIssueIdentifier,
-        issueUrl: issue.url,
-        name: issue.title,
-        ratchetEnabled,
-        startupModePreset,
-      });
-    } else if (issue.githubIssueNumber) {
-      createWorkspaceMutation.mutate({
-        type: 'GITHUB_ISSUE',
-        projectId,
-        issueNumber: issue.githubIssueNumber,
-        issueUrl: issue.url,
-        name: issue.title,
-        ratchetEnabled,
-        startupModePreset,
-      });
-    }
-  };
 
   const externalLabel = isLinear ? 'Open in Linear' : 'Open in GitHub';
 
@@ -192,28 +129,7 @@ function IssueDetailsContent({
       </div>
 
       {/* Fixed footer with action buttons */}
-      <div className="border-t p-4 space-y-3">
-        <div className="flex items-center gap-2">
-          <RatchetToggleButton
-            enabled={ratchetEnabled}
-            state="IDLE"
-            className="h-6 w-6 shrink-0"
-            stopPropagation={false}
-            disabled={isLoadingSettings || createWorkspaceMutation.isPending}
-            onToggle={(enabled) => {
-              setRatchetEnabled(enabled);
-              try {
-                window.localStorage.setItem(ratchetPreferenceKey, String(enabled));
-              } catch {
-                // Ignore localStorage failures without interrupting the toggle.
-              }
-            }}
-          />
-          <span className="text-xs text-muted-foreground">
-            {ratchetEnabled ? 'Ratcheting enabled' : 'Ratcheting disabled'}
-          </span>
-        </div>
-
+      <div className="border-t p-4">
         <div className="flex gap-2">
           <Button
             onClick={() => window.open(issue.url, '_blank', 'noopener,noreferrer')}
@@ -222,29 +138,20 @@ function IssueDetailsContent({
             <ExternalLink className="h-4 w-4 mr-2" />
             {externalLabel}
           </Button>
-          <Select
-            value={startupModePreset}
-            onValueChange={(value) => setStartupModePreset(value as 'non_interactive' | 'plan')}
-            disabled={createWorkspaceMutation.isPending || isLoadingSettings}
-          >
-            <SelectTrigger className="w-[110px]">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="non_interactive">Default</SelectItem>
-              <SelectItem value="plan">Planning</SelectItem>
-            </SelectContent>
-          </Select>
-          <Button
-            onClick={handleStart}
-            disabled={createWorkspaceMutation.isPending || isLoadingSettings}
-            className="flex-1"
-          >
+          <Button onClick={() => setLaunchSheetOpen(true)} className="flex-1">
             <Play className="h-4 w-4 mr-2" />
-            {createWorkspaceMutation.isPending ? 'Starting...' : 'Start Issue'}
+            Start Issue
           </Button>
         </div>
       </div>
+
+      <IssueLaunchSheet
+        issue={issue}
+        projectId={projectId}
+        open={launchSheetOpen}
+        onOpenChange={setLaunchSheetOpen}
+        onStarted={() => onOpenChange(false)}
+      />
     </>
   );
 }

--- a/src/client/components/kanban/issue-launch-sheet.test.tsx
+++ b/src/client/components/kanban/issue-launch-sheet.test.tsx
@@ -1,0 +1,234 @@
+// @vitest-environment jsdom
+
+import { createElement, type ReactNode } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { IssueLaunchSheet } from './issue-launch-sheet';
+
+const mocks = vi.hoisted(() => ({
+  userSettings: {
+    defaultSessionProvider: 'CLAUDE' as 'CLAUDE' | 'CODEX',
+    ratchetEnabled: false,
+  },
+  listWithKanbanStateInvalidateMock: vi.fn(),
+  getProjectSummaryStateInvalidateMock: vi.fn(),
+  getSetDataMock: vi.fn(),
+  createWorkspaceMutateMock: vi.fn(),
+  createOptimisticWorkspaceCacheDataMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+}));
+
+vi.mock('lucide-react', () => ({
+  ExternalLink: () => null,
+  Play: () => null,
+}));
+
+vi.mock('@/client/lib/workspace-cache-helpers', () => ({
+  createOptimisticWorkspaceCacheData: mocks.createOptimisticWorkspaceCacheDataMock,
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: mocks.toastErrorMock,
+  },
+}));
+
+vi.mock('@/client/lib/trpc', () => ({
+  trpc: {
+    useUtils: () => ({
+      workspace: {
+        get: { setData: mocks.getSetDataMock },
+        listWithKanbanState: {
+          invalidate: mocks.listWithKanbanStateInvalidateMock,
+        },
+        getProjectSummaryState: {
+          invalidate: mocks.getProjectSummaryStateInvalidateMock,
+        },
+      },
+    }),
+    userSettings: {
+      get: {
+        useQuery: () => ({
+          data: mocks.userSettings,
+          isLoading: false,
+        }),
+      },
+    },
+    workspace: {
+      create: {
+        useMutation: () => ({
+          mutate: mocks.createWorkspaceMutateMock,
+          isPending: false,
+        }),
+      },
+    },
+  },
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    asChild: _asChild,
+    ...props
+  }: import('react').ButtonHTMLAttributes<HTMLButtonElement> & { asChild?: boolean }) =>
+    createElement('button', props, children),
+}));
+
+vi.mock('@/components/ui/label', () => ({
+  Label: ({ children, ...props }: import('react').LabelHTMLAttributes<HTMLLabelElement>) =>
+    createElement('label', props, children),
+}));
+
+vi.mock('@/components/ui/select', async () => {
+  const React = await vi.importActual<typeof import('react')>('react');
+  const SelectContext = React.createContext<{
+    onValueChange?: (value: string) => void;
+  }>({});
+
+  return {
+    Select: ({
+      children,
+      onValueChange,
+    }: {
+      children: ReactNode;
+      onValueChange?: (value: string) => void;
+    }) =>
+      createElement(
+        SelectContext.Provider,
+        { value: { onValueChange } },
+        createElement('div', null, children)
+      ),
+    SelectContent: ({ children }: { children: ReactNode }) => createElement('div', null, children),
+    SelectItem: ({ children, value }: { children: ReactNode; value: string }) => {
+      const context = React.useContext(SelectContext);
+      return createElement(
+        'button',
+        {
+          type: 'button',
+          onClick: () => context.onValueChange?.(value),
+        },
+        children
+      );
+    },
+    SelectTrigger: ({ children, ...props }: import('react').HTMLAttributes<HTMLButtonElement>) =>
+      createElement('button', props, children),
+    SelectValue: () => null,
+  };
+});
+
+vi.mock('@/components/ui/sheet', () => ({
+  Sheet: ({ children, open }: { children: ReactNode; open: boolean }) =>
+    open ? createElement('div', null, children) : null,
+  SheetContent: ({ children, ...props }: import('react').HTMLAttributes<HTMLDivElement>) =>
+    createElement('div', props, children),
+  SheetDescription: ({ children, ...props }: import('react').HTMLAttributes<HTMLDivElement>) =>
+    createElement('div', props, children),
+  SheetFooter: ({ children, ...props }: import('react').HTMLAttributes<HTMLDivElement>) =>
+    createElement('div', props, children),
+  SheetHeader: ({ children, ...props }: import('react').HTMLAttributes<HTMLDivElement>) =>
+    createElement('div', props, children),
+  SheetTitle: ({ children, ...props }: import('react').HTMLAttributes<HTMLDivElement>) =>
+    createElement('div', props, children),
+}));
+
+vi.mock('@/components/workspace', () => ({
+  RatchetToggleButton: () => null,
+}));
+
+const issue = {
+  id: 'github-42',
+  provider: 'github' as const,
+  title: 'Fix login redirect',
+  body: 'Issue body',
+  url: 'https://github.com/acme/repo/issues/42',
+  displayId: '#42',
+  author: 'octocat',
+  createdAt: '2026-03-14T12:00:00.000Z',
+  githubIssueNumber: 42,
+};
+
+function renderSheet(): { container: HTMLDivElement; root: Root } {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  flushSync(() => {
+    root.render(
+      createElement(IssueLaunchSheet, {
+        projectId: 'project-1',
+        issue,
+        open: true,
+        onOpenChange: vi.fn(),
+      })
+    );
+  });
+
+  return { container, root };
+}
+
+function clickButton(container: HTMLDivElement, label: string) {
+  const button = Array.from(container.querySelectorAll('button')).find((candidate) =>
+    candidate.textContent?.includes(label)
+  );
+
+  if (!button) {
+    throw new Error(`${label} button not found`);
+  }
+
+  flushSync(() => {
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+  });
+}
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
+    configurable: true,
+    writable: true,
+    value: true,
+  });
+  mocks.userSettings = {
+    defaultSessionProvider: 'CLAUDE',
+    ratchetEnabled: false,
+  };
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.clearAllMocks();
+});
+
+describe('IssueLaunchSheet', () => {
+  it('does not reset a user-selected provider after settings refetch', () => {
+    const { container, root } = renderSheet();
+
+    clickButton(container, 'Codex');
+
+    mocks.userSettings = {
+      defaultSessionProvider: 'CLAUDE',
+      ratchetEnabled: true,
+    };
+
+    flushSync(() => {
+      root.render(
+        createElement(IssueLaunchSheet, {
+          projectId: 'project-1',
+          issue,
+          open: true,
+          onOpenChange: vi.fn(),
+        })
+      );
+    });
+
+    clickButton(container, 'Start');
+
+    expect(mocks.createWorkspaceMutateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'CODEX',
+      })
+    );
+
+    root.unmount();
+    container.remove();
+  });
+});

--- a/src/client/components/kanban/issue-launch-sheet.tsx
+++ b/src/client/components/kanban/issue-launch-sheet.tsx
@@ -1,5 +1,5 @@
 import { ExternalLink, Play } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import type { NormalizedIssue } from '@/client/lib/issue-normalization';
 import { trpc } from '@/client/lib/trpc';
@@ -63,16 +63,29 @@ export function IssueLaunchSheet({
   const [ratchetEnabled, setRatchetEnabled] = useState(false);
   const [startupModePreset, setStartupModePreset] = useState<LaunchMode>('non_interactive');
   const [provider, setProvider] = useState<AgentProvider>('CLAUDE');
+  const initializedProviderForOpenRef = useRef(false);
   const ratchetPreferenceKey = `kanban:issue-ratchet:${projectId}:${issue.id}`;
   const promptPreview = useMemo(() => buildPromptPreview(issue), [issue]);
   const issueProviderLabel = getIssueProviderLabel(issue);
 
   useEffect(() => {
-    if (!userSettings) {
+    if (!open) {
+      initializedProviderForOpenRef.current = false;
+      return;
+    }
+
+    if (!userSettings || initializedProviderForOpenRef.current) {
       return;
     }
 
     setProvider(userSettings.defaultSessionProvider ?? 'CLAUDE');
+    initializedProviderForOpenRef.current = true;
+  }, [open, userSettings]);
+
+  useEffect(() => {
+    if (!userSettings) {
+      return;
+    }
 
     try {
       const savedPreference = window.localStorage.getItem(ratchetPreferenceKey);

--- a/src/client/components/kanban/issue-launch-sheet.tsx
+++ b/src/client/components/kanban/issue-launch-sheet.tsx
@@ -1,0 +1,240 @@
+import { ExternalLink, Play } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import type { NormalizedIssue } from '@/client/lib/issue-normalization';
+import { trpc } from '@/client/lib/trpc';
+import { createOptimisticWorkspaceCacheData } from '@/client/lib/workspace-cache-helpers';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import { RatchetToggleButton } from '@/components/workspace';
+
+interface IssueLaunchSheetProps {
+  issue: NormalizedIssue;
+  projectId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onStarted?: () => void;
+}
+
+type LaunchMode = 'non_interactive' | 'plan';
+type AgentProvider = 'CLAUDE' | 'CODEX';
+
+function getIssueProviderLabel(issue: NormalizedIssue) {
+  return issue.provider === 'linear' ? 'Linear' : 'GitHub';
+}
+
+function buildPromptPreview(issue: NormalizedIssue) {
+  const providerLabel = issue.provider === 'linear' ? 'Linear Issue' : 'GitHub Issue';
+  const body = issue.body?.trim() || '(No description provided)';
+
+  return `# ${providerLabel} ${issue.displayId}: ${issue.title}
+
+${body}
+
+Issue URL: ${issue.url}
+
+Start with planning, then implement, test, review, and open a pull request.`;
+}
+
+export function IssueLaunchSheet({
+  issue,
+  projectId,
+  open,
+  onOpenChange,
+  onStarted,
+}: IssueLaunchSheetProps) {
+  const utils = trpc.useUtils();
+  const { data: userSettings, isLoading: isLoadingSettings } = trpc.userSettings.get.useQuery();
+  const [ratchetEnabled, setRatchetEnabled] = useState(false);
+  const [startupModePreset, setStartupModePreset] = useState<LaunchMode>('non_interactive');
+  const [provider, setProvider] = useState<AgentProvider>('CLAUDE');
+  const ratchetPreferenceKey = `kanban:issue-ratchet:${projectId}:${issue.id}`;
+  const promptPreview = useMemo(() => buildPromptPreview(issue), [issue]);
+  const issueProviderLabel = getIssueProviderLabel(issue);
+
+  useEffect(() => {
+    if (!userSettings) {
+      return;
+    }
+
+    setProvider(userSettings.defaultSessionProvider ?? 'CLAUDE');
+
+    try {
+      const savedPreference = window.localStorage.getItem(ratchetPreferenceKey);
+      if (savedPreference === 'true' || savedPreference === 'false') {
+        setRatchetEnabled(savedPreference === 'true');
+        return;
+      }
+    } catch {
+      // Ignore localStorage failures and fall back to admin default.
+    }
+    setRatchetEnabled(userSettings.ratchetEnabled);
+  }, [ratchetPreferenceKey, userSettings]);
+
+  const createWorkspaceMutation = trpc.workspace.create.useMutation({
+    onSuccess: (workspace) => {
+      utils.workspace.get.setData({ id: workspace.id }, (old) => {
+        if (old) {
+          return old;
+        }
+
+        return createOptimisticWorkspaceCacheData(workspace);
+      });
+
+      utils.workspace.listWithKanbanState.invalidate({ projectId });
+      utils.workspace.getProjectSummaryState.invalidate({ projectId });
+      onOpenChange(false);
+      onStarted?.();
+    },
+    onError: (error) => {
+      toast.error(error.message || 'Failed to start workspace');
+    },
+  });
+
+  const handleRatchetToggle = (enabled: boolean) => {
+    setRatchetEnabled(enabled);
+    try {
+      window.localStorage.setItem(ratchetPreferenceKey, String(enabled));
+    } catch {
+      // Ignore localStorage failures without interrupting the toggle.
+    }
+  };
+
+  const handleStart = () => {
+    if (issue.provider === 'linear' && issue.linearIssueId && issue.linearIssueIdentifier) {
+      createWorkspaceMutation.mutate({
+        type: 'LINEAR_ISSUE',
+        projectId,
+        issueId: issue.linearIssueId,
+        issueIdentifier: issue.linearIssueIdentifier,
+        issueUrl: issue.url,
+        name: issue.title,
+        ratchetEnabled,
+        startupModePreset,
+        provider,
+      });
+    } else if (issue.githubIssueNumber) {
+      createWorkspaceMutation.mutate({
+        type: 'GITHUB_ISSUE',
+        projectId,
+        issueNumber: issue.githubIssueNumber,
+        issueUrl: issue.url,
+        name: issue.title,
+        ratchetEnabled,
+        startupModePreset,
+        provider,
+      });
+    }
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-full sm:max-w-md flex flex-col">
+        <SheetHeader>
+          <SheetTitle className="pr-6">Start Issue</SheetTitle>
+          <SheetDescription className="line-clamp-2">
+            {issue.displayId} · {issue.title}
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="flex-1 min-h-0 space-y-4 overflow-y-auto">
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label htmlFor={`issue-mode-${issue.id}`} className="text-xs">
+                Mode
+              </Label>
+              <Select
+                value={startupModePreset}
+                onValueChange={(value) => setStartupModePreset(value as LaunchMode)}
+                disabled={createWorkspaceMutation.isPending || isLoadingSettings}
+              >
+                <SelectTrigger id={`issue-mode-${issue.id}`} className="h-8 text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="non_interactive">Autonomous</SelectItem>
+                  <SelectItem value="plan">Planning</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor={`issue-provider-${issue.id}`} className="text-xs">
+                Provider
+              </Label>
+              <Select
+                value={provider}
+                onValueChange={(value) => setProvider(value as AgentProvider)}
+                disabled={createWorkspaceMutation.isPending || isLoadingSettings}
+              >
+                <SelectTrigger id={`issue-provider-${issue.id}`} className="h-8 text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="CLAUDE">Claude</SelectItem>
+                  <SelectItem value="CODEX">Codex</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between rounded-md border px-3 py-2">
+            <div>
+              <div className="text-sm font-medium">Ratchet</div>
+              <div className="text-xs text-muted-foreground">{ratchetEnabled ? 'On' : 'Off'}</div>
+            </div>
+            <RatchetToggleButton
+              enabled={ratchetEnabled}
+              state="IDLE"
+              className="h-6 w-6"
+              stopPropagation={false}
+              disabled={isLoadingSettings || createWorkspaceMutation.isPending}
+              onToggle={handleRatchetToggle}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <div className="flex items-center justify-between gap-2">
+              <Label className="text-xs">Prompt Preview</Label>
+              <Button variant="ghost" size="sm" className="h-7 px-2 text-xs" asChild>
+                <a href={issue.url} target="_blank" rel="noreferrer">
+                  <ExternalLink className="h-3.5 w-3.5" />
+                  {issueProviderLabel}
+                </a>
+              </Button>
+            </div>
+            <pre className="max-h-64 overflow-auto whitespace-pre-wrap rounded-md border bg-muted/40 p-3 text-xs leading-relaxed text-muted-foreground">
+              {promptPreview}
+            </pre>
+          </div>
+        </div>
+
+        <SheetFooter className="pt-2">
+          <Button
+            onClick={handleStart}
+            disabled={createWorkspaceMutation.isPending || isLoadingSettings}
+            className="w-full sm:w-auto"
+          >
+            <Play className="h-4 w-4 mr-2" />
+            {createWorkspaceMutation.isPending ? 'Starting...' : 'Start'}
+          </Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}


### PR DESCRIPTION
## Summary
- Replace dense issue-card launch controls with a focused issue launch sheet.
- Add launch options for mode, agent provider, ratchet, external issue link, and prompt preview before Start.
- Wire selected provider through GitHub and Linear issue workspace creation with backend coverage.

## Testing
- [x] pnpm vitest run src/client/components/kanban/issue-card.test.tsx src/backend/services/workspace/service/lifecycle/creation.service.test.ts src/backend/trpc/workspace.router.test.ts
- [x] pnpm typecheck
- [x] pnpm check

Notes: `pnpm check` reports existing `<img>` warnings and skips local Codex schema drift because the installed Codex CLI differs from the pinned CI version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the workspace creation API and default session provider for issue-sourced workspaces, but mirrors the existing manual-creation provider flow and is covered by backend and UI tests.
> 
> **Overview**
> Kanban **Start** from issue cards and the issue details sheet now opens a dedicated **Issue launch sheet** instead of inline mode/ratchet controls on the card.
> 
> The sheet lets users pick **Autonomous vs Planning** mode, **Claude vs Codex** provider, ratchet on/off (with the same per-issue localStorage preference), view a **prompt preview**, and open the external issue link before confirming **Start**. Workspace creation logic and cache invalidation move into this shared component; the card only mounts the sheet after **Start** is clicked.
> 
> **Backend:** GitHub and Linear issue workspace creation accept an optional `provider`, validated on the TRPC `workspace.create` path (including CLI health checks like manual creation) and persisted as `defaultSessionProvider` on the new workspace. Tests cover creation service, router, and UI behavior (including not resetting a user-chosen provider when settings refetch).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f43f9283d027095a422359a9eaa605e7673d9337. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->