### PR TITLE
Clean up CI log warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,13 @@ jobs:
     env:
       DATABASE_URL: "file:./test.db"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
+        uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "pnpm"
@@ -73,13 +73,13 @@ jobs:
     env:
       DATABASE_URL: "file:./test.db"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
+        uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "pnpm"
@@ -104,13 +104,13 @@ jobs:
     env:
       DATABASE_URL: "file:./test.db"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
+        uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "pnpm"
@@ -136,13 +136,13 @@ jobs:
     env:
       DATABASE_URL: "file:./test.db"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
+        uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "pnpm"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ jobs:
             build-mode: none
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f

--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -31,13 +31,13 @@ jobs:
     env:
       DATABASE_URL: "file:./test.db"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
+        uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "pnpm"
@@ -71,13 +71,13 @@ jobs:
     env:
       DATABASE_URL: "file:./test.db"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
+        uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "pnpm"
@@ -107,13 +107,13 @@ jobs:
     env:
       DATABASE_URL: "file:./test.db"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
+        uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "pnpm"

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -25,13 +25,13 @@ jobs:
     env:
       DATABASE_URL: "file:./test.db"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
+        uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: "pnpm"

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -32,6 +32,12 @@ const config: StorybookConfig = {
       '@prisma-gen': path.resolve(__dirname, '../prisma/generated'),
     };
 
+    // Storybook's prebundled chunks (iframe, docs renderer) exceed Vite's
+    // default 500 kB warning threshold. Raise the limit to keep the build
+    // log clean — these are vendor bundles we don't control.
+    config.build = config.build || {};
+    config.build.chunkSizeWarningLimit = 2000;
+
     return config;
   },
 

--- a/package.json
+++ b/package.json
@@ -191,6 +191,9 @@
       "protobufjs",
       "sharp"
     ],
+    "ignoredBuiltDependencies": [
+      "electron-winstaller"
+    ],
     "overrides": {
       "@isaacs/brace-expansion": ">=5.0.1",
       "@modelcontextprotocol/sdk>ajv": ">=8.18.0",


### PR DESCRIPTION
## Summary

Cleans up noise in the CI logs identified while reviewing a recent PR's runs ([run #27916288738](https://github.com/purplefish-ai/factory-factory/actions/runs/27916288738/)). Three independent sources of warnings:

### 1. Node.js 20 deprecation annotations (the only PR-level annotations)
The pinned actions still bundle the Node 20 runtime, which GitHub now force-runs on Node 24 and flags as deprecated (4× — once per job). Bumped to Node 24 runtimes across **all** workflows:
- `actions/checkout@v4` → `@v5`
- `actions/setup-node@v4` → `@v5`
- `pnpm/action-setup` SHA pin → `v6.0.9` (`008330803749db0355799c700092d9a85fd074e9`, node24)

Applied to `ci.yml`, `codeql.yml`, `docker-publish.yml`, `npm-publish.yml`, and `electron-release.yml`.

### 2. pnpm `Ignored build scripts: electron-winstaller` warning
A Windows-only installer we don't need built in CI. Added it to `pnpm.ignoredBuiltDependencies` to silence the warning intentionally (rather than `onlyBuiltDependencies`, which would *run* it). No lockfile change.

### 3. Storybook Vite chunk-size warning
Storybook's prebundled vendor chunks (iframe, docs renderer) exceed Vite's default 500 kB threshold. Raised `build.chunkSizeWarningLimit` to 2000 in `.storybook/main.ts`.

## Out of scope (intentionally left as-is)
- Biome's 6 lint warnings (real, separate cleanup)
- Application `[WARN]` logs during the Test job (tests deliberately exercising error paths)
- pnpm self-installer `DEP0169`/`DEP0040` and git `detached HEAD` hints (emitted by tooling we don't control)

## Verification
- `pnpm install --frozen-lockfile` — no `electron-winstaller` warning, lockfile unchanged
- `pnpm build:storybook` — builds clean, no chunk-size warning
- Pre-commit hooks (Biome, `pnpm typecheck`, dependency-cruiser, knip) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow and tooling-only tweaks with no app runtime or security logic changes; main risk is transient CI breakage if a bumped action behaves differently.
> 
> **Overview**
> Reduces noisy CI and build logs without changing application behavior.
> 
> **GitHub Actions** across `ci.yml`, `codeql.yml`, `docker-publish.yml`, `npm-publish.yml`, and `electron-release.yml` now use **`actions/checkout@v5`**, **`actions/setup-node@v5`**, and an updated **`pnpm/action-setup`** pin so jobs stop emitting Node 20 deprecation annotations from older action runtimes.
> 
> **pnpm** adds **`electron-winstaller`** to **`ignoredBuiltDependencies`** so install no longer warns about skipping that Windows-only native build in CI.
> 
> **Storybook** raises Vite **`build.chunkSizeWarningLimit`** to **2000** in `.storybook/main.ts` so prebundled Storybook vendor chunks do not trip the default 500 kB warning during `build:storybook`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 420b31d414e169807795dc549bcfb92870d5fcfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

