### PR TITLE
Fix #1726: Restrict executable tRPC mutations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -111,6 +111,10 @@ PR_REVIEW_TIMEOUT_MINUTES=60
 # The CLI auto-configures this to the frontend origin; only needed for Docker or custom deployments.
 CORS_ALLOWED_ORIGINS=http://localhost:4000,http://localhost:4001
 
+# Additional trusted local gateway CIDRs for published Docker ports (comma-separated).
+# Keep empty unless the app is bound behind a local-only bridge/proxy you control.
+# TRUSTED_LOCAL_CIDRS=172.17.0.1/32
+
 # =============================================================================
 # Logging Configuration
 # =============================================================================

--- a/src/backend/lib/request-trust.test.ts
+++ b/src/backend/lib/request-trust.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { isLoopbackRemoteAddress, isOriginAllowed, isTrustedLocalAddress } from './request-trust';
+
+describe('request trust helpers', () => {
+  describe('isLoopbackRemoteAddress', () => {
+    it('accepts IPv4, IPv4-mapped IPv6, and IPv6 loopback addresses', () => {
+      expect(isLoopbackRemoteAddress('127.0.0.1')).toBe(true);
+      expect(isLoopbackRemoteAddress('127.42.0.9')).toBe(true);
+      expect(isLoopbackRemoteAddress('::ffff:127.0.0.1')).toBe(true);
+      expect(isLoopbackRemoteAddress('::1')).toBe(true);
+    });
+
+    it('rejects non-loopback addresses', () => {
+      expect(isLoopbackRemoteAddress('172.17.0.1')).toBe(false);
+      expect(isLoopbackRemoteAddress('203.0.113.10')).toBe(false);
+      expect(isLoopbackRemoteAddress(undefined)).toBe(false);
+    });
+  });
+
+  describe('isTrustedLocalAddress', () => {
+    it('accepts loopback addresses without extra CIDR configuration', () => {
+      expect(isTrustedLocalAddress('127.0.0.1')).toBe(true);
+    });
+
+    it('accepts addresses covered by configured trusted local CIDRs', () => {
+      expect(isTrustedLocalAddress('172.17.0.1', ['172.17.0.1/32'])).toBe(true);
+      expect(isTrustedLocalAddress('172.18.0.42', ['172.18.0.0/16'])).toBe(true);
+    });
+
+    it('rejects addresses outside configured trusted local CIDRs', () => {
+      expect(isTrustedLocalAddress('172.18.0.42', ['172.17.0.1/32'])).toBe(false);
+      expect(isTrustedLocalAddress('203.0.113.10', ['172.17.0.1/32'])).toBe(false);
+      expect(isTrustedLocalAddress('172.17.0.1', ['not-a-cidr'])).toBe(false);
+    });
+  });
+
+  describe('isOriginAllowed', () => {
+    it('accepts exact allowed origins', () => {
+      expect(isOriginAllowed('https://example.com', ['https://example.com'])).toBe(true);
+    });
+
+    it('treats loopback host aliases as equivalent for the same scheme and port', () => {
+      expect(isOriginAllowed('http://127.0.0.1:3000', ['http://localhost:3000'])).toBe(true);
+      expect(isOriginAllowed('http://localhost:3000', ['http://127.0.0.1:3000'])).toBe(true);
+      expect(isOriginAllowed('http://127.42.0.9:3000', ['http://localhost:3000'])).toBe(true);
+    });
+
+    it('does not match loopback aliases across schemes or ports', () => {
+      expect(isOriginAllowed('http://127.0.0.1:3001', ['http://localhost:3000'])).toBe(false);
+      expect(isOriginAllowed('https://127.0.0.1:3000', ['http://localhost:3000'])).toBe(false);
+    });
+
+    it('does not normalize non-loopback hosts', () => {
+      expect(isOriginAllowed('https://app.example.com', ['https://example.com'])).toBe(false);
+      expect(isOriginAllowed('not a url', ['http://localhost:3000'])).toBe(false);
+    });
+  });
+});

--- a/src/backend/lib/request-trust.test.ts
+++ b/src/backend/lib/request-trust.test.ts
@@ -54,5 +54,13 @@ describe('request trust helpers', () => {
       expect(isOriginAllowed('https://app.example.com', ['https://example.com'])).toBe(false);
       expect(isOriginAllowed('not a url', ['http://localhost:3000'])).toBe(false);
     });
+
+    it('rejects loopback aliases with URL credentials or extra components', () => {
+      expect(isOriginAllowed('http://evil@localhost:3000', ['http://localhost:3000'])).toBe(false);
+      expect(isOriginAllowed('http://localhost:3000/path', ['http://127.0.0.1:3000'])).toBe(false);
+      expect(isOriginAllowed('http://localhost:3000?x=1', ['http://127.0.0.1:3000'])).toBe(false);
+      expect(isOriginAllowed('http://localhost:3000#hash', ['http://127.0.0.1:3000'])).toBe(false);
+      expect(isOriginAllowed('http://localhost:3000/', ['http://127.0.0.1:3000'])).toBe(false);
+    });
   });
 });

--- a/src/backend/lib/request-trust.test.ts
+++ b/src/backend/lib/request-trust.test.ts
@@ -45,6 +45,13 @@ describe('request trust helpers', () => {
       expect(isOriginAllowed('http://127.42.0.9:3000', ['http://localhost:3000'])).toBe(true);
     });
 
+    it('treats explicit default ports as canonical loopback origins', () => {
+      expect(isOriginAllowed('http://127.0.0.1:80', ['http://localhost'])).toBe(true);
+      expect(isOriginAllowed('http://localhost', ['http://127.0.0.1:80'])).toBe(true);
+      expect(isOriginAllowed('https://127.0.0.1:443', ['https://localhost'])).toBe(true);
+      expect(isOriginAllowed('https://localhost', ['https://127.0.0.1:443'])).toBe(true);
+    });
+
     it('does not match loopback aliases across schemes or ports', () => {
       expect(isOriginAllowed('http://127.0.0.1:3001', ['http://localhost:3000'])).toBe(false);
       expect(isOriginAllowed('https://127.0.0.1:3000', ['http://localhost:3000'])).toBe(false);
@@ -61,6 +68,7 @@ describe('request trust helpers', () => {
       expect(isOriginAllowed('http://localhost:3000?x=1', ['http://127.0.0.1:3000'])).toBe(false);
       expect(isOriginAllowed('http://localhost:3000#hash', ['http://127.0.0.1:3000'])).toBe(false);
       expect(isOriginAllowed('http://localhost:3000/', ['http://127.0.0.1:3000'])).toBe(false);
+      expect(isOriginAllowed('http://localhost:80/', ['http://127.0.0.1'])).toBe(false);
     });
   });
 });

--- a/src/backend/lib/request-trust.ts
+++ b/src/backend/lib/request-trust.ts
@@ -98,6 +98,17 @@ function parseOrigin(origin: string): URL | undefined {
   }
 }
 
