### PR TITLE
Open workspace file links in chat

### DIFF
--- a/src/client/lib/workspace-file-links.test.ts
+++ b/src/client/lib/workspace-file-links.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { resolveWorkspaceFileLink } from './workspace-file-links';
+
+const WORKTREE = '/Users/martin/factory-factory/worktrees/factory-factory/workspace-demo';
+const ORIGIN = 'http://localhost:3000';
+
+describe('resolveWorkspaceFileLink', () => {
+  it('resolves an absolute workspace path with a line suffix', () => {
+    expect(
+      resolveWorkspaceFileLink(`${WORKTREE}/.planning/codebase/CONCERNS.md:31`, WORKTREE, ORIGIN)
+    ).toBe('.planning/codebase/CONCERNS.md');
+  });
+
+  it('resolves a same-origin URL that wraps an absolute workspace path', () => {
+    expect(
+      resolveWorkspaceFileLink(
+        `${ORIGIN}${WORKTREE}/src/client/App%20Shell.md:12:4`,
+        WORKTREE,
+        ORIGIN
+      )
+    ).toBe('src/client/App Shell.md');
+  });
+
+  it('rejects paths outside the workspace', () => {
+    expect(
+      resolveWorkspaceFileLink('/Users/martin/factory-factory/other/README.md:3', WORKTREE, ORIGIN)
+    ).toBeNull();
+  });
+
+  it('rejects normal external URLs', () => {
+    expect(
+      resolveWorkspaceFileLink('https://github.com/example/repo', WORKTREE, ORIGIN)
+    ).toBeNull();
+  });
+
+  it('rejects same-origin app routes that are not workspace files', () => {
+    expect(
+      resolveWorkspaceFileLink(
+        `${ORIGIN}/projects/factory-factory/workspaces/workspace-demo`,
+        WORKTREE,
+        ORIGIN
+      )
+    ).toBeNull();
+  });
+});

--- a/src/client/lib/workspace-file-links.test.ts
+++ b/src/client/lib/workspace-file-links.test.ts
@@ -27,6 +27,12 @@ describe('resolveWorkspaceFileLink', () => {
     ).toBeNull();
   });
 
