### PR TITLE
Fix CORS_ALLOWED_ORIGINS env var being overridden by CLI serve command

### DIFF
--- a/src/cli/serve-env.test.ts
+++ b/src/cli/serve-env.test.ts
@@ -31,4 +31,12 @@ describe('buildServeEnv', () => {
 
     expect(env.CORS_ALLOWED_ORIGINS).toBe('http://localhost:3504');
   });
+
+  it('respects CORS_ALLOWED_ORIGINS from the base environment', () => {
+    const env = buildServeEnv({ host: 'localhost' }, '/tmp/factory.db', 3000, 3001, {
+      CORS_ALLOWED_ORIGINS: 'https://home.adeesha.dev',
+    });
+
+    expect(env.CORS_ALLOWED_ORIGINS).toBe('https://home.adeesha.dev');
+  });
 });

--- a/src/cli/serve-env.ts
+++ b/src/cli/serve-env.ts
@@ -21,6 +21,6 @@ export function buildServeEnv(
     BACKEND_HOST: options.host,
     BACKEND_PORT: backendPort.toString(),
     NODE_ENV: options.dev ? 'development' : 'production',
-    CORS_ALLOWED_ORIGINS: corsOrigins,
+    CORS_ALLOWED_ORIGINS: baseEnv.CORS_ALLOWED_ORIGINS || corsOrigins,
   };
 }


### PR DESCRIPTION
## Summary

- `buildServeEnv` in `src/cli/serve-env.ts` was unconditionally overwriting `CORS_ALLOWED_ORIGINS` with the derived local origin (e.g. `http://localhost:3000`), making it impossible for users to override it via environment variable
- This broke WebSocket connections for custom deployments behind reverse proxies or Cloudflare Tunnel, where the public origin differs from the local bind address
- Fix: respect `CORS_ALLOWED_ORIGINS` from the base environment if already set; only fall back to the derived value when not provided

Fixes deployments like Cloudflare Tunnel where the browser origin is `https://example.com` but the server binds to `localhost:3000`.

## Test plan

- [ ] `pnpm test src/cli/serve-env.test.ts` — all 4 tests pass including new test for env var override
- [ ] Set `CORS_ALLOWED_ORIGINS=https://your-domain.com` before `pnpm start` and verify WebSocket connections succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)