### PR TITLE
Make GitHub issue start prompt editable

### DIFF
--- a/src/backend/lib/constants.ts
+++ b/src/backend/lib/constants.ts
@@ -10,4 +10,4 @@ export const LIB_LIMITS = Object.freeze({
 /**
  * Factory Factory signature for PRs created by agents.
  */
-export const FACTORY_SIGNATURE = '🏭 Forged in [Factory Factory](https://factoryfactory.ai)';
+export { FACTORY_SIGNATURE } from '@/shared/issue-start-prompt';

--- a/src/backend/orchestration/workspace-init-issue-prompts.ts
+++ b/src/backend/orchestration/workspace-init-issue-prompts.ts
@@ -1,194 +1,11 @@
-import { FACTORY_SIGNATURE } from '@/backend/lib/constants';
 import { githubCLIService } from '@/backend/services/github';
 import { linearClientService } from '@/backend/services/linear';
 import type { createLogger } from '@/backend/services/logger.service';
 import { workspaceAccessor } from '@/backend/services/workspace';
+import { buildIssueStartPrompt } from '@/shared/issue-start-prompt';
 import { getDecryptedLinearConfig } from './linear-config.helper';
 
 type Logger = ReturnType<typeof createLogger>;
-
-type IssuePromptParams = {
-  providerLabel: string;
-  issueReference: string;
-  title: string;
-  body: string | null | undefined;
-  url: string;
-  commitReference: string;
-  closeReference: string;
-  rawScreenshotBaseUrl: string;
-};
-
-function buildLinkedIssuePrompt(params: IssuePromptParams): string {
-  return `# ${params.providerLabel} ${params.issueReference}: ${params.title}
-
-${params.body || '(No description provided)'}
-
-**Issue URL**: ${params.url}
-
----
-
-## Your Task
-
-Implement this issue following the 5-phase workflow below. Work autonomously—only ask questions if requirements are contradictory or fundamentally unclear.
-
-**Protect your context by delegating to specialized agents:**
-- Exploring unfamiliar code or architecture? Use: "Please use the Explore agent to understand [specific area]"
-- Significant changes to review/simplify? Use: "Please use the code-simplifier agent to review recent changes"
-- Targeted searches only? Use Grep/Glob directly
-
----
-
-## Phase 1: Planning
-
-1. **Understand requirements and find relevant code**
-   - Read issue description and any linked resources
-   - Search for affected files (delegate to Explore agent for broad architecture questions)
-   - Identify which files need changes
-
-2. **Create task list with TodoWrite**
-   Create specific tasks for:
-   - Code changes (which files and what changes?)
-   - Tests to add (which test files?)
-   - Verification commands (typecheck, test, build)
-   - PR creation
-
-   Update status as you work: pending → in_progress → completed
-
-3. **Identify edge cases**
-   - What could go wrong?
-   - What scenarios need tests?
-   - What existing patterns should you follow?
-
-## Phase 2: Implementation
-
-1. **Work through your TodoWrite tasks systematically**
-   - Follow existing code patterns and conventions
-   - Add type definitions and error handling
-   - Keep commits atomic and focused
-   - Update TodoWrite as you discover additional work
-
-2. **Write tests**
-   - Test new functionality and edge cases
-   - Follow existing test patterns in the codebase
-   - Ensure tests are focused and maintainable
-
-3. **Commit frequently**
-   - Atomic commits as you complete logical units
-   - Follow project style: short, imperative, descriptive (<72 chars)
-   - Reference issue number when relevant
-   - Example: "Add session error handling (${params.commitReference})"
-
-## Phase 3: Verification
-
-Run all verification checks:
-
-\`\`\`bash
-pnpm typecheck && pnpm check:fix && pnpm test && pnpm build
-\`\`\`
-
-Fix any failures:
-- **Type errors**: Resolve without type casts when possible
-- **Lint errors**: Review \`pnpm check:fix\` changes
-- **Test failures**: Debug and fix before proceeding
-- **Build failures**: Check for syntax errors or missing dependencies
-
-Update TodoWrite with any additional fix tasks discovered.
-
-## Phase 4: Final Review
-
-1. **Review your changes**
-   \`\`\`bash
-   git diff origin/main
-   \`\`\`
-
-   Look for:
-   - Debug logs or commented code to remove
-   - Unclear variable names to improve
-   - Unnecessary complexity to simplify
-
-2. **Optional: Delegate to code-simplifier for large changes**
-   If you've changed many files (8+) or added complex logic:
-   - Use: "Please use the code-simplifier agent to review recent changes"
-   - Re-run tests after any changes: \`pnpm test\`
-
-3. **Ensure everything is committed**
-   \`\`\`bash
-   git status  # should show clean working directory
-   \`\`\`
-
-## Phase 4.5: Capture UI Screenshots (if applicable)
-
-If your changes affect the UI:
-
-1. Read \`factory-factory.json\` for the \`scripts.run\` command, pick a free port, replace \`{port}\`, and start it in the background.
-2. Use \`browser_navigate\` to visit the dev server URL
-3. Determine the most relevant screen showing your changes and capture a screenshot
-4. Save screenshots:
-   \`\`\`bash
-   mkdir -p .factory-factory/screenshots
-   \`\`\`
-   Save with descriptive names (e.g., \`dashboard-new-widget.png\`)
-5. Commit the screenshots with your changes
-6. Reference them in the PR body using raw GitHub URLs:
-   \`![Description](${params.rawScreenshotBaseUrl}\${branch}/.factory-factory/screenshots/filename.png)\`
-
-## Phase 5: Create Pull Request [REQUIRED - DO NOT SKIP]
-
-**Pre-flight checklist before creating PR:**
-- [ ] All TodoWrite tasks marked completed
-- [ ] \`pnpm test\` passes
-- [ ] \`pnpm typecheck\` passes
-- [ ] \`pnpm build\` succeeds
-- [ ] Working directory clean (\`git status\`)
-- [ ] All commits have descriptive messages
-
-**Now create the PR:**
-
-1. **Push your branch:**
-   \`\`\`bash
-   git push -u origin HEAD
-   \`\`\`
-
-2. **Write PR body to /tmp/pr-body.md:**
-   \`\`\`markdown
-   ## Summary
-   [1-3 bullets describing what this PR accomplishes]
-
-   ## Changes
-   - **[Component/Area]**: [What changed and why]
-   - [Add more lines as needed]
-
-   ## Testing
-   - [x] Tests pass (\`pnpm test\`)
-   - [x] Types pass (\`pnpm typecheck\`)
-   - [x] Build succeeds (\`pnpm build\`)
-   - [ ] Manual testing: [How to verify this change works]
-
-   Closes ${params.closeReference}
-   \`\`\`
-
-3. **IMPORTANT**: Always append the following signature as the very last lines of the PR body, after a horizontal rule:
-   \`\`\`
-   ---
-   ${FACTORY_SIGNATURE}
-   \`\`\`
-
-4. **Create the PR:**
-   \`\`\`bash
-   gh pr create --title "Fix ${params.closeReference}: [concise description]" --body-file /tmp/pr-body.md
-   \`\`\`
-
-4. **Verify PR created successfully:**
-   \`\`\`bash
-   gh pr view --web
-   \`\`\`
-
----
-
-**You have completed this issue successfully when the PR is created and the URL is shown above.**
-
-Start with Phase 1: Planning.`;
-}
 
 export async function buildInitialPromptFromGitHubIssue(
   workspaceId: string,
@@ -225,7 +42,7 @@ export async function buildInitialPromptFromGitHubIssue(
       issueTitle: issue.title,
     });
 
-    return buildLinkedIssuePrompt({
+    return buildIssueStartPrompt({
       providerLabel: 'GitHub Issue',
       issueReference: `#${issue.number}`,
       title: issue.title,
@@ -275,7 +92,7 @@ export async function buildInitialPromptFromLinearIssue(
       issueTitle: issue.title,
     });
 
-    return buildLinkedIssuePrompt({
+    return buildIssueStartPrompt({
       providerLabel: 'Linear Issue',
       issueReference: issue.identifier,
       title: issue.title,

--- a/src/backend/orchestration/workspace-init.orchestrator.test.ts
+++ b/src/backend/orchestration/workspace-init.orchestrator.test.ts
@@ -943,6 +943,34 @@ describe('initializeWorkspaceWorktree', () => {
       );
     });
 
+    it('enqueues saved empty initial prompt without rebuilding issue prompt', async () => {
+      const workspace = makeWorkspaceWithProject({
+        githubIssueNumber: 42,
+        creationMetadata: {
+          issueNumber: 42,
+          issueUrl: 'https://github.com/owner/repo/issues/42',
+          initialPrompt: '',
+        },
+      });
+      setupHappyPath();
+      vi.mocked(workspaceAccessor.findByIdWithProject).mockResolvedValue(workspace);
+      vi.mocked(workspaceAccessor.findById).mockResolvedValue(workspace as never);
+      vi.mocked(agentSessionAccessor.findByWorkspaceId).mockResolvedValue([
+        unsafeCoerce({ id: 'session-1', status: SessionStatus.IDLE, model: 'claude-sonnet' }),
+      ]);
+      vi.mocked(sessionDomainService.enqueue).mockReturnValue({ position: 0 });
+
+      await initializeWorkspaceWorktree(WORKSPACE_ID);
+
+      expect(githubCLIService.getIssue).not.toHaveBeenCalled();
+      expect(sessionDomainService.enqueue).toHaveBeenCalledWith(
+        'session-1',
+        expect.objectContaining({
+          text: '',
+        })
+      );
+    });
+
     it('enqueues GitHub issue prompt when workspace has linked issue', async () => {
       const workspace = makeWorkspaceWithProject({ githubIssueNumber: 42 });
       setupHappyPath();

--- a/src/backend/orchestration/workspace-init.orchestrator.test.ts
+++ b/src/backend/orchestration/workspace-init.orchestrator.test.ts
@@ -943,6 +943,34 @@ describe('initializeWorkspaceWorktree', () => {
       );
     });
 
+    it('escapes XML-like closing sequences in saved initial prompts', async () => {
+      const workspace = makeWorkspaceWithProject({
+        githubIssueNumber: 42,
+        creationMetadata: {
+          issueNumber: 42,
+          issueUrl: 'https://github.com/owner/repo/issues/42',
+          initialPrompt: 'Custom </task> prompt',
+        },
+      });
+      setupHappyPath();
+      vi.mocked(workspaceAccessor.findByIdWithProject).mockResolvedValue(workspace);
+      vi.mocked(workspaceAccessor.findById).mockResolvedValue(workspace as never);
+      vi.mocked(agentSessionAccessor.findByWorkspaceId).mockResolvedValue([
+        unsafeCoerce({ id: 'session-1', status: SessionStatus.IDLE, model: 'claude-sonnet' }),
+      ]);
+      vi.mocked(sessionDomainService.enqueue).mockReturnValue({ position: 0 });
+
+      await initializeWorkspaceWorktree(WORKSPACE_ID);
+
+      expect(githubCLIService.getIssue).not.toHaveBeenCalled();
+      expect(sessionDomainService.enqueue).toHaveBeenCalledWith(
+        'session-1',
+        expect.objectContaining({
+          text: 'Custom <\\/task> prompt',
+        })
+      );
+    });
+
     it('enqueues saved empty initial prompt without rebuilding issue prompt', async () => {
       const workspace = makeWorkspaceWithProject({
         githubIssueNumber: 42,

--- a/src/backend/orchestration/workspace-init.orchestrator.test.ts
+++ b/src/backend/orchestration/workspace-init.orchestrator.test.ts
@@ -915,6 +915,34 @@ describe('initializeWorkspaceWorktree', () => {
   });
 
   describe('GitHub issue prompt', () => {
+    it('enqueues saved initial prompt for GitHub issue workspace without refetching issue', async () => {
+      const workspace = makeWorkspaceWithProject({
+        githubIssueNumber: 42,
+        creationMetadata: {
+          issueNumber: 42,
+          issueUrl: 'https://github.com/owner/repo/issues/42',
+          initialPrompt: 'Custom edited prompt',
+        },
+      });
+      setupHappyPath();
+      vi.mocked(workspaceAccessor.findByIdWithProject).mockResolvedValue(workspace);
+      vi.mocked(workspaceAccessor.findById).mockResolvedValue(workspace as never);
+      vi.mocked(agentSessionAccessor.findByWorkspaceId).mockResolvedValue([
+        unsafeCoerce({ id: 'session-1', status: SessionStatus.IDLE, model: 'claude-sonnet' }),
+      ]);
+      vi.mocked(sessionDomainService.enqueue).mockReturnValue({ position: 0 });
+
+      await initializeWorkspaceWorktree(WORKSPACE_ID);
+
+      expect(githubCLIService.getIssue).not.toHaveBeenCalled();
+      expect(sessionDomainService.enqueue).toHaveBeenCalledWith(
+        'session-1',
+        expect.objectContaining({
+          text: 'Custom edited prompt',
+        })
+      );
+    });
+
     it('enqueues GitHub issue prompt when workspace has linked issue', async () => {
       const workspace = makeWorkspaceWithProject({ githubIssueNumber: 42 });
       setupHappyPath();

--- a/src/backend/orchestration/workspace-init.orchestrator.ts
+++ b/src/backend/orchestration/workspace-init.orchestrator.ts
@@ -302,6 +302,21 @@ async function resolveInitialAutoMessageContent(
   workspaceId: string,
   creationMetadata: Record<string, unknown> | null
 ): Promise<InitialAutoMessageContent | null> {
+  const metadataPromptText =
+    creationMetadata?.initialPrompt && typeof creationMetadata.initialPrompt === 'string'
+      ? creationMetadata.initialPrompt
+      : '';
+  const metadataAttachments = readInitialAttachmentsFromMetadata(creationMetadata, workspaceId);
+
+  if (metadataPromptText || (metadataAttachments && metadataAttachments.length > 0)) {
+    return {
+      text: metadataPromptText,
+      ...(metadataAttachments && metadataAttachments.length > 0
+        ? { attachments: metadataAttachments }
+        : {}),
+    };
+  }
+
   const issuePromptText =
     (await buildInitialPromptFromGitHubIssue(workspaceId, logger)) ||
     (await buildInitialPromptFromLinearIssue(workspaceId, logger));
@@ -309,22 +324,7 @@ async function resolveInitialAutoMessageContent(
     return { text: issuePromptText };
   }
 
-  const metadataPromptText =
-    creationMetadata?.initialPrompt && typeof creationMetadata.initialPrompt === 'string'
-      ? creationMetadata.initialPrompt
-      : '';
-  const metadataAttachments = readInitialAttachmentsFromMetadata(creationMetadata, workspaceId);
-
-  if (!metadataPromptText && (!metadataAttachments || metadataAttachments.length === 0)) {
-    return null;
-  }
-
-  return {
-    text: metadataPromptText,
-    ...(metadataAttachments && metadataAttachments.length > 0
-      ? { attachments: metadataAttachments }
-      : {}),
-  };
+  return null;
 }
 
 async function startDefaultAgentSession(workspaceId: string): Promise<string | null> {

--- a/src/backend/orchestration/workspace-init.orchestrator.ts
+++ b/src/backend/orchestration/workspace-init.orchestrator.ts
@@ -298,19 +298,34 @@ function readStartupModePresetFromMetadata(
   return 'non_interactive';
 }
 
+function readInitialPromptFromMetadata(
+  metadata: Record<string, unknown> | null,
+  workspaceId: string
+): { provided: boolean; text: string } {
+  if (!(metadata && Object.hasOwn(metadata, 'initialPrompt'))) {
+    return { provided: false, text: '' };
+  }
+
+  if (typeof metadata.initialPrompt === 'string') {
+    return { provided: true, text: metadata.initialPrompt };
+  }
+
+  logger.warn('Invalid initial prompt in workspace creation metadata', {
+    workspaceId,
+  });
+  return { provided: false, text: '' };
+}
+
 async function resolveInitialAutoMessageContent(
   workspaceId: string,
   creationMetadata: Record<string, unknown> | null
 ): Promise<InitialAutoMessageContent | null> {
-  const metadataPromptText =
-    creationMetadata?.initialPrompt && typeof creationMetadata.initialPrompt === 'string'
-      ? creationMetadata.initialPrompt
-      : '';
+  const metadataPrompt = readInitialPromptFromMetadata(creationMetadata, workspaceId);
   const metadataAttachments = readInitialAttachmentsFromMetadata(creationMetadata, workspaceId);
 
-  if (metadataPromptText || (metadataAttachments && metadataAttachments.length > 0)) {
+  if (metadataPrompt.provided || (metadataAttachments && metadataAttachments.length > 0)) {
     return {
-      text: metadataPromptText,
+      text: metadataPrompt.text,
       ...(metadataAttachments && metadataAttachments.length > 0
         ? { attachments: metadataAttachments }
         : {}),

--- a/src/backend/orchestration/workspace-init.orchestrator.ts
+++ b/src/backend/orchestration/workspace-init.orchestrator.ts
@@ -307,7 +307,7 @@ function readInitialPromptFromMetadata(
   }
 
   if (typeof metadata.initialPrompt === 'string') {
-    return { provided: true, text: metadata.initialPrompt };
+    return { provided: true, text: metadata.initialPrompt.replaceAll('</', '<\\/') };
   }
 
   logger.warn('Invalid initial prompt in workspace creation metadata', {

--- a/src/backend/services/workspace/service/lifecycle/creation.service.test.ts
+++ b/src/backend/services/workspace/service/lifecycle/creation.service.test.ts
@@ -587,6 +587,30 @@ describe('WorkspaceCreationService', () => {
         );
       });
 
+      it('persists initial prompt in Linear issue creation metadata', async () => {
+        const source: WorkspaceCreationSource = {
+          type: 'LINEAR_ISSUE',
+          projectId: 'proj-1',
+          issueId: 'linear-uuid-123',
+          issueIdentifier: 'ENG-42',
+          issueUrl: 'https://linear.app/team/issue/ENG-42',
+          initialPrompt: 'Custom Linear issue prompt',
+        };
+
+        await service.create(source);
+
+        expect(workspaceAccessorModule.workspaceAccessor.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            creationMetadata: {
+              issueId: 'linear-uuid-123',
+              issueIdentifier: 'ENG-42',
+              issueUrl: 'https://linear.app/team/issue/ENG-42',
+              initialPrompt: 'Custom Linear issue prompt',
+            },
+          })
+        );
+      });
+
       it('persists selected provider for Linear issue workspaces', async () => {
         const source: WorkspaceCreationSource = {
           type: 'LINEAR_ISSUE',

--- a/src/backend/services/workspace/service/lifecycle/creation.service.test.ts
+++ b/src/backend/services/workspace/service/lifecycle/creation.service.test.ts
@@ -496,6 +496,28 @@ describe('WorkspaceCreationService', () => {
         );
       });
 
+      it('persists empty initial prompt in GitHub issue creation metadata', async () => {
+        const source: WorkspaceCreationSource = {
+          type: 'GITHUB_ISSUE',
+          projectId: 'proj-1',
+          issueNumber: 42,
+          issueUrl: 'https://github.com/org/repo/issues/42',
+          initialPrompt: '',
+        };
+
+        await service.create(source);
+
+        expect(workspaceAccessorModule.workspaceAccessor.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            creationMetadata: {
+              issueNumber: 42,
+              issueUrl: 'https://github.com/org/repo/issues/42',
+              initialPrompt: '',
+            },
+          })
+        );
+      });
+
       it('persists selected provider for GitHub issue workspaces', async () => {
         const source: WorkspaceCreationSource = {
           type: 'GITHUB_ISSUE',
@@ -606,6 +628,30 @@ describe('WorkspaceCreationService', () => {
               issueIdentifier: 'ENG-42',
               issueUrl: 'https://linear.app/team/issue/ENG-42',
               initialPrompt: 'Custom Linear issue prompt',
+            },
+          })
+        );
+      });
+
+      it('persists empty initial prompt in Linear issue creation metadata', async () => {
+        const source: WorkspaceCreationSource = {
+          type: 'LINEAR_ISSUE',
+          projectId: 'proj-1',
+          issueId: 'linear-uuid-123',
+          issueIdentifier: 'ENG-42',
+          issueUrl: 'https://linear.app/team/issue/ENG-42',
+          initialPrompt: '',
+        };
+
+        await service.create(source);
+
+        expect(workspaceAccessorModule.workspaceAccessor.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            creationMetadata: {
+              issueId: 'linear-uuid-123',
+              issueIdentifier: 'ENG-42',
+              issueUrl: 'https://linear.app/team/issue/ENG-42',
+              initialPrompt: '',
             },
           })
         );

--- a/src/backend/services/workspace/service/lifecycle/creation.service.test.ts
+++ b/src/backend/services/workspace/service/lifecycle/creation.service.test.ts
@@ -474,6 +474,28 @@ describe('WorkspaceCreationService', () => {
         );
       });
 
+      it('persists initial prompt in GitHub issue creation metadata', async () => {
+        const source: WorkspaceCreationSource = {
+          type: 'GITHUB_ISSUE',
+          projectId: 'proj-1',
+          issueNumber: 42,
+          issueUrl: 'https://github.com/org/repo/issues/42',
+          initialPrompt: 'Custom issue prompt',
+        };
+
+        await service.create(source);
+
+        expect(workspaceAccessorModule.workspaceAccessor.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            creationMetadata: {
+              issueNumber: 42,
+              issueUrl: 'https://github.com/org/repo/issues/42',
+              initialPrompt: 'Custom issue prompt',
+            },
+          })
+        );
+      });
+
       it('persists selected provider for GitHub issue workspaces', async () => {
         const source: WorkspaceCreationSource = {
           type: 'GITHUB_ISSUE',

--- a/src/backend/services/workspace/service/lifecycle/creation.service.ts
+++ b/src/backend/services/workspace/service/lifecycle/creation.service.ts
@@ -94,6 +94,10 @@ type PreparedWorkspaceCreation = {
   };
 };
 
+function hasInitialPrompt(source: { initialPrompt?: string }): source is { initialPrompt: string } {
+  return typeof source.initialPrompt === 'string';
+}
+
 /**
  * Canonical workspace creation orchestrator.
  *
@@ -179,7 +183,7 @@ export class WorkspaceCreationService {
     const autoIterationConfig = configParsed?.success ? configParsed.data : undefined;
 
     const metadata: Record<string, unknown> = {};
-    if (source.initialPrompt) {
+    if (hasInitialPrompt(source)) {
       metadata.initialPrompt = source.initialPrompt;
     }
     if (source.initialAttachments && source.initialAttachments.length > 0) {
@@ -253,7 +257,7 @@ export class WorkspaceCreationService {
     if (source.startupModePreset) {
       metadata.startupModePreset = source.startupModePreset;
     }
-    if (source.initialPrompt) {
+    if (hasInitialPrompt(source)) {
       metadata.initialPrompt = source.initialPrompt;
     }
 
@@ -282,7 +286,7 @@ export class WorkspaceCreationService {
     if (source.startupModePreset) {
       metadata.startupModePreset = source.startupModePreset;
     }
-    if (source.initialPrompt) {
+    if (hasInitialPrompt(source)) {
       metadata.initialPrompt = source.initialPrompt;
     }
 

--- a/src/backend/services/workspace/service/lifecycle/creation.service.ts
+++ b/src/backend/services/workspace/service/lifecycle/creation.service.ts
@@ -60,6 +60,7 @@ export type WorkspaceCreationSource =
       name?: string;
       description?: string;
       ratchetEnabled?: boolean;
+      initialPrompt?: string;
       startupModePreset?: 'non_interactive' | 'plan';
       provider?: SessionProvider;
     };
@@ -280,6 +281,9 @@ export class WorkspaceCreationService {
     };
     if (source.startupModePreset) {
       metadata.startupModePreset = source.startupModePreset;
+    }
+    if (source.initialPrompt) {
+      metadata.initialPrompt = source.initialPrompt;
     }
 
     return {

--- a/src/backend/services/workspace/service/lifecycle/creation.service.ts
+++ b/src/backend/services/workspace/service/lifecycle/creation.service.ts
@@ -47,6 +47,7 @@ export type WorkspaceCreationSource =
       name?: string;
       description?: string;
       ratchetEnabled?: boolean;
+      initialPrompt?: string;
       startupModePreset?: 'non_interactive' | 'plan';
       provider?: SessionProvider;
     }
@@ -250,6 +251,9 @@ export class WorkspaceCreationService {
     };
     if (source.startupModePreset) {
       metadata.startupModePreset = source.startupModePreset;
+    }
+    if (source.initialPrompt) {
+      metadata.initialPrompt = source.initialPrompt;
     }
 
     return {

--- a/src/backend/trpc/workspace.router.test.ts
+++ b/src/backend/trpc/workspace.router.test.ts
@@ -409,6 +409,27 @@ describe('workspaceRouter', () => {
     );
   });
 
+  it('passes initial prompt through Linear issue workspace creation', async () => {
+    const { caller } = createCaller();
+    mockWorkspaceCreationCreate.mockResolvedValue({ id: 'w-created' });
+
+    await caller.create({
+      type: 'LINEAR_ISSUE',
+      projectId: 'p1',
+      issueId: 'linear-42',
+      issueIdentifier: 'ENG-42',
+      issueUrl: 'https://linear.app/org/issue/ENG-42',
+      initialPrompt: 'Custom Linear issue prompt',
+    });
+
+    expect(mockWorkspaceCreationCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'LINEAR_ISSUE',
+        initialPrompt: 'Custom Linear issue prompt',
+      })
+    );
+  });
+
   it('passes provider through Linear issue workspace creation', async () => {
     const { caller } = createCaller();
     mockWorkspaceCreationCreate.mockResolvedValue({ id: 'w-created' });

--- a/src/backend/trpc/workspace.router.test.ts
+++ b/src/backend/trpc/workspace.router.test.ts
@@ -347,6 +347,26 @@ describe('workspaceRouter', () => {
     );
   });
 
+  it('passes initial prompt through GitHub issue workspace creation', async () => {
+    const { caller } = createCaller();
+    mockWorkspaceCreationCreate.mockResolvedValue({ id: 'w-created' });
+
+    await caller.create({
+      type: 'GITHUB_ISSUE',
+      projectId: 'p1',
+      issueNumber: 42,
+      issueUrl: 'https://github.com/org/repo/issues/42',
+      initialPrompt: 'Custom issue prompt',
+    });
+
+    expect(mockWorkspaceCreationCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'GITHUB_ISSUE',
+        initialPrompt: 'Custom issue prompt',
+      })
+    );
+  });
+
   it('passes provider through GitHub issue workspace creation', async () => {
     const { caller } = createCaller();
     mockWorkspaceCreationCreate.mockResolvedValue({ id: 'w-created' });

--- a/src/backend/trpc/workspace.trpc.ts
+++ b/src/backend/trpc/workspace.trpc.ts
@@ -91,6 +91,7 @@ const workspaceCreationSourceSchema = z.discriminatedUnion('type', [
     name: z.string().optional(),
     description: z.string().optional(),
     ratchetEnabled: z.boolean().optional(),
+    initialPrompt: z.string().optional(),
     startupModePreset: z.enum(['non_interactive', 'plan']).optional(),
     provider: z.nativeEnum(SessionProvider).optional(),
   }),

--- a/src/backend/trpc/workspace.trpc.ts
+++ b/src/backend/trpc/workspace.trpc.ts
@@ -104,6 +104,7 @@ const workspaceCreationSourceSchema = z.discriminatedUnion('type', [
     name: z.string().optional(),
     description: z.string().optional(),
     ratchetEnabled: z.boolean().optional(),
+    initialPrompt: z.string().optional(),
     startupModePreset: z.enum(['non_interactive', 'plan']).optional(),
     provider: z.nativeEnum(SessionProvider).optional(),
   }),

--- a/src/client/components/kanban/issue-card.test.tsx
+++ b/src/client/components/kanban/issue-card.test.tsx
@@ -55,6 +55,17 @@ vi.mock('@/client/lib/trpc', () => ({
         }),
       },
     },
+    project: {
+      getById: {
+        useQuery: () => ({
+          data: {
+            githubOwner: 'acme',
+            githubRepo: 'repo',
+          },
+          isLoading: false,
+        }),
+      },
+    },
     workspace: {
       create: {
         useMutation: (options: Record<string, unknown>) => {

--- a/src/client/components/kanban/issue-launch-sheet.test.tsx
+++ b/src/client/components/kanban/issue-launch-sheet.test.tsx
@@ -132,6 +132,11 @@ vi.mock('@/components/ui/sheet', () => ({
     createElement('div', props, children),
 }));
 
+vi.mock('@/components/ui/textarea', () => ({
+  Textarea: (props: import('react').TextareaHTMLAttributes<HTMLTextAreaElement>) =>
+    createElement('textarea', props),
+}));
+
 vi.mock('@/components/workspace', () => ({
   RatchetToggleButton: () => null,
 }));
@@ -181,6 +186,22 @@ function clickButton(container: HTMLDivElement, label: string) {
   });
 }
 
+function changeTextarea(container: HTMLDivElement, value: string) {
+  const textarea = container.querySelector('textarea');
+  if (!textarea) {
+    throw new Error('textarea not found');
+  }
+
+  flushSync(() => {
+    const valueSetter = Object.getOwnPropertyDescriptor(
+      HTMLTextAreaElement.prototype,
+      'value'
+    )?.set;
+    valueSetter?.call(textarea, value);
+    textarea.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }));
+  });
+}
+
 beforeEach(() => {
   Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
     configurable: true,
@@ -199,6 +220,34 @@ afterEach(() => {
 });
 
 describe('IssueLaunchSheet', () => {
+  it('sends edited GitHub issue prompt when starting', () => {
+    const { container, root } = renderSheet();
+
+    changeTextarea(container, 'Please handle this issue with extra care.');
+    clickButton(container, 'Start');
+
+    expect(mocks.createWorkspaceMutateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'GITHUB_ISSUE',
+        issueNumber: 42,
+        initialPrompt: 'Please handle this issue with extra care.',
+      })
+    );
+
+    root.unmount();
+    container.remove();
+  });
+
+  it('seeds the editor with the full GitHub issue workflow prompt', () => {
+    const { container, root } = renderSheet();
+
+    expect(container.querySelector('textarea')?.value).toContain('## Phase 1: Planning');
+    expect(container.querySelector('textarea')?.value).toContain('Closes #42');
+
+    root.unmount();
+    container.remove();
+  });
+
   it('does not reset a user-selected provider after settings refetch', () => {
     const { container, root } = renderSheet();
 

--- a/src/client/components/kanban/issue-launch-sheet.test.tsx
+++ b/src/client/components/kanban/issue-launch-sheet.test.tsx
@@ -12,6 +12,10 @@ const mocks = vi.hoisted(() => ({
     defaultSessionProvider: 'CLAUDE' as 'CLAUDE' | 'CODEX',
     ratchetEnabled: false,
   },
+  project: {
+    githubOwner: 'purplefish-ai',
+    githubRepo: 'factory-factory',
+  },
   listWithKanbanStateInvalidateMock: vi.fn(),
   getProjectSummaryStateInvalidateMock: vi.fn(),
   getSetDataMock: vi.fn(),
@@ -52,6 +56,14 @@ vi.mock('@/client/lib/trpc', () => ({
       get: {
         useQuery: () => ({
           data: mocks.userSettings,
+          isLoading: false,
+        }),
+      },
+    },
+    project: {
+      getById: {
+        useQuery: () => ({
+          data: mocks.project,
           isLoading: false,
         }),
       },
@@ -216,6 +228,10 @@ beforeEach(() => {
     defaultSessionProvider: 'CLAUDE',
     ratchetEnabled: false,
   };
+  mocks.project = {
+    githubOwner: 'purplefish-ai',
+    githubRepo: 'factory-factory',
+  };
 });
 
 afterEach(() => {
@@ -300,6 +316,9 @@ describe('IssueLaunchSheet', () => {
 
     expect(container.querySelector('textarea')?.value).toContain('## Phase 1: Planning');
     expect(container.querySelector('textarea')?.value).toContain('Closes ENG-42');
+    expect(container.querySelector('textarea')?.value).toContain(
+      'https://raw.githubusercontent.com/purplefish-ai/factory-factory/'
+    );
 
     root.unmount();
     container.remove();

--- a/src/client/components/kanban/issue-launch-sheet.test.tsx
+++ b/src/client/components/kanban/issue-launch-sheet.test.tsx
@@ -4,6 +4,7 @@ import { createElement, type ReactNode } from 'react';
 import { flushSync } from 'react-dom';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NormalizedIssue } from '@/client/lib/issue-normalization';
 import { IssueLaunchSheet } from './issue-launch-sheet';
 
 const mocks = vi.hoisted(() => ({
@@ -141,7 +142,7 @@ vi.mock('@/components/workspace', () => ({
   RatchetToggleButton: () => null,
 }));
 
-const issue = {
+const issue: NormalizedIssue = {
   id: 'github-42',
   provider: 'github' as const,
   title: 'Fix login redirect',
@@ -153,7 +154,10 @@ const issue = {
   githubIssueNumber: 42,
 };
 
-function renderSheet(): { container: HTMLDivElement; root: Root } {
+function renderSheet(sheetIssue: NormalizedIssue = issue): {
+  container: HTMLDivElement;
+  root: Root;
+} {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const root = createRoot(container);
@@ -162,7 +166,7 @@ function renderSheet(): { container: HTMLDivElement; root: Root } {
     root.render(
       createElement(IssueLaunchSheet, {
         projectId: 'project-1',
-        issue,
+        issue: sheetIssue,
         open: true,
         onOpenChange: vi.fn(),
       })
@@ -231,6 +235,37 @@ describe('IssueLaunchSheet', () => {
         type: 'GITHUB_ISSUE',
         issueNumber: 42,
         initialPrompt: 'Please handle this issue with extra care.',
+      })
+    );
+
+    root.unmount();
+    container.remove();
+  });
+
+  it('sends edited Linear issue prompt when starting', () => {
+    const linearIssue: NormalizedIssue = {
+      id: 'linear-42',
+      provider: 'linear' as const,
+      title: 'Fix Linear launch prompt',
+      body: 'Linear issue body',
+      url: 'https://linear.app/acme/issue/ENG-42/fix-linear-launch-prompt',
+      displayId: 'ENG-42',
+      author: 'linear-user',
+      createdAt: '2026-03-14T12:00:00.000Z',
+      linearIssueId: 'linear-uuid-42',
+      linearIssueIdentifier: 'ENG-42',
+    };
+    const { container, root } = renderSheet(linearIssue);
+
+    changeTextarea(container, 'Use this custom Linear issue prompt.');
+    clickButton(container, 'Start');
+
+    expect(mocks.createWorkspaceMutateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'LINEAR_ISSUE',
+        issueId: 'linear-uuid-42',
+        issueIdentifier: 'ENG-42',
+        initialPrompt: 'Use this custom Linear issue prompt.',
       })
     );
 

--- a/src/client/components/kanban/issue-launch-sheet.test.tsx
+++ b/src/client/components/kanban/issue-launch-sheet.test.tsx
@@ -289,6 +289,37 @@ describe('IssueLaunchSheet', () => {
     container.remove();
   });
 
+  it('sends an empty Linear issue prompt when the prompt is cleared', () => {
+    const linearIssue: NormalizedIssue = {
+      id: 'linear-42',
+      provider: 'linear' as const,
+      title: 'Fix Linear launch prompt',
+      body: 'Linear issue body',
+      url: 'https://linear.app/acme/issue/ENG-42/fix-linear-launch-prompt',
+      displayId: 'ENG-42',
+      author: 'linear-user',
+      createdAt: '2026-03-14T12:00:00.000Z',
+      linearIssueId: 'linear-uuid-42',
+      linearIssueIdentifier: 'ENG-42',
+    };
+    const { container, root } = renderSheet(linearIssue);
+
+    changeTextarea(container, '');
+    clickButton(container, 'Start');
+
+    expect(mocks.createWorkspaceMutateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'LINEAR_ISSUE',
+        issueId: 'linear-uuid-42',
+        issueIdentifier: 'ENG-42',
+        initialPrompt: '',
+      })
+    );
+
+    root.unmount();
+    container.remove();
+  });
+
   it('seeds the editor with the full GitHub issue workflow prompt', () => {
     const { container, root } = renderSheet();
 

--- a/src/client/components/kanban/issue-launch-sheet.test.tsx
+++ b/src/client/components/kanban/issue-launch-sheet.test.tsx
@@ -283,6 +283,28 @@ describe('IssueLaunchSheet', () => {
     container.remove();
   });
 
+  it('seeds the editor with the full Linear issue workflow prompt', () => {
+    const linearIssue: NormalizedIssue = {
+      id: 'linear-42',
+      provider: 'linear' as const,
+      title: 'Fix Linear launch prompt',
+      body: 'Linear issue body',
+      url: 'https://linear.app/acme/issue/ENG-42/fix-linear-launch-prompt',
+      displayId: 'ENG-42',
+      author: 'linear-user',
+      createdAt: '2026-03-14T12:00:00.000Z',
+      linearIssueId: 'linear-uuid-42',
+      linearIssueIdentifier: 'ENG-42',
+    };
+    const { container, root } = renderSheet(linearIssue);
+
+    expect(container.querySelector('textarea')?.value).toContain('## Phase 1: Planning');
+    expect(container.querySelector('textarea')?.value).toContain('Closes ENG-42');
+
+    root.unmount();
+    container.remove();
+  });
+
   it('does not reset a user-selected provider after settings refetch', () => {
     const { container, root } = renderSheet();
 

--- a/src/client/components/kanban/issue-launch-sheet.test.tsx
+++ b/src/client/components/kanban/issue-launch-sheet.test.tsx
@@ -15,7 +15,8 @@ const mocks = vi.hoisted(() => ({
   project: {
     githubOwner: 'purplefish-ai',
     githubRepo: 'factory-factory',
-  },
+  } as { githubOwner: string; githubRepo: string } | null,
+  isLoadingProject: false,
   listWithKanbanStateInvalidateMock: vi.fn(),
   getProjectSummaryStateInvalidateMock: vi.fn(),
   getSetDataMock: vi.fn(),
@@ -64,7 +65,7 @@ vi.mock('@/client/lib/trpc', () => ({
       getById: {
         useQuery: () => ({
           data: mocks.project,
-          isLoading: false,
+          isLoading: mocks.isLoadingProject,
         }),
       },
     },
@@ -188,7 +189,7 @@ function renderSheet(sheetIssue: NormalizedIssue = issue): {
   return { container, root };
 }
 
-function clickButton(container: HTMLDivElement, label: string) {
+function findButton(container: HTMLDivElement, label: string) {
   const button = Array.from(container.querySelectorAll('button')).find((candidate) =>
     candidate.textContent?.includes(label)
   );
@@ -196,6 +197,12 @@ function clickButton(container: HTMLDivElement, label: string) {
   if (!button) {
     throw new Error(`${label} button not found`);
   }
+
+  return button;
+}
+
+function clickButton(container: HTMLDivElement, label: string) {
+  const button = findButton(container, label);
 
   flushSync(() => {
     button.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
@@ -232,6 +239,7 @@ beforeEach(() => {
     githubOwner: 'purplefish-ai',
     githubRepo: 'factory-factory',
   };
+  mocks.isLoadingProject = false;
 });
 
 afterEach(() => {
@@ -349,6 +357,66 @@ describe('IssueLaunchSheet', () => {
     expect(container.querySelector('textarea')?.value).toContain('Closes ENG-42');
     expect(container.querySelector('textarea')?.value).toContain(
       'https://raw.githubusercontent.com/purplefish-ai/factory-factory/'
+    );
+
+    root.unmount();
+    container.remove();
+  });
+
+  it('starts with the project-enriched Linear prompt after project metadata loads', async () => {
+    const linearIssue: NormalizedIssue = {
+      id: 'linear-42',
+      provider: 'linear' as const,
+      title: 'Fix Linear launch prompt',
+      body: 'Linear issue body',
+      url: 'https://linear.app/acme/issue/ENG-42/fix-linear-launch-prompt',
+      displayId: 'ENG-42',
+      author: 'linear-user',
+      createdAt: '2026-03-14T12:00:00.000Z',
+      linearIssueId: 'linear-uuid-42',
+      linearIssueIdentifier: 'ENG-42',
+    };
+
+    mocks.project = null;
+    mocks.isLoadingProject = true;
+    const { container, root } = renderSheet(linearIssue);
+
+    expect(container.querySelector('textarea')?.value).not.toContain(
+      'https://raw.githubusercontent.com/purplefish-ai/factory-factory/'
+    );
+
+    mocks.project = {
+      githubOwner: 'purplefish-ai',
+      githubRepo: 'factory-factory',
+    };
+    mocks.isLoadingProject = false;
+
+    flushSync(() => {
+      root.render(
+        createElement(IssueLaunchSheet, {
+          projectId: 'project-1',
+          issue: linearIssue,
+          open: true,
+          onOpenChange: vi.fn(),
+        })
+      );
+    });
+
+    expect(findButton(container, 'Start').disabled).toBe(true);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(findButton(container, 'Start').disabled).toBe(false);
+
+    clickButton(container, 'Start');
+
+    expect(mocks.createWorkspaceMutateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'LINEAR_ISSUE',
+        initialPrompt: expect.stringContaining(
+          'https://raw.githubusercontent.com/purplefish-ai/factory-factory/'
+        ),
+      })
     );
 
     root.unmount();

--- a/src/client/components/kanban/issue-launch-sheet.tsx
+++ b/src/client/components/kanban/issue-launch-sheet.tsx
@@ -177,6 +177,7 @@ export function IssueLaunchSheet({
         issueUrl: issue.url,
         name: issue.title,
         ratchetEnabled,
+        initialPrompt: trimmedPrompt,
         startupModePreset,
         provider,
       });

--- a/src/client/components/kanban/issue-launch-sheet.tsx
+++ b/src/client/components/kanban/issue-launch-sheet.tsx
@@ -21,7 +21,9 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/components/ui/sheet';
+import { Textarea } from '@/components/ui/textarea';
 import { RatchetToggleButton } from '@/components/workspace';
+import { buildIssueStartPrompt } from '@/shared/issue-start-prompt';
 
 interface IssueLaunchSheetProps {
   issue: NormalizedIssue;
@@ -39,6 +41,19 @@ function getIssueProviderLabel(issue: NormalizedIssue) {
 }
 
 function buildPromptPreview(issue: NormalizedIssue) {
+  if (issue.provider === 'github') {
+    return buildIssueStartPrompt({
+      providerLabel: 'GitHub Issue',
+      issueReference: issue.displayId,
+      title: issue.title,
+      body: issue.body,
+      url: issue.url,
+      commitReference: issue.displayId,
+      closeReference: issue.displayId,
+      rawScreenshotBaseUrl: deriveGitHubRawScreenshotBaseUrl(issue.url),
+    });
+  }
+
   const providerLabel = issue.provider === 'linear' ? 'Linear Issue' : 'GitHub Issue';
   const body = issue.body?.trim() || '(No description provided)';
 
@@ -51,6 +66,20 @@ Issue URL: ${issue.url}
 Start with planning, then implement, test, review, and open a pull request.`;
 }
 
+function deriveGitHubRawScreenshotBaseUrl(issueUrl: string) {
+  try {
+    const url = new URL(issueUrl);
+    const [owner, repo] = url.pathname.split('/').filter(Boolean);
+    if (url.hostname === 'github.com' && owner && repo) {
+      return `https://raw.githubusercontent.com/${owner}/${repo}/`;
+    }
+  } catch {
+    // Fall through to an empty base URL for malformed issue links.
+  }
+
+  return '';
+}
+
 export function IssueLaunchSheet({
   issue,
   projectId,
@@ -60,18 +89,27 @@ export function IssueLaunchSheet({
 }: IssueLaunchSheetProps) {
   const utils = trpc.useUtils();
   const { data: userSettings, isLoading: isLoadingSettings } = trpc.userSettings.get.useQuery();
+  const promptPreview = useMemo(() => buildPromptPreview(issue), [issue]);
   const [ratchetEnabled, setRatchetEnabled] = useState(false);
   const [startupModePreset, setStartupModePreset] = useState<LaunchMode>('non_interactive');
   const [provider, setProvider] = useState<AgentProvider>('CLAUDE');
+  const [promptText, setPromptText] = useState(promptPreview);
   const initializedProviderForOpenRef = useRef(false);
+  const initializedPromptIssueKeyRef = useRef<string | null>(null);
   const ratchetPreferenceKey = `kanban:issue-ratchet:${projectId}:${issue.id}`;
-  const promptPreview = useMemo(() => buildPromptPreview(issue), [issue]);
   const issueProviderLabel = getIssueProviderLabel(issue);
 
   useEffect(() => {
     if (!open) {
       initializedProviderForOpenRef.current = false;
+      initializedPromptIssueKeyRef.current = null;
       return;
+    }
+
+    const issueKey = `${issue.provider}:${issue.id}`;
+    if (initializedPromptIssueKeyRef.current !== issueKey) {
+      setPromptText(promptPreview);
+      initializedPromptIssueKeyRef.current = issueKey;
     }
 
     if (!userSettings || initializedProviderForOpenRef.current) {
@@ -80,7 +118,7 @@ export function IssueLaunchSheet({
 
     setProvider(userSettings.defaultSessionProvider ?? 'CLAUDE');
     initializedProviderForOpenRef.current = true;
-  }, [open, userSettings]);
+  }, [open, promptPreview, userSettings, issue.id, issue.provider]);
 
   useEffect(() => {
     if (!userSettings) {
@@ -129,6 +167,7 @@ export function IssueLaunchSheet({
   };
 
   const handleStart = () => {
+    const trimmedPrompt = promptText.trim();
     if (issue.provider === 'linear' && issue.linearIssueId && issue.linearIssueIdentifier) {
       createWorkspaceMutation.mutate({
         type: 'LINEAR_ISSUE',
@@ -142,6 +181,11 @@ export function IssueLaunchSheet({
         provider,
       });
     } else if (issue.githubIssueNumber) {
+      if (!trimmedPrompt) {
+        toast.error('Prompt cannot be empty');
+        return;
+      }
+
       createWorkspaceMutation.mutate({
         type: 'GITHUB_ISSUE',
         projectId,
@@ -149,6 +193,7 @@ export function IssueLaunchSheet({
         issueUrl: issue.url,
         name: issue.title,
         ratchetEnabled,
+        initialPrompt: trimmedPrompt,
         startupModePreset,
         provider,
       });
@@ -223,7 +268,9 @@ export function IssueLaunchSheet({
 
           <div className="space-y-1.5">
             <div className="flex items-center justify-between gap-2">
-              <Label className="text-xs">Prompt Preview</Label>
+              <Label htmlFor={`issue-prompt-${issue.id}`} className="text-xs">
+                Prompt
+              </Label>
               <Button variant="ghost" size="sm" className="h-7 px-2 text-xs" asChild>
                 <a href={issue.url} target="_blank" rel="noreferrer">
                   <ExternalLink className="h-3.5 w-3.5" />
@@ -231,16 +278,24 @@ export function IssueLaunchSheet({
                 </a>
               </Button>
             </div>
-            <pre className="max-h-64 overflow-auto whitespace-pre-wrap rounded-md border bg-muted/40 p-3 text-xs leading-relaxed text-muted-foreground">
-              {promptPreview}
-            </pre>
+            <Textarea
+              id={`issue-prompt-${issue.id}`}
+              value={promptText}
+              onChange={(event) => setPromptText(event.target.value)}
+              disabled={createWorkspaceMutation.isPending || isLoadingSettings}
+              className="min-h-64 resize-y whitespace-pre-wrap bg-muted/20 font-mono text-xs leading-relaxed text-muted-foreground"
+            />
           </div>
         </div>
 
         <SheetFooter className="pt-2">
           <Button
             onClick={handleStart}
-            disabled={createWorkspaceMutation.isPending || isLoadingSettings}
+            disabled={
+              createWorkspaceMutation.isPending ||
+              isLoadingSettings ||
+              (issue.provider === 'github' && !promptText.trim())
+            }
             className="w-full sm:w-auto"
           >
             <Play className="h-4 w-4 mr-2" />

--- a/src/client/components/kanban/issue-launch-sheet.tsx
+++ b/src/client/components/kanban/issue-launch-sheet.tsx
@@ -35,13 +35,26 @@ interface IssueLaunchSheetProps {
 
 type LaunchMode = 'non_interactive' | 'plan';
 type AgentProvider = 'CLAUDE' | 'CODEX';
+type PromptProject = {
+  githubOwner?: string | null;
+  githubRepo?: string | null;
+};
 
 function getIssueProviderLabel(issue: NormalizedIssue) {
   return issue.provider === 'linear' ? 'Linear' : 'GitHub';
 }
 
-function buildPromptPreview(issue: NormalizedIssue) {
+function buildProjectRawScreenshotBaseUrl(project: PromptProject | null | undefined) {
+  if (project?.githubOwner && project.githubRepo) {
+    return `https://raw.githubusercontent.com/${project.githubOwner}/${project.githubRepo}/`;
+  }
+
+  return '';
+}
+
+function buildPromptPreview(issue: NormalizedIssue, project: PromptProject | null | undefined) {
   const providerLabel = issue.provider === 'linear' ? 'Linear Issue' : 'GitHub Issue';
+  const projectRawScreenshotBaseUrl = buildProjectRawScreenshotBaseUrl(project);
   return buildIssueStartPrompt({
     providerLabel,
     issueReference: issue.displayId,
@@ -51,7 +64,8 @@ function buildPromptPreview(issue: NormalizedIssue) {
     commitReference: issue.displayId,
     closeReference: issue.displayId,
     rawScreenshotBaseUrl:
-      issue.provider === 'github' ? deriveGitHubRawScreenshotBaseUrl(issue.url) : '',
+      projectRawScreenshotBaseUrl ||
+      (issue.provider === 'github' ? deriveGitHubRawScreenshotBaseUrl(issue.url) : ''),
   });
 }
 
@@ -78,13 +92,17 @@ export function IssueLaunchSheet({
 }: IssueLaunchSheetProps) {
   const utils = trpc.useUtils();
   const { data: userSettings, isLoading: isLoadingSettings } = trpc.userSettings.get.useQuery();
-  const promptPreview = useMemo(() => buildPromptPreview(issue), [issue]);
+  const { data: project, isLoading: isLoadingProject } = trpc.project.getById.useQuery({
+    id: projectId,
+  });
+  const promptPreview = useMemo(() => buildPromptPreview(issue, project), [issue, project]);
   const [ratchetEnabled, setRatchetEnabled] = useState(false);
   const [startupModePreset, setStartupModePreset] = useState<LaunchMode>('non_interactive');
   const [provider, setProvider] = useState<AgentProvider>('CLAUDE');
   const [promptText, setPromptText] = useState(promptPreview);
   const initializedProviderForOpenRef = useRef(false);
   const initializedPromptIssueKeyRef = useRef<string | null>(null);
+  const lastPromptPreviewRef = useRef(promptPreview);
   const ratchetPreferenceKey = `kanban:issue-ratchet:${projectId}:${issue.id}`;
   const issueProviderLabel = getIssueProviderLabel(issue);
 
@@ -92,14 +110,21 @@ export function IssueLaunchSheet({
     if (!open) {
       initializedProviderForOpenRef.current = false;
       initializedPromptIssueKeyRef.current = null;
+      lastPromptPreviewRef.current = promptPreview;
       return;
     }
 
     const issueKey = `${issue.provider}:${issue.id}`;
+    const previousPromptPreview = lastPromptPreviewRef.current;
     if (initializedPromptIssueKeyRef.current !== issueKey) {
       setPromptText(promptPreview);
       initializedPromptIssueKeyRef.current = issueKey;
+    } else if (previousPromptPreview !== promptPreview) {
+      setPromptText((currentPromptText) =>
+        currentPromptText === previousPromptPreview ? promptPreview : currentPromptText
+      );
     }
+    lastPromptPreviewRef.current = promptPreview;
 
     if (!userSettings || initializedProviderForOpenRef.current) {
       return;
@@ -272,7 +297,7 @@ export function IssueLaunchSheet({
               id={`issue-prompt-${issue.id}`}
               value={promptText}
               onChange={(event) => setPromptText(event.target.value)}
-              disabled={createWorkspaceMutation.isPending || isLoadingSettings}
+              disabled={createWorkspaceMutation.isPending || isLoadingSettings || isLoadingProject}
               className="min-h-64 resize-y whitespace-pre-wrap bg-muted/20 font-mono text-xs leading-relaxed text-muted-foreground"
             />
           </div>
@@ -284,6 +309,7 @@ export function IssueLaunchSheet({
             disabled={
               createWorkspaceMutation.isPending ||
               isLoadingSettings ||
+              isLoadingProject ||
               (issue.provider === 'github' && !promptText.trim())
             }
             className="w-full sm:w-auto"

--- a/src/client/components/kanban/issue-launch-sheet.tsx
+++ b/src/client/components/kanban/issue-launch-sheet.tsx
@@ -41,29 +41,18 @@ function getIssueProviderLabel(issue: NormalizedIssue) {
 }
 
 function buildPromptPreview(issue: NormalizedIssue) {
-  if (issue.provider === 'github') {
-    return buildIssueStartPrompt({
-      providerLabel: 'GitHub Issue',
-      issueReference: issue.displayId,
-      title: issue.title,
-      body: issue.body,
-      url: issue.url,
-      commitReference: issue.displayId,
-      closeReference: issue.displayId,
-      rawScreenshotBaseUrl: deriveGitHubRawScreenshotBaseUrl(issue.url),
-    });
-  }
-
   const providerLabel = issue.provider === 'linear' ? 'Linear Issue' : 'GitHub Issue';
-  const body = issue.body?.trim() || '(No description provided)';
-
-  return `# ${providerLabel} ${issue.displayId}: ${issue.title}
-
-${body}
-
-Issue URL: ${issue.url}
-
-Start with planning, then implement, test, review, and open a pull request.`;
+  return buildIssueStartPrompt({
+    providerLabel,
+    issueReference: issue.displayId,
+    title: issue.title,
+    body: issue.body,
+    url: issue.url,
+    commitReference: issue.displayId,
+    closeReference: issue.displayId,
+    rawScreenshotBaseUrl:
+      issue.provider === 'github' ? deriveGitHubRawScreenshotBaseUrl(issue.url) : '',
+  });
 }
 
 function deriveGitHubRawScreenshotBaseUrl(issueUrl: string) {

--- a/src/client/components/kanban/issue-launch-sheet.tsx
+++ b/src/client/components/kanban/issue-launch-sheet.tsx
@@ -105,6 +105,12 @@ export function IssueLaunchSheet({
   const lastPromptPreviewRef = useRef(promptPreview);
   const ratchetPreferenceKey = `kanban:issue-ratchet:${projectId}:${issue.id}`;
   const issueProviderLabel = getIssueProviderLabel(issue);
+  const issueKey = `${issue.provider}:${issue.id}`;
+  const isPromptPreviewSyncPending =
+    open &&
+    initializedPromptIssueKeyRef.current === issueKey &&
+    lastPromptPreviewRef.current !== promptPreview &&
+    promptText === lastPromptPreviewRef.current;
 
   useEffect(() => {
     if (!open) {
@@ -114,7 +120,6 @@ export function IssueLaunchSheet({
       return;
     }
 
-    const issueKey = `${issue.provider}:${issue.id}`;
     const previousPromptPreview = lastPromptPreviewRef.current;
     if (initializedPromptIssueKeyRef.current !== issueKey) {
       setPromptText(promptPreview);
@@ -132,7 +137,7 @@ export function IssueLaunchSheet({
 
     setProvider(userSettings.defaultSessionProvider ?? 'CLAUDE');
     initializedProviderForOpenRef.current = true;
-  }, [open, promptPreview, userSettings, issue.id, issue.provider]);
+  }, [open, promptPreview, userSettings, issueKey]);
 
   useEffect(() => {
     if (!userSettings) {
@@ -181,7 +186,8 @@ export function IssueLaunchSheet({
   };
 
   const handleStart = () => {
-    const trimmedPrompt = promptText.trim();
+    const currentPromptText = isPromptPreviewSyncPending ? promptPreview : promptText;
+    const trimmedPrompt = currentPromptText.trim();
     if (issue.provider === 'linear' && issue.linearIssueId && issue.linearIssueIdentifier) {
       createWorkspaceMutation.mutate({
         type: 'LINEAR_ISSUE',
@@ -310,6 +316,7 @@ export function IssueLaunchSheet({
               createWorkspaceMutation.isPending ||
               isLoadingSettings ||
               isLoadingProject ||
+              isPromptPreviewSyncPending ||
               (issue.provider === 'github' && !promptText.trim())
             }
             className="w-full sm:w-auto"

--- a/src/shared/issue-start-prompt.ts
+++ b/src/shared/issue-start-prompt.ts
@@ -1,0 +1,184 @@
+export const FACTORY_SIGNATURE = '🏭 Forged in [Factory Factory](https://factoryfactory.ai)';
+
+type IssueStartPromptParams = {
+  providerLabel: string;
+  issueReference: string;
+  title: string;
+  body: string | null | undefined;
+  url: string;
+  commitReference: string;
+  closeReference: string;
+  rawScreenshotBaseUrl: string;
+};
+
+export function buildIssueStartPrompt(params: IssueStartPromptParams): string {
+  return `# ${params.providerLabel} ${params.issueReference}: ${params.title}
+
+${params.body || '(No description provided)'}
+
+**Issue URL**: ${params.url}
+
+---
+
+## Your Task
+
+Implement this issue following the 5-phase workflow below. Work autonomously—only ask questions if requirements are contradictory or fundamentally unclear.
+
+**Protect your context by delegating to specialized agents:**
+- Exploring unfamiliar code or architecture? Use: "Please use the Explore agent to understand [specific area]"
+- Significant changes to review/simplify? Use: "Please use the code-simplifier agent to review recent changes"
+- Targeted searches only? Use Grep/Glob directly
+
+---
+
+## Phase 1: Planning
+
+1. **Understand requirements and find relevant code**
+   - Read issue description and any linked resources
+   - Search for affected files (delegate to Explore agent for broad architecture questions)
+   - Identify which files need changes
+
+2. **Create task list with TodoWrite**
+   Create specific tasks for:
+   - Code changes (which files and what changes?)
+   - Tests to add (which test files?)
+   - Verification commands (typecheck, test, build)
+   - PR creation
+
+   Update status as you work: pending → in_progress → completed
+
+3. **Identify edge cases**
+   - What could go wrong?
+   - What scenarios need tests?
+   - What existing patterns should you follow?
+
+## Phase 2: Implementation
+
+1. **Work through your TodoWrite tasks systematically**
+   - Follow existing code patterns and conventions
+   - Add type definitions and error handling
+   - Keep commits atomic and focused
+   - Update TodoWrite as you discover additional work
+
+2. **Write tests**
+   - Test new functionality and edge cases
+   - Follow existing test patterns in the codebase
+   - Ensure tests are focused and maintainable
+
+3. **Commit frequently**
+   - Atomic commits as you complete logical units
+   - Follow project style: short, imperative, descriptive (<72 chars)
+   - Reference issue number when relevant
+   - Example: "Add session error handling (${params.commitReference})"
+
+## Phase 3: Verification
+
+Run all verification checks:
+
+\`\`\`bash
+pnpm typecheck && pnpm check:fix && pnpm test && pnpm build
+\`\`\`
+
+Fix any failures:
+- **Type errors**: Resolve without type casts when possible
+- **Lint errors**: Review \`pnpm check:fix\` changes
+- **Test failures**: Debug and fix before proceeding
+- **Build failures**: Check for syntax errors or missing dependencies
+
+Update TodoWrite with any additional fix tasks discovered.
+
+## Phase 4: Final Review
+
+1. **Review your changes**
+   \`\`\`bash
+   git diff origin/main
+   \`\`\`
+
+   Look for:
+   - Debug logs or commented code to remove
+   - Unclear variable names to improve
+   - Unnecessary complexity to simplify
+
+2. **Optional: Delegate to code-simplifier for large changes**
+   If you've changed many files (8+) or added complex logic:
+   - Use: "Please use the code-simplifier agent to review recent changes"
+   - Re-run tests after any changes: \`pnpm test\`
+
+3. **Ensure everything is committed**
+   \`\`\`bash
+   git status  # should show clean working directory
+   \`\`\`
+
+## Phase 4.5: Capture UI Screenshots (if applicable)
+
+If your changes affect the UI:
+
+1. Read \`factory-factory.json\` for the \`scripts.run\` command, pick a free port, replace \`{port}\`, and start it in the background.
+2. Use \`browser_navigate\` to visit the dev server URL
+3. Determine the most relevant screen showing your changes and capture a screenshot
+4. Save screenshots:
+   \`\`\`bash
+   mkdir -p .factory-factory/screenshots
+   \`\`\`
+   Save with descriptive names (e.g., \`dashboard-new-widget.png\`)
+5. Commit the screenshots with your changes
+6. Reference them in the PR body using raw GitHub URLs:
+   \`![Description](${params.rawScreenshotBaseUrl}\${branch}/.factory-factory/screenshots/filename.png)\`
+
+## Phase 5: Create Pull Request [REQUIRED - DO NOT SKIP]
+
+**Pre-flight checklist before creating PR:**
+- [ ] All TodoWrite tasks marked completed
+- [ ] \`pnpm test\` passes
+- [ ] \`pnpm typecheck\` passes
+- [ ] \`pnpm build\` succeeds
+- [ ] Working directory clean (\`git status\`)
+- [ ] All commits have descriptive messages
+
+**Now create the PR:**
+
+1. **Push your branch:**
+   \`\`\`bash
+   git push -u origin HEAD
+   \`\`\`
+
+2. **Write PR body to /tmp/pr-body.md:**
+   \`\`\`markdown
+   ## Summary
+   [1-3 bullets describing what this PR accomplishes]
+
+   ## Changes
+   - **[Component/Area]**: [What changed and why]
+   - [Add more lines as needed]
+
+   ## Testing
+   - [x] Tests pass (\`pnpm test\`)
+   - [x] Types pass (\`pnpm typecheck\`)
+   - [x] Build succeeds (\`pnpm build\`)
+   - [ ] Manual testing: [How to verify this change works]
+
+   Closes ${params.closeReference}
+   \`\`\`
+
+3. **IMPORTANT**: Always append the following signature as the very last lines of the PR body, after a horizontal rule:
+   \`\`\`
+   ---
+   ${FACTORY_SIGNATURE}
+   \`\`\`
+
+4. **Create the PR:**
+   \`\`\`bash
+   gh pr create --title "Fix ${params.closeReference}: [concise description]" --body-file /tmp/pr-body.md
+   \`\`\`
+
+4. **Verify PR created successfully:**
+   \`\`\`bash
+   gh pr view --web
+   \`\`\`
+
+---
+
+**You have completed this issue successfully when the PR is created and the URL is shown above.**
+
+Start with Phase 1: Planning.`;
+}


### PR DESCRIPTION
## Summary
- Make the GitHub issue Start Issue prompt editable before workspace creation.
- Seed the editor with the full issue workflow prompt that the agent will actually receive.
- Persist edited issue prompts in workspace creation metadata and reuse them during initialization.

## Changes
- Shared the issue-start prompt builder between client preview/editing and backend fallback generation.
- Extended GitHub issue workspace creation input to accept `initialPrompt` and store it in `creationMetadata`.
- Updated workspace initialization to prefer saved creation metadata before rebuilding prompts from GitHub or Linear.
- Added focused tests for the editable prompt UI, tRPC input plumbing, metadata persistence, and init-time prompt reuse.

## Testing
- [x] `pnpm vitest run src/client/components/kanban/issue-launch-sheet.test.tsx src/backend/services/workspace/service/lifecycle/creation.service.test.ts src/backend/trpc/workspace.router.test.ts src/backend/orchestration/workspace-init.orchestrator.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm check`

Notes: `pnpm check` still reports existing non-failing `<img>` warnings and skips local Codex schema drift enforcement because the installed Codex CLI differs from the pinned CI version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what initial message agents receive at workspace startup; behavior is covered by new tests but affects core orchestration flow.
> 
> **Overview**
> Users can **edit the agent start prompt** in the issue launch sheet before creating a workspace from GitHub or Linear issues. The sheet seeds a **textarea** with the same full **5-phase workflow** prompt the backend would build, enriched with project **raw GitHub screenshot** URLs when project metadata is available.
> 
> **`initialPrompt`** is threaded through **tRPC** and **workspace creation** into **`creationMetadata`** (including empty strings). On init, the orchestrator **uses saved metadata first** and skips refetching the issue; it **escapes** `</`-like sequences in stored prompts. The prompt builder and **`FACTORY_SIGNATURE`** live in **`@/shared/issue-start-prompt`** for client/backend parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74fef39579ecb8033c9cd937c33cac77dbe45b95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->