### PR TITLE
Honor Codex default reasoning effort after plan approval

### DIFF
--- a/src/backend/services/session/service/acp/codex-app-server-adapter/session-config-resolver.test.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/session-config-resolver.test.ts
@@ -246,4 +246,26 @@ describe('session-config-resolver helpers', () => {
       },
     });
   });
+
+  it('resolves default collaboration mode with session defaults', () => {
+    const session = createSession({
+      defaults: {
+        ...createSession().defaults,
+        collaborationMode: 'default',
+        model: 'gpt-5-mini',
+        reasoningEffort: 'high',
+      },
+    });
+
+    const mode = resolveTurnCollaborationMode(collaborationModes, session);
+
+    expect(mode).toEqual({
+      mode: 'default',
+      settings: {
+        model: 'gpt-5-mini',
+        reasoning_effort: 'high',
+        developer_instructions: null,
+      },
+    });
+  });
 });

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/session-config-resolver.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/session-config-resolver.ts
@@ -287,12 +287,17 @@ export function resolveTurnCollaborationMode(
   const modeEntry = collaborationModes.find(
     (entry) => entry.mode === session.defaults.collaborationMode
   );
+  const shouldUseSessionDefaults = session.defaults.collaborationMode.toLowerCase() === 'default';
 
   return {
     mode: modeEntry?.mode ?? session.defaults.collaborationMode,
     settings: {
-      model: modeEntry?.model ?? session.defaults.model,
-      reasoning_effort: modeEntry?.reasoningEffort ?? session.defaults.reasoningEffort,
+      model: shouldUseSessionDefaults
+        ? session.defaults.model
+        : (modeEntry?.model ?? session.defaults.model),
+      reasoning_effort: shouldUseSessionDefaults
+        ? session.defaults.reasoningEffort
+        : (modeEntry?.reasoningEffort ?? session.defaults.reasoningEffort),
       developer_instructions: modeEntry?.developerInstructions ?? null,
     },
   };

--- a/src/backend/services/session/service/lifecycle/session.config.service.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.config.service.test.ts
@@ -631,6 +631,51 @@ describe('SessionConfigService', () => {
     );
   });
 
