### PR TITLE
Backfill missing Codex tool calls

### DIFF
--- a/src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.test.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.test.ts
@@ -790,17 +790,10 @@ describe('createLoadSessionHandler', () => {
     expect(mocks.markHistoryHydrated).toHaveBeenCalledWith('session-codex-no-dup', 'none');
   });
 
-  it('skips CODEX tool backfill after JSONL was already checked', async () => {
-    mocks.findById.mockResolvedValue({
-      provider: 'CODEX',
-      status: 'RUNNING',
-      model: 'gpt-5.3-codex',
-      providerSessionId: 'codex-provider-session-1',
-      workspace: { status: 'READY', worktreePath: '/tmp/worktree' },
-    });
-    mocks.isHistoryHydrated.mockReturnValue(true);
-    mocks.getHistoryHydrationSource.mockReturnValue('none');
-    mocks.getTranscriptSnapshot.mockReturnValue([
+  it('rechecks CODEX tool backfill after a no-op cooldown', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-14T00:00:10.000Z'));
+    const existingTranscript = [
       {
         id: 'existing-tool',
         source: 'agent',
@@ -820,7 +813,88 @@ describe('createLoadSessionHandler', () => {
         timestamp: '2026-02-14T00:00:02.000Z',
         order: 0,
       },
-    ]);
+      {
+        id: 'existing-result',
+        source: 'agent',
+        message: {
+          type: 'user',
+          message: {
+            role: 'user',
+            content: [{ type: 'tool_result', tool_use_id: 'call-present', content: 'ok' }],
+          },
+        },
+        timestamp: '2026-02-14T00:00:03.000Z',
+        order: 1,
+      },
+    ];
+
+    mocks.findById.mockResolvedValue({
+      provider: 'CODEX',
+      status: 'RUNNING',
+      model: 'gpt-5.3-codex',
+      providerSessionId: 'codex-provider-session-1',
+      workspace: { status: 'READY', worktreePath: '/tmp/worktree' },
+    });
+    mocks.isHistoryHydrated.mockReturnValue(true);
+    mocks.getHistoryHydrationSource.mockReturnValueOnce(undefined).mockReturnValue('none');
+    mocks.getTranscriptSnapshot.mockReturnValue(existingTranscript);
+    mocks.loadCodexSessionHistory
+      .mockResolvedValueOnce({
+        status: 'loaded',
+        filePath:
+          '/tmp/.codex/sessions/2026/02/14/rollout-2026-02-14T00-00-00-codex-provider-session-1.jsonl',
+        history: [
+          {
+            type: 'tool_use',
+            content: '',
+            timestamp: '2026-02-14T00:00:02.000Z',
+            toolName: 'exec_command',
+            toolId: 'call-present',
+            toolInput: { cmd: 'pwd' },
+          },
+          {
+            type: 'tool_result',
+            content: 'ok',
+            timestamp: '2026-02-14T00:00:03.000Z',
+            toolId: 'call-present',
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        status: 'loaded',
+        filePath:
+          '/tmp/.codex/sessions/2026/02/14/rollout-2026-02-14T00-00-00-codex-provider-session-1.jsonl',
+        history: [
+          {
+            type: 'tool_use',
+            content: '',
+            timestamp: '2026-02-14T00:00:02.000Z',
+            toolName: 'exec_command',
+            toolId: 'call-present',
+            toolInput: { cmd: 'pwd' },
+          },
+          {
+            type: 'tool_result',
+            content: 'ok',
+            timestamp: '2026-02-14T00:00:03.000Z',
+            toolId: 'call-present',
+          },
+          {
+            type: 'tool_use',
+            content: '',
+            timestamp: '2026-02-14T00:00:04.000Z',
+            toolName: 'exec_command',
+            toolId: 'call-missing',
+            toolInput: { cmd: 'whoami' },
+          },
+          {
+            type: 'tool_result',
+            content: 'martin',
+            timestamp: '2026-02-14T00:00:05.000Z',
+            toolId: 'call-missing',
+          },
+        ],
+      });
 
     const handler = createLoadSessionHandler({
       getClientCreator: () => null,
@@ -830,14 +904,67 @@ describe('createLoadSessionHandler', () => {
     const ws = { send: vi.fn() } as unknown as { send: (payload: string) => void };
     await handler({
       ws: ws as never,
-      sessionId: 'session-codex-already-checked',
+      sessionId: 'session-codex-recheck',
       workingDir: '/tmp/worktree',
       message: { type: 'load_session' } as never,
     });
 
-    expect(mocks.loadCodexSessionHistory).not.toHaveBeenCalled();
+    expect(mocks.loadCodexSessionHistory).toHaveBeenCalledTimes(1);
     expect(mocks.replaceTranscript).not.toHaveBeenCalled();
-    expect(mocks.markHistoryHydrated).not.toHaveBeenCalled();
+    expect(mocks.markHistoryHydrated).toHaveBeenCalledWith('session-codex-recheck', 'none');
+
+    await handler({
+      ws: ws as never,
+      sessionId: 'session-codex-recheck',
+      workingDir: '/tmp/worktree',
+      message: { type: 'load_session' } as never,
+    });
+
+    expect(mocks.loadCodexSessionHistory).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(5000);
+    await handler({
+      ws: ws as never,
+      sessionId: 'session-codex-recheck',
+      workingDir: '/tmp/worktree',
+      message: { type: 'load_session' } as never,
+    });
+
+    expect(mocks.loadCodexSessionHistory).toHaveBeenCalledTimes(2);
+    expect(mocks.replaceTranscript).toHaveBeenCalledWith(
+      'session-codex-recheck',
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: 'agent',
+          message: expect.objectContaining({
+            type: 'stream_event',
+            event: expect.objectContaining({
+              content_block: expect.objectContaining({
+                type: 'tool_use',
+                id: 'call-missing',
+                name: 'exec_command',
+              }),
+            }),
+          }),
+        }),
+        expect.objectContaining({
+          source: 'agent',
+          message: expect.objectContaining({
+            type: 'user',
+            message: expect.objectContaining({
+              content: expect.arrayContaining([
+                expect.objectContaining({
+                  type: 'tool_result',
+                  tool_use_id: 'call-missing',
+                  content: 'martin',
+                }),
+              ]),
+            }),
+          }),
+        }),
+      ]),
+      { historySource: 'jsonl' }
+    );
   });
 
   it('emits config options using fallback-aware session service method', async () => {

--- a/src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.test.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.test.ts
@@ -565,6 +565,227 @@ describe('createLoadSessionHandler', () => {
     );
   });
 
+  it('backfills missing CODEX tool calls from JSONL when a live transcript already exists', async () => {
+    const existingTranscript = [
+      {
+        id: 'existing-user',
+        source: 'user',
+        text: 'start',
+        timestamp: '2026-02-14T00:00:00.000Z',
+        order: 0,
+      },
+      {
+        id: 'existing-assistant-1',
+        source: 'agent',
+        message: {
+          type: 'assistant',
+          message: { role: 'assistant', content: [{ type: 'text', text: 'before tool' }] },
+        },
+        timestamp: '2026-02-14T00:00:01.000Z',
+        order: 1,
+      },
+      {
+        id: 'existing-assistant-2',
+        source: 'agent',
+        message: {
+          type: 'assistant',
+          message: { role: 'assistant', content: [{ type: 'text', text: 'after tool' }] },
+        },
+        timestamp: '2026-02-14T00:00:04.000Z',
+        order: 2,
+      },
+    ];
+
+    mocks.findById.mockResolvedValue({
+      provider: 'CODEX',
+      status: 'RUNNING',
+      model: 'gpt-5.3-codex',
+      providerSessionId: 'codex-provider-session-1',
+      workspace: { status: 'READY', worktreePath: '/tmp/worktree' },
+    });
+    mocks.isHistoryHydrated.mockReturnValue(true);
+    mocks.getTranscriptSnapshot.mockReturnValue(existingTranscript);
+    mocks.loadCodexSessionHistory.mockResolvedValue({
+      status: 'loaded',
+      filePath:
+        '/tmp/.codex/sessions/2026/02/14/rollout-2026-02-14T00-00-00-codex-provider-session-1.jsonl',
+      history: [
+        {
+          type: 'assistant',
+          content: 'before tool',
+          timestamp: '2026-02-14T00:00:01.000Z',
+        },
+        {
+          type: 'tool_use',
+          content: '',
+          timestamp: '2026-02-14T00:00:02.000Z',
+          toolName: 'exec_command',
+          toolId: 'call-missing',
+          toolInput: { cmd: 'pwd', workdir: '/missing' },
+        },
+        {
+          type: 'tool_result',
+          content: 'failed before process start',
+          timestamp: '2026-02-14T00:00:03.000Z',
+          toolId: 'call-missing',
+          isError: true,
+        },
+        {
+          type: 'assistant',
+          content: 'after tool',
+          timestamp: '2026-02-14T00:00:04.000Z',
+        },
+      ],
+    });
+
+    const handler = createLoadSessionHandler({
+      getClientCreator: () => null,
+      tryDispatchNextMessage: mocks.tryDispatchNextMessage,
+      setManualDispatchResume: vi.fn(),
+    });
+    const ws = { send: vi.fn() } as unknown as { send: (payload: string) => void };
+    await handler({
+      ws: ws as never,
+      sessionId: 'session-codex-backfill',
+      workingDir: '/tmp/worktree',
+      message: { type: 'load_session' } as never,
+    });
+
+    expect(mocks.loadCodexSessionHistory).toHaveBeenCalledWith({
+      providerSessionId: 'codex-provider-session-1',
+      workingDir: '/tmp/worktree',
+    });
+    expect(mocks.replaceTranscript).toHaveBeenCalledTimes(1);
+    const backfilledTranscript = mocks.replaceTranscript.mock.calls[0]?.[1] ?? [];
+    expect(backfilledTranscript).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: 'agent',
+          message: expect.objectContaining({
+            type: 'stream_event',
+            event: expect.objectContaining({
+              content_block: expect.objectContaining({
+                type: 'tool_use',
+                id: 'call-missing',
+                name: 'exec_command',
+              }),
+            }),
+          }),
+        }),
+        expect.objectContaining({
+          source: 'agent',
+          message: expect.objectContaining({
+            type: 'user',
+            message: expect.objectContaining({
+              content: expect.arrayContaining([
+                expect.objectContaining({
+                  type: 'tool_result',
+                  tool_use_id: 'call-missing',
+                  content: 'failed before process start',
+                  is_error: true,
+                }),
+              ]),
+            }),
+          }),
+        }),
+      ])
+    );
+    expect(backfilledTranscript.map((message: { order: number }) => message.order)).toEqual([
+      0, 1, 2, 3, 4,
+    ]);
+    expect(mocks.replaceTranscript).toHaveBeenCalledWith(
+      'session-codex-backfill',
+      expect.any(Array),
+      {
+        historySource: 'jsonl',
+      }
+    );
+  });
+
+  it('does not duplicate CODEX tool calls already captured by the live transcript', async () => {
+    const existingTranscript = [
+      {
+        id: 'existing-tool',
+        source: 'agent',
+        message: {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_start',
+            index: 0,
+            content_block: {
+              type: 'tool_use',
+              id: 'call-present',
+              name: 'exec_command',
+              input: { cmd: 'pwd' },
+            },
+          },
+        },
+        timestamp: '2026-02-14T00:00:02.000Z',
+        order: 0,
+      },
+      {
+        id: 'existing-result',
+        source: 'agent',
+        message: {
+          type: 'user',
+          message: {
+            role: 'user',
+            content: [{ type: 'tool_result', tool_use_id: 'call-present', content: 'ok' }],
+          },
+        },
+        timestamp: '2026-02-14T00:00:03.000Z',
+        order: 1,
+      },
+    ];
+
+    mocks.findById.mockResolvedValue({
+      provider: 'CODEX',
+      status: 'RUNNING',
+      model: 'gpt-5.3-codex',
+      providerSessionId: 'codex-provider-session-1',
+      workspace: { status: 'READY', worktreePath: '/tmp/worktree' },
+    });
+    mocks.isHistoryHydrated.mockReturnValue(true);
+    mocks.getTranscriptSnapshot.mockReturnValue(existingTranscript);
+    mocks.loadCodexSessionHistory.mockResolvedValue({
+      status: 'loaded',
+      filePath:
+        '/tmp/.codex/sessions/2026/02/14/rollout-2026-02-14T00-00-00-codex-provider-session-1.jsonl',
+      history: [
+        {
+          type: 'tool_use',
+          content: '',
+          timestamp: '2026-02-14T00:00:02.000Z',
+          toolName: 'exec_command',
+          toolId: 'call-present',
+          toolInput: { cmd: 'pwd' },
+        },
+        {
+          type: 'tool_result',
+          content: 'ok',
+          timestamp: '2026-02-14T00:00:03.000Z',
+          toolId: 'call-present',
+        },
+      ],
+    });
+
+    const handler = createLoadSessionHandler({
+      getClientCreator: () => null,
+      tryDispatchNextMessage: mocks.tryDispatchNextMessage,
+      setManualDispatchResume: vi.fn(),
+    });
+    const ws = { send: vi.fn() } as unknown as { send: (payload: string) => void };
+    await handler({
+      ws: ws as never,
+      sessionId: 'session-codex-no-dup',
+      workingDir: '/tmp/worktree',
+      message: { type: 'load_session' } as never,
+    });
+
+    expect(mocks.loadCodexSessionHistory).toHaveBeenCalledTimes(1);
+    expect(mocks.replaceTranscript).not.toHaveBeenCalled();
+  });
+
   it('emits config options using fallback-aware session service method', async () => {
     mocks.findById.mockResolvedValue({
       provider: 'CLAUDE',

--- a/src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.test.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   emitDelta: vi.fn(),
   getTranscriptSnapshot: vi.fn(),
   isHistoryHydrated: vi.fn(),
+  getHistoryHydrationSource: vi.fn(),
   canAttemptHistoryHydration: vi.fn(),
   setHistoryRetryAt: vi.fn(),
   clearHistoryRetryCooldown: vi.fn(),
@@ -54,6 +55,7 @@ vi.mock('@/backend/services/session/service/session-domain.service', () => ({
     emitDelta: mocks.emitDelta,
     getTranscriptSnapshot: mocks.getTranscriptSnapshot,
     isHistoryHydrated: mocks.isHistoryHydrated,
+    getHistoryHydrationSource: mocks.getHistoryHydrationSource,
     canAttemptHistoryHydration: mocks.canAttemptHistoryHydration,
     setHistoryRetryAt: mocks.setHistoryRetryAt,
     clearHistoryRetryCooldown: mocks.clearHistoryRetryCooldown,
@@ -152,6 +154,7 @@ describe('createLoadSessionHandler', () => {
     mocks.getSessionConfigOptionsWithFallback.mockResolvedValue([]);
     mocks.getTranscriptSnapshot.mockReturnValue([]);
     mocks.isHistoryHydrated.mockReturnValue(true);
+    mocks.getHistoryHydrationSource.mockReturnValue(undefined);
     mocks.consumeInitialMessage.mockReturnValue(null);
     mocks.enqueue.mockReturnValue({ position: 0 });
     mocks.loadClaudeSessionHistory.mockResolvedValue({ status: 'not_found' });
@@ -784,6 +787,57 @@ describe('createLoadSessionHandler', () => {
 
     expect(mocks.loadCodexSessionHistory).toHaveBeenCalledTimes(1);
     expect(mocks.replaceTranscript).not.toHaveBeenCalled();
+    expect(mocks.markHistoryHydrated).toHaveBeenCalledWith('session-codex-no-dup', 'none');
+  });
+
+  it('skips CODEX tool backfill after JSONL was already checked', async () => {
+    mocks.findById.mockResolvedValue({
+      provider: 'CODEX',
+      status: 'RUNNING',
+      model: 'gpt-5.3-codex',
+      providerSessionId: 'codex-provider-session-1',
+      workspace: { status: 'READY', worktreePath: '/tmp/worktree' },
+    });
+    mocks.isHistoryHydrated.mockReturnValue(true);
+    mocks.getHistoryHydrationSource.mockReturnValue('none');
+    mocks.getTranscriptSnapshot.mockReturnValue([
+      {
+        id: 'existing-tool',
+        source: 'agent',
+        message: {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_start',
+            index: 0,
+            content_block: {
+              type: 'tool_use',
+              id: 'call-present',
+              name: 'exec_command',
+              input: { cmd: 'pwd' },
+            },
+          },
+        },
+        timestamp: '2026-02-14T00:00:02.000Z',
+        order: 0,
+      },
+    ]);
+
+    const handler = createLoadSessionHandler({
+      getClientCreator: () => null,
+      tryDispatchNextMessage: mocks.tryDispatchNextMessage,
+      setManualDispatchResume: vi.fn(),
+    });
+    const ws = { send: vi.fn() } as unknown as { send: (payload: string) => void };
+    await handler({
+      ws: ws as never,
+      sessionId: 'session-codex-already-checked',
+      workingDir: '/tmp/worktree',
+      message: { type: 'load_session' } as never,
+    });
+
+    expect(mocks.loadCodexSessionHistory).not.toHaveBeenCalled();
+    expect(mocks.replaceTranscript).not.toHaveBeenCalled();
+    expect(mocks.markHistoryHydrated).not.toHaveBeenCalled();
   });
 
   it('emits config options using fallback-aware session service method', async () => {

--- a/src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.ts
@@ -346,8 +346,8 @@ function getCompleteHistoryToolUseIds(historyTranscript: ChatMessage[]): Set<str
 }
 
 function normalizeTranscriptOrder(messages: ChatMessage[]): ChatMessage[] {
-  return messages
-    .toSorted((left, right) => {
+  return [...messages]
+    .sort((left, right) => {
       const leftTime = Date.parse(left.timestamp);
       const rightTime = Date.parse(right.timestamp);
       const leftSortTime = Number.isNaN(leftTime) ? 0 : leftTime;

--- a/src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.ts
@@ -14,10 +14,16 @@ import { sessionService } from '@/backend/services/session/service/lifecycle/ses
 import { sessionDomainService } from '@/backend/services/session/service/session-domain.service';
 import { buildTranscriptFromHistory } from '@/backend/services/session/service/store/session-transcript';
 import { slashCommandCacheService } from '@/backend/services/session/service/store/slash-command-cache.service';
+import type { ChatMessage } from '@/shared/acp-protocol';
 import type { LoadSessionMessage } from '@/shared/websocket';
 
 const logger = createLogger('load-session-handler');
 const HISTORY_READ_RETRY_COOLDOWN_MS = 30_000;
+type ProviderSessionRecord = NonNullable<Awaited<ReturnType<typeof agentSessionAccessor.findById>>>;
+type ProviderHistoryLoadResult =
+  | Awaited<ReturnType<typeof claudeSessionHistoryLoaderService.loadSessionHistory>>
+  | Awaited<ReturnType<typeof codexSessionHistoryLoaderService.loadSessionHistory>>;
+type LoadedProviderHistory = Extract<ProviderHistoryLoadResult, { status: 'loaded' }>;
 
 export function createLoadSessionHandler(
   deps: HandlerRegistryDependencies
@@ -70,18 +76,23 @@ export function createLoadSessionHandler(
 
 async function hydrateProviderHistoryIfNeeded(
   sessionId: string,
-  dbSession: NonNullable<Awaited<ReturnType<typeof agentSessionAccessor.findById>>>
+  dbSession: ProviderSessionRecord
 ): Promise<void> {
   if (dbSession.provider !== 'CLAUDE' && dbSession.provider !== 'CODEX') {
     return;
   }
 
-  if (sessionDomainService.isHistoryHydrated(sessionId)) {
+  const existingTranscript = sessionDomainService.getTranscriptSnapshot(sessionId);
+  const shouldAttemptCodexToolBackfill =
+    dbSession.provider === 'CODEX' &&
+    existingTranscript.length > 0 &&
+    Boolean(dbSession.providerSessionId);
+
+  if (sessionDomainService.isHistoryHydrated(sessionId) && !shouldAttemptCodexToolBackfill) {
     return;
   }
 
-  const transcriptCount = sessionDomainService.getTranscriptSnapshot(sessionId).length;
-  if (transcriptCount > 0) {
+  if (existingTranscript.length > 0 && dbSession.provider !== 'CODEX') {
     sessionDomainService.markHistoryHydrated(sessionId, 'none');
     return;
   }
@@ -93,63 +104,170 @@ async function hydrateProviderHistoryIfNeeded(
   }
 
   if (!sessionDomainService.canAttemptHistoryHydration(sessionId)) {
-    logger.debug('Skipping provider JSONL history hydration during retry cooldown', {
-      sessionId,
-      provider: dbSession.provider,
-      providerSessionId: dbSession.providerSessionId,
-      retryAfterMs: HISTORY_READ_RETRY_COOLDOWN_MS,
-    });
+    logHistoryRetryCooldownSkip(sessionId, dbSession);
     return;
   }
 
   const loadStart = Date.now();
-  const loadResult =
-    dbSession.provider === 'CLAUDE'
-      ? await claudeSessionHistoryLoaderService.loadSessionHistory({
-          providerSessionId: dbSession.providerSessionId,
-          workingDir: dbSession.workspace.worktreePath ?? '',
-        })
-      : await codexSessionHistoryLoaderService.loadSessionHistory({
-          providerSessionId: dbSession.providerSessionId,
-          workingDir: dbSession.workspace.worktreePath ?? '',
-        });
+  const loadResult = await loadProviderHistory(dbSession);
 
   if (loadResult.status === 'loaded') {
-    sessionDomainService.clearHistoryRetryCooldown(sessionId);
-    if (sessionDomainService.isHistoryHydrated(sessionId)) {
-      return;
-    }
-
-    const latestTranscriptCount = sessionDomainService.getTranscriptSnapshot(sessionId).length;
-    if (latestTranscriptCount > 0) {
-      sessionDomainService.markHistoryHydrated(sessionId, 'none');
-      logger.debug(
-        'Skipping provider JSONL history replace because transcript is no longer empty',
-        {
-          sessionId,
-          provider: dbSession.provider,
-          providerSessionId: dbSession.providerSessionId,
-          transcriptCount: latestTranscriptCount,
-          loadDurationMs: Date.now() - loadStart,
-        }
-      );
-      return;
-    }
-
-    const transcript = buildTranscriptFromHistory(loadResult.history);
-    sessionDomainService.replaceTranscript(sessionId, transcript, { historySource: 'jsonl' });
-    logger.debug('Hydrated provider transcript from JSONL history', {
+    handleLoadedProviderHistory({
       sessionId,
-      provider: dbSession.provider,
-      providerSessionId: dbSession.providerSessionId,
-      filePath: loadResult.filePath,
-      historyCount: loadResult.history.length,
-      transcriptCount: transcript.length,
-      loadDurationMs: Date.now() - loadStart,
+      dbSession,
+      loadResult,
+      shouldAttemptCodexToolBackfill,
+      loadStart,
     });
     return;
   }
 
+  handleUnavailableProviderHistory(sessionId, dbSession, loadResult);
+}
+
+function logHistoryRetryCooldownSkip(sessionId: string, dbSession: ProviderSessionRecord): void {
+  logger.debug('Skipping provider JSONL history hydration during retry cooldown', {
+    sessionId,
+    provider: dbSession.provider,
+    providerSessionId: dbSession.providerSessionId,
+    retryAfterMs: HISTORY_READ_RETRY_COOLDOWN_MS,
+  });
+}
+
+async function loadProviderHistory(
+  dbSession: ProviderSessionRecord
+): Promise<ProviderHistoryLoadResult> {
+  const input = {
+    providerSessionId: dbSession.providerSessionId ?? '',
+    workingDir: dbSession.workspace.worktreePath ?? '',
+  };
+
+  if (dbSession.provider === 'CLAUDE') {
+    return await claudeSessionHistoryLoaderService.loadSessionHistory(input);
+  }
+
+  return await codexSessionHistoryLoaderService.loadSessionHistory(input);
+}
+
+function handleLoadedProviderHistory({
+  sessionId,
+  dbSession,
+  loadResult,
+  shouldAttemptCodexToolBackfill,
+  loadStart,
+}: {
+  sessionId: string;
+  dbSession: ProviderSessionRecord;
+  loadResult: LoadedProviderHistory;
+  shouldAttemptCodexToolBackfill: boolean;
+  loadStart: number;
+}): void {
+  sessionDomainService.clearHistoryRetryCooldown(sessionId);
+  if (sessionDomainService.isHistoryHydrated(sessionId) && !shouldAttemptCodexToolBackfill) {
+    return;
+  }
+
+  const transcript = buildTranscriptFromHistory(loadResult.history);
+  const latestTranscript = sessionDomainService.getTranscriptSnapshot(sessionId);
+  if (latestTranscript.length > 0) {
+    handleLoadedHistoryWithExistingTranscript({
+      sessionId,
+      dbSession,
+      loadResult,
+      transcript,
+      latestTranscript,
+      loadStart,
+    });
+    return;
+  }
+
+  sessionDomainService.replaceTranscript(sessionId, transcript, { historySource: 'jsonl' });
+  logger.debug('Hydrated provider transcript from JSONL history', {
+    sessionId,
+    provider: dbSession.provider,
+    providerSessionId: dbSession.providerSessionId,
+    filePath: loadResult.filePath,
+    historyCount: loadResult.history.length,
+    transcriptCount: transcript.length,
+    loadDurationMs: Date.now() - loadStart,
+  });
+}
+
+function handleLoadedHistoryWithExistingTranscript({
+  sessionId,
+  dbSession,
+  loadResult,
+  transcript,
+  latestTranscript,
+  loadStart,
+}: {
+  sessionId: string;
+  dbSession: ProviderSessionRecord;
+  loadResult: LoadedProviderHistory;
+  transcript: ChatMessage[];
+  latestTranscript: ChatMessage[];
+  loadStart: number;
+}): void {
+  if (dbSession.provider === 'CODEX') {
+    backfillCodexToolTranscript({
+      sessionId,
+      dbSession,
+      loadResult,
+      transcript,
+      latestTranscript,
+      loadStart,
+    });
+    return;
+  }
+
+  sessionDomainService.markHistoryHydrated(sessionId, 'none');
+  logger.debug('Skipping provider JSONL history replace because transcript is no longer empty', {
+    sessionId,
+    provider: dbSession.provider,
+    providerSessionId: dbSession.providerSessionId,
+    transcriptCount: latestTranscript.length,
+    loadDurationMs: Date.now() - loadStart,
+  });
+}
+
+function backfillCodexToolTranscript({
+  sessionId,
+  dbSession,
+  loadResult,
+  transcript,
+  latestTranscript,
+  loadStart,
+}: {
+  sessionId: string;
+  dbSession: ProviderSessionRecord;
+  loadResult: LoadedProviderHistory;
+  transcript: ChatMessage[];
+  latestTranscript: ChatMessage[];
+  loadStart: number;
+}): void {
+  const backfilledTranscript = backfillMissingCodexToolTranscript(latestTranscript, transcript);
+  if (!backfilledTranscript) {
+    return;
+  }
+
+  sessionDomainService.replaceTranscript(sessionId, backfilledTranscript, {
+    historySource: 'jsonl',
+  });
+  logger.debug('Backfilled missing Codex tool calls from JSONL history', {
+    sessionId,
+    providerSessionId: dbSession.providerSessionId,
+    filePath: loadResult.filePath,
+    existingTranscriptCount: latestTranscript.length,
+    backfilledTranscriptCount: backfilledTranscript.length,
+    loadDurationMs: Date.now() - loadStart,
+  });
+}
+
+function handleUnavailableProviderHistory(
+  sessionId: string,
+  dbSession: ProviderSessionRecord,
+  loadResult: Exclude<ProviderHistoryLoadResult, { status: 'loaded' }>
+): void {
   if (loadResult.status === 'error') {
     sessionDomainService.setHistoryRetryAt(sessionId, Date.now() + HISTORY_READ_RETRY_COOLDOWN_MS);
     logger.warn('Provider JSONL history hydration failed; keeping session eligible for retry', {
@@ -169,6 +287,120 @@ async function hydrateProviderHistoryIfNeeded(
     providerSessionId: dbSession.providerSessionId,
     loadStatus: loadResult.status,
   });
+}
+
+function getToolUseId(message: ChatMessage): string | null {
+  if (message.source !== 'agent' || !message.message) {
+    return null;
+  }
+
+  const agentMessage = message.message;
+  if (
+    agentMessage.type === 'stream_event' &&
+    agentMessage.event?.type === 'content_block_start' &&
+    agentMessage.event.content_block.type === 'tool_use'
+  ) {
+    return agentMessage.event.content_block.id;
+  }
+
+  const content = agentMessage.message?.content;
+  if (!Array.isArray(content)) {
+    return null;
+  }
+
+  const toolUse = content.find((item) => item.type === 'tool_use');
+  return toolUse?.type === 'tool_use' ? toolUse.id : null;
+}
+
+function getToolResultUseId(message: ChatMessage): string | null {
+  if (message.source !== 'agent' || !message.message) {
+    return null;
+  }
+
+  const content = message.message.message?.content;
+  if (!Array.isArray(content)) {
+    return null;
+  }
+
+  const toolResult = content.find((item) => item.type === 'tool_result');
+  return toolResult?.type === 'tool_result' ? toolResult.tool_use_id : null;
+}
+
+function getCompleteHistoryToolUseIds(historyTranscript: ChatMessage[]): Set<string> {
+  const toolUseIds = new Set<string>();
+  const toolResultIds = new Set<string>();
+
+  for (const message of historyTranscript) {
+    const toolUseId = getToolUseId(message);
+    if (toolUseId) {
+      toolUseIds.add(toolUseId);
+    }
+
+    const toolResultId = getToolResultUseId(message);
+    if (toolResultId) {
+      toolResultIds.add(toolResultId);
+    }
+  }
+
+  return new Set([...toolUseIds].filter((toolUseId) => toolResultIds.has(toolUseId)));
+}
+
+function normalizeTranscriptOrder(messages: ChatMessage[]): ChatMessage[] {
+  return messages
+    .toSorted((left, right) => {
+      const leftTime = Date.parse(left.timestamp);
+      const rightTime = Date.parse(right.timestamp);
+      const leftSortTime = Number.isNaN(leftTime) ? 0 : leftTime;
+      const rightSortTime = Number.isNaN(rightTime) ? 0 : rightTime;
+      if (leftSortTime !== rightSortTime) {
+        return leftSortTime - rightSortTime;
+      }
+      return left.order - right.order;
+    })
+    .map((message, order) => ({ ...message, order }));
+}
+
+function backfillMissingCodexToolTranscript(
+  existingTranscript: ChatMessage[],
+  historyTranscript: ChatMessage[]
+): ChatMessage[] | null {
+  const completeHistoryToolUseIds = getCompleteHistoryToolUseIds(historyTranscript);
+  if (completeHistoryToolUseIds.size === 0) {
+    return null;
+  }
+
+  const existingToolUseIds = new Set<string>();
+  const existingToolResultIds = new Set<string>();
+  for (const message of existingTranscript) {
+    const toolUseId = getToolUseId(message);
+    if (toolUseId) {
+      existingToolUseIds.add(toolUseId);
+    }
+
+    const toolResultId = getToolResultUseId(message);
+    if (toolResultId) {
+      existingToolResultIds.add(toolResultId);
+    }
+  }
+
+  const missingToolMessages = historyTranscript.filter((message) => {
+    const toolUseId = getToolUseId(message);
+    if (toolUseId) {
+      return completeHistoryToolUseIds.has(toolUseId) && !existingToolUseIds.has(toolUseId);
+    }
+
+    const toolResultId = getToolResultUseId(message);
+    if (!toolResultId) {
+      return false;
+    }
+    return completeHistoryToolUseIds.has(toolResultId) && !existingToolResultIds.has(toolResultId);
+  });
+
+  if (missingToolMessages.length === 0) {
+    return null;
+  }
+
+  return normalizeTranscriptOrder([...existingTranscript, ...missingToolMessages]);
 }
 
 async function enqueueInitialMessageIfPresent(

--- a/src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.ts
@@ -19,6 +19,7 @@ import type { LoadSessionMessage } from '@/shared/websocket';
 
 const logger = createLogger('load-session-handler');
 const HISTORY_READ_RETRY_COOLDOWN_MS = 30_000;
+const CODEX_TOOL_BACKFILL_RECHECK_COOLDOWN_MS = 5000;
 type ProviderSessionRecord = NonNullable<Awaited<ReturnType<typeof agentSessionAccessor.findById>>>;
 type ProviderHistoryLoadResult =
   | Awaited<ReturnType<typeof claudeSessionHistoryLoaderService.loadSessionHistory>>
@@ -91,8 +92,7 @@ async function hydrateProviderHistoryIfNeeded(
     dbSession.provider === 'CODEX' &&
     existingTranscript.length > 0 &&
     Boolean(dbSession.providerSessionId) &&
-    historyHydrationSource !== 'jsonl' &&
-    historyHydrationSource !== 'none';
+    historyHydrationSource !== 'jsonl';
 
   if (isHistoryHydrated && !shouldAttemptCodexToolBackfill) {
     return;
@@ -128,15 +128,16 @@ async function hydrateProviderHistoryIfNeeded(
     return;
   }
 
-  handleUnavailableProviderHistory(sessionId, dbSession, loadResult);
+  handleUnavailableProviderHistory(sessionId, dbSession, loadResult, {
+    shouldRecheckCodexToolBackfill: shouldAttemptCodexToolBackfill,
+  });
 }
 
 function logHistoryRetryCooldownSkip(sessionId: string, dbSession: ProviderSessionRecord): void {
-  logger.debug('Skipping provider JSONL history hydration during retry cooldown', {
+  logger.debug('Skipping provider JSONL history hydration during cooldown', {
     sessionId,
     provider: dbSession.provider,
     providerSessionId: dbSession.providerSessionId,
-    retryAfterMs: HISTORY_READ_RETRY_COOLDOWN_MS,
   });
 }
 
@@ -254,6 +255,7 @@ function backfillCodexToolTranscript({
   const backfilledTranscript = backfillMissingCodexToolTranscript(latestTranscript, transcript);
   if (!backfilledTranscript) {
     sessionDomainService.markHistoryHydrated(sessionId, 'none');
+    scheduleCodexToolBackfillRecheck(sessionId);
     return;
   }
 
@@ -273,7 +275,8 @@ function backfillCodexToolTranscript({
 function handleUnavailableProviderHistory(
   sessionId: string,
   dbSession: ProviderSessionRecord,
-  loadResult: Exclude<ProviderHistoryLoadResult, { status: 'loaded' }>
+  loadResult: Exclude<ProviderHistoryLoadResult, { status: 'loaded' }>,
+  options?: { shouldRecheckCodexToolBackfill?: boolean }
 ): void {
   if (loadResult.status === 'error') {
     sessionDomainService.setHistoryRetryAt(sessionId, Date.now() + HISTORY_READ_RETRY_COOLDOWN_MS);
@@ -288,12 +291,22 @@ function handleUnavailableProviderHistory(
 
   sessionDomainService.clearHistoryRetryCooldown(sessionId);
   sessionDomainService.markHistoryHydrated(sessionId, 'none');
+  if (options?.shouldRecheckCodexToolBackfill) {
+    scheduleCodexToolBackfillRecheck(sessionId);
+  }
   logger.debug('Provider JSONL history not available; skipping runtime fallback hydration', {
     sessionId,
     provider: dbSession.provider,
     providerSessionId: dbSession.providerSessionId,
     loadStatus: loadResult.status,
   });
+}
+
+function scheduleCodexToolBackfillRecheck(sessionId: string): void {
+  sessionDomainService.setHistoryRetryAt(
+    sessionId,
+    Date.now() + CODEX_TOOL_BACKFILL_RECHECK_COOLDOWN_MS
+  );
 }
 
 function getToolUseId(message: ChatMessage): string | null {

--- a/src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.ts
@@ -83,12 +83,18 @@ async function hydrateProviderHistoryIfNeeded(
   }
 
   const existingTranscript = sessionDomainService.getTranscriptSnapshot(sessionId);
+  const isHistoryHydrated = sessionDomainService.isHistoryHydrated(sessionId);
+  const historyHydrationSource = isHistoryHydrated
+    ? sessionDomainService.getHistoryHydrationSource(sessionId)
+    : undefined;
   const shouldAttemptCodexToolBackfill =
     dbSession.provider === 'CODEX' &&
     existingTranscript.length > 0 &&
-    Boolean(dbSession.providerSessionId);
+    Boolean(dbSession.providerSessionId) &&
+    historyHydrationSource !== 'jsonl' &&
+    historyHydrationSource !== 'none';
 
-  if (sessionDomainService.isHistoryHydrated(sessionId) && !shouldAttemptCodexToolBackfill) {
+  if (isHistoryHydrated && !shouldAttemptCodexToolBackfill) {
     return;
   }
 
@@ -247,6 +253,7 @@ function backfillCodexToolTranscript({
 }): void {
   const backfilledTranscript = backfillMissingCodexToolTranscript(latestTranscript, transcript);
   if (!backfilledTranscript) {
+    sessionDomainService.markHistoryHydrated(sessionId, 'none');
     return;
   }
 

--- a/src/backend/services/session/service/session-domain.service.test.ts
+++ b/src/backend/services/session/service/session-domain.service.test.ts
@@ -372,6 +372,7 @@ describe('SessionDomainService additional behavior', () => {
     expect(sessionDomainService.isHistoryHydrated('s1')).toBe(false);
     sessionDomainService.markHistoryHydrated('s1', 'jsonl');
     expect(sessionDomainService.isHistoryHydrated('s1')).toBe(true);
+    expect(sessionDomainService.getHistoryHydrationSource('s1')).toBe('jsonl');
 
     sessionDomainService.replaceTranscript(
       's1',
@@ -394,6 +395,7 @@ describe('SessionDomainService additional behavior', () => {
       { historySource: 'acp_fallback' }
     );
 
+    expect(sessionDomainService.getHistoryHydrationSource('s1')).toBe('acp_fallback');
     expect(sessionDomainService.getTranscriptSnapshot('s1').map((m) => m.id)).toEqual(['m1', 'm2']);
 
     const order = sessionDomainService.allocateOrder('s1');

--- a/src/backend/services/session/service/session-domain.service.ts
+++ b/src/backend/services/session/service/session-domain.service.ts
@@ -464,6 +464,11 @@ export class SessionDomainService extends EventEmitter {
     return store.historyHydrated === true;
   }
 
+  getHistoryHydrationSource(sessionId: string): 'jsonl' | 'acp_fallback' | 'none' | undefined {
+    const store = this.registry.getOrCreate(sessionId);
+    return store.historyHydrationSource;
+  }
+
   setHistoryRetryAt(sessionId: string, retryAt: number): void {
     this.registry.setHistoryRetryAt(sessionId, retryAt);
   }


### PR DESCRIPTION
## Summary
- Backfill missing Codex tool call/result pairs from JSONL history when a live transcript already exists.
- Keep the backfill Codex-only and avoid duplicating tool calls already captured by ACP.
- Add regression coverage for missing and already-present Codex tool calls during session load.

## Verification
- pnpm vitest run src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.test.ts
- pnpm typecheck
- pnpm check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session-load transcript mutation for running Codex sessions; incorrect merge or ordering could affect chat replay, though scope is Codex-only and guarded by tests.
> 
> **Overview**
> **Codex sessions** can now **merge missing tool call/result pairs** from provider JSONL when a **live transcript already exists** but did not come from full JSONL hydration (e.g. ACP stream gaps).
> 
> On `load_session`, hydration logic is refactored and gated by **`getHistoryHydrationSource`**: backfill runs only for **CODEX**, with a non-empty transcript and a provider session id, and **skips** when the source is already **`jsonl`**. Matching uses complete tool-use/result pairs from history, **dedupes** by tool id against the live transcript, then **`replaceTranscript`** with timestamp-ordered messages. If nothing is missing, it marks hydration **`none`** and schedules a **5s recheck** (reusing history retry cooldown) so late JSONL entries can be picked up later.
> 
> **`sessionDomainService`** exposes **`getHistoryHydrationSource`**; regression tests cover backfill, no-duplicate, and recheck-after-cooldown paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c33f29e9e86e5a84358e25f1c74868065cc4088. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->