### PR TITLE
Fix #1737: Recover auto-iteration resume failures

### DIFF
--- a/src/backend/services/auto-iteration/service/auto-iteration.service.test.ts
+++ b/src/backend/services/auto-iteration/service/auto-iteration.service.test.ts
@@ -119,7 +119,7 @@ describe('AutoIterationService resume', () => {
     expect(loop.loopPromise).not.toBeNull();
   });
 
-  it('releases the resume sentinel if restarting the loop fails', async () => {
+  it('restores paused state and releases the resume sentinel if restarting the loop fails', async () => {
     const loop = createPausedLoop('ws-1');
     serviceInternals.loops.set('ws-1', loop);
 
@@ -149,9 +149,53 @@ describe('AutoIterationService resume', () => {
     await expect(firstResume).rejects.toThrow('status update failed');
     await secondResume;
 
-    expect(workspaceBridge.updateAutoIterationStatus).toHaveBeenCalledTimes(2);
-    expect(workspaceBridge.getWorktreePath).toHaveBeenCalledTimes(1);
+    expect(workspaceBridge.updateAutoIterationStatus).toHaveBeenNthCalledWith(
+      2,
+      'ws-1',
+      AutoIterationStatus.PAUSED
+    );
+    expect(workspaceBridge.updateAutoIterationStatus).toHaveBeenCalledTimes(3);
+    expect(workspaceBridge.getWorktreePath).toHaveBeenCalledTimes(2);
     expect(runLoop).toHaveBeenCalledTimes(1);
     expect(loop.loopPromise).not.toBeNull();
+    expect(loop.pauseRequested).toBe(false);
+  });
+
+  it('keeps resume recoverable when worktree lookup fails', async () => {
+    const loop = createPausedLoop('ws-1');
+    serviceInternals.loops.set('ws-1', loop);
+
+    vi.mocked(workspaceBridge.getWorktreePath)
+      .mockRejectedValueOnce(new Error('Workspace ws-1 has no worktree path'))
+      .mockResolvedValueOnce('/tmp/worktree');
+
+    const runLoop = vi
+      .spyOn(serviceInternals, 'runLoop')
+      .mockImplementation(() => new Promise<void>(() => undefined));
+
+    await expect(service.resume('ws-1')).rejects.toThrow('has no worktree path');
+
+    expect(workspaceBridge.updateAutoIterationStatus).toHaveBeenCalledWith(
+      'ws-1',
+      AutoIterationStatus.PAUSED
+    );
+    expect(workspaceBridge.updateAutoIterationStatus).not.toHaveBeenCalledWith(
+      'ws-1',
+      AutoIterationStatus.RUNNING
+    );
+    expect(loop.loopPromise).toBeNull();
+    expect(loop.pauseRequested).toBe(true);
+    expect(service.getStatus('ws-1')?.status).toBe(AutoIterationStatus.PAUSED);
+
+    await service.resume('ws-1');
+
+    expect(workspaceBridge.getWorktreePath).toHaveBeenCalledTimes(2);
+    expect(workspaceBridge.updateAutoIterationStatus).toHaveBeenLastCalledWith(
+      'ws-1',
+      AutoIterationStatus.RUNNING
+    );
+    expect(runLoop).toHaveBeenCalledTimes(1);
+    expect(loop.loopPromise).not.toBeNull();
+    expect(loop.pauseRequested).toBe(false);
   });
 });

--- a/src/backend/services/auto-iteration/service/auto-iteration.service.ts
+++ b/src/backend/services/auto-iteration/service/auto-iteration.service.ts
@@ -226,8 +226,6 @@ export class AutoIterationService {
       );
     }
 
-    loop.pauseRequested = false;
-
     // Set a pending sentinel synchronously so concurrent resume() calls wait until
     // this call has swapped in the real runLoop promise or reset after failure.
     let releaseSentinel = (): void => undefined;
@@ -237,9 +235,10 @@ export class AutoIterationService {
     loop.loopPromise = sentinel;
 
     try {
+      const worktreePath = await this.workspace.getWorktreePath(workspaceId);
       await this.workspace.updateAutoIterationStatus(workspaceId, AutoIterationStatus.RUNNING);
 
-      const worktreePath = await this.workspace.getWorktreePath(workspaceId);
+      loop.pauseRequested = false;
       loop.loopPromise = this.runLoop(loop, worktreePath).catch((err) => {
         this.logger.error('Auto-iteration loop failed on resume', {
           workspaceId,
@@ -249,7 +248,16 @@ export class AutoIterationService {
         this.loops.delete(workspaceId);
       });
     } catch (err) {
+      loop.pauseRequested = true;
       loop.loopPromise = null;
+      try {
+        await this.workspace.updateAutoIterationStatus(workspaceId, AutoIterationStatus.PAUSED);
+      } catch (recoveryError) {
+        this.logger.error('Failed to restore paused auto-iteration status after resume failure', {
+          workspaceId,
+          error: String(recoveryError),
+        });
+      }
       throw err;
     } finally {
       releaseSentinel();


### PR DESCRIPTION
## Summary
- Keeps paused auto-iteration resume failures recoverable instead of leaving workspaces stuck as RUNNING.
- Validates the workspace worktree before persisting RUNNING and restores PAUSED on resume startup failures.
- Adds focused regression coverage for failed status updates and missing worktree paths.

## Changes
- **Auto-iteration resume**: Fetches the worktree path before the RUNNING transition, delays clearing the paused flag until the run loop can be attached, and restores PAUSED if startup fails.
- **Tests**: Extends resume tests to verify sentinel release, in-memory paused state restoration, persisted PAUSED recovery, and retry success after a worktree lookup failure.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not run; backend service logic covered by focused regression tests.

Closes #1737

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration and persisted workspace status on resume; mistakes could leave wrong PAUSED/RUNNING state, but scope is limited to resume error paths with new regression tests.
> 
> **Overview**
> **Resume startup** no longer marks a workspace **RUNNING** until the worktree path is validated. **`pauseRequested`** stays true until the run loop is actually attached, so a failed startup does not look like an active loop in memory.
> 
> If resume fails (missing worktree, status update error, etc.), the service **rolls back**: clears the pending loop promise, sets **`pauseRequested`** back, and **persists `PAUSED`** (with error logging if that recovery write fails). Users can retry resume instead of staying stuck as RUNNING.
> 
> Tests cover **PAUSED restoration** after a failed status transition (including concurrent resume) and **retry after worktree lookup failure**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6522174af86c99ba051c06c1d1e148db522318c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