+  it('applies configured reasoning effort to a new ACP handle without immediate emit when requested', async () => {
+    vi.mocked(userSettingsAccessor.get).mockResolvedValue(
+      unsafeCoerce({
+        defaultCodexReasoningEffort: 'high',
+      })
+    );
+    const handle = unsafeCoerce<AcpProcessHandle>({
+      provider: 'CODEX',
+      providerSessionId: 'provider-codex-1',
+      configOptions: [
+        {
+          id: 'reasoning_effort',
+          name: 'Reasoning Effort',
+          type: 'select',
+          category: 'thought_level',
+          currentValue: 'medium',
+          options: [
+            { value: 'medium', name: 'Medium' },
+            { value: 'high', name: 'High' },
+          ],
+        },
+      ],
+    });
+    runtimeManager.setConfigOption.mockResolvedValue([
+      {
+        ...handle.configOptions[0],
+        currentValue: 'high',
+      },
+    ]);
+
+    await service.applyConfiguredReasoningEffort('session-1', handle, {
+      persistSnapshot: false,
+      emitUpdates: false,
+    });
+
+    expect(runtimeManager.setConfigOption).toHaveBeenCalledWith(
+      'session-1',
+      'reasoning_effort',
+      'high'
+    );
+    expect(handle.configOptions[0]?.currentValue).toBe('high');
+    expect(repository.updateSession).not.toHaveBeenCalled();
+    expect(sessionDomain.emitDelta).not.toHaveBeenCalled();
+  });
+
   it('updates cached config snapshot when setting config on inactive session', async () => {
     runtimeManager.getClient.mockReturnValue(undefined);
     repository.getSessionById.mockResolvedValue(

--- a/src/backend/services/session/service/lifecycle/session.config.service.ts
+++ b/src/backend/services/session/service/lifecycle/session.config.service.ts
@@ -322,6 +322,32 @@ export class SessionConfigService {
     });
   }
 
+  async applyConfiguredReasoningEffort(
+    sessionId: string,
+    handle: AcpProcessHandle,
+    options?: {
+      persistSnapshot?: boolean;
+      emitUpdates?: boolean;
+    }
+  ): Promise<void> {
+    const targetReasoningEffort = await this.resolveConfiguredReasoningEffortFromSettings(
+      sessionId,
+      handle.provider as SessionProvider
+    );
+    if (!targetReasoningEffort) {
+      return;
+    }
+
+    await this.applyReasoningEffortTarget({
+      sessionId,
+      handle,
+      targetReasoningEffort,
+      source: 'settings',
+      persistSnapshot: options?.persistSnapshot,
+      emitUpdates: options?.emitUpdates,
+    });
+  }
+
   async setSessionConfigOption(sessionId: string, configId: string, value: string): Promise<void> {
     const acpHandle = this.runtimeManager.getClient(sessionId);
     if (!acpHandle) {
@@ -654,6 +680,8 @@ export class SessionConfigService {
     handle: AcpProcessHandle;
     targetReasoningEffort: string;
     source: 'message' | 'settings';
+    persistSnapshot?: boolean;
+    emitUpdates?: boolean;
   }): Promise<void> {
     const reasoningOption = params.handle.configOptions.find(
       (option) =>
@@ -696,19 +724,23 @@ export class SessionConfigService {
       params.targetReasoningEffort
     );
     params.handle.configOptions = configOptions;
-    await this.persistAcpConfigSnapshot(params.sessionId, {
-      provider: params.handle.provider as SessionProvider,
-      providerSessionId: params.handle.providerSessionId,
-      configOptions,
-    });
-    this.sessionDomainService.emitDelta(params.sessionId, {
-      type: 'config_options_update',
-      configOptions,
-    } as SessionDeltaEvent);
-    this.sessionDomainService.emitDelta(params.sessionId, {
-      type: 'chat_capabilities',
-      capabilities: this.buildAcpChatBarCapabilities(params.handle),
-    });
+    if (params.persistSnapshot !== false) {
+      await this.persistAcpConfigSnapshot(params.sessionId, {
+        provider: params.handle.provider as SessionProvider,
+        providerSessionId: params.handle.providerSessionId,
+        configOptions,
+      });
+    }
+    if (params.emitUpdates !== false) {
+      this.sessionDomainService.emitDelta(params.sessionId, {
+        type: 'config_options_update',
+        configOptions,
+      } as SessionDeltaEvent);
+      this.sessionDomainService.emitDelta(params.sessionId, {
+        type: 'chat_capabilities',
+        capabilities: this.buildAcpChatBarCapabilities(params.handle),
+      });
+    }
   }
 
   private resolveConfiguredExecutionModeTarget(

--- a/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
+++ b/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
@@ -511,6 +511,10 @@ export class SessionLifecycleService {
         workspaceId: sessionContext.workspaceId,
         workingDir: sessionContext.workingDir,
       });
+      await this.sessionConfigService.applyConfiguredReasoningEffort(sessionId, handle, {
+        persistSnapshot: false,
+        emitUpdates: false,
+      });
     } catch (error) {
       this.acpEventProcessor.clearSessionState(sessionId);
       throw error;


### PR DESCRIPTION
## Summary
- Apply configured default reasoning effort when ACP sessions start so Codex sessions begin with the user preference instead of provider defaults.
- Keep Codex `default` collaboration mode on the session-selected model and reasoning effort after approving a plan, while preserving mode-specific defaults for plan mode.
- Add focused coverage for startup reasoning defaults and default-mode turn resolution.

## Tests
- `pnpm vitest run src/backend/services/session/service/acp/codex-app-server-adapter/session-config-resolver.test.ts`
- `pnpm vitest run src/backend/services/session/service/lifecycle/session.config.service.test.ts`
- `pnpm typecheck`
- `pnpm exec biome check src/backend/services/session/service/acp/codex-app-server-adapter/session-config-resolver.ts src/backend/services/session/service/acp/codex-app-server-adapter/session-config-resolver.test.ts src/backend/services/session/service/lifecycle/session.config.service.ts src/backend/services/session/service/lifecycle/session.config.service.test.ts src/backend/services/session/service/lifecycle/session.lifecycle.service.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session startup and turn config resolution for Codex ACP; behavior change is scoped but affects model/reasoning on every new client and post-plan turns.
> 
> **Overview**
> Codex ACP sessions now pick up the user’s configured default **reasoning effort** as soon as the runtime client is created, instead of staying on the provider’s initial value until something else changes config.
> 
> **Session startup:** After `getOrCreateClient`, lifecycle calls `applyConfiguredReasoningEffort` with `persistSnapshot: false` and `emitUpdates: false` so the handle is updated in memory and the following single `persistAcpConfigSnapshot` / delta emit still reflects the correct effort.
> 
> **Turn collaboration mode:** In `resolveTurnCollaborationMode`, when the active mode is **`default`**, turn settings use the session’s **model** and **reasoning effort** rather than the collaboration-mode catalog entry (e.g. after plan approval, default mode no longer forces catalog `medium` on `gpt-5`).
> 
> **Config plumbing:** `applyReasoningEffortTarget` accepts optional flags to skip DB snapshot persistence and client deltas when applying settings-driven effort during startup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2fb104be55363c515d3943e99c3d0b6f66dd45c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->