### PR TITLE
Fix #1712: Fetch all ratchet review comments

### DIFF
--- a/src/backend/services/ratchet/service/ratchet-pr-state.helpers.test.ts
+++ b/src/backend/services/ratchet/service/ratchet-pr-state.helpers.test.ts
@@ -7,6 +7,7 @@ import {
   computeCiSnapshotKey,
   computeDispatchSnapshotKey,
   determineRatchetState,
+  fetchPRState,
   shouldSkipCleanPR,
 } from './ratchet-pr-state.helpers';
 
@@ -205,6 +206,70 @@ describe('computeCiSnapshotKey', () => {
     ]);
 
     expect(key).toBe('ci:FAILURE:ci:STARTUP_FAILURE:100');
+  });
+});
+
+describe('fetchPRState', () => {
+  it('fetches all inline review comments even after a prior review check', async () => {
+    const getReviewComments = vi.fn().mockResolvedValue([
+      {
+        author: { login: 'reviewer' },
+        body: 'Please handle this edge case.',
+        path: 'src/example.ts',
+        line: 42,
+        updatedAt: '2026-01-01T00:00:00Z',
+        url: 'https://github.com/example/repo/pull/123#discussion_r1',
+      },
+    ]);
+    const github = {
+      extractPRInfo: vi.fn().mockReturnValue({ owner: 'example', repo: 'repo', number: 123 }),
+      getPRFullDetails: vi.fn().mockResolvedValue({
+        state: 'OPEN',
+        number: 123,
+        url: 'https://github.com/example/repo/pull/123',
+        reviewDecision: 'CHANGES_REQUESTED',
+        mergeStateStatus: 'CLEAN',
+        reviews: [],
+        comments: [],
+        statusCheckRollup: null,
+      }),
+      getReviewComments,
+      computeCIStatus: vi.fn().mockReturnValue(CIStatus.SUCCESS),
+      getAuthenticatedUsername: vi.fn(),
+      fetchAndComputePRState: vi.fn(),
+      startFetch: vi.fn(),
+      registerFetch: vi.fn(),
+      cancelFetch: vi.fn(),
+    };
+
+    const result = await fetchPRState({
+      workspace: {
+        id: 'ws-1',
+        prUrl: 'https://github.com/example/repo/pull/123',
+        prNumber: 123,
+        prReviewLastCheckedAt: new Date('2026-01-02T00:00:00Z'),
+      } as never,
+      authenticatedUsername: null,
+      github,
+      backoff: { handleError: vi.fn() } as never,
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      } as never,
+    });
+
+    expect(getReviewComments.mock.calls[0]).toEqual(['example/repo', 123]);
+    expect(result?.reviewComments).toEqual([
+      {
+        author: 'reviewer',
+        body: 'Please handle this edge case.',
+        path: 'src/example.ts',
+        line: 42,
+        url: 'https://github.com/example/repo/pull/123#discussion_r1',
+      },
+    ]);
   });
 });
 

--- a/src/backend/services/ratchet/service/ratchet-pr-state.helpers.ts
+++ b/src/backend/services/ratchet/service/ratchet-pr-state.helpers.ts
@@ -407,11 +407,7 @@ export async function fetchPRState(params: {
 
     const [prDetails, reviewComments] = await Promise.all([
       github.getPRFullDetails(prContext.repo, prContext.prNumber),
-      github.getReviewComments(
-        prContext.repo,
-        prContext.prNumber,
-        workspace.prReviewLastCheckedAt ?? undefined
-      ),
+      github.getReviewComments(prContext.repo, prContext.prNumber),
     ]);
 
     const statusCheckRollup =


### PR DESCRIPTION
## Summary
- Stops ratchet PR state fetches from filtering inline review comments by `prReviewLastCheckedAt`.
- Keeps older unresolved line-level review feedback visible to fixer agents on later dispatches.
- Adds a regression test for the exact bridge call shape after a prior review check.

## Changes
- **Ratchet PR state**: Always fetch all inline review comments from GitHub so prompt context is complete.
- **Tests**: Covers a workspace with an existing `prReviewLastCheckedAt` and verifies no `since` argument is passed.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; backend-only behavior covered by regression test.

Closes #1712

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow backend fetch behavior change for ratchet prompts; slightly more GitHub data per fetch but no auth or persistence changes.
> 
> **Overview**
> **Ratchet PR state** no longer passes `prReviewLastCheckedAt` as a `since` filter when loading inline review comments from GitHub. Every `fetchPRState` call now requests the full comment thread so older line-level feedback still appears in fixer prompt context on later dispatches (fixes #1712).
> 
> A regression test asserts that workspaces with an existing `prReviewLastCheckedAt` still call `getReviewComments` with only `repo` and PR number, and that returned comments are mapped into `reviewComments`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 558a703263c29686f25d19b8cdadd580d252c0ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->