### PR TITLE
Fix #1730: Harden worktree cleanup paths

### DIFF
--- a/src/backend/orchestration/workspace-init.orchestrator.ts
+++ b/src/backend/orchestration/workspace-init.orchestrator.ts
@@ -166,7 +166,7 @@ async function cleanupUnregisteredWorktreeAfterInitFailure(
       return;
     }
 
-    assertWorktreePathSafe(worktreeInfo.worktreePath, project.worktreeBasePath);
+    await assertWorktreePathSafe(worktreeInfo.worktreePath, project.worktreeBasePath);
     await gitOpsService.removeWorktree(worktreeInfo.worktreePath, project);
     logger.info('Removed unregistered worktree after init failure', {
       workspaceId,

--- a/src/backend/services/git-ops.service.test.ts
+++ b/src/backend/services/git-ops.service.test.ts
@@ -48,6 +48,7 @@ const project = {
 describe('gitOpsService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGitClient.getWorktreePath.mockImplementation((name: string) => `/repo/worktrees/${name}`);
   });
 
   it('forwards workspace git stats helper', async () => {
@@ -98,22 +99,41 @@ describe('gitOpsService', () => {
   });
 
   it('removeWorktree uses git when registered and fs fallback otherwise', async () => {
-    mockGitClient.checkWorktreeExists.mockResolvedValueOnce(true);
+    mockGitClient.listWorktreesWithBranches.mockResolvedValueOnce([{ path: '/repo/worktrees/w1' }]);
 
     await gitOpsService.removeWorktree('/repo/worktrees/w1', project);
     expect(mockGitClient.deleteWorktree).toHaveBeenCalledWith('w1');
 
-    mockGitClient.checkWorktreeExists.mockResolvedValueOnce(false);
+    mockGitClient.listWorktreesWithBranches.mockResolvedValueOnce([]);
     mockPathExists.mockResolvedValueOnce(true);
 
     await gitOpsService.removeWorktree('/repo/worktrees/w2', project);
     expect(mockRm).toHaveBeenCalledWith('/repo/worktrees/w2', { recursive: true, force: true });
 
-    mockGitClient.checkWorktreeExists.mockResolvedValueOnce(false);
+    mockGitClient.listWorktreesWithBranches.mockResolvedValueOnce([]);
     mockPathExists.mockResolvedValueOnce(false);
 
     await gitOpsService.removeWorktree('/repo/worktrees/w3', project);
     expect(mockRm).toHaveBeenCalledTimes(1);
+  });
+
+  it('removeWorktree refuses requested paths that do not match the configured worktree path', async () => {
+    await expect(gitOpsService.removeWorktree('/repo/other/w1', project)).rejects.toThrow(
+      'Refusing to remove worktree because requested path does not match project'
+    );
+    expect(mockGitClient.listWorktreesWithBranches).not.toHaveBeenCalled();
+    expect(mockGitClient.deleteWorktree).not.toHaveBeenCalled();
+    expect(mockRm).not.toHaveBeenCalled();
+  });
+
+  it('removeWorktree refuses registered worktrees whose path differs from the requested path', async () => {
+    mockGitClient.listWorktreesWithBranches.mockResolvedValueOnce([{ path: '/tmp/external/w1' }]);
+
+    await expect(gitOpsService.removeWorktree('/repo/worktrees/w1', project)).rejects.toThrow(
+      'Refusing to remove worktree because Git registered a different path for that name'
+    );
+    expect(mockGitClient.deleteWorktree).not.toHaveBeenCalled();
+    expect(mockRm).not.toHaveBeenCalled();
   });
 
   it('ensures base branch exists unless repository is blank', async () => {

--- a/src/backend/services/git-ops.service.test.ts
+++ b/src/backend/services/git-ops.service.test.ts
@@ -126,13 +126,25 @@ describe('gitOpsService', () => {
     expect(mockRm).not.toHaveBeenCalled();
   });
 
-  it('removeWorktree refuses registered worktrees whose path differs from the requested path', async () => {
-    mockGitClient.listWorktreesWithBranches.mockResolvedValueOnce([{ path: '/tmp/external/w1' }]);
-
-    await expect(gitOpsService.removeWorktree('/repo/worktrees/w1', project)).rejects.toThrow(
-      'Refusing to remove worktree because Git registered a different path for that name'
+  it('removeWorktree matches the registered worktree by full path when basenames collide', async () => {
+    const collidingProject = {
+      repoPath: '/repo/factory-factory',
+      worktreeBasePath: '/repo/factory-factory/worktrees',
+    };
+    mockGitClient.getWorktreePath.mockImplementation(
+      (name: string) => `/repo/factory-factory/worktrees/${name}`
     );
-    expect(mockGitClient.deleteWorktree).not.toHaveBeenCalled();
+    mockGitClient.listWorktreesWithBranches.mockResolvedValueOnce([
+      { path: '/repo/factory-factory' },
+      { path: '/repo/factory-factory/worktrees/factory-factory' },
+    ]);
+
+    await gitOpsService.removeWorktree(
+      '/repo/factory-factory/worktrees/factory-factory',
+      collidingProject
+    );
+
+    expect(mockGitClient.deleteWorktree).toHaveBeenCalledWith('factory-factory');
     expect(mockRm).not.toHaveBeenCalled();
   });
 

--- a/src/backend/services/git-ops.service.ts
+++ b/src/backend/services/git-ops.service.ts
@@ -103,14 +103,9 @@ class GitOpsService {
     }
 
     const registeredWorktree = (await gitClient.listWorktreesWithBranches()).find(
-      (entry) => path.basename(entry.path) === worktreeName
+      (entry) => path.resolve(entry.path) === expectedWorktreePath
     );
     if (registeredWorktree) {
-      if (path.resolve(registeredWorktree.path) !== expectedWorktreePath) {
-        throw new Error(
-          'Refusing to remove worktree because Git registered a different path for that name'
-        );
-      }
       await gitClient.deleteWorktree(worktreeName);
       return;
     }

--- a/src/backend/services/git-ops.service.ts
+++ b/src/backend/services/git-ops.service.ts
@@ -95,9 +95,22 @@ class GitOpsService {
       worktreeBasePath: project.worktreeBasePath,
     });
     const worktreeName = path.basename(worktreePath);
+    const expectedWorktreePath = path.resolve(worktreePath);
+    const configuredWorktreePath = path.resolve(gitClient.getWorktreePath(worktreeName));
 
-    const registeredWorktree = await gitClient.checkWorktreeExists(worktreeName);
+    if (expectedWorktreePath !== configuredWorktreePath) {
+      throw new Error('Refusing to remove worktree because requested path does not match project');
+    }
+
+    const registeredWorktree = (await gitClient.listWorktreesWithBranches()).find(
+      (entry) => path.basename(entry.path) === worktreeName
+    );
     if (registeredWorktree) {
+      if (path.resolve(registeredWorktree.path) !== expectedWorktreePath) {
+        throw new Error(
+          'Refusing to remove worktree because Git registered a different path for that name'
+        );
+      }
       await gitClient.deleteWorktree(worktreeName);
       return;
     }

--- a/src/backend/services/workspace/service/worktree/worktree-lifecycle.service.test.ts
+++ b/src/backend/services/workspace/service/worktree/worktree-lifecycle.service.test.ts
@@ -1,4 +1,8 @@
+import { mkdir, mkdtemp, rm, symlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { gitOpsService } from '@/backend/services/git-ops.service';
 import { workspaceAccessor } from '@/backend/services/workspace';
 import { unsafeCoerce } from '@/test-utils/unsafe-coerce';
 import {
@@ -8,20 +12,81 @@ import {
 } from './worktree-lifecycle.service';
 
 describe('worktreeLifecycleService path safety', () => {
-  it('allows worktree paths under the base path', () => {
-    expect(() => assertWorktreePathSafe('/tmp/worktrees/ws-1', '/tmp/worktrees')).not.toThrow();
+  it('allows worktree paths under the base path', async () => {
+    await expect(assertWorktreePathSafe('/tmp/worktrees/ws-1', '/tmp/worktrees')).resolves.toBe(
+      undefined
+    );
   });
 
-  it('rejects worktree paths that equal the base path', () => {
-    expect(() => assertWorktreePathSafe('/tmp/worktrees', '/tmp/worktrees')).toThrow(
+  it('rejects worktree paths that equal the base path', async () => {
+    await expect(assertWorktreePathSafe('/tmp/worktrees', '/tmp/worktrees')).rejects.toThrow(
       WorktreePathSafetyError
     );
   });
 
-  it('rejects worktree paths outside the base path', () => {
-    expect(() => assertWorktreePathSafe('/tmp/worktrees/../other', '/tmp/worktrees')).toThrow(
-      WorktreePathSafetyError
-    );
+  it('rejects worktree paths outside the base path', async () => {
+    await expect(
+      assertWorktreePathSafe('/tmp/worktrees/../other', '/tmp/worktrees')
+    ).rejects.toThrow(WorktreePathSafetyError);
+  });
+
+  it('rejects a worktree root that has been replaced with a symlink', async () => {
+    const tempRoot = await mkdtemp(path.join(tmpdir(), 'ff-worktree-safety-'));
+    const worktreeBasePath = path.join(tempRoot, 'worktrees');
+    const victimWorktreePath = path.join(worktreeBasePath, 'victim');
+    const swappedWorktreePath = path.join(worktreeBasePath, 'swapped');
+
+    await mkdir(victimWorktreePath, { recursive: true });
+    await symlink(victimWorktreePath, swappedWorktreePath, 'dir');
+
+    try {
+      await expect(assertWorktreePathSafe(swappedWorktreePath, worktreeBasePath)).rejects.toThrow(
+        WorktreePathSafetyError
+      );
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('worktreeLifecycleService cleanup', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('refuses cleanup when the worktree root is a symlink to another worktree', async () => {
+    const tempRoot = await mkdtemp(path.join(tmpdir(), 'ff-worktree-cleanup-'));
+    const worktreeBasePath = path.join(tempRoot, 'worktrees');
+    const victimWorktreePath = path.join(worktreeBasePath, 'victim');
+    const swappedWorktreePath = path.join(worktreeBasePath, 'swapped');
+    const commitSpy = vi.spyOn(gitOpsService, 'commitIfNeeded').mockResolvedValue(undefined);
+    const removeSpy = vi.spyOn(gitOpsService, 'removeWorktree').mockResolvedValue(undefined);
+
+    await mkdir(victimWorktreePath, { recursive: true });
+    await symlink(victimWorktreePath, swappedWorktreePath, 'dir');
+
+    const workspace = unsafeCoerce<
+      Parameters<typeof worktreeLifecycleService.cleanupWorkspaceWorktree>[0]
+    >({
+      name: 'Swapped workspace',
+      worktreePath: swappedWorktreePath,
+      project: {
+        repoPath: path.join(tempRoot, 'repo'),
+        worktreeBasePath,
+      },
+    });
+
+    try {
+      await expect(
+        worktreeLifecycleService.cleanupWorkspaceWorktree(workspace, {
+          commitUncommitted: true,
+        })
+      ).rejects.toThrow(WorktreePathSafetyError);
+      expect(commitSpy).not.toHaveBeenCalled();
+      expect(removeSpy).not.toHaveBeenCalled();
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/backend/services/workspace/service/worktree/worktree-lifecycle.service.ts
+++ b/src/backend/services/workspace/service/worktree/worktree-lifecycle.service.ts
@@ -1,3 +1,4 @@
+import { lstat, realpath } from 'node:fs/promises';
 import * as path from 'node:path';
 import { pathExists } from '@/backend/lib/file-helpers';
 import { gitOpsService } from '@/backend/services/git-ops.service';
@@ -10,14 +11,60 @@ export class WorktreePathSafetyError extends Error {
   }
 }
 
-export function assertWorktreePathSafe(worktreePath: string, worktreeBasePath: string): void {
-  const resolvedWorktreePath = path.resolve(worktreePath);
-  const resolvedBasePath = path.resolve(worktreeBasePath);
-  const basePrefix = `${resolvedBasePath}${path.sep}`;
+const isErrnoCode = (error: unknown, code: string): boolean =>
+  (error as NodeJS.ErrnoException).code === code;
 
-  if (resolvedWorktreePath === resolvedBasePath || !resolvedWorktreePath.startsWith(basePrefix)) {
+function assertPathWithinBase(worktreePath: string, basePath: string): void {
+  const basePrefix = `${basePath}${path.sep}`;
+
+  if (worktreePath === basePath || !worktreePath.startsWith(basePrefix)) {
     throw new WorktreePathSafetyError(
       'Workspace worktree path is outside the worktree base directory'
+    );
+  }
+}
+
+export async function assertWorktreePathSafe(
+  worktreePath: string,
+  worktreeBasePath: string
+): Promise<void> {
+  const resolvedWorktreePath = path.resolve(worktreePath);
+  const resolvedBasePath = path.resolve(worktreeBasePath);
+
+  assertPathWithinBase(resolvedWorktreePath, resolvedBasePath);
+
+  let worktreeStats: Awaited<ReturnType<typeof lstat>>;
+  try {
+    worktreeStats = await lstat(resolvedWorktreePath);
+  } catch (error) {
+    if (isErrnoCode(error, 'ENOENT')) {
+      return;
+    }
+    throw error;
+  }
+
+  if (worktreeStats.isSymbolicLink()) {
+    throw new WorktreePathSafetyError('Workspace worktree path must not be a symbolic link');
+  }
+
+  let realBasePath: string;
+  let realWorktreePath: string;
+  try {
+    [realBasePath, realWorktreePath] = await Promise.all([
+      realpath(resolvedBasePath),
+      realpath(resolvedWorktreePath),
+    ]);
+  } catch (error) {
+    throw new WorktreePathSafetyError(
+      `Unable to verify workspace worktree path: ${(error as Error).message}`
+    );
+  }
+
+  try {
+    assertPathWithinBase(realWorktreePath, realBasePath);
+  } catch {
+    throw new WorktreePathSafetyError(
+      'Workspace worktree real path is outside the worktree base directory'
     );
   }
 }
@@ -81,7 +128,7 @@ class WorktreeLifecycleService {
     }
 
     const project = getProjectOrThrow(workspace);
-    assertWorktreePathSafe(worktreePath, project.worktreeBasePath);
+    await assertWorktreePathSafe(worktreePath, project.worktreeBasePath);
 
     const worktreeExists = await pathExists(worktreePath);
     if (!worktreeExists) {


### PR DESCRIPTION
## Summary
- Reject symlinked workspace worktree roots before archive cleanup can commit or remove them.
- Verify canonical worktree paths stay under the real worktree base path.
- Require Git's registered worktree path to match the requested removal target before `git worktree remove`.

## Changes
- **Workspace cleanup**: Changed worktree path safety validation to use `lstat()` and `realpath()` so swapped symlink roots fail closed before cleanup.
- **Git operations**: Replaced basename-only registered worktree removal with path-matching validation against `git worktree list --porcelain`.
- **Tests**: Added regression coverage for symlinked worktree roots and mismatched registered worktree paths.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not run; covered by filesystem-backed symlink regression tests and full automated verification.

Closes #1730

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes filesystem deletion and git worktree removal guards on archive/init cleanup; mistakes could block legitimate cleanup or leave orphans, but the behavior is fail-closed with regression tests.
> 
> **Overview**
> Hardens workspace worktree cleanup so archive/init failure paths cannot commit or delete the wrong directory when paths are swapped or mis-registered.
> 
> **`assertWorktreePathSafe`** is now async and uses `lstat` plus `realpath` to reject symlinked worktree roots and to ensure the canonical path stays under the real worktree base. Cleanup and init-failure rollback **await** this check before `commitIfNeeded` / `removeWorktree`.
> 
> **`removeWorktree`** refuses targets whose resolved path does not match the project’s configured worktree path for that basename, and treats a worktree as “registered” only when **`git worktree list`** reports an entry with the same full path (fixing basename collisions). Tests cover symlink regressions, path mismatch refusal, and colliding names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d89128884981ca5f8142ea73543d2e375dc8b77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

