### PR TITLE
Fix #1677: Handle markdown workspace middle-clicks

### DIFF
--- a/src/components/ui/markdown.test.tsx
+++ b/src/components/ui/markdown.test.tsx
@@ -39,6 +39,66 @@ describe('MarkdownRenderer workspace file links', () => {
     root.unmount();
   });
 
+  it('intercepts middle-clicks on resolved workspace file links', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const onWorkspaceFileLink = vi.fn();
+
+    flushSync(() => {
+      root.render(
+        createElement(MarkdownRenderer, {
+          content: '[Concerns](/Users/demo/workspace/.planning/CONCERNS.md:31)',
+          resolveWorkspaceFileLink: () => '.planning/CONCERNS.md',
+          onWorkspaceFileLink,
+        })
+      );
+    });
+
+    const link = container.querySelector('a');
+    const event = new MouseEvent('auxclick', {
+      bubbles: true,
+      button: 1,
+      cancelable: true,
+    });
+    const wasNotCanceled = link?.dispatchEvent(event);
+
+    expect(wasNotCanceled).toBe(false);
+    expect(onWorkspaceFileLink).toHaveBeenCalledWith('.planning/CONCERNS.md');
+
+    root.unmount();
+  });
+
+  it('ignores non-middle auxclicks on resolved workspace file links', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const onWorkspaceFileLink = vi.fn();
+
+    flushSync(() => {
+      root.render(
+        createElement(MarkdownRenderer, {
+          content: '[Concerns](/Users/demo/workspace/.planning/CONCERNS.md:31)',
+          resolveWorkspaceFileLink: () => '.planning/CONCERNS.md',
+          onWorkspaceFileLink,
+        })
+      );
+    });
+
+    const link = container.querySelector('a');
+    const event = new MouseEvent('auxclick', {
+      bubbles: true,
+      button: 2,
+      cancelable: true,
+    });
+    const wasNotCanceled = link?.dispatchEvent(event);
+
+    expect(wasNotCanceled).toBe(true);
+    expect(onWorkspaceFileLink).not.toHaveBeenCalled();
+
+    root.unmount();
+  });
+
   it('keeps external links opening in a new tab', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);

--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -130,6 +130,14 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
                 event.preventDefault();
                 onWorkspaceFileLink(workspacePath);
               }}
+              onAuxClick={(event) => {
+                if (event.button !== 1) {
+                  return;
+                }
+
+                event.preventDefault();
+                onWorkspaceFileLink(workspacePath);
+              }}
               className="text-primary underline hover:no-underline inline-flex items-center gap-0.5"
             >
               {children}


### PR DESCRIPTION
## Summary
- Intercepts middle-clicks on resolved workspace file links in markdown.
- Prevents raw filesystem-style link navigation from breaking the Electron/dev app route.
- Adds regression coverage for middle-click handling and non-middle auxclick behavior.

## Changes
- **MarkdownRenderer**: Added `onAuxClick` handling for middle mouse button workspace file links, routing them through `onWorkspaceFileLink`.
- **Tests**: Covered middle-click cancellation/opening and preserved non-middle auxclick defaults for workspace links.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Manual testing: Verified via focused jsdom regression test dispatching a cancelable `auxclick` event with `button: 1`.

Closes #1677

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI event-handling change aligned with existing click behavior; no auth, data, or API impact.
> 
> **Overview**
> **Middle-clicks** on resolved workspace file links in markdown now open files through the app’s `onWorkspaceFileLink` handler instead of following the raw `href`, matching existing left-click behavior and avoiding broken navigation in Electron/dev.
> 
> `MarkdownRenderer` adds an `onAuxClick` handler that only runs for **button 1** (middle mouse); other aux clicks are unchanged. Tests assert middle-click is canceled and routed, and that non-middle aux clicks do not invoke the handler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a62caa9675609e1257dff4a28c699735ec45ff34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->