### PR TITLE
Fix ratchet dispatch for review summary feedback

### DIFF
--- a/src/backend/services/ratchet/service/bridges.ts
+++ b/src/backend/services/ratchet/service/bridges.ts
@@ -27,9 +27,16 @@ export interface RatchetSessionBridge {
 export interface RatchetPRFullDetails {
   state: string;
   number: number;
+  url: string;
   reviewDecision: string | null;
   mergeStateStatus?: string;
-  reviews: Array<{ submittedAt: string | null; author: { login: string } }>;
+  reviews: Array<{
+    submittedAt: string | null;
+    author: { login: string };
+    state?: string;
+    body?: string;
+    url?: string;
+  }>;
   comments: Array<{ updatedAt: string; author: { login: string } }>;
   statusCheckRollup: Array<{
     name?: string;

--- a/src/backend/services/ratchet/service/ratchet-pr-state.helpers.test.ts
+++ b/src/backend/services/ratchet/service/ratchet-pr-state.helpers.test.ts
@@ -3,6 +3,7 @@ import { CIStatus, RatchetState } from '@/shared/core';
 import type { PRStateInfo } from './ratchet.types';
 import {
   buildFailedCheckDiagnostics,
+  buildReviewSummariesForPrompt,
   computeCiSnapshotKey,
   computeDispatchSnapshotKey,
   determineRatchetState,
@@ -204,6 +205,63 @@ describe('computeCiSnapshotKey', () => {
     ]);
 
     expect(key).toBe('ci:FAILURE:ci:STARTUP_FAILURE:100');
+  });
+});
+
+describe('buildReviewSummariesForPrompt', () => {
+  it('includes actionable commented review bodies as prompt feedback', () => {
+    const summaries = buildReviewSummariesForPrompt(
+      {
+        url: 'https://github.com/example/repo/pull/1',
+        reviews: [
+          {
+            author: { login: 'cubic-dev-ai' },
+            state: 'COMMENTED',
+            body: 'Please fix the hydration edge case.',
+            url: 'https://github.com/example/repo/pull/1#pullrequestreview-1',
+          },
+        ],
+      },
+      null
+    );
+
+    expect(summaries).toEqual([
+      {
+        author: 'cubic-dev-ai',
+        body: 'Please fix the hydration edge case.',
+        path: 'PR review',
+        line: null,
+        url: 'https://github.com/example/repo/pull/1#pullrequestreview-1',
+      },
+    ]);
+  });
+
+  it('ignores approvals, empty bodies, and the authenticated user', () => {
+    const summaries = buildReviewSummariesForPrompt(
+      {
+        url: 'https://github.com/example/repo/pull/1',
+        reviews: [
+          {
+            author: { login: 'reviewer' },
+            state: 'APPROVED',
+            body: 'Looks good.',
+          },
+          {
+            author: { login: 'reviewer' },
+            state: 'COMMENTED',
+            body: '   ',
+          },
+          {
+            author: { login: 'me' },
+            state: 'CHANGES_REQUESTED',
+            body: 'My own note.',
+          },
+        ],
+      },
+      'me'
+    );
+
+    expect(summaries).toEqual([]);
   });
 });
 

--- a/src/backend/services/ratchet/service/ratchet-pr-state.helpers.ts
+++ b/src/backend/services/ratchet/service/ratchet-pr-state.helpers.ts
@@ -152,6 +152,39 @@ export function computeLatestReviewActivityAtMs(
   return timestamps.length > 0 ? Math.max(...timestamps) : null;
 }
 
+const ACTIONABLE_REVIEW_STATES = new Set(['COMMENTED', 'CHANGES_REQUESTED']);
+
+export function buildReviewSummariesForPrompt(
+  prDetails: {
+    url: string;
+    reviews: Array<{
+      author: { login: string };
+      state?: string;
+      body?: string;
+      url?: string;
+    }>;
+  },
+  authenticatedUsername: string | null
+): PRStateInfo['reviewComments'] {
+  return prDetails.reviews
+    .filter((review) => {
+      if (isIgnoredReviewAuthor(review.author.login, authenticatedUsername)) {
+        return false;
+      }
+      if (!ACTIONABLE_REVIEW_STATES.has(review.state?.toUpperCase() ?? '')) {
+        return false;
+      }
+      return (review.body?.trim().length ?? 0) > 0;
+    })
+    .map((review) => ({
+      author: review.author.login,
+      body: review.body?.trim() ?? '',
+      path: 'PR review',
+      line: null,
+      url: review.url ?? prDetails.url,
+    }));
+}
+
 export function hasNewReviewActivitySinceLastDispatch(
   workspace: WorkspaceWithPR,
   prStateInfo: PRStateInfo,
@@ -390,6 +423,7 @@ export async function fetchPRState(params: {
         line: c.line,
         url: c.url,
       }));