+function isCanonicalOriginUrl(origin: string, url: URL): boolean {
+  return (
+    url.origin === origin &&
+    url.username === '' &&
+    url.password === '' &&
+    url.pathname === '/' &&
+    url.search === '' &&
+    url.hash === ''
+  );
+}
+
 function getEffectivePort(url: URL): string {
   if (url.port) {
     return url.port;
@@ -112,13 +123,25 @@ export function isOriginAllowed(origin: string, allowedOrigins: readonly string[
   }
 
   const parsedOrigin = parseOrigin(origin);
-  if (!(parsedOrigin && isLoopbackHostname(parsedOrigin.hostname))) {
+  if (
+    !(
+      parsedOrigin &&
+      isCanonicalOriginUrl(origin, parsedOrigin) &&
+      isLoopbackHostname(parsedOrigin.hostname)
+    )
+  ) {
     return false;
   }
 
   return allowedOrigins.some((allowedOrigin) => {
     const parsedAllowedOrigin = parseOrigin(allowedOrigin);
-    if (!(parsedAllowedOrigin && isLoopbackHostname(parsedAllowedOrigin.hostname))) {
+    if (
+      !(
+        parsedAllowedOrigin &&
+        isCanonicalOriginUrl(allowedOrigin, parsedAllowedOrigin) &&
+        isLoopbackHostname(parsedAllowedOrigin.hostname)
+      )
+    ) {
       return false;
     }
 

--- a/src/backend/lib/request-trust.ts
+++ b/src/backend/lib/request-trust.ts
@@ -99,8 +99,13 @@ function parseOrigin(origin: string): URL | undefined {
 }
 
 function isCanonicalOriginUrl(origin: string, url: URL): boolean {
+  const canonicalOrigin =
+    url.origin === origin ||
+    (url.protocol === 'http:' && origin === `${url.origin}:80`) ||
+    (url.protocol === 'https:' && origin === `${url.origin}:443`);
+
   return (
-    url.origin === origin &&
+    canonicalOrigin &&
     url.username === '' &&
     url.password === '' &&
     url.pathname === '/' &&

--- a/src/backend/lib/request-trust.ts
+++ b/src/backend/lib/request-trust.ts
@@ -1,0 +1,130 @@
+import { isIP } from 'node:net';
+
+function normalizeAddress(address: string | undefined): string | undefined {
+  return address?.startsWith('::ffff:') ? address.slice('::ffff:'.length) : address;
+}
+
+function ipv4ToInt(address: string): number | undefined {
+  const parts = address.split('.');
+  if (parts.length !== 4) {
+    return undefined;
+  }
+
+  let value = 0;
+  for (const part of parts) {
+    const octet = Number(part);
+    if (!Number.isInteger(octet) || octet < 0 || octet > 255) {
+      return undefined;
+    }
+    value = (value << 8) + octet;
+  }
+
+  return value >>> 0;
+}
+
+function isIpv4AddressInCidr(address: string, cidr: string): boolean {
+  const [rangeAddress, prefixLengthRaw] = cidr.trim().split('/');
+  if (!rangeAddress || isIP(rangeAddress) !== 4) {
+    return false;
+  }
+
+  const prefixLength = prefixLengthRaw === undefined ? 32 : Number.parseInt(prefixLengthRaw, 10);
+  if (
+    !Number.isInteger(prefixLength) ||
+    prefixLength < 0 ||
+    prefixLength > 32 ||
+    (prefixLengthRaw !== undefined && String(prefixLength) !== prefixLengthRaw)
+  ) {
+    return false;
+  }
+
+  const addressInt = ipv4ToInt(address);
+  const rangeInt = ipv4ToInt(rangeAddress);
+  if (addressInt === undefined || rangeInt === undefined) {
+    return false;
+  }
+
+  const mask = prefixLength === 0 ? 0 : (0xff_ff_ff_ff << (32 - prefixLength)) >>> 0;
+  return (addressInt & mask) === (rangeInt & mask);
+}
+
+export function isLoopbackRemoteAddress(remoteAddress: string | undefined): boolean {
+  const normalized = normalizeAddress(remoteAddress);
+  if (!normalized) {
+    return false;
+  }
+
+  if (normalized === '::1' || normalized === '0:0:0:0:0:0:0:1') {
+    return true;
+  }
+
+  return isIP(normalized) === 4 && normalized.startsWith('127.');
+}
+
+export function isTrustedLocalAddress(
+  remoteAddress: string | undefined,
+  trustedLocalCidrs: readonly string[] = []
+): boolean {
+  const normalized = normalizeAddress(remoteAddress);
+  if (!normalized) {
+    return false;
+  }
+
+  if (isLoopbackRemoteAddress(normalized)) {
+    return true;
+  }
+
+  if (isIP(normalized) !== 4) {
+    return false;
+  }
+
+  return trustedLocalCidrs.some((cidr) => isIpv4AddressInCidr(normalized, cidr));
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  if (normalized === 'localhost' || normalized === '::1' || normalized === '[::1]') {
+    return true;
+  }
+
+  return isIP(normalized) === 4 && normalized.startsWith('127.');
+}
+
+function parseOrigin(origin: string): URL | undefined {
+  try {
+    return new URL(origin);
+  } catch {
+    return undefined;
+  }
+}
+
+function getEffectivePort(url: URL): string {
+  if (url.port) {
+    return url.port;
+  }
+
+  return url.protocol === 'https:' ? '443' : '80';
+}
+
+export function isOriginAllowed(origin: string, allowedOrigins: readonly string[]): boolean {
+  if (allowedOrigins.includes(origin)) {
+    return true;
+  }
+
+  const parsedOrigin = parseOrigin(origin);
+  if (!(parsedOrigin && isLoopbackHostname(parsedOrigin.hostname))) {
+    return false;
+  }
+
+  return allowedOrigins.some((allowedOrigin) => {
+    const parsedAllowedOrigin = parseOrigin(allowedOrigin);
+    if (!(parsedAllowedOrigin && isLoopbackHostname(parsedAllowedOrigin.hostname))) {
+      return false;
+    }
+
+    return (
+      parsedOrigin.protocol === parsedAllowedOrigin.protocol &&
+      getEffectivePort(parsedOrigin) === getEffectivePort(parsedAllowedOrigin)
+    );
+  });
+}

--- a/src/backend/middleware/cors.middleware.ts
+++ b/src/backend/middleware/cors.middleware.ts
@@ -1,5 +1,6 @@
 import type { NextFunction, Request, Response } from 'express';
 import type { AppContext } from '@/backend/app-context';
+import { isOriginAllowed } from '@/backend/lib/request-trust';
 
 /**
  * CORS middleware.
@@ -13,7 +14,7 @@ export function createCorsMiddleware(appContext: AppContext) {
     const ALLOWED_ORIGINS = appContext.services.configService.getCorsConfig().allowedOrigins;
 
     const origin = req.headers.origin;
-    if (origin && ALLOWED_ORIGINS.includes(origin)) {
+    if (origin && isOriginAllowed(origin, ALLOWED_ORIGINS)) {
       res.header('Access-Control-Allow-Origin', origin);
     }
     res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');

--- a/src/backend/middleware/middleware.test.ts
+++ b/src/backend/middleware/middleware.test.ts
@@ -155,6 +155,16 @@ describe('corsMiddleware', () => {
       expect(mockRes.headers['Access-Control-Allow-Origin']).toBe('http://localhost:3001');
     });
 
+    it('should set Access-Control-Allow-Origin for equivalent loopback origins', () => {
+      const mockReq = createMockReq({
+        headers: { origin: 'http://127.0.0.1:3000' },
+      });
+
+      corsMiddleware(mockReq, toResponse(mockRes), mockNext);
+
+      expect(mockRes.headers['Access-Control-Allow-Origin']).toBe('http://127.0.0.1:3000');
+    });
+
     it('should not set Access-Control-Allow-Origin for disallowed origins', () => {
       const mockReq = createMockReq({
         headers: { origin: 'http://evil.com' },
@@ -199,6 +209,20 @@ describe('corsMiddleware', () => {
       corsMiddleware(mockReq, toResponse(mockRes), mockNext);
 
       expect(mockRes.headers['Access-Control-Allow-Origin']).toBeUndefined();
+    });
+
+    it('should allow equivalent loopback origins when custom config uses localhost', () => {
+      mockGetCorsConfig.mockReturnValue({
+        allowedOrigins: ['http://localhost:4000'],
+      });
+
+      const mockReq = createMockReq({
+        headers: { origin: 'http://127.0.0.1:4000' },
+      });
+
+      corsMiddleware(mockReq, toResponse(mockRes), mockNext);
+
+      expect(mockRes.headers['Access-Control-Allow-Origin']).toBe('http://127.0.0.1:4000');
     });
   });
 

--- a/src/backend/routers/websocket/upgrade-utils.test.ts
+++ b/src/backend/routers/websocket/upgrade-utils.test.ts
@@ -90,4 +90,20 @@ describe('validateWebSocketOrigin', () => {
     expect(socket.write).not.toHaveBeenCalled();
     expect(socket.destroy).not.toHaveBeenCalled();
   });
+
+  it('rejects credentialed loopback origins', () => {
+    const socket = createSocket();
+
+    const isValid = validateWebSocketOrigin({
+      request: { headers: { origin: 'http://evil@localhost:3000' } } as IncomingMessage,
+      socket,
+      configService: createConfigService(['http://localhost:3000']),
+      logger: createLogger(),
+      connectionName: 'terminal WebSocket',
+    });
+
+    expect(isValid).toBe(false);
+    expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('Unauthorized origin'));
+    expect(socket.destroy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/backend/routers/websocket/upgrade-utils.test.ts
+++ b/src/backend/routers/websocket/upgrade-utils.test.ts
@@ -74,4 +74,20 @@ describe('validateWebSocketOrigin', () => {
     expect(socket.write).not.toHaveBeenCalled();
     expect(socket.destroy).not.toHaveBeenCalled();
   });
+
+  it('allows upgrades from equivalent loopback origins', () => {
+    const socket = createSocket();
+
+    const isValid = validateWebSocketOrigin({
+      request: { headers: { origin: 'http://127.0.0.1:3000' } } as IncomingMessage,
+      socket,
+      configService: createConfigService(['http://localhost:3000']),
+      logger: createLogger(),
+      connectionName: 'terminal WebSocket',
+    });
+
+    expect(isValid).toBe(true);
+    expect(socket.write).not.toHaveBeenCalled();
+    expect(socket.destroy).not.toHaveBeenCalled();
+  });
 });

--- a/src/backend/routers/websocket/upgrade-utils.ts
+++ b/src/backend/routers/websocket/upgrade-utils.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage } from 'node:http';
 import type { Duplex } from 'node:stream';
 import type { WebSocket } from 'ws';
 import type { AppServices } from '@/backend/app-context';
+import { isOriginAllowed } from '@/backend/lib/request-trust';
 
 type WebSocketOriginLogger = Pick<ReturnType<AppServices['createLogger']>, 'warn'>;
 type WebSocketOriginConfigService = Pick<AppServices['configService'], 'getCorsConfig'>;
@@ -33,7 +34,7 @@ export function validateWebSocketOrigin({
   }
 
   const allowedOrigins = configService.getCorsConfig().allowedOrigins;
-  if (!allowedOrigins.includes(origin)) {
+  if (!isOriginAllowed(origin, allowedOrigins)) {
     logger.warn(`Rejected ${connectionName} connection from unauthorized origin`, { origin });
     sendBadRequest(socket, 'Unauthorized origin');
     return false;

--- a/src/backend/services/config.service.test.ts
+++ b/src/backend/services/config.service.test.ts
@@ -64,6 +64,7 @@ describe('configService environment accessors', () => {
     process.env.NOTIFICATION_QUIET_HOURS_START = '22';
     process.env.NOTIFICATION_QUIET_HOURS_END = '7';
     process.env.CORS_ALLOWED_ORIGINS = 'http://localhost:9999, https://example.com';
+    process.env.TRUSTED_LOCAL_CIDRS = '172.17.0.1/32, 172.18.0.0/16';
     process.env.BRANCH_RENAME_MESSAGE_THRESHOLD = '4';
     process.env.EVENT_COMPRESSION_ENABLED = 'false';
     process.env.WEB_CONCURRENCY = '3';
@@ -117,6 +118,7 @@ describe('configService environment accessors', () => {
     });
     expect(configService.getCorsConfig()).toEqual({
       allowedOrigins: ['http://localhost:9999', 'https://example.com'],
+      trustedLocalCidrs: ['172.17.0.1/32', '172.18.0.0/16'],
     });
     expect(configService.getDebugConfig()).toEqual({ chatWebSocket: true });
     expect(configService.getCompressionConfig()).toEqual({ enabled: false });

--- a/src/backend/services/config.service.ts
+++ b/src/backend/services/config.service.ts
@@ -69,6 +69,7 @@ export interface NotificationConfig {
  */
 export interface CorsConfig {
   allowedOrigins: string[];
+  trustedLocalCidrs?: string[];
 }
 
 /**
@@ -238,10 +239,17 @@ function buildNotificationConfig(env: ConfigEnv): NotificationConfig {
  */
 function buildCorsConfig(env: ConfigEnv): CorsConfig {
   const originsEnv = env.CORS_ALLOWED_ORIGINS;
+  const trustedCidrsEnv = env.TRUSTED_LOCAL_CIDRS;
   const defaultOrigins = ['http://localhost:3000', 'http://localhost:3001'];
 
   return {
     allowedOrigins: originsEnv ? originsEnv.split(',').map((o) => o.trim()) : defaultOrigins,
+    trustedLocalCidrs: trustedCidrsEnv
+      ? trustedCidrsEnv
+          .split(',')
+          .map((cidr) => cidr.trim())
+          .filter(Boolean)
+      : [],
   };
 }
 
@@ -540,7 +548,10 @@ class ConfigService {
    * Get CORS configuration
    */
   getCorsConfig(): CorsConfig {
-    return { ...this.config.cors };
+    return {
+      allowedOrigins: [...this.config.cors.allowedOrigins],
+      trustedLocalCidrs: [...(this.config.cors.trustedLocalCidrs ?? [])],
+    };
   }
 
   /**

--- a/src/backend/services/env-schemas.ts
+++ b/src/backend/services/env-schemas.ts
@@ -89,6 +89,7 @@ export const ConfigEnvSchema = z.object({
   NOTIFICATION_QUIET_HOURS_START: HourEnvSchema.optional().catch(undefined),
   NOTIFICATION_QUIET_HOURS_END: HourEnvSchema.optional().catch(undefined),
   CORS_ALLOWED_ORIGINS: z.preprocess(toTrimmedString, z.string()).optional().catch(undefined),
+  TRUSTED_LOCAL_CIDRS: z.preprocess(toTrimmedString, z.string()).optional().catch(undefined),
   BASE_DIR: z.preprocess(toTrimmedString, z.string()).optional().catch(undefined),
   WORKTREE_BASE_DIR: z.preprocess(toTrimmedString, z.string()).optional().catch(undefined),
   REPOS_DIR: z.preprocess(toTrimmedString, z.string()).optional().catch(undefined),

--- a/src/backend/trpc/project.router.test.ts
+++ b/src/backend/trpc/project.router.test.ts
@@ -62,13 +62,21 @@ vi.mock('@/backend/services/git-clone.service', () => ({
 
 import { projectRouter } from './project.trpc';
 
-function createCaller() {
+function createCaller(requestTrust?: {
+  remoteAddress?: string;
+  origin?: string;
+  isLocal: boolean;
+}) {
   return projectRouter.createCaller({
+    requestTrust,
     appContext: {
       services: {
         configService: {
           getWorktreeBaseDir: () => '/tmp/worktrees',
           getReposDir: () => '/repos',
+          getCorsConfig: () => ({
+            allowedOrigins: ['http://localhost:3000', 'http://localhost:3001'],
+          }),
         },
       },
     },
@@ -302,6 +310,75 @@ describe('projectRouter', () => {
         },
       })
     );
+  });
+
+  it('rejects privileged project mutations from untrusted requests', async () => {
+    const caller = createCaller({
+      remoteAddress: '203.0.113.10',
+      origin: 'https://attacker.example',
+      isLocal: false,
+    });
+
+    await expect(caller.create({ repoPath: '/repo/path' })).rejects.toThrow(
+      'trusted local Factory Factory client'
+    );
+    await expect(caller.update({ id: 'p1', name: 'Renamed' })).rejects.toThrow(
+      'trusted local Factory Factory client'
+    );
+    await expect(
+      caller.createFromGithub({ githubUrl: 'https://github.com/purplefish-ai/factory-factory' })
+    ).rejects.toThrow('trusted local Factory Factory client');
+    await expect(
+      caller.saveFactoryConfig({
+        projectId: 'p1',
+        config: { scripts: { run: 'pnpm dev' } },
+      })
+    ).rejects.toThrow('trusted local Factory Factory client');
+
+    expect(mockProjectManagementService.validateRepoPath).not.toHaveBeenCalled();
+    expect(mockProjectManagementService.create).not.toHaveBeenCalled();
+    expect(mockProjectManagementService.update).not.toHaveBeenCalled();
+    expect(mockGetClonePath).not.toHaveBeenCalled();
+    expect(mockCloneRepo).not.toHaveBeenCalled();
+  });
+
+  it('allows privileged project mutations from trusted local origins', async () => {
+    const caller = createCaller({
+      remoteAddress: '127.0.0.1',
+      origin: 'http://localhost:3000',
+      isLocal: true,
+    });
+    mockProjectManagementService.validateRepoPath.mockResolvedValue({ valid: true });
+    mockProjectManagementService.create.mockResolvedValue({ id: 'created' });
+
+    await expect(
+      caller.create({
+        repoPath: '/good/path',
+        startupScriptPath: 'scripts/start.sh',
+      })
+    ).resolves.toEqual({ id: 'created' });
+    expect(mockProjectManagementService.create).toHaveBeenCalledWith(
+      {
+        repoPath: '/good/path',
+        startupScriptCommand: undefined,
+        startupScriptPath: 'scripts/start.sh',
+        startupScriptTimeout: undefined,
+      },
+      { worktreeBaseDir: '/tmp/worktrees' }
+    );
+  });
+
+  it('rejects privileged project mutations from disallowed browser origins', async () => {
+    const caller = createCaller({
+      remoteAddress: '127.0.0.1',
+      origin: 'https://attacker.example',
+      isLocal: true,
+    });
+
+    await expect(caller.create({ repoPath: '/repo/path' })).rejects.toThrow(
+      'trusted local Factory Factory client'
+    );
+    expect(mockProjectManagementService.validateRepoPath).not.toHaveBeenCalled();
   });
 
   it('creates projects successfully and validates update edge cases', async () => {

--- a/src/backend/trpc/project.router.test.ts
+++ b/src/backend/trpc/project.router.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CorsConfig } from '@/backend/services/config.service';
 import { IssueProvider } from '@/shared/core/enums';
 
 const mockProjectManagementService = vi.hoisted(() => ({
@@ -62,11 +63,16 @@ vi.mock('@/backend/services/git-clone.service', () => ({
 
 import { projectRouter } from './project.trpc';
 
-function createCaller(requestTrust?: {
-  remoteAddress?: string;
-  origin?: string;
-  isLocal: boolean;
-}) {
+function createCaller(
+  requestTrust?: {
+    remoteAddress?: string;
+    origin?: string;
+    isLocal: boolean;
+  },
+  corsConfig: CorsConfig = {
+    allowedOrigins: ['http://localhost:3000', 'http://localhost:3001'],
+  }
+) {
   return projectRouter.createCaller({
     requestTrust,
     appContext: {
@@ -74,9 +80,7 @@ function createCaller(requestTrust?: {
         configService: {
           getWorktreeBaseDir: () => '/tmp/worktrees',
           getReposDir: () => '/repos',
-          getCorsConfig: () => ({
-            allowedOrigins: ['http://localhost:3000', 'http://localhost:3001'],
-          }),
+          getCorsConfig: () => corsConfig,
         },
       },
     },
@@ -366,6 +370,38 @@ describe('projectRouter', () => {
       },
       { worktreeBaseDir: '/tmp/worktrees' }
     );
+  });
+
+  it('allows privileged project mutations from equivalent loopback origins', async () => {
+    const caller = createCaller({
+      remoteAddress: '127.0.0.1',
+      origin: 'http://127.0.0.1:3000',
+      isLocal: true,
+    });
+    mockProjectManagementService.validateRepoPath.mockResolvedValue({ valid: true });
+    mockProjectManagementService.create.mockResolvedValue({ id: 'created' });
+
+    await expect(caller.create({ repoPath: '/good/path' })).resolves.toEqual({ id: 'created' });
+    expect(mockProjectManagementService.create).toHaveBeenCalled();
+  });
+
+  it('allows privileged project mutations from configured trusted local CIDRs', async () => {
+    const caller = createCaller(
+      {
+        remoteAddress: '172.17.0.1',
+        origin: 'http://localhost:3000',
+        isLocal: false,
+      },
+      {
+        allowedOrigins: ['http://localhost:3000'],
+        trustedLocalCidrs: ['172.17.0.1/32'],
+      }
+    );
+    mockProjectManagementService.validateRepoPath.mockResolvedValue({ valid: true });
+    mockProjectManagementService.create.mockResolvedValue({ id: 'created' });
+
+    await expect(caller.create({ repoPath: '/good/path' })).resolves.toEqual({ id: 'created' });
+    expect(mockProjectManagementService.create).toHaveBeenCalled();
   });
 
   it('rejects privileged project mutations from disallowed browser origins', async () => {

--- a/src/backend/trpc/project.trpc.ts
+++ b/src/backend/trpc/project.trpc.ts
@@ -15,7 +15,7 @@ import {
   IssueTrackerConfigSchema,
   sanitizeIssueTrackerConfig,
 } from '@/shared/schemas/issue-tracker-config.schema';
-import { publicProcedure, router } from './trpc';
+import { publicProcedure, router, trustedLocalProcedure } from './trpc';
 
 function parseCommandFileDescription(filePath: string): string {
   try {
@@ -272,7 +272,7 @@ export const projectRouter = router({
     }),
 
   // Create a new project (only repoPath required - name/slug/worktree derived)
-  create: publicProcedure
+  create: trustedLocalProcedure
     .input(
       z.object({
         repoPath: z.string().min(1, 'Repository path is required'),
@@ -311,7 +311,7 @@ export const projectRouter = router({
     }),
 
   // Update a project
-  update: publicProcedure
+  update: trustedLocalProcedure
     .input(
       z.object({
         id: z.string(),
@@ -383,7 +383,7 @@ export const projectRouter = router({
     }),
 
   // Save factory-factory.json to the project repo
-  saveFactoryConfig: publicProcedure
+  saveFactoryConfig: trustedLocalProcedure
     .input(
       z.object({
         projectId: z.string(),
@@ -408,7 +408,7 @@ export const projectRouter = router({
   }),
 
   // Clone a GitHub repo and create a project
-  createFromGithub: publicProcedure
+  createFromGithub: trustedLocalProcedure
     .input(
       z.object({
         githubUrl: z

--- a/src/backend/trpc/trpc.test.ts
+++ b/src/backend/trpc/trpc.test.ts
@@ -1,0 +1,21 @@
+import type { Request } from 'express';
+import { describe, expect, it } from 'vitest';
+import { createContext } from './trpc';
+
+describe('createContext request trust', () => {
+  it('prefers Express proxy-aware req.ip over the socket remote address', () => {
+    const contextFactory = createContext({} as never);
+    const ctx = contextFactory({
+      req: {
+        headers: {},
+        ip: '203.0.113.10',
+        socket: { remoteAddress: '127.0.0.1' },
+      } as Request,
+    });
+
+    expect(ctx.requestTrust).toMatchObject({
+      remoteAddress: '203.0.113.10',
+      isLocal: false,
+    });
+  });
+});

--- a/src/backend/trpc/trpc.ts
+++ b/src/backend/trpc/trpc.ts
@@ -1,8 +1,14 @@
-import { isIP } from 'node:net';
 import { initTRPC, TRPCError } from '@trpc/server';
 import type { Request } from 'express';
 import superjson from 'superjson';
 import type { AppContext } from '@/backend/app-context';
+import {
+  isLoopbackRemoteAddress,
+  isOriginAllowed,
+  isTrustedLocalAddress,
+} from '@/backend/lib/request-trust';
+
+export { isLoopbackRemoteAddress };
 
 export type RequestTrustInfo = {
   remoteAddress?: string;
@@ -29,24 +35,8 @@ function getHeaderValue(value: string | string[] | undefined): string | undefine
   return Array.isArray(value) ? value[0] : value;
 }
 
-export function isLoopbackRemoteAddress(remoteAddress: string | undefined): boolean {
-  if (!remoteAddress) {
-    return false;
-  }
-
-  const normalized = remoteAddress.startsWith('::ffff:')
-    ? remoteAddress.slice('::ffff:'.length)
-    : remoteAddress;
-
-  if (normalized === '::1' || normalized === '0:0:0:0:0:0:0:1') {
-    return true;
-  }
-
-  return isIP(normalized) === 4 && normalized.startsWith('127.');
-}
-
 function buildRequestTrust(req: Request): RequestTrustInfo {
-  const remoteAddress = req.socket.remoteAddress ?? req.ip;
+  const remoteAddress = req.ip ?? req.socket.remoteAddress;
   return {
     remoteAddress,
     origin: getHeaderValue(req.headers.origin),
@@ -87,7 +77,11 @@ function isTrustedLocalContext(ctx: Context): boolean {
     return true;
   }
 
-  if (!ctx.requestTrust.isLocal) {
+  const corsConfig = ctx.appContext.services.configService.getCorsConfig();
+  const isLocal =
+    ctx.requestTrust.isLocal ||
+    isTrustedLocalAddress(ctx.requestTrust.remoteAddress, corsConfig.trustedLocalCidrs);
+  if (!isLocal) {
     return false;
   }
 
@@ -95,8 +89,7 @@ function isTrustedLocalContext(ctx: Context): boolean {
     return true;
   }
 
-  const allowedOrigins = ctx.appContext.services.configService.getCorsConfig().allowedOrigins;
-  return allowedOrigins.includes(ctx.requestTrust.origin);
+  return isOriginAllowed(ctx.requestTrust.origin, corsConfig.allowedOrigins);
 }
 
 /**

--- a/src/backend/trpc/trpc.ts
+++ b/src/backend/trpc/trpc.ts
@@ -1,7 +1,14 @@
-import { initTRPC } from '@trpc/server';
+import { isIP } from 'node:net';
+import { initTRPC, TRPCError } from '@trpc/server';
 import type { Request } from 'express';
 import superjson from 'superjson';
 import type { AppContext } from '@/backend/app-context';
+
+export type RequestTrustInfo = {
+  remoteAddress?: string;
+  origin?: string;
+  isLocal: boolean;
+};
 
 /**
  * Context for tRPC procedures.
@@ -12,9 +19,40 @@ export type Context = {
   projectId?: string;
   /** Top-level Task ID from X-Top-Level-Task-Id header */
   topLevelTaskId?: string;
+  /** Request trust metadata for privileged state-changing procedures */
+  requestTrust?: RequestTrustInfo;
   /** App-level services and config */
   appContext: AppContext;
 };
+
+function getHeaderValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export function isLoopbackRemoteAddress(remoteAddress: string | undefined): boolean {
+  if (!remoteAddress) {
+    return false;
+  }
+
+  const normalized = remoteAddress.startsWith('::ffff:')
+    ? remoteAddress.slice('::ffff:'.length)
+    : remoteAddress;
+
+  if (normalized === '::1' || normalized === '0:0:0:0:0:0:0:1') {
+    return true;
+  }
+
+  return isIP(normalized) === 4 && normalized.startsWith('127.');
+}
+
+function buildRequestTrust(req: Request): RequestTrustInfo {
+  const remoteAddress = req.socket.remoteAddress ?? req.ip;
+  return {
+    remoteAddress,
+    origin: getHeaderValue(req.headers.origin),
+    isLocal: isLoopbackRemoteAddress(remoteAddress),
+  };
+}
 
 /**
  * Creates tRPC context from Express request.
@@ -29,6 +67,7 @@ export const createContext =
     return {
       projectId: typeof projectId === 'string' ? projectId : undefined,
       topLevelTaskId: typeof topLevelTaskId === 'string' ? topLevelTaskId : undefined,
+      requestTrust: buildRequestTrust(req),
       appContext,
     };
   };
@@ -40,3 +79,38 @@ const t = initTRPC.context<Context>().create({
 export const router = t.router;
 export const publicProcedure = t.procedure;
 export const middleware = t.middleware;
+
+function isTrustedLocalContext(ctx: Context): boolean {
+  // In-process callers, including tests and orchestration code using createCaller,
+  // do not cross the HTTP trust boundary.
+  if (!ctx.requestTrust) {
+    return true;
+  }
+
+  if (!ctx.requestTrust.isLocal) {
+    return false;
+  }
+
+  if (!ctx.requestTrust.origin) {
+    return true;
+  }
+
+  const allowedOrigins = ctx.appContext.services.configService.getCorsConfig().allowedOrigins;
+  return allowedOrigins.includes(ctx.requestTrust.origin);
+}
+
+/**
+ * Procedure for mutations that can create workspaces, write executable config,
+ * or trigger local command execution. HTTP callers must be local and use an
+ * allowed browser origin when an Origin header is present.
+ */
+export const trustedLocalProcedure = publicProcedure.use(({ ctx, next }) => {
+  if (!isTrustedLocalContext(ctx)) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'This action is only available from a trusted local Factory Factory client.',
+    });
+  }
+
+  return next();
+});

--- a/src/backend/trpc/workspace.router.test.ts
+++ b/src/backend/trpc/workspace.router.test.ts
@@ -113,7 +113,11 @@ vi.mock('./workspace/run-script.trpc', () => ({
 
 import { workspaceRouter } from './workspace.trpc';
 
-function createCaller() {
+function createCaller(requestTrust?: {
+  remoteAddress?: string;
+  origin?: string;
+  isLocal: boolean;
+}) {
   const sessionService = {
     stopWorkspaceSessions: vi.fn(async () => undefined),
   };
@@ -135,11 +139,15 @@ function createCaller() {
   };
 
   const caller = workspaceRouter.createCaller({
+    requestTrust,
     appContext: {
       services: {
         configService: {
           getWorktreeBaseDir: () => '/tmp/worktrees',
           getMaxSessionsPerWorkspace: () => 2,
+          getCorsConfig: () => ({
+            allowedOrigins: ['http://localhost:3000', 'http://localhost:3001'],
+          }),
         },
         cliHealthService,
         createLogger: () => ({
@@ -245,6 +253,35 @@ describe('workspaceRouter', () => {
     expect(mockCheckWorkspaceById).toHaveBeenCalledWith('w-created');
 
     await expect(caller.archive({ id: 'w-created' })).resolves.toEqual({ archived: true });
+  });
+
+  it('rejects privileged workspace mutations from untrusted requests', async () => {
+    const { caller } = createCaller({
+      remoteAddress: '203.0.113.10',
+      origin: 'https://attacker.example',
+      isLocal: false,
+    });
+
+    await expect(
+      caller.create({
+        type: 'MANUAL',
+        projectId: 'p1',
+        name: 'New Workspace',
+      })
+    ).rejects.toThrow('trusted local Factory Factory client');
+
+    await expect(
+      caller.createChild({
+        parentWorkspaceId: 'parent-1',
+        projectId: 'p1',
+        name: 'Child Workspace',
+      })
+    ).rejects.toThrow('trusted local Factory Factory client');
+
+    expect(mockResolveProviderForWorkspaceCreation).not.toHaveBeenCalled();
+    expect(mockWorkspaceCreationCreate).not.toHaveBeenCalled();
+    expect(mockCreateAgentSession).not.toHaveBeenCalled();
+    expect(mockInitializeWorkspaceWorktree).not.toHaveBeenCalled();
   });
 
   it('passes initial attachments through manual workspace creation', async () => {

--- a/src/backend/trpc/workspace.trpc.ts
+++ b/src/backend/trpc/workspace.trpc.ts
@@ -42,7 +42,7 @@ import { autoIterationConfigSchema } from '@/shared/schemas/auto-iteration.schem
 import { findWorkspaceSessionRuntimeError } from '@/shared/session-runtime';
 import { AttachmentSchema } from '@/shared/websocket';
 import { deriveWorkspaceSidebarStatus } from '@/shared/workspace-sidebar-status';
-import { type Context, publicProcedure, router } from './trpc';
+import { type Context, publicProcedure, router, trustedLocalProcedure } from './trpc';
 import { workspaceFilesRouter } from './workspace/files.trpc';
 import { workspaceGitRouter } from './workspace/git.trpc';
 import { workspaceIdeRouter } from './workspace/ide.trpc';
@@ -218,78 +218,82 @@ export const workspaceRouter = router({
   }),
 
   // Create a new workspace
-  create: publicProcedure.input(workspaceCreationSourceSchema).mutation(async ({ ctx, input }) => {
-    const logger = getLogger(ctx);
-    const { configService } = ctx.appContext.services;
-    const maxSessionsPerWorkspace = configService.getMaxSessionsPerWorkspace();
-    const explicitProvider =
-      input.type === 'MANUAL' || input.type === 'GITHUB_ISSUE' || input.type === 'LINEAR_ISSUE'
-        ? input.provider
-        : undefined;
-    let defaultSessionProvider: SessionProvider | undefined;
-
-    // Workspace creation provisions a default session when session capacity is enabled.
-    // Block creation if the effective provider cannot be used on this machine.
-    if (maxSessionsPerWorkspace > 0) {
-      defaultSessionProvider =
-        await sessionProviderResolverService.resolveProviderForWorkspaceCreation(explicitProvider);
-      const cliHealth = await ctx.appContext.services.cliHealthService.checkHealth();
-      const providerUnavailableMessage = getProviderUnavailableMessage(
-        defaultSessionProvider,
-        cliHealth
-      );
-      if (providerUnavailableMessage) {
-        throw new TRPCError({
-          code: 'PRECONDITION_FAILED',
-          message: `Cannot create workspace: ${providerUnavailableMessage}`,
-        });
-      }
-    }
-
-    // Use the canonical workspace creation service
-    const workspaceCreationService = new WorkspaceCreationService({
-      logger,
-    });
-
-    const workspace = await workspaceCreationService.create(input);
-
-    if (maxSessionsPerWorkspace > 0 && defaultSessionProvider) {
-      try {
-        await sessionDataService.createAgentSession({
-          workspaceId: workspace.id,
-          workflow: DEFAULT_FOLLOWUP,
-          name: 'Chat 1',
-          provider: defaultSessionProvider,
-          providerProjectPath: null,
-        });
-      } catch (error) {
-        logger.warn('Failed to create default session for workspace', {
-          workspaceId: workspace.id,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-    }
-
-    const branchName =
-      input.type === 'MANUAL'
-        ? input.branchName
-        : input.type === 'RESUME_BRANCH'
-          ? input.branchName
+  create: trustedLocalProcedure
+    .input(workspaceCreationSourceSchema)
+    .mutation(async ({ ctx, input }) => {
+      const logger = getLogger(ctx);
+      const { configService } = ctx.appContext.services;
+      const maxSessionsPerWorkspace = configService.getMaxSessionsPerWorkspace();
+      const explicitProvider =
+        input.type === 'MANUAL' || input.type === 'GITHUB_ISSUE' || input.type === 'LINEAR_ISSUE'
+          ? input.provider
           : undefined;
-    const useExistingBranch = input.type === 'RESUME_BRANCH';
+      let defaultSessionProvider: SessionProvider | undefined;
 
-    void initializeWorkspaceWorktree(workspace.id, {
-      branchName,
-      useExistingBranch,
-    }).catch((error) => {
-      const initError = error instanceof Error ? error : new Error(String(error));
-      logger.error('Unexpected error during background workspace initialization', initError, {
-        workspaceId: workspace.id,
+      // Workspace creation provisions a default session when session capacity is enabled.
+      // Block creation if the effective provider cannot be used on this machine.
+      if (maxSessionsPerWorkspace > 0) {
+        defaultSessionProvider =
+          await sessionProviderResolverService.resolveProviderForWorkspaceCreation(
+            explicitProvider
+          );
+        const cliHealth = await ctx.appContext.services.cliHealthService.checkHealth();
+        const providerUnavailableMessage = getProviderUnavailableMessage(
+          defaultSessionProvider,
+          cliHealth
+        );
+        if (providerUnavailableMessage) {
+          throw new TRPCError({
+            code: 'PRECONDITION_FAILED',
+            message: `Cannot create workspace: ${providerUnavailableMessage}`,
+          });
+        }
+      }
+
+      // Use the canonical workspace creation service
+      const workspaceCreationService = new WorkspaceCreationService({
+        logger,
       });
-    });
 
-    return workspace;
-  }),
+      const workspace = await workspaceCreationService.create(input);
+
+      if (maxSessionsPerWorkspace > 0 && defaultSessionProvider) {
+        try {
+          await sessionDataService.createAgentSession({
+            workspaceId: workspace.id,
+            workflow: DEFAULT_FOLLOWUP,
+            name: 'Chat 1',
+            provider: defaultSessionProvider,
+            providerProjectPath: null,
+          });
+        } catch (error) {
+          logger.warn('Failed to create default session for workspace', {
+            workspaceId: workspace.id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+
+      const branchName =
+        input.type === 'MANUAL'
+          ? input.branchName
+          : input.type === 'RESUME_BRANCH'
+            ? input.branchName
+            : undefined;
+      const useExistingBranch = input.type === 'RESUME_BRANCH';
+
+      void initializeWorkspaceWorktree(workspace.id, {
+        branchName,
+        useExistingBranch,
+      }).catch((error) => {
+        const initError = error instanceof Error ? error : new Error(String(error));
+        logger.error('Unexpected error during background workspace initialization', initError, {
+          workspaceId: workspace.id,
+        });
+      });
+
+      return workspace;
+    }),
 
   // Rename a workspace
   rename: publicProcedure
@@ -513,7 +517,7 @@ export const workspaceRouter = router({
   // -------------------------------------------------------------------------
 
   // Create a child workspace under a parent, optionally in a different project
-  createChild: publicProcedure
+  createChild: trustedLocalProcedure
     .input(
       z.object({
         parentWorkspaceId: z.string(),

--- a/src/backend/trpc/workspace/init.router.test.ts
+++ b/src/backend/trpc/workspace/init.router.test.ts
@@ -64,8 +64,23 @@ vi.mock('@/backend/services/logger.service', () => ({
 
 import { workspaceInitRouter } from './init.trpc';
 
-function createCaller() {
-  return workspaceInitRouter.createCaller({ appContext: {} } as never);
+function createCaller(requestTrust?: {
+  remoteAddress?: string;
+  origin?: string;
+  isLocal: boolean;
+}) {
+  return workspaceInitRouter.createCaller({
+    requestTrust,
+    appContext: {
+      services: {
+        configService: {
+          getCorsConfig: () => ({
+            allowedOrigins: ['http://localhost:3000', 'http://localhost:3001'],
+          }),
+        },
+      },
+    },
+  } as never);
 }
 
 describe('workspaceInitRouter', () => {
@@ -188,6 +203,21 @@ describe('workspaceInitRouter', () => {
     await expect(caller.retryInit({ id: 'w1' })).rejects.toMatchObject({
       code: 'TOO_MANY_REQUESTS',
     });
+  });
+
+  it('rejects retry initialization from untrusted requests', async () => {
+    const caller = createCaller({
+      remoteAddress: '203.0.113.10',
+      origin: 'https://attacker.example',
+      isLocal: false,
+    });
+
+    await expect(caller.retryInit({ id: 'w1' })).rejects.toThrow(
+      'trusted local Factory Factory client'
+    );
+    expect(mockFindByIdWithProject).not.toHaveBeenCalled();
+    expect(mockInitializeWorkspaceWorktree).not.toHaveBeenCalled();
+    expect(mockExecuteStartupScriptPipeline).not.toHaveBeenCalled();
   });
 
   it('throws TOO_MANY_REQUESTS when failed existing-worktree retry exceeds max retries', async () => {

--- a/src/backend/trpc/workspace/init.trpc.ts
+++ b/src/backend/trpc/workspace/init.trpc.ts
@@ -15,7 +15,7 @@ import {
   workspaceStateMachine,
   worktreeLifecycleService,
 } from '@/backend/services/workspace';
-import { publicProcedure, router } from '@/backend/trpc/trpc';
+import { publicProcedure, router, trustedLocalProcedure } from '@/backend/trpc/trpc';
 
 const logger = createLogger('workspace-init-trpc');
 
@@ -87,7 +87,7 @@ export const workspaceInitRouter = router({
   }),
 
   // Retry failed initialization
-  retryInit: publicProcedure
+  retryInit: trustedLocalProcedure
     .input(z.object({ id: z.string(), useExistingBranch: z.boolean().optional() }))
     .mutation(async ({ input }) => {
       const workspace = await workspaceDataService.findByIdWithProject(input.id);

--- a/src/backend/trpc/workspace/run-script.router.test.ts
+++ b/src/backend/trpc/workspace/run-script.router.test.ts
@@ -21,20 +21,29 @@ vi.mock('@/backend/services/run-script-config-persistence.service', () => ({
 
 import { workspaceRunScriptRouter } from './run-script.trpc';
 
-function createCaller(runScriptService?: {
-  startRunScript?: (workspaceId: string) => Promise<{
-    success: boolean;
-    error?: string;
-    port?: number;
-    pid?: number;
-    proxyUrl?: string | null;
-  }>;
-  stopRunScript?: (workspaceId: string) => Promise<{ success: boolean; error?: string }>;
-  getRunScriptStatus?: (workspaceId: string) => Promise<unknown>;
-}) {
+function createCaller(
+  runScriptService?: {
+    startRunScript?: (workspaceId: string) => Promise<{
+      success: boolean;
+      error?: string;
+      port?: number;
+      pid?: number;
+      proxyUrl?: string | null;
+    }>;
+    stopRunScript?: (workspaceId: string) => Promise<{ success: boolean; error?: string }>;
+    getRunScriptStatus?: (workspaceId: string) => Promise<unknown>;
+  },
+  requestTrust?: { remoteAddress?: string; origin?: string; isLocal: boolean }
+) {
   return workspaceRunScriptRouter.createCaller({
+    requestTrust,
     appContext: {
       services: {
+        configService: {
+          getCorsConfig: () => ({
+            allowedOrigins: ['http://localhost:3000', 'http://localhost:3001'],
+          }),
+        },
         runScriptService: {
           startRunScript: runScriptService?.startRunScript ?? (async () => ({ success: true })),
           stopRunScript: runScriptService?.stopRunScript ?? (async () => ({ success: true })),
@@ -165,6 +174,34 @@ describe('workspaceRunScriptRouter', () => {
     expect(startRunScript).toHaveBeenCalledWith('w1');
     expect(stopRunScript).toHaveBeenCalledWith('w1');
     expect(getRunScriptStatus).toHaveBeenCalledWith('w1');
+  });
+
+  it('rejects privileged run-script mutations from untrusted requests', async () => {
+    const startRunScript = vi.fn(async () => ({ success: true }));
+    const stopRunScript = vi.fn(async () => ({ success: true }));
+    const caller = createCaller(
+      { startRunScript, stopRunScript },
+      {
+        remoteAddress: '203.0.113.10',
+        origin: 'https://attacker.example',
+        isLocal: false,
+      }
+    );
+
+    await expect(
+      caller.createFactoryConfig({ workspaceId: 'w1', config: { scripts: {} } })
+    ).rejects.toThrow('trusted local Factory Factory client');
+    await expect(caller.startRunScript({ workspaceId: 'w1' })).rejects.toThrow(
+      'trusted local Factory Factory client'
+    );
+    await expect(caller.stopRunScript({ workspaceId: 'w1' })).rejects.toThrow(
+      'trusted local Factory Factory client'
+    );
+
+    expect(mockFindByIdWithProject).not.toHaveBeenCalled();
+    expect(mockWriteFactoryConfigAndSyncWorkspace).not.toHaveBeenCalled();
+    expect(startRunScript).not.toHaveBeenCalled();
+    expect(stopRunScript).not.toHaveBeenCalled();
   });
 
   it('returns trpc error when start/stop run script fails', async () => {

--- a/src/backend/trpc/workspace/run-script.trpc.ts
+++ b/src/backend/trpc/workspace/run-script.trpc.ts
@@ -2,12 +2,12 @@ import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 import { runScriptConfigPersistenceService } from '@/backend/services/run-script-config-persistence.service';
 import { workspaceDataService } from '@/backend/services/workspace';
-import { publicProcedure, router } from '@/backend/trpc/trpc';
+import { publicProcedure, router, trustedLocalProcedure } from '@/backend/trpc/trpc';
 import { FactoryConfigSchema } from '@/shared/schemas/factory-config.schema';
 
 export const workspaceRunScriptRouter = router({
   // Create factory-factory.json configuration file
-  createFactoryConfig: publicProcedure
+  createFactoryConfig: trustedLocalProcedure
     .input(
       z.object({
         workspaceId: z.string(),
@@ -55,7 +55,7 @@ export const workspaceRunScriptRouter = router({
       }
     }),
   // Start the run script for a workspace
-  startRunScript: publicProcedure
+  startRunScript: trustedLocalProcedure
     .input(z.object({ workspaceId: z.string() }))
     .mutation(async ({ ctx, input }) => {
       const result = await ctx.appContext.services.runScriptService.startRunScript(
@@ -78,7 +78,7 @@ export const workspaceRunScriptRouter = router({
     }),
 
   // Stop the run script for a workspace
-  stopRunScript: publicProcedure
+  stopRunScript: trustedLocalProcedure
     .input(z.object({ workspaceId: z.string() }))
     .mutation(async ({ ctx, input }) => {
       const result = await ctx.appContext.services.runScriptService.stopRunScript(


### PR DESCRIPTION
## Summary
- Adds a trusted-local tRPC procedure guard for mutations that can persist executable config or trigger local command execution.
- Applies the guard to project creation/update, GitHub project creation, workspace creation, initialization retry, and run-script/config mutations.
- Adds denial and allowed-origin tests to verify untrusted callers cannot reach side-effecting code paths.

## Changes
- **tRPC security**: Captures request trust metadata from HTTP requests and rejects privileged mutations unless the caller is local and, when present, uses an allowed Origin.
- **Project routes**: Protects project create/update/GitHub-create and factory config writes from untrusted HTTP callers.
- **Workspace routes**: Protects workspace creation, child workspace creation, initialization retry, and run-script start/stop/config routes.
- **Tests**: Covers untrusted remote callers, disallowed browser origins, allowed local origins, and verifies protected paths do not invoke downstream side effects.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Manual testing: verified `pnpm typecheck && pnpm check:fix && pnpm test && pnpm build` twice locally; `check:fix` reports existing `<img>` warnings only.

Closes #1726

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authorization on mutations that execute commands and write config; misconfigured `TRUSTED_LOCAL_CIDRS` or origin rules could block legitimate Docker clients or leave gaps if proxy `req.ip` is wrong.
> 
> **Overview**
> Adds a **trusted-local** gate for HTTP callers on mutations that can create workspaces, persist executable config, or run local commands. tRPC context now records remote address, `Origin`, and loopback/CIDR trust; **`trustedLocalProcedure`** rejects requests that are not local (or not in optional **`TRUSTED_LOCAL_CIDRS`**) or that send a disallowed browser origin. In-process `createCaller` paths without `requestTrust` remain allowed.
> 
> **Project**, **workspace**, **init**, and **run-script** routes move sensitive mutations from `publicProcedure` to `trustedLocalProcedure` (e.g. project create/update/GitHub clone, `saveFactoryConfig`, workspace/child create, `retryInit`, run-script start/stop/config).
> 
> New **`request-trust`** helpers tighten **CORS** and **WebSocket** origin checks: loopback host aliases (`localhost` vs `127.0.0.1`), default ports, and rejection of credentialed or non-canonical origins. **`TRUSTED_LOCAL_CIDRS`** is documented in `.env.example` and wired through config/env schemas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd668b04faa1fc25cdfc3b795127daed11b445e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

