### PR TITLE
Fix slash commands disabled for Claude sessions

### DIFF
--- a/src/backend/services/session/service/lifecycle/session-config-option-helpers.ts
+++ b/src/backend/services/session/service/lifecycle/session-config-option-helpers.ts
@@ -277,7 +277,7 @@ export function buildCapabilitiesFromConfigOptions(
     attachments: isCodexProvider
       ? { enabled: false, kinds: [] }
       : { enabled: true, kinds: ['image', 'text'] },
-    slashCommands: { enabled: false },
+    slashCommands: { enabled: !isCodexProvider },
     usageStats: { enabled: false, contextWindow: false },
     rewind: { enabled: false },
   };


### PR DESCRIPTION
## Summary
- `buildCapabilitiesFromConfigOptions` was hardcoding `slashCommands: { enabled: false }` for all sessions, including Claude sessions
- This caused the slash command palette to never appear in the UI even for Claude sessions where it should be available
- Fix: enable slash commands for non-Codex (Claude) sessions, consistent with how other capabilities like `attachments` are handled

## Test plan
- [ ] Start a Claude session, type `/` in the chat input — slash command palette should appear
- [ ] Codex sessions should still have slash commands disabled (no palette on `/`)
- [ ] `pnpm test` — all tests pass
- [ ] `pnpm typecheck` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)