### PR TITLE
Fix #1678: Restore recovered plan approval

### DIFF
--- a/src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.test.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.test.ts
@@ -1320,6 +1320,94 @@ describe('CodexAppServerAcpAdapter', () => {
     );
   });
 
+  it('requests ExitPlanMode approval after recovered completed plan item in plan mode', async () => {
+    const { connection } = createMockConnection();
+    (connection.requestPermission as ReturnType<typeof vi.fn>).mockResolvedValue({
+      outcome: { outcome: 'selected', optionId: 'default' },
+    } satisfies RequestPermissionResponse);
+
+    const { client: codexClient, mocks: codex } = createMockCodexClient();
+    const adapter = new CodexAppServerAcpAdapter(connection as AgentSideConnection, codexClient);
+
+    await initializeAdapterWithDefaultModel(adapter, codex);
+
+    codex.request.mockResolvedValueOnce({
+      thread: { id: 'thread_recovered_plan_approval', cwd: '/tmp/workspace' },
+      approvalPolicy: DEFAULT_APPROVAL_POLICY,
+      reasoningEffort: 'medium',
+    });
+    const session = await adapter.newSession({
+      cwd: '/tmp/workspace',
+      mcpServers: [],
+    });
+    await adapter.setSessionMode({ sessionId: session.sessionId, modeId: 'plan' });
+
+    await (
+      adapter as unknown as {
+        handleCodexNotification: (method: string, params: unknown) => Promise<void>;
+      }
+    ).handleCodexNotification('item/plan/delta', {
+      threadId: 'thread_recovered_plan_approval',
+      turnId: 'turn_recovered_plan_approval',
+      itemId: 'item_recovered_plan_approval',
+      delta: '## Recovered Plan\n1. Request approval after recovery',
+    });
+
+    await (
+      adapter as unknown as {
+        handleCodexNotification: (method: string, params: unknown) => Promise<void>;
+      }
+    ).handleCodexNotification('item/completed', {
+      threadId: 'thread_recovered_plan_approval',
+      turnId: 'turn_recovered_plan_approval',
+      item: {
+        type: 'plan',
+        id: 'item_recovered_plan_approval',
+        status: 'completed',
+      },
+    });
+
+    expect(connection.requestPermission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolCall: expect.objectContaining({
+          title: 'ExitPlanMode',
+          kind: 'switch_mode',
+        }),
+      })
+    );
+    expect((connection.sessionUpdate as ReturnType<typeof vi.fn>).mock.calls).toEqual(
+      expect.arrayContaining([
+        [
+          expect.objectContaining({
+            update: expect.objectContaining({
+              sessionUpdate: 'tool_call',
+              title: 'plan',
+              kind: 'think',
+              status: 'completed',
+            }),
+          }),
+        ],
+        [
+          expect.objectContaining({
+            update: expect.objectContaining({
+              sessionUpdate: 'tool_call',
+              title: 'ExitPlanMode',
+              kind: 'switch_mode',
+              status: 'pending',
+              rawInput: expect.objectContaining({
+                type: 'ExitPlanMode',
+                plan: expect.objectContaining({
+                  type: 'text',
+                  text: expect.stringContaining('## Recovered Plan'),
+                }),
+              }),
+            }),
+          }),
+        ],
+      ])
+    );
+  });
+
   it('switches to the selected non-plan mode id when plan approval is accepted', async () => {
     const { connection } = createMockConnection();
     (connection.requestPermission as ReturnType<typeof vi.fn>).mockResolvedValue({

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.test.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.test.ts
@@ -164,4 +164,67 @@ describe('stream-event-handler', () => {
       expect.anything()
     );
   });
+
+  it('requests plan approval for recovered completed plan items', async () => {
+    const session = createSession();
+    session.defaults.collaborationMode = 'plan';
+    session.planTextByItemId.set('item_plan', '## Proposed Plan\n1. Fix recovery approval');
+
+    const emitSessionUpdate = vi.fn(async () => undefined);
+    const shouldHoldTurnForPlanApproval = vi.fn(() => true);
+    const holdTurnUntilPlanApprovalResolves = vi.fn();
+    const maybeRequestPlanApproval = vi.fn(async () => undefined);
+    const toolState: ToolCallState = {
+      toolCallId: 'call_plan',
+      kind: 'think',
+      title: 'plan',
+      locations: [],
+    };
+
+    const handler = new CodexStreamEventHandler({
+      codex: { request: vi.fn() },
+      sessionIdByThreadId: new Map([['thread_1', 'sess_thread_1']]),
+      sessions: new Map([['sess_thread_1', session]]),
+      requireSession: vi.fn(),
+      emitSessionUpdate,
+      reportShapeDrift: vi.fn(),
+      buildToolCallState: vi.fn(() => toolState),
+      emitReasoningThoughtChunkFromItem: vi.fn(async () => undefined),
+      shouldHoldTurnForPlanApproval,
+      holdTurnUntilPlanApprovalResolves,
+      maybeRequestPlanApproval,
+      hasPendingPlanApprovals: vi.fn(() => false),
+      settleTurn: vi.fn(),
+      emitTurnFailureMessage: vi.fn(async () => undefined),
+    });
+
+    const item = {
+      type: 'plan',
+      id: 'item_plan',
+      status: 'completed',
+    };
+
+    await handler.handleCodexNotification({
+      method: 'item/completed',
+      params: {
+        threadId: 'thread_1',
+        turnId: 'turn_1',
+        item,
+      },
+    });
+
+    expect(shouldHoldTurnForPlanApproval).toHaveBeenCalledWith(session, item, 'turn_1');
+    expect(holdTurnUntilPlanApprovalResolves).toHaveBeenCalledWith(session, 'turn_1');
+    expect(emitSessionUpdate).toHaveBeenCalledWith(
+      'sess_thread_1',
+      expect.objectContaining({
+        sessionUpdate: 'tool_call',
+        toolCallId: 'call_plan',
+        title: 'plan',
+        kind: 'think',
+        status: 'completed',
+      })
+    );
+    expect(maybeRequestPlanApproval).toHaveBeenCalledWith(session, item, 'turn_1', toolState);
+  });
 });

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.ts
@@ -640,6 +640,10 @@ export class CodexStreamEventHandler {
   ): Promise<void> {
     const recovered = this.deps.buildToolCallState(session, item, turnId);
     if (recovered) {
+      if (this.deps.shouldHoldTurnForPlanApproval(session, item, turnId)) {
+        this.deps.holdTurnUntilPlanApprovalResolves(session, turnId);
+      }
+
       await this.deps.emitSessionUpdate(session.sessionId, {
         sessionUpdate: 'tool_call',
         toolCallId: recovered.toolCallId,
@@ -650,6 +654,8 @@ export class CodexStreamEventHandler {
         rawInput: item,
         rawOutput: item,
       });
+
+      await this.deps.maybeRequestPlanApproval(session, item, turnId, recovered);
       return;
     }
 


### PR DESCRIPTION
## Summary
- Restores ExitPlanMode approval requests when completed plan items are recovered without prior started state
- Keeps recovered plan items aligned with the normal plan completion workflow
- Adds regression coverage at both stream-handler and adapter levels

## Changes
- **ACP stream recovery**: Runs plan approval hold and request hooks after rebuilding recovered completed tool state.
- **Tests**: Covers recovered completed plan items requesting ExitPlanMode approval in plan mode.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Manual testing: Verified through focused ACP adapter tests that simulate completed plan recovery without `item/started`

Closes #1678

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to stream recovery for plan items in plan mode, with targeted regression tests and no auth or data-layer impact.
> 
> **Overview**
> Fixes a gap where **completed plan items** that arrive only via **`item/completed`** (no prior **`item/started`**) were recovered as tool calls but **skipped** the normal plan-mode workflow.
> 
> **`CodexStreamEventHandler`** now runs the same **turn hold** and **`ExitPlanMode`** approval hooks on that recovery path as on a standard plan completion, so users still get permission to leave plan mode with the accumulated plan text.
> 
> Regression tests cover the stream handler and end-to-end **ACP adapter** behavior when plan deltas are followed by a lone completed plan item.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a66e6217959fb28054e4b8c6a6b866160dcdf149. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->