### PR TITLE
Fix #1689: Skip enqueueing cleared initial prompts

### DIFF
--- a/src/backend/orchestration/workspace-init.orchestrator.test.ts
+++ b/src/backend/orchestration/workspace-init.orchestrator.test.ts
@@ -971,7 +971,7 @@ describe('initializeWorkspaceWorktree', () => {
       );
     });
 
-    it('enqueues saved empty initial prompt without rebuilding issue prompt', async () => {
+    it('skips enqueue for saved empty initial prompt without rebuilding issue prompt', async () => {
       const workspace = makeWorkspaceWithProject({
         githubIssueNumber: 42,
         creationMetadata: {
@@ -991,10 +991,71 @@ describe('initializeWorkspaceWorktree', () => {
       await initializeWorkspaceWorktree(WORKSPACE_ID);
 
       expect(githubCLIService.getIssue).not.toHaveBeenCalled();
+      expect(sessionDomainService.enqueue).not.toHaveBeenCalled();
+    });
+
+    it('skips enqueue for saved whitespace-only initial prompt without rebuilding issue prompt', async () => {
+      const workspace = makeWorkspaceWithProject({
+        githubIssueNumber: 42,
+        creationMetadata: {
+          issueNumber: 42,
+          issueUrl: 'https://github.com/owner/repo/issues/42',
+          initialPrompt: '   \n\t',
+        },
+      });
+      setupHappyPath();
+      vi.mocked(workspaceAccessor.findByIdWithProject).mockResolvedValue(workspace);
+      vi.mocked(workspaceAccessor.findById).mockResolvedValue(workspace as never);
+      vi.mocked(agentSessionAccessor.findByWorkspaceId).mockResolvedValue([
+        unsafeCoerce({ id: 'session-1', status: SessionStatus.IDLE, model: 'claude-sonnet' }),
+      ]);
+      vi.mocked(sessionDomainService.enqueue).mockReturnValue({ position: 0 });
+
+      await initializeWorkspaceWorktree(WORKSPACE_ID);
+
+      expect(githubCLIService.getIssue).not.toHaveBeenCalled();
+      expect(sessionDomainService.enqueue).not.toHaveBeenCalled();
+    });
+
+    it('enqueues attachments when saved initial prompt is empty but attachments exist', async () => {
+      const workspace = makeWorkspaceWithProject({
+        githubIssueNumber: 42,
+        creationMetadata: {
+          issueNumber: 42,
+          issueUrl: 'https://github.com/owner/repo/issues/42',
+          initialPrompt: '',
+          initialAttachments: [
+            {
+              id: 'att-1',
+              name: 'evidence.png',
+              type: 'image/png',
+              size: 120,
+              data: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB',
+              contentType: 'image',
+            },
+          ],
+        },
+      });
+      setupHappyPath();
+      vi.mocked(workspaceAccessor.findByIdWithProject).mockResolvedValue(workspace);
+      vi.mocked(workspaceAccessor.findById).mockResolvedValue(workspace as never);
+      vi.mocked(agentSessionAccessor.findByWorkspaceId).mockResolvedValue([
+        unsafeCoerce({ id: 'session-1', status: SessionStatus.IDLE, model: 'claude-sonnet' }),
+      ]);
+      vi.mocked(sessionDomainService.enqueue).mockReturnValue({ position: 0 });
+
+      await initializeWorkspaceWorktree(WORKSPACE_ID);
+
+      expect(githubCLIService.getIssue).not.toHaveBeenCalled();
       expect(sessionDomainService.enqueue).toHaveBeenCalledWith(
         'session-1',
         expect.objectContaining({
           text: '',
+          attachments: [
+            expect.objectContaining({
+              id: 'att-1',
+            }),
+          ],
         })
       );
     });

--- a/src/backend/orchestration/workspace-init.orchestrator.ts
+++ b/src/backend/orchestration/workspace-init.orchestrator.ts
@@ -323,12 +323,17 @@ async function resolveInitialAutoMessageContent(
   const metadataPrompt = readInitialPromptFromMetadata(creationMetadata, workspaceId);
   const metadataAttachments = readInitialAttachmentsFromMetadata(creationMetadata, workspaceId);
 
-  if (metadataPrompt.provided || (metadataAttachments && metadataAttachments.length > 0)) {
+  const hasAttachments = metadataAttachments !== undefined && metadataAttachments.length > 0;
+  if (metadataPrompt.provided || hasAttachments) {
+    // A provided-but-blank prompt means the user cleared it: send nothing rather
+    // than enqueueing an empty message the agent adapter would reject (#1689),
+    // and don't fall through to rebuilding the issue prompt.
+    if (!(metadataPrompt.text.trim() || hasAttachments)) {
+      return null;
+    }
     return {
       text: metadataPrompt.text,
-      ...(metadataAttachments && metadataAttachments.length > 0
-        ? { attachments: metadataAttachments }
-        : {}),
+      ...(hasAttachments ? { attachments: metadataAttachments } : {}),
     };
   }
 


### PR DESCRIPTION
Fixes #1689

## Problem

When a workspace is created with `initialPrompt: ''` (possible via the Linear issue launch path, which doesn't block empty prompts in the UI), the orchestrator enqueued an empty auto message. The CODEX adapter rejects prompts with no non-empty content blocks, and `handleDispatchError` requeues the failed message to the front of the session queue without any retry scheduling or removal — so the same empty message blocked every subsequent dispatch until manually removed.

## Root cause

#1681 changed `resolveInitialAutoMessageContent` to honor a user-cleared prompt (skip re-fetching the issue prompt when `initialPrompt` is present in creation metadata), but the check `metadataPrompt.provided || ...` only tested for the key's presence, not for non-empty text. Empty prompts therefore got enqueued, whereas the pre-#1681 code returned `null` for them.

## Fix

In `resolveInitialAutoMessageContent`, a provided-but-blank prompt (empty or whitespace-only) with no attachments now resolves to `null`: nothing is enqueued, and the issue prompt is still not re-fetched, preserving the cleared-prompt behavior #1681 intended. Attachment-only launches continue to enqueue normally.

## Tests

- Updated the test that pinned the buggy behavior: a saved empty initial prompt now asserts no enqueue (and still no issue re-fetch).
- Added a whitespace-only prompt test.
- Added an empty-prompt-with-attachments test pinning that attachments still dispatch.

`pnpm test` (3237 passed), `pnpm typecheck`, and `pnpm check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow orchestration change to initial message resolution with expanded unit tests; no auth, data migration, or broad API surface changes.
> 
> **Overview**
> Fixes **#1689** by tightening how workspace init resolves the first auto message when creation metadata includes a user-cleared prompt.
> 
> In `resolveInitialAutoMessageContent`, if `initialPrompt` is present but empty or whitespace-only **and** there are no `initialAttachments`, the function now returns **`null`** so nothing is enqueued and the linked GitHub/Linear issue prompt is **not** rebuilt—keeping the “user cleared the prompt” behavior from #1681 without shipping an empty queue item that adapters reject and that could wedge the session queue.
> 
> **Attachment-only** launches still enqueue (empty text with attachments). Tests now expect no enqueue for empty/whitespace prompts and assert attachments still dispatch when the saved prompt is blank.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27ad61f7041857a99459befa4a4dec994455d527. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->