### PR TITLE
Fix multi-instance WebSocket: pass CORS_ALLOWED_ORIGINS from CLI

### DIFF
--- a/src/cli/serve-env.test.ts
+++ b/src/cli/serve-env.test.ts
@@ -14,6 +14,7 @@ describe('buildServeEnv', () => {
       BACKEND_HOST: 'localhost',
       BACKEND_PORT: '3001',
       NODE_ENV: 'production',
+      CORS_ALLOWED_ORIGINS: 'http://localhost:3001',
     });
   });
 
@@ -22,5 +23,12 @@ describe('buildServeEnv', () => {
 
     expect(env.NODE_ENV).toBe('development');
     expect(env.BACKEND_HOST).toBe('127.0.0.1');
+    expect(env.CORS_ALLOWED_ORIGINS).toBe('http://127.0.0.1:3100');
+  });
+
+  it('sets CORS_ALLOWED_ORIGINS to the frontend origin in dev mode', () => {
+    const env = buildServeEnv({ dev: true, host: 'localhost' }, '/tmp/factory.db', 3504, 3503, {});
+
+    expect(env.CORS_ALLOWED_ORIGINS).toBe('http://localhost:3504');
   });
 });

--- a/src/cli/serve-env.ts
+++ b/src/cli/serve-env.ts
@@ -10,6 +10,10 @@ export function buildServeEnv(
   backendPort: number,
   baseEnv: NodeJS.ProcessEnv = process.env
 ): NodeJS.ProcessEnv {
+  const corsOrigins = options.dev
+    ? `http://${options.host}:${frontendPort}`
+    : `http://${options.host}:${backendPort}`;
+
   return {
     ...baseEnv,
     DATABASE_PATH: databasePath,
@@ -17,5 +21,6 @@ export function buildServeEnv(
     BACKEND_HOST: options.host,
     BACKEND_PORT: backendPort.toString(),
     NODE_ENV: options.dev ? 'development' : 'production',
+    CORS_ALLOWED_ORIGINS: corsOrigins,
   };
 }


### PR DESCRIPTION
## Summary

- The backend's WebSocket origin check fell back to a hardcoded allowed-origins list (`['http://localhost:3000', 'http://localhost:3001']`) when `CORS_ALLOWED_ORIGINS` was not set
- Running a second `pnpm dev` instance caused port selection to assign dynamic ports (e.g. frontend: 3504, backend: 3503), which were not in the hardcoded list — resulting in all WebSocket connections being rejected
- `buildServeEnv` now always sets `CORS_ALLOWED_ORIGINS` to the actual frontend origin resolved by the CLI, so each backend instance only allows connections from its own frontend

## Test plan

- [ ] `pnpm test src/cli/serve-env.test.ts` passes
- [ ] Run `pnpm dev` twice simultaneously — second instance should start cleanly on dynamic ports with WebSocket connections succeeding