### PR TITLE
[codex] Prepare 0.3.21 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to Factory Factory will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.21] - 2026-06-22
+
+### Added
+
+- Open workspace file links in chat (#1674)
+
+### Changed
+
+- Sync export schema provider enums (#1668)
+- Simplify issue intake launch flow (#1670)
+- Backfill missing Codex tool calls (#1672)
+- Honor default Codex reasoning effort after plan approval (#1675)
+- Unify workspace status reason (#1671)
+- Make GitHub issue start prompt editable (#1681)
+- Clean up CI log warnings (#1703)
+
+### Fixed
+
+- Fix chat test message id lookup (#1667)
+- Fix rewind capability checks (#1666)
+- Handle wrapped base64 attachments (#1669)
+- Fix ratchet handling of review summaries (#1673)
+- Fix session history hydration race (#1679, #1685)
+- Fix recovered plan approval workflow (#1678, #1684)
+- Fix stale ratchet review summaries (#1680, #1683)
+- Fix markdown workspace middle-clicks (#1677, #1682)
+- Handle file lock restore failures (#1676, #1686)
+- Filter stale changes-requested after approve-then-comment (#1688, #1691)
+- Skip enqueueing cleared initial prompts (#1689, #1690)
+- Fix slash commands not appearing in workspace chat window (#1698)
+- Fix multi-instance WebSocket origin propagation from the CLI (#1699)
+- Update workspace branch names when PRs are on a different branch (#1700)
+
+### Security
+
+- Fix Dependabot dependency alerts (#1687, #1701)
+- Add CodeQL workflow with merge_group trigger (#1694)
+- Fix CodeQL advanced workflow triggers (#1702)
+
 ## [0.3.20] - 2026-05-29
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "factory-factory",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "description": "Workspace-based coding environment for running multiple Claude Code and Codex sessions in parallel",
   "private": false,
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Bump the root package version from `0.3.20` to `0.3.21`.
- Add the `0.3.21` changelog entry dated 2026-06-22.
- Summarize the merged fixes, security updates, and small behavior changes since `v0.3.20`.

## Validation

- `pnpm check`
- Commit hook: `pnpm typecheck`
- Commit hook: `pnpm deps:check`
- Commit hook: `pnpm knip`

Notes: `pnpm check` reported existing Biome `<img>` warnings and skipped the local Codex schema drift check because the installed Codex CLI differs from the pinned CI version. The command exited successfully.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-metadata only; no runtime or application code is modified in this diff.
> 
> **Overview**
> Prepares the **0.3.21** patch release by bumping `package.json` from **0.3.20** to **0.3.21** and adding a **2026-06-22** changelog section.
> 
> The new entry catalogs work already merged since **v0.3.20**: one addition (workspace file links in chat), several behavior/sync tweaks (Codex tool backfill, issue intake, export schema enums, etc.), many bugfixes (session hydration, ratchet/review summaries, WebSocket origins, slash commands, PR branch names), and security/CI items (Dependabot, CodeQL workflows).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d441f65d790058abdb937dad864d0c1f1d700dad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->