### PR TITLE
Fix #1680: Drop stale ratchet review feedback

### DIFF
--- a/src/backend/services/ratchet/service/ratchet-pr-state.helpers.test.ts
+++ b/src/backend/services/ratchet/service/ratchet-pr-state.helpers.test.ts
@@ -263,6 +263,73 @@ describe('buildReviewSummariesForPrompt', () => {
 
     expect(summaries).toEqual([]);
   });
+
+  it('excludes stale changes-requested reviews after the same reviewer approves', () => {
+    const summaries = buildReviewSummariesForPrompt(
+      {
+        url: 'https://github.com/example/repo/pull/1',
+        reviews: [
+          {
+            author: { login: 'reviewer-a' },
+            state: 'CHANGES_REQUESTED',
+            body: 'A requests changes first',
+          },
+          {
+            author: { login: 'reviewer-b' },
+            state: 'CHANGES_REQUESTED',
+            body: 'B requests changes',
+          },
+          {
+            author: { login: 'reviewer-a' },
+            state: 'APPROVED',
+            body: '',
+          },
+        ],
+      },
+      null
+    );
+
+    expect(summaries).toEqual([
+      {
+        author: 'reviewer-b',
+        body: 'B requests changes',
+        path: 'PR review',
+        line: null,
+        url: 'https://github.com/example/repo/pull/1',
+      },
+    ]);
+  });
+
+  it('keeps changes-requested reviews when they are the reviewer latest state', () => {
+    const summaries = buildReviewSummariesForPrompt(
+      {
+        url: 'https://github.com/example/repo/pull/1',
+        reviews: [
+          {
+            author: { login: 'reviewer-a' },
+            state: 'APPROVED',
+            body: '',
+          },
+          {
+            author: { login: 'reviewer-a' },
+            state: 'CHANGES_REQUESTED',
+            body: 'A found a later issue',
+          },
+        ],
+      },
+      null
+    );
+
+    expect(summaries).toEqual([
+      {
+        author: 'reviewer-a',
+        body: 'A found a later issue',
+        path: 'PR review',
+        line: null,
+        url: 'https://github.com/example/repo/pull/1',
+      },
+    ]);
+  });
 });
 
 describe('buildFailedCheckDiagnostics', () => {

--- a/src/backend/services/ratchet/service/ratchet-pr-state.helpers.ts
+++ b/src/backend/services/ratchet/service/ratchet-pr-state.helpers.ts
@@ -166,14 +166,34 @@ export function buildReviewSummariesForPrompt(
   },
   authenticatedUsername: string | null
 ): PRStateInfo['reviewComments'] {
+  const latestStateByAuthor = new Map<string, string>();
+
+  for (const review of prDetails.reviews) {
+    const state = review.state?.toUpperCase();
+    if (state) {
+      latestStateByAuthor.set(review.author.login, state);
+    }
+  }
+
   return prDetails.reviews
     .filter((review) => {
       if (isIgnoredReviewAuthor(review.author.login, authenticatedUsername)) {
         return false;
       }
-      if (!ACTIONABLE_REVIEW_STATES.has(review.state?.toUpperCase() ?? '')) {
+
+      const state = review.state?.toUpperCase() ?? '';
+
+      if (
+        state === 'CHANGES_REQUESTED' &&
+        latestStateByAuthor.get(review.author.login) === 'APPROVED'
+      ) {
         return false;
       }
+
+      if (!ACTIONABLE_REVIEW_STATES.has(state)) {
+        return false;
+      }
+
       return (review.body?.trim().length ?? 0) > 0;
     })
     .map((review) => ({


### PR DESCRIPTION
## Summary
- Filters stale changes-requested review bodies from ratchet fixer prompts after the same reviewer later approves.
- Adds regression coverage for interleaved reviewer timelines.

## Changes
- **Ratchet PR state**: Track each reviewer latest review state before summarizing actionable review bodies.
- **Tests**: Cover stale changes-requested feedback after approval and ensure later changes-requested reviews remain actionable.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Manual testing: Verified with focused `pnpm vitest run src/backend/services/ratchet/service/ratchet-pr-state.helpers.test.ts`

Closes #1680

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow prompt-filtering change with unit tests; only affects which review text is sent to the ratchet fixer, not merge/CI logic.
> 
> **Overview**
> Ratchet fixer prompts no longer treat **stale** `CHANGES_REQUESTED` review bodies as actionable feedback when that reviewer’s **latest** review is `APPROVED`.
> 
> `buildReviewSummariesForPrompt` now records each reviewer’s final review state from the PR timeline, then skips older changes-requested entries superseded by approval. **Later** changes-requested reviews from the same reviewer still appear in the prompt. Regression tests cover interleaved reviewers and approve-then-request-changes ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9911c87989ed25433f349c61a4726b37d0edb59f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->