### PR TITLE
Add CodeQL workflow with merge_group trigger

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,10 @@
 name: CodeQL
 
 on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
   merge_group:
     types: [checks_requested]
   schedule:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,8 +25,6 @@ jobs:
         include:
           - language: javascript-typescript
             build-mode: none
-          - language: actions
-            build-mode: none
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  merge_group:
+    types: [checks_requested]
+  schedule:
+    - cron: "30 1 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+            build-mode: none
+          - language: actions
+            build-mode: none
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,10 +1,6 @@
 name: CodeQL
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
   merge_group:
     types: [checks_requested]
   schedule:


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/codeql.yml` with a `merge_group` trigger to fix merge queue timeouts
- The merge queue was timing out (1hr) because the CodeQL check never ran on merge group branches — GitHub Default Setup only runs on PR/push events, not `merge_group`

## Root cause
GitHub Advanced Security (app 57789) creates the required "CodeQL" summary check only after `Analyze` jobs complete. GitHub's Default Setup doesn't trigger on `merge_group` branches, so the merge queue waited 3600s and timed out every time.

## Required manual step before merging

**Disable CodeQL Default Setup** in the repo security settings:

> Settings → Security → Code scanning → CodeQL analysis → disable Default setup

This is necessary because GitHub rejects SARIF uploads from custom (`codeql.yml`) workflows when Default Setup is active:
> `CodeQL analyses from advanced configurations cannot be processed when the default setup is enabled`

Once Default Setup is disabled, this `codeql.yml` becomes the sole CodeQL runner — covering `pull_request`, `push` to main, `merge_group`, and a weekly schedule.

## Test plan
- [ ] Disable Default Setup in repo security settings
- [ ] Verify `Analyze (javascript-typescript)` and `Analyze (actions)` checks appear on the merge group branch
- [ ] Verify "CodeQL" summary check passes on the merge group branch
- [ ] Verify the merge queue proceeds without timing out