+  it('rejects decoded path traversal outside the workspace', () => {
+    expect(
+      resolveWorkspaceFileLink(`${ORIGIN}${WORKTREE}/src/%2e%2e/%2e%2e/README.md`, WORKTREE, ORIGIN)
+    ).toBeNull();
+  });
+
   it('rejects normal external URLs', () => {
     expect(
       resolveWorkspaceFileLink('https://github.com/example/repo', WORKTREE, ORIGIN)

--- a/src/client/lib/workspace-file-links.ts
+++ b/src/client/lib/workspace-file-links.ts
@@ -1,0 +1,56 @@
+function stripLineSuffix(pathname: string): string {
+  return pathname.replace(/(?::\d+){1,2}$/, '');
+}
+
+function normalizePathForComparison(pathname: string): string {
+  return pathname.replace(/\/+$/, '');
+}
+
+function getPathnameFromHref(href: string, origin?: string): string | null {
+  const trimmed = href.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    const base = origin ?? 'http://localhost';
+    const url = new URL(trimmed, base);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:' && url.protocol !== 'file:') {
+      return null;
+    }
+    if (origin && url.origin !== origin && url.protocol !== 'file:') {
+      return null;
+    }
+    return decodeURIComponent(url.pathname);
+  } catch {
+    try {
+      return decodeURIComponent(trimmed);
+    } catch {
+      return trimmed;
+    }
+  }
+}
+
+export function resolveWorkspaceFileLink(
+  href: string | undefined,
+  worktreePath: string | null | undefined,
+  origin = typeof window !== 'undefined' ? window.location.origin : undefined
+): string | null {
+  if (!(href && worktreePath)) {
+    return null;
+  }
+
+  const pathname = getPathnameFromHref(href, origin);
+  if (!pathname) {
+    return null;
+  }
+
+  const filePath = normalizePathForComparison(stripLineSuffix(pathname));
+  const workspaceRoot = normalizePathForComparison(worktreePath);
+  if (!(filePath === workspaceRoot || filePath.startsWith(`${workspaceRoot}/`))) {
+    return null;
+  }
+
+  const relativePath = filePath.slice(workspaceRoot.length).replace(/^\/+/, '');
+  return relativePath.length > 0 ? relativePath : null;
+}

--- a/src/client/lib/workspace-file-links.ts
+++ b/src/client/lib/workspace-file-links.ts
@@ -2,8 +2,42 @@ function stripLineSuffix(pathname: string): string {
   return pathname.replace(/(?::\d+){1,2}$/, '');
 }
 
+function appendNormalizedSegment(
+  segments: string[],
+  segment: string,
+  hasLeadingSlash: boolean
+): void {
+  if (!segment || segment === '.') {
+    return;
+  }
+
+  if (segment === '..') {
+    const previousSegment = segments[segments.length - 1];
+    if (segments.length > 0 && previousSegment !== '..') {
+      segments.pop();
+    } else if (!hasLeadingSlash) {
+      segments.push(segment);
+    }
+    return;
+  }
+
+  segments.push(segment);
+}
+
 function normalizePathForComparison(pathname: string): string {
-  return pathname.replace(/\/+$/, '');
+  const hasLeadingSlash = pathname.startsWith('/');
+  const segments: string[] = [];
+
+  for (const segment of pathname.split('/')) {
+    appendNormalizedSegment(segments, segment, hasLeadingSlash);
+  }
+
+  const normalized = `${hasLeadingSlash ? '/' : ''}${segments.join('/')}`.replace(/\/+$/, '');
+  if (normalized) {
+    return normalized;
+  }
+
+  return hasLeadingSlash ? '/' : '.';
 }
 
 function getPathnameFromHref(href: string, origin?: string): string | null {

--- a/src/client/routes/projects/workspaces/workspace-detail-chat-content.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-chat-content.tsx
@@ -17,6 +17,8 @@ import { useRetryWorkspaceInit } from './use-retry-workspace-init';
 
 export interface ChatContentProps {
   workspaceId: string;
+  resolveWorkspaceFileLink?: (href: string) => string | null;
+  onWorkspaceFileLink?: (path: string) => void;
   messages: ReturnType<typeof useChatWebSocket>['messages'];
   sessionStatus: ReturnType<typeof useChatWebSocket>['sessionStatus'];
   sessionRuntime: SessionRuntimeState;
@@ -273,6 +275,8 @@ export const ChatContent = memo(function ChatContent(props: ChatContentProps) {
           isCompacting={props.isCompacting}
           getUuidForMessageId={props.getUuidForMessageId}
           onRewindToMessage={rewindEnabled ? props.startRewindPreview : undefined}
+          resolveWorkspaceFileLink={props.resolveWorkspaceFileLink}
+          onWorkspaceFileLink={props.onWorkspaceFileLink}
           initBanner={props.initBanner}
         />
       </div>

--- a/src/client/routes/projects/workspaces/workspace-detail-container.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-container.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { trpc } from '@/client/lib/trpc';
 import { isWorkspaceDoneOrMerged } from '@/client/lib/workspace-archive';
+import { resolveWorkspaceFileLink } from '@/client/lib/workspace-file-links';
 import { WorkspaceDetailHeaderSlot } from '@/client/routes/projects/workspaces/workspace-detail-header';
 import { useChatWebSocket } from '@/components/chat';
 import { usePersistentScroll, useWorkspacePanel } from '@/components/workspace';
@@ -133,7 +134,7 @@ export function WorkspaceDetailContainer() {
     void navigate('/projects', { replace: true });
   }, [workspace?.status, slug, navigate]);
 
-  const { rightPanelVisible, setRightPanelVisible, activeTabId, clearScrollState } =
+  const { rightPanelVisible, setRightPanelVisible, activeTabId, clearScrollState, openTab } =
     useWorkspacePanel();
   const { data: userSettings } = trpc.userSettings.get.useQuery();
 
@@ -365,6 +366,18 @@ export function WorkspaceDetailContainer() {
     persistChatScroll();
   }, [onScroll, persistChatScroll]);
 
+  const resolveWorkspaceChatFileLink = useCallback(
+    (href: string) => resolveWorkspaceFileLink(href, workspace?.worktreePath),
+    [workspace?.worktreePath]
+  );
+
+  const handleWorkspaceFileLink = useCallback(
+    (path: string) => {
+      openTab('file', path, path.split('/').pop() ?? path);
+    },
+    [openTab]
+  );
+
   useAutoFocusChatInput({
     workspaceLoading,
     workspace,
@@ -376,6 +389,8 @@ export function WorkspaceDetailContainer() {
 
   const chatViewModel: ChatContentProps = {
     workspaceId,
+    resolveWorkspaceFileLink: resolveWorkspaceChatFileLink,
+    onWorkspaceFileLink: handleWorkspaceFileLink,
     messages,
     sessionStatus,
     sessionRuntime,

--- a/src/components/agent-activity/agent-activity.tsx
+++ b/src/components/agent-activity/agent-activity.tsx
@@ -61,6 +61,8 @@ export interface MessageItemProps {
   userMessageUuid?: string;
   /** Callback to initiate rewind to before this message */
   onRewindToMessage?: (uuid: string) => void;
+  resolveWorkspaceFileLink?: (href: string) => string | null;
+  onWorkspaceFileLink?: (path: string) => void;
 }
 
 export const MessageItem = memo(function MessageItem({
@@ -69,6 +71,8 @@ export const MessageItem = memo(function MessageItem({
   onRemove,
   userMessageUuid,
   onRewindToMessage,
+  resolveWorkspaceFileLink,
+  onWorkspaceFileLink,
 }: MessageItemProps) {
   // User messages
   if (message.source === 'user') {
@@ -176,11 +180,21 @@ export const MessageItem = memo(function MessageItem({
       <MessageWrapper>
         {assistantText !== null ? (
           <div className="group relative">
-            <AssistantMessageRenderer message={message.message} messageId={message.id} />
+            <AssistantMessageRenderer
+              message={message.message}
+              messageId={message.id}
+              resolveWorkspaceFileLink={resolveWorkspaceFileLink}
+              onWorkspaceFileLink={onWorkspaceFileLink}
+            />
             <CopyMessageButton textContent={assistantText} />
           </div>
         ) : (
-          <AssistantMessageRenderer message={message.message} messageId={message.id} />
+          <AssistantMessageRenderer
+            message={message.message}
+            messageId={message.id}
+            resolveWorkspaceFileLink={resolveWorkspaceFileLink}
+            onWorkspaceFileLink={onWorkspaceFileLink}
+          />
         )}
       </MessageWrapper>
     );
@@ -203,6 +217,8 @@ export interface GroupedMessageItemRendererProps {
   userMessageUuid?: string;
   /** Callback to initiate rewind to before this message */
   onRewindToMessage?: (uuid: string) => void;
+  resolveWorkspaceFileLink?: (href: string) => string | null;
+  onWorkspaceFileLink?: (path: string) => void;
   /** Reads persisted expansion state by key */
   getToolExpansionState?: (key: string, defaultOpen: boolean) => boolean;
   /** Persists expansion state by key */
@@ -220,6 +236,8 @@ export const GroupedMessageItemRenderer = memo(function GroupedMessageItemRender
   onRemove,
   userMessageUuid,
   onRewindToMessage,
+  resolveWorkspaceFileLink,
+  onWorkspaceFileLink,
   getToolExpansionState,
   setToolExpansionState,
   toolExpansionToken: _toolExpansionToken,
@@ -260,6 +278,8 @@ export const GroupedMessageItemRenderer = memo(function GroupedMessageItemRender
       onRemove={onRemove}
       userMessageUuid={userMessageUuid}
       onRewindToMessage={onRewindToMessage}
+      resolveWorkspaceFileLink={resolveWorkspaceFileLink}
+      onWorkspaceFileLink={onWorkspaceFileLink}
     />
   );
 });

--- a/src/components/agent-activity/message-renderers/assistant-message-renderer.tsx
+++ b/src/components/agent-activity/message-renderers/assistant-message-renderer.tsx
@@ -1,7 +1,6 @@
 import { Loader2 } from 'lucide-react';
 import { memo } from 'react';
 import { ToolInfoRenderer } from '@/components/agent-activity/tool-renderers';
-import { MarkdownRenderer } from '@/components/ui/markdown';
 import type { AgentMessage } from '@/lib/chat-protocol';
 import {
   extractTextFromMessage,
@@ -15,6 +14,7 @@ import {
   ResultRenderer,
   StreamEventRenderer,
   SystemMessageRenderer,
+  TextRenderer,
   ThinkingRenderer,
 } from './stream-event-renderer';
 
@@ -48,7 +48,14 @@ export const AssistantMessageRenderer = memo(function AssistantMessageRenderer({
 
   // Handle result messages with stats
   if (message.type === 'result') {
-    return <ResultRenderer message={message} className={className} />;
+    return (
+      <ResultRenderer
+        message={message}
+        className={className}
+        resolveWorkspaceFileLink={resolveWorkspaceFileLink}
+        onWorkspaceFileLink={onWorkspaceFileLink}
+      />
+    );
   }
 
   // Handle error messages
@@ -78,6 +85,8 @@ export const AssistantMessageRenderer = memo(function AssistantMessageRenderer({
           text={firstContent.thinking}
           messageId={messageId}
           className={className}
+          resolveWorkspaceFileLink={resolveWorkspaceFileLink}
+          onWorkspaceFileLink={onWorkspaceFileLink}
         />
       );
     }
@@ -127,33 +136,6 @@ export const ToolCallRenderer = memo(function ToolCallRenderer({
     <div className={cn('my-1', className)}>
       <ToolInfoRenderer message={message} />
     </div>
-  );
-});
-
-// =============================================================================
-// Text Renderer
-// =============================================================================
-
-interface TextRendererProps {
-  text: string;
-  resolveWorkspaceFileLink?: (href: string) => string | null;
-  onWorkspaceFileLink?: (path: string) => void;
-}
-
-/**
- * Renders text content with full markdown support.
- */
-const TextRenderer = memo(function TextRenderer({
-  text,
-  resolveWorkspaceFileLink,
-  onWorkspaceFileLink,
-}: TextRendererProps) {
-  return (
-    <MarkdownRenderer
-      content={text}
-      resolveWorkspaceFileLink={resolveWorkspaceFileLink}
-      onWorkspaceFileLink={onWorkspaceFileLink}
-    />
   );
 });
 

--- a/src/components/agent-activity/message-renderers/assistant-message-renderer.tsx
+++ b/src/components/agent-activity/message-renderers/assistant-message-renderer.tsx
@@ -27,6 +27,8 @@ interface AssistantMessageRendererProps {
   /** The ID of the ChatMessage containing this AgentMessage (for thinking completion tracking) */
   messageId?: string;
   className?: string;
+  resolveWorkspaceFileLink?: (href: string) => string | null;
+  onWorkspaceFileLink?: (path: string) => void;
 }
 
 /**
@@ -36,6 +38,8 @@ export const AssistantMessageRenderer = memo(function AssistantMessageRenderer({
   message,
   messageId,
   className,
+  resolveWorkspaceFileLink,
+  onWorkspaceFileLink,
 }: AssistantMessageRendererProps) {
   // Handle tool use/result messages
   if (isToolUseMessage(message) || isToolResultMessage(message)) {
@@ -55,7 +59,13 @@ export const AssistantMessageRenderer = memo(function AssistantMessageRenderer({
   // Handle stream events
   if (message.type === 'stream_event' && message.event) {
     return (
-      <StreamEventRenderer event={message.event} messageId={messageId} className={className} />
+      <StreamEventRenderer
+        event={message.event}
+        messageId={messageId}
+        className={className}
+        resolveWorkspaceFileLink={resolveWorkspaceFileLink}
+        onWorkspaceFileLink={onWorkspaceFileLink}
+      />
     );
   }
 
@@ -80,7 +90,11 @@ export const AssistantMessageRenderer = memo(function AssistantMessageRenderer({
       <div
         className={cn('prose prose-sm dark:prose-invert max-w-none text-sm break-words', className)}
       >
-        <TextRenderer text={text} />
+        <TextRenderer
+          text={text}
+          resolveWorkspaceFileLink={resolveWorkspaceFileLink}
+          onWorkspaceFileLink={onWorkspaceFileLink}
+        />
       </div>
     );
   }
@@ -122,13 +136,25 @@ export const ToolCallRenderer = memo(function ToolCallRenderer({
 
 interface TextRendererProps {
   text: string;
+  resolveWorkspaceFileLink?: (href: string) => string | null;
+  onWorkspaceFileLink?: (path: string) => void;
 }
 
 /**
  * Renders text content with full markdown support.
  */
-const TextRenderer = memo(function TextRenderer({ text }: TextRendererProps) {
-  return <MarkdownRenderer content={text} />;
+const TextRenderer = memo(function TextRenderer({
+  text,
+  resolveWorkspaceFileLink,
+  onWorkspaceFileLink,
+}: TextRendererProps) {
+  return (
+    <MarkdownRenderer
+      content={text}
+      resolveWorkspaceFileLink={resolveWorkspaceFileLink}
+      onWorkspaceFileLink={onWorkspaceFileLink}
+    />
+  );
 });
 
 // =============================================================================

--- a/src/components/agent-activity/message-renderers/stream-event-renderer.tsx
+++ b/src/components/agent-activity/message-renderers/stream-event-renderer.tsx
@@ -46,7 +46,13 @@ export const StreamEventRenderer = memo(function StreamEventRenderer({
       }
       if (isThinkingContent(block)) {
         return (
-          <ThinkingRenderer text={block.thinking} messageId={messageId} className={className} />
+          <ThinkingRenderer
+            text={block.thinking}
+            messageId={messageId}
+            className={className}
+            resolveWorkspaceFileLink={resolveWorkspaceFileLink}
+            onWorkspaceFileLink={onWorkspaceFileLink}
+          />
         );
       }
       // Tool use blocks are handled by ToolInfoRenderer
@@ -99,7 +105,7 @@ export const StreamDeltaRenderer = memo(function StreamDeltaRenderer({
 // Text Renderer
 // =============================================================================
 
-interface TextRendererProps {
+export interface TextRendererProps {
   text: string;
   resolveWorkspaceFileLink?: (href: string) => string | null;
   onWorkspaceFileLink?: (path: string) => void;
@@ -108,7 +114,7 @@ interface TextRendererProps {
 /**
  * Renders text content with full markdown support.
  */
-const TextRenderer = memo(function TextRenderer({
+export const TextRenderer = memo(function TextRenderer({
   text,
   resolveWorkspaceFileLink,
   onWorkspaceFileLink,
@@ -131,6 +137,8 @@ interface ThinkingRendererProps {
   /** The ID of the ChatMessage containing this thinking block (for completion tracking) */
   messageId?: string;
   className?: string;
+  resolveWorkspaceFileLink?: (href: string) => string | null;
+  onWorkspaceFileLink?: (path: string) => void;
 }
 
 /**
@@ -144,6 +152,8 @@ export const ThinkingRenderer = memo(function ThinkingRenderer({
   text,
   messageId,
   className,
+  resolveWorkspaceFileLink,
+  onWorkspaceFileLink,
 }: ThinkingRendererProps) {
   const isInProgress = useIsThinkingInProgress(messageId);
 
@@ -158,7 +168,12 @@ export const ThinkingRenderer = memo(function ThinkingRenderer({
         <Loader2 className={cn('h-3 w-3', isInProgress && 'animate-spin')} />
         <span>Thinking</span>
       </div>
-      <MarkdownRenderer content={text} className="text-muted-foreground" />
+      <MarkdownRenderer
+        content={text}
+        className="text-muted-foreground"
+        resolveWorkspaceFileLink={resolveWorkspaceFileLink}
+        onWorkspaceFileLink={onWorkspaceFileLink}
+      />
     </div>
   );
 });
@@ -250,6 +265,8 @@ export const SystemMessageRenderer = memo(function SystemMessageRenderer({
 interface ResultRendererProps {
   message: AgentMessage;
   className?: string;
+  resolveWorkspaceFileLink?: (href: string) => string | null;
+  onWorkspaceFileLink?: (path: string) => void;
 }
 
 /**
@@ -259,13 +276,19 @@ interface ResultRendererProps {
 export const ResultRenderer = memo(function ResultRenderer({
   message,
   className,
+  resolveWorkspaceFileLink,
+  onWorkspaceFileLink,
 }: ResultRendererProps) {
   // Result messages often just indicate completion; we may not need to render them visibly
   // But if there's result content, show it with proper markdown formatting
   if (message.result && typeof message.result === 'string') {
     return (
       <div className={cn('prose prose-sm dark:prose-invert max-w-none text-sm', className)}>
-        <MarkdownRenderer content={message.result} />
+        <MarkdownRenderer
+          content={message.result}
+          resolveWorkspaceFileLink={resolveWorkspaceFileLink}
+          onWorkspaceFileLink={onWorkspaceFileLink}
+        />
       </div>
     );
   }

--- a/src/components/agent-activity/message-renderers/stream-event-renderer.tsx
+++ b/src/components/agent-activity/message-renderers/stream-event-renderer.tsx
@@ -16,6 +16,8 @@ interface StreamEventRendererProps {
   /** The ID of the ChatMessage containing this event (for thinking completion tracking) */
   messageId?: string;
   className?: string;
+  resolveWorkspaceFileLink?: (href: string) => string | null;
+  onWorkspaceFileLink?: (path: string) => void;
 }
 
 /**
@@ -25,6 +27,8 @@ export const StreamEventRenderer = memo(function StreamEventRenderer({
   event,
   messageId,
   className,
+  resolveWorkspaceFileLink,
+  onWorkspaceFileLink,
 }: StreamEventRendererProps) {
   switch (event.type) {
     case 'content_block_start': {
@@ -32,7 +36,11 @@ export const StreamEventRenderer = memo(function StreamEventRenderer({
       if (isTextContent(block)) {
         return (
           <div className={cn('prose prose-sm dark:prose-invert max-w-none text-sm', className)}>
-            <TextRenderer text={block.text} />
+            <TextRenderer
+              text={block.text}
+              resolveWorkspaceFileLink={resolveWorkspaceFileLink}
+              onWorkspaceFileLink={onWorkspaceFileLink}
+            />
           </div>
         );
       }
@@ -93,13 +101,25 @@ export const StreamDeltaRenderer = memo(function StreamDeltaRenderer({
 
 interface TextRendererProps {
   text: string;
+  resolveWorkspaceFileLink?: (href: string) => string | null;
+  onWorkspaceFileLink?: (path: string) => void;
 }
 
 /**
  * Renders text content with full markdown support.
  */
-const TextRenderer = memo(function TextRenderer({ text }: TextRendererProps) {
-  return <MarkdownRenderer content={text} />;
+const TextRenderer = memo(function TextRenderer({
+  text,
+  resolveWorkspaceFileLink,
+  onWorkspaceFileLink,
+}: TextRendererProps) {
+  return (
+    <MarkdownRenderer
+      content={text}
+      resolveWorkspaceFileLink={resolveWorkspaceFileLink}
+      onWorkspaceFileLink={onWorkspaceFileLink}
+    />
+  );
 });
 
 // =============================================================================

--- a/src/components/chat/virtualized-message-list.tsx
+++ b/src/components/chat/virtualized-message-list.tsx
@@ -44,6 +44,8 @@ interface VirtualizedMessageListProps {
   getUuidForMessageId?: (messageId: string) => string | undefined;
   /** Callback when user initiates rewind to a message */
   onRewindToMessage?: (uuid: string) => void;
+  resolveWorkspaceFileLink?: (href: string) => string | null;
+  onWorkspaceFileLink?: (path: string) => void;
   /** Init banner for showing workspace initialization status */
   initBanner?: WorkspaceInitBanner | null;
 }
@@ -119,6 +121,8 @@ interface VirtualRowProps {
   userMessageUuid?: string;
   /** Callback when user initiates rewind to this message */
   onRewindToMessage?: (uuid: string) => void;
+  resolveWorkspaceFileLink?: (href: string) => string | null;
+  onWorkspaceFileLink?: (path: string) => void;
   /** Reads persisted expansion state for tool rows/groups */
   getToolExpansionState?: (key: string, defaultOpen: boolean) => boolean;
   /** Persists expansion state for tool rows/groups */
@@ -135,6 +139,8 @@ const VirtualRow = memo(function VirtualRow({
   onRemove,
   userMessageUuid,
   onRewindToMessage,
+  resolveWorkspaceFileLink,
+  onWorkspaceFileLink,
   getToolExpansionState,
   setToolExpansionState,
   toolExpansionToken,
@@ -147,6 +153,8 @@ const VirtualRow = memo(function VirtualRow({
         onRemove={onRemove}
         userMessageUuid={userMessageUuid}
         onRewindToMessage={onRewindToMessage}
+        resolveWorkspaceFileLink={resolveWorkspaceFileLink}
+        onWorkspaceFileLink={onWorkspaceFileLink}
         getToolExpansionState={getToolExpansionState}
         setToolExpansionState={setToolExpansionState}
         toolExpansionToken={toolExpansionToken}
@@ -176,6 +184,8 @@ export const VirtualizedMessageList = memo(function VirtualizedMessageList({
   isCompacting = false,
   getUuidForMessageId,
   onRewindToMessage,
+  resolveWorkspaceFileLink,
+  onWorkspaceFileLink,
   initBanner,
 }: VirtualizedMessageListProps) {
   const { getExpansionState, setExpansionState } = useWorkspaceToolExpansionState(workspaceId);
@@ -513,6 +523,8 @@ export const VirtualizedMessageList = memo(function VirtualizedMessageList({
                   }
                   userMessageUuid={userMessageUuid}
                   onRewindToMessage={onRewindToMessage}
+                  resolveWorkspaceFileLink={resolveWorkspaceFileLink}
+                  onWorkspaceFileLink={onWorkspaceFileLink}
                   getToolExpansionState={getToolExpansionState}
                   setToolExpansionState={setToolExpansionState}
                   toolExpansionToken={toolExpansionToken}

--- a/src/components/ui/markdown.test.tsx
+++ b/src/components/ui/markdown.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+
+import { createElement } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MarkdownRenderer } from './markdown';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('MarkdownRenderer workspace file links', () => {
+  it('intercepts resolved workspace file links', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const onWorkspaceFileLink = vi.fn();
+
+    flushSync(() => {
+      root.render(
+        createElement(MarkdownRenderer, {
+          content: '[Concerns](/Users/demo/workspace/.planning/CONCERNS.md:31)',
+          resolveWorkspaceFileLink: () => '.planning/CONCERNS.md',
+          onWorkspaceFileLink,
+        })
+      );
+    });
+
+    const link = container.querySelector('a');
+    expect(link?.getAttribute('target')).toBeNull();
+
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+    const wasNotCanceled = link?.dispatchEvent(event);
+
+    expect(wasNotCanceled).toBe(false);
+    expect(onWorkspaceFileLink).toHaveBeenCalledWith('.planning/CONCERNS.md');
+
+    root.unmount();
+  });
+
+  it('keeps external links opening in a new tab', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const onWorkspaceFileLink = vi.fn();
+
+    flushSync(() => {
+      root.render(
+        createElement(MarkdownRenderer, {
+          content: '[GitHub](https://github.com/example/repo)',
+          resolveWorkspaceFileLink: () => null,
+          onWorkspaceFileLink,
+        })
+      );
+    });
+
+    const link = container.querySelector('a');
+    expect(link?.getAttribute('target')).toBe('_blank');
+    expect(link?.getAttribute('rel')).toBe('noopener noreferrer');
+
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+    const wasNotCanceled = link?.dispatchEvent(event);
+
+    expect(wasNotCanceled).toBe(true);
+    expect(onWorkspaceFileLink).not.toHaveBeenCalled();
+
+    root.unmount();
+  });
+});

--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink } from 'lucide-react';
+import { ExternalLink, FileCode } from 'lucide-react';
 import mermaid from 'mermaid';
 import {
   type ComponentPropsWithoutRef,
@@ -25,6 +25,8 @@ if (typeof window !== 'undefined') {
 interface MarkdownRendererProps {
   content: string;
   className?: string;
+  resolveWorkspaceFileLink?: (href: string) => string | null;
+  onWorkspaceFileLink?: (path: string) => void;
 }
 
 // Component to render Mermaid diagrams
@@ -67,6 +69,8 @@ function MermaidDiagram({ chart }: { chart: string }) {
 export const MarkdownRenderer = memo(function MarkdownRenderer({
   content,
   className,
+  resolveWorkspaceFileLink,
+  onWorkspaceFileLink,
 }: MarkdownRendererProps) {
   // Memoize the markdown components to prevent recreating on every render
   const components = useMemo(
@@ -116,23 +120,42 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
         );
       },
       // Override link rendering
-      a: ({ href, children }: ComponentPropsWithoutRef<'a'>) => (
-        <a
-          href={href}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-primary underline hover:no-underline inline-flex items-center gap-0.5"
-        >
-          {children}
-          <ExternalLink className="h-3 w-3 shrink-0" />
-        </a>
-      ),
+      a: ({ href, children }: ComponentPropsWithoutRef<'a'>) => {
+        const workspacePath = href ? resolveWorkspaceFileLink?.(href) : null;
+        if (workspacePath && onWorkspaceFileLink) {
+          return (
+            <a
+              href={href}
+              onClick={(event) => {
+                event.preventDefault();
+                onWorkspaceFileLink(workspacePath);
+              }}
+              className="text-primary underline hover:no-underline inline-flex items-center gap-0.5"
+            >
+              {children}
+              <FileCode className="h-3 w-3 shrink-0" />
+            </a>
+          );
+        }
+
+        return (
+          <a
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary underline hover:no-underline inline-flex items-center gap-0.5"
+          >
+            {children}
+            <ExternalLink className="h-3 w-3 shrink-0" />
+          </a>
+        );
+      },
       // Override paragraph with comfortable spacing
       p: ({ children }: ComponentPropsWithoutRef<'p'>) => (
         <p className="mb-4 last:mb-0">{children}</p>
       ),
     }),
-    []
+    [onWorkspaceFileLink, resolveWorkspaceFileLink]
   );
 
   return (


### PR DESCRIPTION
## Summary
- Open chat markdown links that point inside the current workspace as workspace file tabs instead of browser tabs.
- Add workspace-file link normalization for absolute local paths, same-origin URL-wrapped paths, encoded paths, and trailing line/column suffixes.
- Thread optional workspace link handlers through the chat/assistant markdown rendering path while keeping external links opening in a new tab.

## Tests
- pnpm exec vitest run src/client/lib/workspace-file-links.test.ts src/components/ui/markdown.test.tsx
- pnpm exec biome check src/client/lib/workspace-file-links.ts src/client/lib/workspace-file-links.test.ts src/components/ui/markdown.tsx src/components/ui/markdown.test.tsx src/components/agent-activity/agent-activity.tsx src/components/agent-activity/message-renderers/assistant-message-renderer.tsx src/components/agent-activity/message-renderers/stream-event-renderer.tsx src/components/chat/virtualized-message-list.tsx src/client/routes/projects/workspaces/workspace-detail-chat-content.tsx src/client/routes/projects/workspaces/workspace-detail-container.tsx
- pnpm typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI/navigation change with path containment checks and unit tests; no auth or server changes.
> 
> **Overview**
> Chat markdown links that point at files under the current worktree now open in the workspace **file** panel instead of a new browser tab.
> 
> A new **`resolveWorkspaceFileLink`** helper normalizes hrefs (absolute paths, same-origin URL-wrapped paths, URL decoding, line/column suffixes) and returns a workspace-relative path only when the target stays inside the worktree; traversal and non-file URLs are rejected. **`MarkdownRenderer`** uses optional resolve/click handlers to intercept those links (with a file icon); other links still use **`target="_blank"`**.
> 
> The workspace detail view wires resolution to **`worktreePath`** and **`openTab('file', …)`**, and passes the handlers through the virtualized chat list into assistant/thinking/result markdown rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 316725ccb06a3086bfa81f9093dc0a4c9cf9ff6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->