### PR TITLE
Fix #1688: Filter stale changes-requested after approve-then-comment

### DIFF
--- a/src/backend/services/ratchet/service/ratchet-pr-state.helpers.test.ts
+++ b/src/backend/services/ratchet/service/ratchet-pr-state.helpers.test.ts
@@ -330,6 +330,78 @@ describe('buildReviewSummariesForPrompt', () => {
       },
     ]);
   });
+
+  it('excludes stale changes-requested reviews when the reviewer approves then comments', () => {
+    const summaries = buildReviewSummariesForPrompt(
+      {
+        url: 'https://github.com/example/repo/pull/1',
+        reviews: [
+          {
+            author: { login: 'reviewer-a' },
+            state: 'CHANGES_REQUESTED',
+            body: 'Please fix the null check',
+          },
+          {
+            author: { login: 'reviewer-a' },
+            state: 'APPROVED',
+            body: '',
+          },
+          {
+            author: { login: 'reviewer-a' },
+            state: 'COMMENTED',
+            body: 'Thanks for the fix!',
+          },
+        ],
+      },
+      null
+    );
+
+    expect(summaries).toEqual([
+      {
+        author: 'reviewer-a',
+        body: 'Thanks for the fix!',
+        path: 'PR review',
+        line: null,
+        url: 'https://github.com/example/repo/pull/1',
+      },
+    ]);
+  });
+
+  it('keeps changes-requested reviews submitted after the reviewer last approved', () => {
+    const summaries = buildReviewSummariesForPrompt(
+      {
+        url: 'https://github.com/example/repo/pull/1',
+        reviews: [
+          {
+            author: { login: 'reviewer-a' },
+            state: 'CHANGES_REQUESTED',
+            body: 'First round of feedback',
+          },
+          {
+            author: { login: 'reviewer-a' },
+            state: 'APPROVED',
+            body: '',
+          },
+          {
+            author: { login: 'reviewer-a' },
+            state: 'CHANGES_REQUESTED',
+            body: 'Found a new issue after approving',
+          },
+        ],
+      },
+      null
+    );
+
+    expect(summaries).toEqual([
+      {
+        author: 'reviewer-a',
+        body: 'Found a new issue after approving',
+        path: 'PR review',
+        line: null,
+        url: 'https://github.com/example/repo/pull/1',
+      },
+    ]);
+  });
 });
 
 describe('buildFailedCheckDiagnostics', () => {

--- a/src/backend/services/ratchet/service/ratchet-pr-state.helpers.ts
+++ b/src/backend/services/ratchet/service/ratchet-pr-state.helpers.ts
@@ -166,17 +166,18 @@ export function buildReviewSummariesForPrompt(
   },
   authenticatedUsername: string | null
 ): PRStateInfo['reviewComments'] {
-  const latestStateByAuthor = new Map<string, string>();
+  // A CHANGES_REQUESTED review is stale once the same reviewer approves later,
+  // even if they leave further COMMENTED reviews after the approval.
+  const lastApprovedIndexByAuthor = new Map<string, number>();
 
-  for (const review of prDetails.reviews) {
-    const state = review.state?.toUpperCase();
-    if (state) {
-      latestStateByAuthor.set(review.author.login, state);
+  prDetails.reviews.forEach((review, index) => {
+    if (review.state?.toUpperCase() === 'APPROVED') {
+      lastApprovedIndexByAuthor.set(review.author.login, index);
     }
-  }
+  });
 
   return prDetails.reviews
-    .filter((review) => {
+    .filter((review, index) => {
       if (isIgnoredReviewAuthor(review.author.login, authenticatedUsername)) {
         return false;
       }
@@ -185,7 +186,7 @@ export function buildReviewSummariesForPrompt(
 
       if (
         state === 'CHANGES_REQUESTED' &&
-        latestStateByAuthor.get(review.author.login) === 'APPROVED'
+        (lastApprovedIndexByAuthor.get(review.author.login) ?? -1) > index
       ) {
         return false;
       }


### PR DESCRIPTION
Fixes #1688

## Problem

`buildReviewSummariesForPrompt` filtered stale `CHANGES_REQUESTED` reviews only when the reviewer's *latest* review state was `APPROVED`. In the common sequence `CHANGES_REQUESTED → APPROVED → COMMENTED` (e.g., reviewer approves and then says "Thanks for the fix!"), the final state is `COMMENTED`, so the stale `CHANGES_REQUESTED` body was still included in the prompt sent to the auto-fix agent — causing it to re-address already-fixed feedback.

## Fix

Track the index of each reviewer's last `APPROVED` review instead of just their final state. A `CHANGES_REQUESTED` review is now filtered whenever the same reviewer approved *later* in the review sequence, regardless of any subsequent `COMMENTED` reviews.

This also fixes a related edge case: in `CHANGES_REQUESTED → APPROVED → CHANGES_REQUESTED`, the first (stale) request is now filtered while the new post-approval request is kept. Previously both were included.

## Testing

- Added test: stale `CHANGES_REQUESTED` is excluded after the reviewer approves then comments
- Added test: a `CHANGES_REQUESTED` submitted after the reviewer's last approval is kept
- `pnpm test` (3237 passed), `pnpm typecheck`, `pnpm check` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
