### PR TITLE
Fix #1760: Paginate review and Linear lists

### DIFF
--- a/src/backend/services/github/service/github-cli.service.test.ts
+++ b/src/backend/services/github/service/github-cli.service.test.ts
@@ -1135,6 +1135,7 @@ describe('GitHubCLIService', () => {
         stdout: JSON.stringify({
           data: {
             search: {
+              pageInfo: { hasNextPage: false, endCursor: null },
               nodes: [
                 {
                   number: 12,
@@ -1174,6 +1175,90 @@ describe('GitHubCLIService', () => {
 
       // Only one execFile call — no N+1
       expect(mockExecFile).toHaveBeenCalledTimes(1);
+    });
+
+    it('paginates review requests until GitHub search has no next page', async () => {
+      mockExecFile
+        .mockResolvedValueOnce({
+          stdout: JSON.stringify({
+            data: {
+              search: {
+                pageInfo: { hasNextPage: true, endCursor: 'cursor-1' },
+                nodes: [
+                  {
+                    number: 50,
+                    title: 'Boundary PR',
+                    url: 'https://github.com/o/r/pull/50',
+                    repository: { nameWithOwner: 'o/r' },
+                    author: { login: 'alice' },
+                    createdAt: '2026-01-10T00:00:00Z',
+                    isDraft: false,
+                    reviewDecision: null,
+                    additions: 1,
+                    deletions: 2,
+                    changedFiles: 3,
+                  },
+                ],
+              },
+            },
+          }),
+          stderr: '',
+        })
+        .mockResolvedValueOnce({
+          stdout: JSON.stringify({
+            data: {
+              search: {
+                pageInfo: { hasNextPage: false, endCursor: 'cursor-2' },
+                nodes: [
+                  {
+                    number: 51,
+                    title: 'Overflow PR',
+                    url: 'https://github.com/o/r/pull/51',
+                    repository: { nameWithOwner: 'o/r' },
+                    author: null,
+                    createdAt: '2026-01-11T00:00:00Z',
+                    isDraft: true,
+                  },
+                ],
+              },
+            },
+          }),
+          stderr: '',
+        });
+
+      await expect(githubCLIService.listReviewRequests()).resolves.toEqual([
+        {
+          number: 50,
+          title: 'Boundary PR',
+          url: 'https://github.com/o/r/pull/50',
+          repository: { nameWithOwner: 'o/r' },
+          author: { login: 'alice' },
+          createdAt: '2026-01-10T00:00:00Z',
+          isDraft: false,
+          reviewDecision: null,
+          additions: 1,
+          deletions: 2,
+          changedFiles: 3,
+        },
+        {
+          number: 51,
+          title: 'Overflow PR',
+          url: 'https://github.com/o/r/pull/51',
+          repository: { nameWithOwner: 'o/r' },
+          author: { login: '' },
+          createdAt: '2026-01-11T00:00:00Z',
+          isDraft: true,
+          reviewDecision: null,
+          additions: 0,
+          deletions: 0,
+          changedFiles: 0,
+        },
+      ]);
+
+      expect(mockExecFile).toHaveBeenCalledTimes(2);
+      expect(mockExecFile.mock.calls[1]?.[1]).toEqual(
+        expect.arrayContaining([expect.stringContaining('after: "cursor-1"')])
+      );
     });
 
     it('falls back to empty array when GraphQL response is malformed', async () => {

--- a/src/backend/services/github/service/github-cli.service.test.ts
+++ b/src/backend/services/github/service/github-cli.service.test.ts
@@ -1270,6 +1270,55 @@ describe('GitHubCLIService', () => {
       await expect(githubCLIService.listReviewRequests()).resolves.toEqual([]);
     });
 
+    it('keeps fetched review requests when a later GraphQL page is malformed', async () => {
+      mockExecFile
+        .mockResolvedValueOnce({
+          stdout: JSON.stringify({
+            data: {
+              search: {
+                pageInfo: { hasNextPage: true, endCursor: 'cursor-1' },
+                nodes: [
+                  {
+                    number: 50,
+                    title: 'Boundary PR',
+                    url: 'https://github.com/o/r/pull/50',
+                    repository: { nameWithOwner: 'o/r' },
+                    author: { login: 'alice' },
+                    createdAt: '2026-01-10T00:00:00Z',
+                    isDraft: false,
+                    reviewDecision: null,
+                    additions: 1,
+                    deletions: 2,
+                    changedFiles: 3,
+                  },
+                ],
+              },
+            },
+          }),
+          stderr: '',
+        })
+        .mockResolvedValueOnce({
+          stdout: JSON.stringify({ data: { search: { nodes: 'not-an-array' } } }),
+          stderr: '',
+        });
+
+      await expect(githubCLIService.listReviewRequests()).resolves.toEqual([
+        {
+          number: 50,
+          title: 'Boundary PR',
+          url: 'https://github.com/o/r/pull/50',
+          repository: { nameWithOwner: 'o/r' },
+          author: { login: 'alice' },
+          createdAt: '2026-01-10T00:00:00Z',
+          isDraft: false,
+          reviewDecision: null,
+          additions: 1,
+          deletions: 2,
+          changedFiles: 3,
+        },
+      ]);
+    });
+
     it('approves PR and logs failures with contextual error', async () => {
       mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       await expect(githubCLIService.approvePR('o', 'r', 22)).resolves.toBeUndefined();

--- a/src/backend/services/github/service/github-cli.service.ts
+++ b/src/backend/services/github/service/github-cli.service.ts
@@ -353,7 +353,7 @@ class GitHubCLIService {
         logger.warn('Failed to parse listReviewRequests GraphQL response', {
           error: parsed.error.message,
         });
-        return [];
+        return prs;
       }
 
       prs.push(

--- a/src/backend/services/github/service/github-cli.service.ts
+++ b/src/backend/services/github/service/github-cli.service.ts
@@ -315,50 +315,72 @@ class GitHubCLIService {
 
   /**
    * List all PRs where the authenticated user is requested as a reviewer.
-   * Uses a single GraphQL query to fetch all fields in one API call.
+   * Uses paginated GraphQL search calls to fetch all matching PRs.
    */
   async listReviewRequests(): Promise<ReviewRequestedPR[]> {
-    const query = `
-      query {
-        search(query: "is:pr is:open review-requested:@me", type: ISSUE, first: 50) {
-          nodes {
-            ... on PullRequest {
-              number title url isDraft createdAt
-              author { login }
-              repository { nameWithOwner }
-              reviewDecision
-              additions deletions changedFiles
+    const prs: ReviewRequestedPR[] = [];
+    let afterCursor: string | null = null;
+    let hasNextPage = true;
+
+    while (hasNextPage) {
+      const afterClause = afterCursor ? `, after: ${JSON.stringify(afterCursor)}` : '';
+      const query = `
+        query {
+          search(query: "is:pr is:open review-requested:@me", type: ISSUE, first: 50${afterClause}) {
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+            nodes {
+              ... on PullRequest {
+                number title url isDraft createdAt
+                author { login }
+                repository { nameWithOwner }
+                reviewDecision
+                additions deletions changedFiles
+              }
             }
           }
         }
-      }
-    `;
+      `;
 
-    const { stdout } = await this.exec(['api', 'graphql', '-f', `query=${query}`], {
-      timeout: GH_TIMEOUT_MS.default,
-    });
-
-    const parsed = reviewRequestedPRGraphQLSchema.safeParse(JSON.parse(stdout));
-    if (!parsed.success) {
-      logger.warn('Failed to parse listReviewRequests GraphQL response', {
-        error: parsed.error.message,
+      const { stdout } = await this.exec(['api', 'graphql', '-f', `query=${query}`], {
+        timeout: GH_TIMEOUT_MS.default,
       });
-      return [];
+
+      const parsed = reviewRequestedPRGraphQLSchema.safeParse(JSON.parse(stdout));
+      if (!parsed.success) {
+        logger.warn('Failed to parse listReviewRequests GraphQL response', {
+          error: parsed.error.message,
+        });
+        return [];
+      }
+
+      prs.push(
+        ...parsed.data.data.search.nodes.map((pr) => ({
+          number: pr.number,
+          title: pr.title,
+          url: pr.url,
+          repository: { nameWithOwner: pr.repository.nameWithOwner },
+          author: { login: pr.author?.login ?? '' },
+          createdAt: pr.createdAt,
+          isDraft: pr.isDraft,
+          reviewDecision: (pr.reviewDecision as ReviewRequestedPR['reviewDecision']) ?? null,
+          additions: pr.additions ?? 0,
+          deletions: pr.deletions ?? 0,
+          changedFiles: pr.changedFiles ?? 0,
+        }))
+      );
+
+      hasNextPage = parsed.data.data.search.pageInfo.hasNextPage;
+      afterCursor = parsed.data.data.search.pageInfo.endCursor;
+      if (hasNextPage && !afterCursor) {
+        logger.warn('GitHub review request page is missing an end cursor');
+        return prs;
+      }
     }
 
-    return parsed.data.data.search.nodes.map((pr) => ({
-      number: pr.number,
-      title: pr.title,
-      url: pr.url,
-      repository: { nameWithOwner: pr.repository.nameWithOwner },
-      author: { login: pr.author?.login ?? '' },
-      createdAt: pr.createdAt,
-      isDraft: pr.isDraft,
-      reviewDecision: (pr.reviewDecision as ReviewRequestedPR['reviewDecision']) ?? null,
-      additions: pr.additions ?? 0,
-      deletions: pr.deletions ?? 0,
-      changedFiles: pr.changedFiles ?? 0,
-    }));
+    return prs;
   }
 
   /**

--- a/src/backend/services/github/service/github-cli/schemas.ts
+++ b/src/backend/services/github/service/github-cli/schemas.ts
@@ -152,6 +152,10 @@ export const issueSchema = z.object({
 export const reviewRequestedPRGraphQLSchema = z.object({
   data: z.object({
     search: z.object({
+      pageInfo: z.object({
+        hasNextPage: z.boolean(),
+        endCursor: z.string().nullable(),
+      }),
       nodes: z.array(
         z.object({
           number: z.number(),

--- a/src/backend/services/linear/service/linear-client.service.test.ts
+++ b/src/backend/services/linear/service/linear-client.service.test.ts
@@ -122,6 +122,7 @@ describe('LinearClientService', () => {
   describe('listMyIssues', () => {
     it('returns normalized issues with fallbacks', async () => {
       const assignedIssues = vi.fn().mockResolvedValue({
+        pageInfo: { hasNextPage: false, endCursor: null },
         nodes: [
           {
             id: 'issue-1',
@@ -178,6 +179,84 @@ describe('LinearClientService', () => {
           state: 'Unknown',
           createdAt: '2024-01-02T00:00:00.000Z',
           assigneeName: 'Bob',
+        },
+      ]);
+    });
+
+    it('paginates assigned issues beyond the first page', async () => {
+      const assignedIssues = vi
+        .fn()
+        .mockResolvedValueOnce({
+          pageInfo: { hasNextPage: true, endCursor: 'cursor-1' },
+          nodes: [
+            {
+              id: 'issue-50',
+              identifier: 'ENG-50',
+              title: 'Boundary issue',
+              description: null,
+              url: 'https://linear.app/example/issue/ENG-50',
+              createdAt: new Date('2024-02-01T00:00:00.000Z'),
+              state: Promise.resolve({ name: 'Todo' }),
+              assignee: Promise.resolve(null),
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          pageInfo: { hasNextPage: false, endCursor: 'cursor-2' },
+          nodes: [
+            {
+              id: 'issue-51',
+              identifier: 'ENG-51',
+              title: 'Overflow issue',
+              description: 'Page two',
+              url: 'https://linear.app/example/issue/ENG-51',
+              createdAt: new Date('2024-02-02T00:00:00.000Z'),
+              state: Promise.resolve({ name: 'Todo' }),
+              assignee: Promise.resolve({ displayName: 'Casey', name: 'Casey C.' }),
+            },
+          ],
+        });
+      setMockClient({
+        viewer: Promise.resolve({ assignedIssues }),
+      });
+
+      const result = await linearClientService.listMyIssues('linear-api-key', 'team-1');
+
+      expect(assignedIssues).toHaveBeenNthCalledWith(1, {
+        filter: {
+          team: { id: { eq: 'team-1' } },
+          state: { type: { eq: 'unstarted' } },
+        },
+        first: 50,
+      });
+      expect(assignedIssues).toHaveBeenNthCalledWith(2, {
+        filter: {
+          team: { id: { eq: 'team-1' } },
+          state: { type: { eq: 'unstarted' } },
+        },
+        first: 50,
+        after: 'cursor-1',
+      });
+      expect(result).toEqual([
+        {
+          id: 'issue-50',
+          identifier: 'ENG-50',
+          title: 'Boundary issue',
+          description: '',
+          url: 'https://linear.app/example/issue/ENG-50',
+          state: 'Todo',
+          createdAt: '2024-02-01T00:00:00.000Z',
+          assigneeName: null,
+        },
+        {
+          id: 'issue-51',
+          identifier: 'ENG-51',
+          title: 'Overflow issue',
+          description: 'Page two',
+          url: 'https://linear.app/example/issue/ENG-51',
+          state: 'Todo',
+          createdAt: '2024-02-02T00:00:00.000Z',
+          assigneeName: 'Casey',
         },
       ]);
     });

--- a/src/backend/services/linear/service/linear-client.service.ts
+++ b/src/backend/services/linear/service/linear-client.service.ts
@@ -93,29 +93,47 @@ class LinearClientService {
   async listMyIssues(apiKey: string, teamId: string): Promise<LinearIssue[]> {
     const client = this.createClient(apiKey);
     const viewer = await client.viewer;
-    const issues = await viewer.assignedIssues({
-      filter: {
-        team: { id: { eq: teamId } },
-        state: { type: { eq: 'unstarted' } },
-      },
-      first: 50,
-    });
+    const linearIssues: LinearIssue[] = [];
+    let afterCursor: string | undefined;
+    let hasNextPage = true;
 
-    return Promise.all(
-      issues.nodes.map(async (issue) => {
-        const [state, assignee] = await Promise.all([issue.state, issue.assignee]);
-        return {
-          id: issue.id,
-          identifier: issue.identifier,
-          title: issue.title,
-          description: issue.description ?? '',
-          url: issue.url,
-          state: state?.name ?? 'Unknown',
-          createdAt: issue.createdAt.toISOString(),
-          assigneeName: assignee?.displayName ?? assignee?.name ?? null,
-        };
-      })
-    );
+    while (hasNextPage) {
+      const issues = await viewer.assignedIssues({
+        filter: {
+          team: { id: { eq: teamId } },
+          state: { type: { eq: 'unstarted' } },
+        },
+        first: 50,
+        ...(afterCursor ? { after: afterCursor } : {}),
+      });
+
+      linearIssues.push(
+        ...(await Promise.all(
+          issues.nodes.map(async (issue) => {
+            const [state, assignee] = await Promise.all([issue.state, issue.assignee]);
+            return {
+              id: issue.id,
+              identifier: issue.identifier,
+              title: issue.title,
+              description: issue.description ?? '',
+              url: issue.url,
+              state: state?.name ?? 'Unknown',
+              createdAt: issue.createdAt.toISOString(),
+              assigneeName: assignee?.displayName ?? assignee?.name ?? null,
+            };
+          })
+        ))
+      );
+      hasNextPage = issues.pageInfo.hasNextPage;
+      afterCursor = issues.pageInfo.endCursor ?? undefined;
+
+      if (hasNextPage && !afterCursor) {
+        logger.warn('Linear assigned issues page is missing an end cursor');
+        break;
+      }
+    }
+
+    return linearIssues;
   }
 
   /** Fetch a single issue by ID. */


### PR DESCRIPTION
## Summary
- Fetch all GitHub review-request pages instead of only the first 50 results.
- Fetch all assigned unstarted Linear issues across pages.
- Add regression tests for page-boundary and cursor behavior.

## Changes
- **GitHub reviews**: Add `pageInfo` parsing and loop GraphQL search requests with `after` until no next page remains.
- **Linear intake**: Follow the Linear assigned issues connection cursor and normalize results from every fetched page.
- **Tests**: Cover multi-page GitHub review requests and Linear assigned issue pagination.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; backend pagination behavior is covered by service unit tests.

Closes #1760

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how review and Linear intake lists are loaded (more API calls, different failure/partial-result behavior); low security impact but affects what users see in those views.
> 
> **Overview**
> Fixes incomplete intake when users have more than 50 open review requests or assigned unstarted Linear issues.
> 
> **GitHub:** `listReviewRequests` now loops GraphQL search pages using `pageInfo` and an `after` cursor instead of a single `first: 50` query. The Zod schema requires `pageInfo`. On a bad response, it returns PRs already fetched (not an empty list). It stops with a warning if `hasNextPage` is true but `endCursor` is missing.
> 
> **Linear:** `listMyIssues` pages `viewer.assignedIssues` with the same cursor pattern and the same missing-cursor guard.
> 
> **Tests:** Multi-page flows, cursor arguments, and GitHub partial success when a later page fails validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 693dc84b6f557d234a72fa930df88a813a50308a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

