### PR TITLE
Fix CodeQL advanced workflow: add push + pull_request triggers

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,10 @@
 name: CodeQL
 
 on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
   merge_group:
     types: [checks_requested]
   schedule:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,6 +25,8 @@ jobs:
         include:
           - language: javascript-typescript
             build-mode: none
+          - language: actions
+            build-mode: none
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
Completes the advanced-CodeQL migration started in #1694.

`codeql.yml` only triggered on `merge_group` + `schedule`. It also requires
**CodeQL Default Setup to be disabled** — a manual step from #1694 that was
never performed — which is why every CodeQL run is currently failing:

```
Code Scanning could not process the submitted SARIF file:
CodeQL analyses from advanced configurations cannot be processed when the default setup is enabled
```

(merge_group runs surface this as `ref ... not found` because the ephemeral
queue branch is gone by the time the rejected upload retries.)

This PR adds `push` (main) + `pull_request` (main) triggers so the advanced
workflow fully replaces Default Setup once it's disabled.

## Required step (ordering matters)
**Disable CodeQL Default Setup** in repo Security settings (or via API:
`PATCH /repos/.../code-scanning/default-setup {"state":"not-configured"}`).

Recommended order to avoid stranding the other open PRs:
1. Disable Default Setup.
2. Merge this PR (its `merge_group` + `pull_request` CodeQL runs will now
   upload successfully and report the required `CodeQL` check).
3. Other open PRs re-run / rebase to pick up the new triggers.

## Test plan
- [ ] Default Setup disabled
- [ ] `Analyze (javascript-typescript)` uploads succeed (no "configuration error")
- [ ] Required `CodeQL` check passes on PR + in merge queue
- [ ] Merge queue proceeds without the 1-hour timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow trigger and matrix changes only; no application runtime or auth/data logic is modified.
> 
> **Overview**
> Extends the advanced **CodeQL** workflow so it runs on **`push`** and **`pull_request`** to **`main`**, in addition to **`merge_group`** and the weekly schedule. That lets this workflow replace GitHub’s CodeQL Default Setup once Default Setup is turned off in repo security settings.
> 
> Adds **`actions`** to the analysis matrix (with **`javascript-typescript`**), so workflow YAML is scanned as its own CodeQL language.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f8b401e9d0db7e2c0a4912e5e81d5824edda9ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

