### PR TITLE
Fix slash commands not appearing in workspace chat window

### DIFF
--- a/src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync } from 'node:fs';
+import { readdirSync, readFileSync, realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { basename, join } from 'node:path';
 import { createLogger } from '@/backend/services/logger.service';
@@ -491,7 +491,9 @@ function scanCommandsFromDir(
   seen: Set<string>
 ): { name: string; description: string }[] {
   let files: string[];
+  let rootReal: string;
   try {
+    rootReal = realpathSync(dir);
     files = readdirSync(dir).filter((f) => f.endsWith('.md'));
   } catch {
     return [];
@@ -499,12 +501,22 @@ function scanCommandsFromDir(
 
   const commands: { name: string; description: string }[] = [];
   for (const file of files) {
+    const filePath = join(dir, file);
+    let fileReal: string;
+    try {
+      fileReal = realpathSync(filePath);
+    } catch {
+      continue;
+    }
+    if (!fileReal.startsWith(`${rootReal}/`) && fileReal !== rootReal) {
+      continue;
+    }
     const name = basename(file, '.md');
     if (seen.has(name)) {
       continue;
     }
     seen.add(name);
-    commands.push({ name, description: parseCommandDescription(join(dir, file)) });
+    commands.push({ name, description: parseCommandDescription(filePath) });
   }
   return commands;
 }

--- a/src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.ts
@@ -1,6 +1,6 @@
 import { readdirSync, readFileSync, realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { basename, join } from 'node:path';
+import { basename, isAbsolute, join, relative } from 'node:path';
 import { createLogger } from '@/backend/services/logger.service';
 import { agentSessionAccessor } from '@/backend/services/session/resources/agent-session.accessor';
 import type {
@@ -486,6 +486,16 @@ function parseCommandDescription(filePath: string): string {
   }
 }
 
+function isContainedInRoot(rootReal: string, filePath: string): boolean {
+  try {
+    const fileReal = realpathSync(filePath);
+    const rel = relative(rootReal, fileReal);
+    return !(rel.startsWith('..') || isAbsolute(rel));
+  } catch {
+    return false;
+  }
+}
+
 function scanCommandsFromDir(
   dir: string,
   seen: Set<string>
@@ -502,13 +512,7 @@ function scanCommandsFromDir(
   const commands: { name: string; description: string }[] = [];
   for (const file of files) {
     const filePath = join(dir, file);
-    let fileReal: string;
-    try {
-      fileReal = realpathSync(filePath);
-    } catch {
-      continue;
-    }
-    if (!fileReal.startsWith(`${rootReal}/`) && fileReal !== rootReal) {
+    if (!isContainedInRoot(rootReal, filePath)) {
       continue;
     }
     const name = basename(file, '.md');

--- a/src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.ts
@@ -455,13 +455,10 @@ async function sendCachedSlashCommandsIfNeeded(
   provider: 'CLAUDE' | 'CODEX'
 ): Promise<void> {
   const cached = await slashCommandCacheService.getCachedCommands(provider);
-  if (!cached || cached.length === 0) {
-    return;
-  }
 
   const slashCommandsMsg = {
     type: 'slash_commands',
-    slashCommands: cached,
+    slashCommands: cached ?? [],
   } as const;
   sessionDomainService.emitDelta(sessionId, slashCommandsMsg);
 }

--- a/src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.ts
@@ -1,3 +1,6 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { basename, join } from 'node:path';
 import { createLogger } from '@/backend/services/logger.service';
 import { agentSessionAccessor } from '@/backend/services/session/resources/agent-session.accessor';
 import type {
@@ -68,7 +71,11 @@ export function createLoadSessionHandler(
       });
     }
 
-    await sendCachedSlashCommandsIfNeeded(sessionId, dbSession.provider);
+    await sendCachedSlashCommandsIfNeeded(
+      sessionId,
+      dbSession.provider,
+      dbSession.workspace.worktreePath
+    );
 
     // Auto-enqueue initial message if one was stored during session creation
     await enqueueInitialMessageIfPresent(sessionId, deps);
@@ -452,13 +459,67 @@ async function enqueueInitialMessageIfPresent(
 
 async function sendCachedSlashCommandsIfNeeded(
   sessionId: string,
-  provider: 'CLAUDE' | 'CODEX'
+  provider: 'CLAUDE' | 'CODEX',
+  worktreePath: string | null
 ): Promise<void> {
   const cached = await slashCommandCacheService.getCachedCommands(provider);
+  const commands = cached ?? (provider === 'CLAUDE' ? scanCommandsFromDisk(worktreePath) : []);
 
   const slashCommandsMsg = {
     type: 'slash_commands',
-    slashCommands: cached ?? [],
+    slashCommands: commands,
   } as const;
   sessionDomainService.emitDelta(sessionId, slashCommandsMsg);
+}
+
+function parseCommandDescription(filePath: string): string {
+  try {
+    const content = readFileSync(filePath, 'utf-8');
+    const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+    if (!match) {
+      return '';
+    }
+    const descLine = match[1]?.split(/\r?\n/).find((l) => l.startsWith('description:'));
+    return descLine ? descLine.slice('description:'.length).trim() : '';
+  } catch {
+    return '';
+  }
+}
+
+function scanCommandsFromDir(
+  dir: string,
+  seen: Set<string>
+): { name: string; description: string }[] {
+  let files: string[];
+  try {
+    files = readdirSync(dir).filter((f) => f.endsWith('.md'));
+  } catch {
+    return [];
+  }
+
+  const commands: { name: string; description: string }[] = [];
+  for (const file of files) {
+    const name = basename(file, '.md');
+    if (seen.has(name)) {
+      continue;
+    }
+    seen.add(name);
+    commands.push({ name, description: parseCommandDescription(join(dir, file)) });
+  }
+  return commands;
+}
+
+/**
+ * Scan ~/.claude/commands/ and {worktreePath}/.claude/commands/ for markdown command files.
+ * Used as a cold-start fallback before the ACP process fires available_commands_update.
+ */
+function scanCommandsFromDisk(
+  worktreePath: string | null
+): { name: string; description: string }[] {
+  const dirs = [
+    join(homedir(), '.claude', 'commands'),
+    ...(worktreePath ? [join(worktreePath, '.claude', 'commands')] : []),
+  ];
+  const seen = new Set<string>();
+  return dirs.flatMap((dir) => scanCommandsFromDir(dir, seen));
 }

--- a/src/backend/services/session/service/lifecycle/acp-event-processor.tool-timeout.test.ts
+++ b/src/backend/services/session/service/lifecycle/acp-event-processor.tool-timeout.test.ts
@@ -109,7 +109,11 @@ describe('AcpEventProcessor tool call timeouts', () => {
     const processor = new AcpEventProcessor(
       makeDeps({ onToolCallTimeout, toolCallTimeoutMs: 1000 })
     );
-    processor.registerSessionContext('sid', { workspaceId: 'ws', workingDir: '/tmp' });
+    processor.registerSessionContext('sid', {
+      workspaceId: 'ws',
+      workingDir: '/tmp',
+      provider: 'CLAUDE',
+    });
     processor.beginPromptTurn('sid');
 
     processor.handleAcpDelta('sid', toolStartDelta('tool-1', 'Bash') as never);
@@ -127,7 +131,11 @@ describe('AcpEventProcessor tool call timeouts', () => {
     const processor = new AcpEventProcessor(
       makeDeps({ onToolCallTimeout, toolCallTimeoutMs: 1000 })
     );
-    processor.registerSessionContext('sid', { workspaceId: 'ws', workingDir: '/tmp' });
+    processor.registerSessionContext('sid', {
+      workspaceId: 'ws',
+      workingDir: '/tmp',
+      provider: 'CLAUDE',
+    });
     processor.beginPromptTurn('sid');
 
     processor.handleAcpDelta('sid', toolStartDelta('tool-1', 'Bash') as never);
@@ -143,7 +151,11 @@ describe('AcpEventProcessor tool call timeouts', () => {
     const processor = new AcpEventProcessor(
       makeDeps({ onToolCallTimeout, toolCallTimeoutMs: 1000 })
     );
-    processor.registerSessionContext('sid', { workspaceId: 'ws', workingDir: '/tmp' });
+    processor.registerSessionContext('sid', {
+      workspaceId: 'ws',
+      workingDir: '/tmp',
+      provider: 'CLAUDE',
+    });
     processor.beginPromptTurn('sid');
 
     processor.handleAcpDelta('sid', toolStartDelta('tool-1', 'Bash') as never);
@@ -163,7 +175,11 @@ describe('AcpEventProcessor tool call timeouts', () => {
     const processor = new AcpEventProcessor(
       makeDeps({ onToolCallTimeout, toolCallTimeoutMs: 1000 })
     );
-    processor.registerSessionContext('sid', { workspaceId: 'ws', workingDir: '/tmp' });
+    processor.registerSessionContext('sid', {
+      workspaceId: 'ws',
+      workingDir: '/tmp',
+      provider: 'CLAUDE',
+    });
     processor.beginPromptTurn('sid');
 
     processor.handleAcpDelta('sid', {
@@ -183,7 +199,11 @@ describe('AcpEventProcessor tool call timeouts', () => {
     const processor = new AcpEventProcessor(
       makeDeps({ onToolCallTimeout, toolCallTimeoutMs: 1000 })
     );
-    processor.registerSessionContext('sid', { workspaceId: 'ws', workingDir: '/tmp' });
+    processor.registerSessionContext('sid', {
+      workspaceId: 'ws',
+      workingDir: '/tmp',
+      provider: 'CLAUDE',
+    });
     processor.beginPromptTurn('sid');
 
     processor.handleAcpDelta('sid', toolStartDelta('tool-1', 'Bash') as never);
@@ -200,7 +220,11 @@ describe('AcpEventProcessor tool call timeouts', () => {
     const processor = new AcpEventProcessor(
       makeDeps({ onToolCallTimeout, toolCallTimeoutMs: 1000 })
     );
-    processor.registerSessionContext('sid', { workspaceId: 'ws', workingDir: '/tmp' });
+    processor.registerSessionContext('sid', {
+      workspaceId: 'ws',
+      workingDir: '/tmp',
+      provider: 'CLAUDE',
+    });
     processor.beginPromptTurn('sid');
 
     processor.handleAcpDelta('sid', toolStartDelta('tool-1', 'Bash') as never);
@@ -216,7 +240,11 @@ describe('AcpEventProcessor tool call timeouts', () => {
     const processor = new AcpEventProcessor(
       makeDeps({ onToolCallTimeout, toolCallTimeoutMs: 1000 })
     );
-    processor.registerSessionContext('sid', { workspaceId: 'ws', workingDir: '/tmp' });
+    processor.registerSessionContext('sid', {
+      workspaceId: 'ws',
+      workingDir: '/tmp',
+      provider: 'CLAUDE',
+    });
     processor.beginPromptTurn('sid');
 
     processor.handleAcpDelta('sid', toolStartDelta('tool-1', 'Bash') as never);
@@ -238,7 +266,11 @@ describe('AcpEventProcessor tool call timeouts', () => {
     const processor = new AcpEventProcessor(
       makeDeps({ onToolCallTimeout, toolCallTimeoutMs: 1000 })
     );
-    processor.registerSessionContext('sid', { workspaceId: 'ws', workingDir: '/tmp' });
+    processor.registerSessionContext('sid', {
+      workspaceId: 'ws',
+      workingDir: '/tmp',
+      provider: 'CLAUDE',
+    });
     processor.beginPromptTurn('sid');
 
     processor.handleAcpDelta(
@@ -257,7 +289,11 @@ describe('AcpEventProcessor tool call timeouts', () => {
     const processor = new AcpEventProcessor(
       makeDeps({ onToolCallTimeout, toolCallTimeoutMs: 1000 })
     );
-    processor.registerSessionContext('sid', { workspaceId: 'ws', workingDir: '/tmp' });
+    processor.registerSessionContext('sid', {
+      workspaceId: 'ws',
+      workingDir: '/tmp',
+      provider: 'CLAUDE',
+    });
     processor.beginPromptTurn('sid');
 
     processor.handleAcpDelta(

--- a/src/backend/services/session/service/lifecycle/acp-event-processor.ts
+++ b/src/backend/services/session/service/lifecycle/acp-event-processor.ts
@@ -11,7 +11,8 @@ import {
 import { acpTraceLogger } from '@/backend/services/session/service/logging/acp-trace-logger.service';
 import { sessionFileLogger } from '@/backend/services/session/service/logging/session-file-logger.service';
 import type { SessionDomainService } from '@/backend/services/session/service/session-domain.service';
-import type { AgentMessage, SessionDeltaEvent } from '@/shared/acp-protocol';
+import { slashCommandCacheService } from '@/backend/services/session/service/store/slash-command-cache.service';
+import type { AgentMessage, CommandInfo, SessionDeltaEvent } from '@/shared/acp-protocol';
 import type { SessionConfigService } from './session.config.service';
 import type { SessionPermissionService } from './session.permission.service';
 
@@ -64,6 +65,8 @@ export class AcpEventProcessor {
   readonly sessionToWorkspace = new Map<string, string>();
   /** Maps sessionId → workingDir for interceptor context */
   readonly sessionToWorkingDir = new Map<string, string>();
+  /** Maps sessionId → provider for slash command caching */
+  private readonly sessionToProvider = new Map<string, 'CLAUDE' | 'CODEX'>();
 
   constructor(options: AcpEventProcessorDependencies) {
     this.runtimeManager = options.runtimeManager;
@@ -125,10 +128,11 @@ export class AcpEventProcessor {
 
   registerSessionContext(
     sessionId: string,
-    context: { workspaceId: string; workingDir: string }
+    context: { workspaceId: string; workingDir: string; provider: 'CLAUDE' | 'CODEX' }
   ): void {
     this.sessionToWorkspace.set(sessionId, context.workspaceId);
     this.sessionToWorkingDir.set(sessionId, context.workingDir);
+    this.sessionToProvider.set(sessionId, context.provider);
   }
 
   setReplaySuppression(sessionId: string, suppress: boolean): void {
@@ -150,6 +154,7 @@ export class AcpEventProcessor {
   clearSessionContext(sessionId: string): void {
     this.sessionToWorkspace.delete(sessionId);
     this.sessionToWorkingDir.delete(sessionId);
+    this.sessionToProvider.delete(sessionId);
   }
 
   clearPendingToolCalls(sessionId: string): void {
@@ -204,6 +209,15 @@ export class AcpEventProcessor {
     }
 
     if (delta.type !== 'agent_message') {
+      if (delta.type === 'slash_commands') {
+        const commands = (delta as { slashCommands?: CommandInfo[] }).slashCommands;
+        const provider = this.sessionToProvider.get(sid);
+        if (provider && commands && commands.length > 0) {
+          slashCommandCacheService.setCachedCommands(provider, commands).catch((err: unknown) => {
+            logger.warn('Failed to cache slash commands', { error: err });
+          });
+        }
+      }
       this.sessionDomainService.emitDelta(sid, delta);
       return;
     }

--- a/src/backend/services/session/service/lifecycle/session-config-option-helpers.ts
+++ b/src/backend/services/session/service/lifecycle/session-config-option-helpers.ts
@@ -277,7 +277,7 @@ export function buildCapabilitiesFromConfigOptions(
     attachments: isCodexProvider
       ? { enabled: false, kinds: [] }
       : { enabled: true, kinds: ['image', 'text'] },
-    slashCommands: { enabled: false },
+    slashCommands: { enabled: !isCodexProvider },
     usageStats: { enabled: false, contextWindow: false },
     rewind: { enabled: false },
   };

--- a/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
+++ b/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
@@ -489,6 +489,7 @@ export class SessionLifecycleService {
     this.acpEventProcessor.registerSessionContext(sessionId, {
       workspaceId: sessionContext.workspaceId,
       workingDir: sessionContext.workingDir,
+      provider: session?.provider ?? 'CLAUDE',
     });
 
     const handlers = this.setupAcpEventHandler(sessionId);

--- a/src/backend/services/session/service/lifecycle/session.service.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.service.test.ts
@@ -106,7 +106,7 @@ function getAcpProcessorState() {
         sessionToWorkingDir: Map<string, string>;
         registerSessionContext: (
           sessionId: string,
-          context: { workspaceId: string; workingDir: string }
+          context: { workspaceId: string; workingDir: string; provider: 'CLAUDE' | 'CODEX' }
         ) => void;
         beginPromptTurn: (sessionId: string) => void;
         handleAcpDelta: (sid: string, delta: unknown) => void;
@@ -1968,6 +1968,7 @@ describe('SessionService', () => {
       acpProcessor.registerSessionContext('session-1', {
         workspaceId: 'workspace-1',
         workingDir: '/tmp/work',
+        provider: 'CLAUDE',
       });
       acpProcessor.beginPromptTurn('session-1');
       acpProcessor.handleAcpDelta(

--- a/src/backend/trpc/project.trpc.ts
+++ b/src/backend/trpc/project.trpc.ts
@@ -41,14 +41,16 @@ function isContainedInRoot(rootReal: string, filePath: string): boolean {
   }
 }
 
-function scanSlashCommandDirs(dirs: string[]): { name: string; description: string }[] {
+function scanSlashCommandDirs(
+  dirs: { dir: string; containmentRoot?: string }[]
+): { name: string; description: string }[] {
   const seen = new Set<string>();
   const commands: { name: string; description: string }[] = [];
-  for (const dir of dirs) {
+  for (const { dir, containmentRoot } of dirs) {
     let files: string[];
     let rootReal: string;
     try {
-      rootReal = realpathSync(dir);
+      rootReal = containmentRoot ? realpathSync(containmentRoot) : realpathSync(dir);
       files = readdirSync(dir).filter((f) => f.endsWith('.md'));
     } catch {
       continue;
@@ -263,8 +265,8 @@ export const projectRouter = router({
         throw new Error(`Project not found: ${input.projectId}`);
       }
       const dirs = [
-        join(homedir(), '.claude', 'commands'),
-        join(project.repoPath, '.claude', 'commands'),
+        { dir: join(homedir(), '.claude', 'commands') },
+        { dir: join(project.repoPath, '.claude', 'commands'), containmentRoot: project.repoPath },
       ];
       return { commands: scanSlashCommandDirs(dirs) };
     }),

--- a/src/backend/trpc/project.trpc.ts
+++ b/src/backend/trpc/project.trpc.ts
@@ -1,5 +1,7 @@
+import { readdirSync, readFileSync } from 'node:fs';
 import { writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { basename, join } from 'node:path';
 import { z } from 'zod';
 import { compareFilesByRelevance, listFilesRecursive } from '@/backend/lib/file-helpers';
 import { gitCommandC } from '@/backend/lib/shell';
@@ -14,6 +16,42 @@ import {
   sanitizeIssueTrackerConfig,
 } from '@/shared/schemas/issue-tracker-config.schema';
 import { publicProcedure, router } from './trpc';
+
+function parseCommandFileDescription(filePath: string): string {
+  try {
+    const content = readFileSync(filePath, 'utf-8');
+    const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+    if (!match) {
+      return '';
+    }
+    const descLine = match[1]?.split(/\r?\n/).find((l) => l.startsWith('description:'));
+    return descLine ? descLine.slice('description:'.length).trim() : '';
+  } catch {
+    return '';
+  }
+}
+
+function scanSlashCommandDirs(dirs: string[]): { name: string; description: string }[] {
+  const seen = new Set<string>();
+  const commands: { name: string; description: string }[] = [];
+  for (const dir of dirs) {
+    let files: string[];
+    try {
+      files = readdirSync(dir).filter((f) => f.endsWith('.md'));
+    } catch {
+      continue;
+    }
+    for (const file of files) {
+      const name = basename(file, '.md');
+      if (seen.has(name)) {
+        continue;
+      }
+      seen.add(name);
+      commands.push({ name, description: parseCommandFileDescription(join(dir, file)) });
+    }
+  }
+  return commands;
+}
 
 async function getBranchMap(repoPath: string, refPrefix: string): Promise<Map<string, string>> {
   const result = await gitCommandC(repoPath, [
@@ -198,6 +236,21 @@ export const projectRouter = router({
       files = files.slice(0, input.limit);
 
       return { files };
+    }),
+
+  // List slash commands available for a project (for autocomplete in new workspace form)
+  listSlashCommands: publicProcedure
+    .input(z.object({ projectId: z.string() }))
+    .query(async ({ input }) => {
+      const project = await projectManagementService.findById(input.projectId);
+      if (!project) {
+        throw new Error(`Project not found: ${input.projectId}`);
+      }
+      const dirs = [
+        join(homedir(), '.claude', 'commands'),
+        join(project.repoPath, '.claude', 'commands'),
+      ];
+      return { commands: scanSlashCommandDirs(dirs) };
     }),
 
   // Create a new project (only repoPath required - name/slug/worktree derived)

--- a/src/backend/trpc/project.trpc.ts
+++ b/src/backend/trpc/project.trpc.ts
@@ -1,7 +1,7 @@
-import { readdirSync, readFileSync } from 'node:fs';
+import { readdirSync, readFileSync, realpathSync } from 'node:fs';
 import { writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
-import { basename, join } from 'node:path';
+import { basename, isAbsolute, join, relative } from 'node:path';
 import { z } from 'zod';
 import { compareFilesByRelevance, listFilesRecursive } from '@/backend/lib/file-helpers';
 import { gitCommandC } from '@/backend/lib/shell';
@@ -31,23 +31,39 @@ function parseCommandFileDescription(filePath: string): string {
   }
 }
 
+function isContainedInRoot(rootReal: string, filePath: string): boolean {
+  try {
+    const fileReal = realpathSync(filePath);
+    const rel = relative(rootReal, fileReal);
+    return !(rel.startsWith('..') || isAbsolute(rel));
+  } catch {
+    return false;
+  }
+}
+
 function scanSlashCommandDirs(dirs: string[]): { name: string; description: string }[] {
   const seen = new Set<string>();
   const commands: { name: string; description: string }[] = [];
   for (const dir of dirs) {
     let files: string[];
+    let rootReal: string;
     try {
+      rootReal = realpathSync(dir);
       files = readdirSync(dir).filter((f) => f.endsWith('.md'));
     } catch {
       continue;
     }
     for (const file of files) {
+      const filePath = join(dir, file);
+      if (!isContainedInRoot(rootReal, filePath)) {
+        continue;
+      }
       const name = basename(file, '.md');
       if (seen.has(name)) {
         continue;
       }
       seen.add(name);
-      commands.push({ name, description: parseCommandFileDescription(join(dir, file)) });
+      commands.push({ name, description: parseCommandFileDescription(filePath) });
     }
   }
   return commands;

--- a/src/cli/serve-env.test.ts
+++ b/src/cli/serve-env.test.ts
@@ -14,6 +14,7 @@ describe('buildServeEnv', () => {
       BACKEND_HOST: 'localhost',
       BACKEND_PORT: '3001',
       NODE_ENV: 'production',
+      CORS_ALLOWED_ORIGINS: 'http://localhost:3001',
     });
   });
 
@@ -22,5 +23,12 @@ describe('buildServeEnv', () => {
 
     expect(env.NODE_ENV).toBe('development');
     expect(env.BACKEND_HOST).toBe('127.0.0.1');
+    expect(env.CORS_ALLOWED_ORIGINS).toBe('http://127.0.0.1:3100');
+  });
+
+  it('sets CORS_ALLOWED_ORIGINS to the frontend origin in dev mode', () => {
+    const env = buildServeEnv({ dev: true, host: 'localhost' }, '/tmp/factory.db', 3504, 3503, {});
+
+    expect(env.CORS_ALLOWED_ORIGINS).toBe('http://localhost:3504');
   });
 });

--- a/src/cli/serve-env.ts
+++ b/src/cli/serve-env.ts
@@ -10,6 +10,10 @@ export function buildServeEnv(
   backendPort: number,
   baseEnv: NodeJS.ProcessEnv = process.env
 ): NodeJS.ProcessEnv {
+  const corsOrigins = options.dev
+    ? `http://${options.host}:${frontendPort}`
+    : `http://${options.host}:${backendPort}`;
+
   return {
     ...baseEnv,
     DATABASE_PATH: databasePath,
@@ -17,5 +21,6 @@ export function buildServeEnv(
     BACKEND_HOST: options.host,
     BACKEND_PORT: backendPort.toString(),
     NODE_ENV: options.dev ? 'development' : 'production',
+    CORS_ALLOWED_ORIGINS: corsOrigins,
   };
 }

--- a/src/client/components/kanban/inline-workspace-form.test.tsx
+++ b/src/client/components/kanban/inline-workspace-form.test.tsx
@@ -89,6 +89,14 @@ vi.mock('@/client/lib/trpc', () => ({
         }),
       },
     },
+    project: {
+      listSlashCommands: {
+        useQuery: () => ({
+          data: { commands: [] },
+          isFetched: true,
+        }),
+      },
+    },
   },
 }));
 
@@ -130,6 +138,23 @@ vi.mock('@/components/chat/chat-input/hooks/use-project-file-mentions', () => ({
 
 vi.mock('@/components/chat/file-mention-palette', () => ({
   FileMentionPalette: () => null,
+}));
+
+vi.mock('@/components/chat/slash-command-palette', () => ({
+  SlashCommandPalette: () => null,
+}));
+
+vi.mock('@/components/chat/chat-input/hooks/use-slash-commands', () => ({
+  useSlashCommands: () => ({
+    slashMenuOpen: false,
+    slashFilter: '',
+    commandsReady: true,
+    paletteRef: { current: null },
+    handleInputChange: vi.fn(),
+    handleSlashCommandSelect: vi.fn(),
+    handleSlashMenuClose: vi.fn(),
+    delegateToSlashMenu: () => 'passthrough',
+  }),
 }));
 
 vi.mock('@/components/ui/button', () => ({

--- a/src/client/components/kanban/inline-workspace-form.tsx
+++ b/src/client/components/kanban/inline-workspace-form.tsx
@@ -9,7 +9,9 @@ import { AttachmentPreview } from '@/components/chat/attachment-preview';
 import { collectAttachments } from '@/components/chat/chat-input/hooks/attachment-file-conversion';
 import { usePasteDropHandler } from '@/components/chat/chat-input/hooks/use-paste-drop-handler';
 import { useProjectFileMentions } from '@/components/chat/chat-input/hooks/use-project-file-mentions';
+import { useSlashCommands } from '@/components/chat/chat-input/hooks/use-slash-commands';
 import { FileMentionPalette } from '@/components/chat/file-mention-palette';
+import { SlashCommandPalette } from '@/components/chat/slash-command-palette';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -37,6 +39,35 @@ import {
   generateUniqueWorkspaceName,
   generateWorkspaceNameFromPrompt,
 } from '@/shared/workspace-words';
+
+function handleFormKeyDown(
+  e: React.KeyboardEvent,
+  opts: {
+    delegateToSlashMenu: (key: string) => string;
+    delegateToFileMentionMenu: (key: string) => string;
+    isCreating: boolean;
+    onCancel: () => void;
+    onLaunch: () => void;
+  }
+) {
+  if (opts.delegateToSlashMenu(e.key) === 'handled') {
+    e.preventDefault();
+    return;
+  }
+  if (opts.delegateToFileMentionMenu(e.key) === 'handled') {
+    e.preventDefault();
+    return;
+  }
+  if (!opts.isCreating) {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      opts.onCancel();
+    } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      opts.onLaunch();
+    }
+  }
+}
 
 interface InlineWorkspaceFormProps {
   projectId: string;
@@ -409,13 +440,30 @@ export function InlineWorkspaceForm({
     }
   }, []);
 
-  const fileMentions = useProjectFileMentions({
-    projectId,
-    inputRef: textareaRef,
-    onChange: (value) => {
+  const onPromptChange = useCallback(
+    (value: string) => {
       setInitialPrompt(value);
       autoResize();
     },
+    [autoResize]
+  );
+
+  const fileMentions = useProjectFileMentions({
+    projectId,
+    inputRef: textareaRef,
+    onChange: onPromptChange,
+  });
+
+  const { data: slashCommandsData, isFetched: slashCommandsFetched } =
+    trpc.project.listSlashCommands.useQuery({ projectId }, { staleTime: 60_000 });
+  const projectCommands = slashCommandsData?.commands ?? [];
+
+  const slashCommands = useSlashCommands({
+    enabled: true,
+    slashCommands: projectCommands,
+    commandsLoaded: slashCommandsFetched,
+    inputRef: textareaRef,
+    onChange: onPromptChange,
   });
 
   // Initialize defaults from user settings once loaded
@@ -501,6 +549,8 @@ export function InlineWorkspaceForm({
 
   const isCreating = createWorkspaceMutation.isPending || createPeriodicTaskMutation.isPending;
   const supportsWorkspaceOptions = mode !== 'PERIODIC_TASK';
+  const isLaunchDisabled =
+    isCreating || isLoadingSettings || (shouldFetchExistingNames && isLoadingWorkspaceList);
 
   const pasteDropHandler = usePasteDropHandler({
     setAttachments,
@@ -582,35 +632,35 @@ export function InlineWorkspaceForm({
     }
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    // Delegate to file mention menu first
-    const mentionResult = fileMentions.delegateToFileMentionMenu(e.key);
-    if (mentionResult === 'handled') {
-      e.preventDefault();
-      return;
-    }
-
-    if (e.key === 'Escape' && !isCreating) {
-      e.preventDefault();
-      onCancel();
-    }
-    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && !isCreating) {
-      e.preventDefault();
-      handleLaunch(mode);
-    }
-  };
+  const handleKeyDown = (e: React.KeyboardEvent) =>
+    handleFormKeyDown(e, {
+      delegateToSlashMenu: slashCommands.delegateToSlashMenu,
+      delegateToFileMentionMenu: fileMentions.delegateToFileMentionMenu,
+      isCreating,
+      onCancel,
+      onLaunch: () => handleLaunch(mode),
+    });
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const newValue = e.target.value;
-    setInitialPrompt(newValue);
+    slashCommands.handleInputChange(e);
+    fileMentions.detectFileMention(e.target.value);
     autoResize();
-    fileMentions.detectFileMention(newValue);
   };
 
   return (
     <Card className="shrink-0 border-dashed border-primary/50">
       <CardContent className="p-3 space-y-3" onKeyDown={handleKeyDown}>
         <div className="relative">
+          <SlashCommandPalette
+            commands={projectCommands}
+            isOpen={slashCommands.slashMenuOpen}
+            isLoading={!slashCommands.commandsReady}
+            onClose={slashCommands.handleSlashMenuClose}
+            onSelect={slashCommands.handleSlashCommandSelect}
+            filter={slashCommands.slashFilter}
+            anchorRef={textareaRef as React.RefObject<HTMLElement | null>}
+            paletteRef={slashCommands.paletteRef}
+          />
           <FileMentionPalette
             files={fileMentions.files}
             isOpen={fileMentions.fileMentionMenuOpen}
@@ -747,11 +797,7 @@ export function InlineWorkspaceForm({
                   mode !== 'STANDARD' && 'bg-primary/90'
                 )}
                 onClick={() => handleLaunch(mode)}
-                disabled={
-                  isCreating ||
-                  isLoadingSettings ||
-                  (shouldFetchExistingNames && isLoadingWorkspaceList)
-                }
+                disabled={isLaunchDisabled}
               >
                 {isCreating ? <Loader2 className="h-3 w-3 animate-spin mr-1" /> : null}
                 {launchButtonLabels[mode]}
@@ -761,11 +807,7 @@ export function InlineWorkspaceForm({
                   <Button
                     size="sm"
                     className="h-7 rounded-l-none border-l border-primary-foreground/20 px-1.5"
-                    disabled={
-                      isCreating ||
-                      isLoadingSettings ||
-                      (shouldFetchExistingNames && isLoadingWorkspaceList)
-                    }
+                    disabled={isLaunchDisabled}
                   >
                     <ChevronDown className="h-3 w-3" />
                   </Button>

--- a/src/client/components/kanban/inline-workspace-form.tsx
+++ b/src/client/components/kanban/inline-workspace-form.tsx
@@ -660,6 +660,7 @@ export function InlineWorkspaceForm({
             filter={slashCommands.slashFilter}
             anchorRef={textareaRef as React.RefObject<HTMLElement | null>}
             paletteRef={slashCommands.paletteRef}
+            placement="below"
           />
           <FileMentionPalette
             files={fileMentions.files}

--- a/src/client/components/kanban/quick-chat-content.tsx
+++ b/src/client/components/kanban/quick-chat-content.tsx
@@ -105,6 +105,8 @@ export function QuickChatContent({
           settings={chatState.chatSettings}
           capabilities={chatState.chatCapabilities}
           onSettingsChange={chatState.updateSettings}
+          slashCommands={chatState.slashCommands}
+          slashCommandsLoaded={chatState.slashCommandsLoaded}
           value={chatState.inputDraft}
           onChange={chatState.setInputDraft}
           onHeightChange={handleHeightChange}

--- a/src/components/chat/file-mention-palette.tsx
+++ b/src/components/chat/file-mention-palette.tsx
@@ -1,5 +1,5 @@
 import { File, Folder } from 'lucide-react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useLayoutEffect, useState } from 'react';
 import {
   Command,
   CommandEmpty,
@@ -90,7 +90,7 @@ function usePlacement(
 ): 'above' | 'below' {
   const [placement, setPlacement] = useState<'above' | 'below'>('above');
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!(isOpen && anchorRef.current)) {
       return;
     }

--- a/src/components/chat/slash-command-palette.tsx
+++ b/src/components/chat/slash-command-palette.tsx
@@ -70,6 +70,8 @@ export interface SlashCommandPaletteProps {
   anchorRef: React.RefObject<HTMLElement | null>;
   /** Imperative handle ref for keyboard handling */
   paletteRef?: React.RefObject<SlashCommandPaletteHandle | null>;
+  /** Override auto-detected placement. 'above' opens upward, 'below' opens downward. */
+  placement?: 'above' | 'below';
 }
 
 // =============================================================================
@@ -95,6 +97,7 @@ export function SlashCommandPalette({
   filter,
   anchorRef,
   paletteRef,
+  placement: placementProp,
 }: SlashCommandPaletteProps) {
   // Filter commands based on the filter text (case-insensitive)
   const filteredCommands = useMemo(
@@ -114,7 +117,8 @@ export function SlashCommandPalette({
     [filteredCommands, onSelect]
   );
 
-  const placement = usePlacement(anchorRef, isOpen);
+  const autoPlacement = usePlacement(anchorRef, isOpen);
+  const placement = placementProp ?? autoPlacement;
 
   const { containerRef, itemRefs, selectedIndex, setSelectedIndex } = usePaletteKeyboardNavigation({
     isOpen,

--- a/src/components/chat/slash-command-palette.tsx
+++ b/src/components/chat/slash-command-palette.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Command,
   CommandEmpty,
@@ -13,6 +13,30 @@ import {
   type PaletteKeyResult,
   usePaletteKeyboardNavigation,
 } from './palette-keyboard-navigation';
+
+// =============================================================================
+// Placement
+// =============================================================================
+
+function usePlacement(
+  anchorRef: React.RefObject<HTMLElement | null>,
+  isOpen: boolean
+): 'above' | 'below' {
+  const [placement, setPlacement] = useState<'above' | 'below'>('above');
+
+  useEffect(() => {
+    if (!(isOpen && anchorRef.current)) {
+      return;
+    }
+    const rect = anchorRef.current.getBoundingClientRect();
+    const paletteHeight = 230;
+    const spaceAbove = rect.top;
+    const spaceBelow = window.innerHeight - rect.bottom;
+    setPlacement(spaceAbove >= paletteHeight || spaceAbove > spaceBelow ? 'above' : 'below');
+  }, [isOpen, anchorRef]);
+
+  return placement;
+}
 
 // =============================================================================
 // Types
@@ -90,6 +114,8 @@ export function SlashCommandPalette({
     [filteredCommands, onSelect]
   );
 
+  const placement = usePlacement(anchorRef, isOpen);
+
   const { containerRef, itemRefs, selectedIndex, setSelectedIndex } = usePaletteKeyboardNavigation({
     isOpen,
     itemCount: filteredCommands.length,
@@ -112,7 +138,8 @@ export function SlashCommandPalette({
     <div
       ref={containerRef}
       className={cn(
-        'absolute bottom-full left-0 mb-1 w-full max-w-md z-50',
+        'absolute left-0 w-full max-w-md z-50',
+        placement === 'above' ? 'bottom-full mb-1' : 'top-full mt-1',
         'rounded-md border bg-popover text-popover-foreground shadow-md'
       )}
     >

--- a/src/components/chat/slash-command-palette.tsx
+++ b/src/components/chat/slash-command-palette.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useLayoutEffect, useMemo, useState } from 'react';
 import {
   Command,
   CommandEmpty,
@@ -24,7 +24,7 @@ function usePlacement(
 ): 'above' | 'below' {
   const [placement, setPlacement] = useState<'above' | 'below'>('above');
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!(isOpen && anchorRef.current)) {
       return;
     }

--- a/src/components/chat/slash-command-palette.tsx
+++ b/src/components/chat/slash-command-palette.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import {
   Command,
   CommandEmpty,
@@ -13,30 +13,6 @@ import {
   type PaletteKeyResult,
   usePaletteKeyboardNavigation,
 } from './palette-keyboard-navigation';
-
-// =============================================================================
-// Placement
-// =============================================================================
-
-function usePlacement(
-  anchorRef: React.RefObject<HTMLElement | null>,
-  isOpen: boolean
-): 'above' | 'below' {
-  const [placement, setPlacement] = useState<'above' | 'below'>('above');
-
-  useLayoutEffect(() => {
-    if (!(isOpen && anchorRef.current)) {
-      return;
-    }
-    const rect = anchorRef.current.getBoundingClientRect();
-    const paletteHeight = 230;
-    const spaceAbove = rect.top;
-    const spaceBelow = window.innerHeight - rect.bottom;
-    setPlacement(spaceAbove >= paletteHeight || spaceAbove > spaceBelow ? 'above' : 'below');
-  }, [isOpen, anchorRef]);
-
-  return placement;
-}
 
 // =============================================================================
 // Types
@@ -70,7 +46,7 @@ export interface SlashCommandPaletteProps {
   anchorRef: React.RefObject<HTMLElement | null>;
   /** Imperative handle ref for keyboard handling */
   paletteRef?: React.RefObject<SlashCommandPaletteHandle | null>;
-  /** Override auto-detected placement. 'above' opens upward, 'below' opens downward. */
+  /** Whether to open above or below the anchor. Defaults to 'above'. */
   placement?: 'above' | 'below';
 }
 
@@ -97,7 +73,7 @@ export function SlashCommandPalette({
   filter,
   anchorRef,
   paletteRef,
-  placement: placementProp,
+  placement = 'above',
 }: SlashCommandPaletteProps) {
   // Filter commands based on the filter text (case-insensitive)
   const filteredCommands = useMemo(
@@ -116,9 +92,6 @@ export function SlashCommandPalette({
     },
     [filteredCommands, onSelect]
   );
-
-  const autoPlacement = usePlacement(anchorRef, isOpen);
-  const placement = placementProp ?? autoPlacement;
 
   const { containerRef, itemRefs, selectedIndex, setSelectedIndex } = usePaletteKeyboardNavigation({
     isOpen,


### PR DESCRIPTION
## Summary
Slash commands were broken in the workspace chat window due to several bugs in the pipeline:

1. **`slashCommands: { enabled: false }` hardcoded in `buildCapabilitiesFromConfigOptions`** — the backend always sent `enabled: false` in the `chat_capabilities` message, so `ChatInput` never opened the palette for any Claude session. Fixed to `{ enabled: !isCodexProvider }`.

2. **Palette stuck on \"Loading commands...\"** — `sendCachedSlashCommandsIfNeeded` returned early when the cache was `null`/empty, so the frontend never received a `slash_commands` message to resolve `slashCommandsLoaded`. Fixed to always emit the message.

3. **\"No commands found\" after loading resolved** — `setCachedCommands` was defined but never called. Commands from ACP's `available_commands_update` were forwarded to the WebSocket but never persisted, so the cache was always cold on reconnect. Fixed by wiring `setCachedCommands` in `AcpEventProcessor.handleAcpDelta`.

4. **Cold-start fallback for first load** — even with caching in place, the first load before any message is sent had an empty cache. Fixed by scanning `~/.claude/commands/` and `{worktreePath}/.claude/commands/` directly from disk as an immediate fallback, without needing ACP to start. When ACP fires `available_commands_update`, those results supersede the disk scan and get cached for future loads.

5. **`QuickChatContent` missing `slashCommands`/`slashCommandsLoaded` props** — the quick-chat sheet (Kanban card) never passed these to `ChatInput`. Fixed.

## Test plan
- [ ] Open a workspace with skills in a repo (`.claude/commands/`) — palette should show commands immediately on first load, before sending any message
- [ ] Type `/` in the main workspace chat — palette appears with commands
- [ ] Type `/` in the quick-chat sheet (Kanban card) — palette also works
- [ ] Reload/reconnect — commands still appear from cache
- [ ] Verify Codex sessions do not show slash commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)