+    const reviewSummaries = buildReviewSummariesForPrompt(prDetails, authenticatedUsername);
 
     return {
       ciStatus,
@@ -400,7 +434,7 @@ export async function fetchPRState(params: {
       statusCheckRollup: reducedStatusCheckRollup,
       prState: prDetails.state,
       prNumber: prDetails.number,
-      reviewComments: filteredReviewComments,
+      reviewComments: [...filteredReviewComments, ...reviewSummaries],
     };
   } catch (error) {
     backoff.handleError(

--- a/src/backend/services/ratchet/service/ratchet.service.test.ts
+++ b/src/backend/services/ratchet/service/ratchet.service.test.ts
@@ -508,6 +508,63 @@ describe('ratchet service (state-change + idle dispatch)', () => {
     });
   });
 
+  it('dispatches for PR review summary feedback without changes requested', async () => {
+    const workspace = {
+      id: 'ws-review-summary',
+      prUrl: 'https://github.com/example/repo/pull/57',
+      prNumber: 57,
+      prState: 'OPEN',
+      prCiStatus: CIStatus.UNKNOWN,
+      ratchetEnabled: true,
+      ratchetState: RatchetState.READY,
+      ratchetActiveSessionId: null,
+      ratchetLastCiRunId: 'ci:SUCCESS|no-changes-requested:old|merge:clean',
+      prReviewLastCheckedAt: new Date('2026-01-02T00:00:00Z'),
+    };
+
+    vi.spyOn(
+      unsafeCoerce<{
+        fetchPRState: (...args: unknown[]) => Promise<unknown>;
+      }>(ratchetService),
+      'fetchPRState'
+    ).mockResolvedValue({
+      ciStatus: CIStatus.SUCCESS,
+      snapshotKey: 'ci:SUCCESS|no-changes-requested:1767315600000|merge:clean',
+      hasChangesRequested: false,
+      hasMergeConflict: false,
+      latestReviewActivityAtMs: new Date('2026-01-02T01:00:00Z').getTime(),
+      statusCheckRollup: null,
+      prState: 'OPEN',
+      prNumber: 57,
+      reviewComments: [
+        {
+          author: 'cubic-dev-ai',
+          body: 'Please fix the hydration edge case.',
+          path: 'PR review',
+          line: null,
+          url: 'https://github.com/example/repo/pull/57#pullrequestreview-1',
+        },
+      ],
+    });
+    vi.mocked(workspaceAccessor.update).mockResolvedValue({} as never);
+    vi.mocked(agentSessionAccessor.findByWorkspaceId).mockResolvedValue([] as never);
+    vi.mocked(fixerSessionService.acquireAndDispatch).mockResolvedValue({
+      status: 'started',
+      sessionId: 'ratchet-session',
+      promptSent: true,
+    } as never);
+
+    const result = await unsafeCoerce<{
+      processWorkspace: (workspaceArg: typeof workspace) => Promise<unknown>;
+    }>(ratchetService).processWorkspace(workspace);
+
+    expect(result).toMatchObject({
+      action: { type: 'TRIGGERED_FIXER' },
+      newState: RatchetState.READY,
+    });
+    expect(fixerSessionService.acquireAndDispatch).toHaveBeenCalled();
+  });
+
   it('treats closed PR as IDLE and does not dispatch', () => {
     const state = unsafeCoerce<{
       determineRatchetState: (pr: unknown) => RatchetState;


### PR DESCRIPTION
## Summary
- Treat actionable PR review summary bodies (`COMMENTED` and `CHANGES_REQUESTED`) as ratchet feedback, not only inline review comments.
- Include those review summaries in the fixer prompt while ignoring approvals, empty reviews, and the authenticated user's own reviews.
- Add regression coverage for review-summary extraction and ratchet dispatch from summary-only feedback.

## Verification
- pnpm vitest run src/backend/services/ratchet/service/ratchet-pr-state.helpers.test.ts src/backend/services/ratchet/service/ratchet.service.test.ts
- pnpm typecheck
- pnpm check

Note: `pnpm check` completed successfully and reported existing Biome `<img>` warnings unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when ratchet triggers fixer sessions based on review text; behavior is narrowed by filters and covered by new tests, but could increase automated fix runs on green PRs.
> 
> **Overview**
> Ratchet now treats **top-level PR review bodies** (not only inline review threads) as fixer feedback when CI is green and GitHub has not marked **changes requested**.
> 
> `buildReviewSummariesForPrompt` maps GitHub reviews in `COMMENTED` or `CHANGES_REQUESTED` with non-empty bodies into the same `reviewComments` shape used for dispatch prompts (`path: 'PR review'`), while skipping approvals, whitespace-only bodies, and the authenticated user. `fetchPRState` **appends** these summaries to inline comments, and `RatchetPRFullDetails` gains `url` plus optional `state`, `body`, and `url` on each review.
> 
> Regression tests cover summary extraction and **fixer dispatch** when only summary-style feedback exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fd698c7725eabf868d7d9e129ae133c5c5add47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->