### PR TITLE
Fix #1732: Prevent ratchet disable race

### DIFF
--- a/scripts/check-single-writer.mjs
+++ b/scripts/check-single-writer.mjs
@@ -190,6 +190,11 @@ const workspaceMutationRules = {
   },
   markHasHadSessions: { type: 'static', fields: ['hasHadSessions'] },
   clearRatchetActiveSession: { type: 'static', fields: ['ratchetActiveSessionId'] },
+  setRatchetActiveSessionIfEnabled: { type: 'static', fields: ['ratchetActiveSessionId'] },
+  updateRatchetCheckIfEnabled: {
+    type: 'static',
+    fields: ['ratchetState', 'ratchetLastCheckedAt', 'ratchetLastCiRunId'],
+  },
   appendInitOutput: { type: 'static', fields: ['initOutput'] },
   clearInitOutput: { type: 'static', fields: ['initOutput'] },
   setInitScriptPid: { type: 'static', fields: ['initScriptPid'] },

--- a/src/backend/orchestration/domain-bridges.orchestrator.ts
+++ b/src/backend/orchestration/domain-bridges.orchestrator.ts
@@ -130,6 +130,8 @@ export function configureDomainBridges(services: Partial<BridgeServices> = {}): 
 
   // === Ratchet domain bridges ===
   const ratchetSessionBridge: RatchetSessionBridge = {
+    findSessionsByWorkspaceId: (workspaceId) =>
+      sessionDataService.findAgentSessionsByWorkspaceId(workspaceId),
     isSessionRunning: (id) => sessionService.isSessionRunning(id),
     isSessionWorking: (id) => sessionService.isSessionWorking(id),
     stopSession: (id) => sessionService.stopSession(id),

--- a/src/backend/services/ratchet/service/bridges.ts
+++ b/src/backend/services/ratchet/service/bridges.ts
@@ -4,12 +4,19 @@
  * The ratchet domain never imports from other domains directly.
  */
 
-import type { CIStatus } from '@/shared/core';
+import type { CIStatus, SessionStatus } from '@/shared/core';
 
 // --- Session bridge ---
 
 /** Session capabilities needed by ratchet domain */
+export interface RatchetSessionSummary {
+  id: string;
+  workflow: string;
+  status: SessionStatus;
+}
+
 export interface RatchetSessionBridge {
+  findSessionsByWorkspaceId(workspaceId: string): Promise<RatchetSessionSummary[]>;
   isSessionRunning(sessionId: string): boolean;
   isSessionWorking(sessionId: string): boolean;
   stopSession(sessionId: string): Promise<void>;

--- a/src/backend/services/ratchet/service/fixer-session.service.test.ts
+++ b/src/backend/services/ratchet/service/fixer-session.service.test.ts
@@ -45,6 +45,7 @@ import { workspaceAccessor } from '@/backend/services/workspace';
 import { fixerSessionService } from './fixer-session.service';
 
 const mockSessionBridge: RatchetSessionBridge = {
+  findSessionsByWorkspaceId: vi.fn(),
   isSessionRunning: vi.fn(),
   isSessionWorking: vi.fn(),
   stopSession: vi.fn(),

--- a/src/backend/services/ratchet/service/fixer-session.service.test.ts
+++ b/src/backend/services/ratchet/service/fixer-session.service.test.ts
@@ -85,6 +85,27 @@ describe('FixerSessionService', () => {
     });
   });
 
+  it('skips before acquisition when workspace ratcheting is disabled', async () => {
+    vi.mocked(workspaceAccessor.findById).mockResolvedValue({
+      worktreePath: '/tmp/w',
+      ratchetEnabled: false,
+    } as never);
+
+    const result = await fixerSessionService.acquireAndDispatch({
+      workspaceId: 'w1',
+      workflow: 'ci-fix',
+      sessionName: 'CI Fixing',
+      runningIdleAction: 'send_message',
+      buildPrompt: () => 'hello',
+    });
+
+    expect(result).toEqual({
+      status: 'skipped',
+      reason: 'Workspace ratcheting disabled',
+    });
+    expect(agentSessionAccessor.acquireFixerSession).not.toHaveBeenCalled();
+  });
+
   it('returns already_active when existing session is actively working', async () => {
     vi.mocked(workspaceAccessor.findById).mockResolvedValue({ worktreePath: '/tmp/w' } as never);
     vi.mocked(agentSessionAccessor.acquireFixerSession).mockResolvedValue({

--- a/src/backend/services/ratchet/service/fixer-session.service.ts
+++ b/src/backend/services/ratchet/service/fixer-session.service.ts
@@ -103,6 +103,14 @@ class FixerSessionService {
         return { status: 'skipped', reason: 'Workspace not ready (no worktree path)' };
       }
 
+      if (workspace.ratchetEnabled === false) {
+        logger.info('Skipping fixer session because ratchet is disabled', {
+          workspaceId,
+          workflow,
+        });
+        return { status: 'skipped', reason: 'Workspace ratcheting disabled' };
+      }
+
       const acquisitionResult = await this.acquireSessionDecision(input);
 
       if (acquisitionResult.action === 'limit_reached') {

--- a/src/backend/services/ratchet/service/ratchet-fixer-dispatch.helpers.ts
+++ b/src/backend/services/ratchet/service/ratchet-fixer-dispatch.helpers.ts
@@ -3,18 +3,106 @@ import { buildRatchetDispatchPrompt } from '@/backend/prompts/ratchet-dispatch';
 import type { createLogger } from '@/backend/services/logger.service';
 import { userSettingsAccessor } from '@/backend/services/settings';
 import type { RatchetSessionBridge } from './bridges';
-import { fixerSessionService } from './fixer-session.service';
+import { type AcquireAndDispatchResult, fixerSessionService } from './fixer-session.service';
 import type { PRStateInfo, RatchetAction, WorkspaceWithPR } from './ratchet.types';
 
 type Logger = ReturnType<typeof createLogger>;
 
 const RATCHET_WORKFLOW = 'ratchet';
 
+async function recordActiveSessionOrDisable(params: {
+  workspaceId: string;
+  sessionId: string;
+  setActiveSession: (workspaceId: string, sessionId: string) => Promise<boolean>;
+  sessionBridge: RatchetSessionBridge;
+  logger: Logger;
+  logMessage: string;
+}): Promise<RatchetAction | null> {
+  const { workspaceId, sessionId, setActiveSession, sessionBridge, logger, logMessage } = params;
+  const recorded = await setActiveSession(workspaceId, sessionId);
+  if (recorded) {
+    return null;
+  }
+
+  logger.info(logMessage, {
+    workspaceId,
+    sessionId,
+  });
+  if (sessionBridge.isSessionRunning(sessionId)) {
+    await sessionBridge.stopSession(sessionId);
+  }
+  return { type: 'DISABLED', reason: 'Workspace ratcheting disabled' };
+}
+
+async function handleStartedFixerResult(params: {
+  workspaceId: string;
+  result: Extract<AcquireAndDispatchResult, { status: 'started' }>;
+  sessionBridge: RatchetSessionBridge;
+  setActiveSession: (workspaceId: string, sessionId: string) => Promise<boolean>;
+  clearActiveSession: (workspaceId: string) => Promise<void>;
+  logger: Logger;
+}): Promise<RatchetAction> {
+  const { workspaceId, result, sessionBridge, setActiveSession, clearActiveSession, logger } =
+    params;
+  const promptSent = result.promptSent ?? true;
+  if (!promptSent) {
+    logger.warn('Ratchet session started but prompt delivery failed', {
+      workspaceId,
+      sessionId: result.sessionId,
+    });
+    await clearActiveSession(workspaceId);
+    if (sessionBridge.isSessionRunning(result.sessionId)) {
+      await sessionBridge.stopSession(result.sessionId);
+    }
+    return { type: 'ERROR', error: 'Failed to deliver initial ratchet prompt' };
+  }
+
+  const disabledAction = await recordActiveSessionOrDisable({
+    workspaceId,
+    sessionId: result.sessionId,
+    setActiveSession,
+    sessionBridge,
+    logger,
+    logMessage: 'Ratchet disabled before fixer session could be recorded',
+  });
+  if (disabledAction) {
+    return disabledAction;
+  }
+
+  return {
+    type: 'TRIGGERED_FIXER',
+    sessionId: result.sessionId,
+    promptSent,
+  };
+}
+
+async function handleAlreadyActiveFixerResult(params: {
+  workspaceId: string;
+  result: Extract<AcquireAndDispatchResult, { status: 'already_active' }>;
+  sessionBridge: RatchetSessionBridge;
+  setActiveSession: (workspaceId: string, sessionId: string) => Promise<boolean>;
+  logger: Logger;
+}): Promise<RatchetAction> {
+  const { workspaceId, result, sessionBridge, setActiveSession, logger } = params;
+  const disabledAction = await recordActiveSessionOrDisable({
+    workspaceId,
+    sessionId: result.sessionId,
+    setActiveSession,
+    sessionBridge,
+    logger,
+    logMessage: 'Ratchet disabled before active fixer session could be recorded',
+  });
+  if (disabledAction) {
+    return disabledAction;
+  }
+  return { type: 'FIXER_ACTIVE', sessionId: result.sessionId };
+}
+
 export async function triggerRatchetFixer(params: {
   workspace: WorkspaceWithPR;
   prStateInfo: PRStateInfo;
   sessionBridge: RatchetSessionBridge;
-  setActiveSession: (workspaceId: string, sessionId: string) => Promise<void>;
+  setActiveSession: (workspaceId: string, sessionId: string) => Promise<boolean>;
   clearActiveSession: (workspaceId: string) => Promise<void>;
   logger: Logger;
 }): Promise<RatchetAction> {
@@ -45,31 +133,24 @@ export async function triggerRatchetFixer(params: {
     });
 
     if (result.status === 'started') {
-      const promptSent = result.promptSent ?? true;
-      if (!promptSent) {
-        logger.warn('Ratchet session started but prompt delivery failed', {
-          workspaceId: workspace.id,
-          sessionId: result.sessionId,
-        });
-        await clearActiveSession(workspace.id);
-        if (sessionBridge.isSessionRunning(result.sessionId)) {
-          await sessionBridge.stopSession(result.sessionId);
-        }
-        return { type: 'ERROR', error: 'Failed to deliver initial ratchet prompt' };
-      }
-
-      await setActiveSession(workspace.id, result.sessionId);
-
-      return {
-        type: 'TRIGGERED_FIXER',
-        sessionId: result.sessionId,
-        promptSent,
-      };
+      return await handleStartedFixerResult({
+        workspaceId: workspace.id,
+        result,
+        sessionBridge,
+        setActiveSession,
+        clearActiveSession,
+        logger,
+      });
     }
 
     if (result.status === 'already_active') {
-      await setActiveSession(workspace.id, result.sessionId);
-      return { type: 'FIXER_ACTIVE', sessionId: result.sessionId };
+      return await handleAlreadyActiveFixerResult({
+        workspaceId: workspace.id,
+        result,
+        sessionBridge,
+        setActiveSession,
+        logger,
+      });
     }
 
     if (result.status === 'skipped') {

--- a/src/backend/services/ratchet/service/ratchet.service.test.ts
+++ b/src/backend/services/ratchet/service/ratchet.service.test.ts
@@ -10,6 +10,8 @@ vi.mock('@/backend/services/workspace', () => ({
     findWithPRsForRatchet: vi.fn(),
     findForRatchetById: vi.fn(),
     update: vi.fn(),
+    updateRatchetCheckIfEnabled: vi.fn(),
+    setRatchetActiveSessionIfEnabled: vi.fn(),
   },
 }));
 
@@ -96,6 +98,9 @@ describe('ratchet service (state-change + idle dispatch)', () => {
       github: mockGitHubBridge,
       snapshot: mockSnapshotBridge,
     });
+    vi.mocked(workspaceAccessor.updateRatchetCheckIfEnabled).mockResolvedValue(true);
+    vi.mocked(workspaceAccessor.setRatchetActiveSessionIfEnabled).mockResolvedValue(true);
+    vi.mocked(agentSessionAccessor.findByWorkspaceId).mockResolvedValue([] as never);
     vi.mocked(mockGitHubBridge.getAuthenticatedUsername).mockResolvedValue(null);
     vi.mocked(mockSessionBridge.isSessionWorking).mockReturnValue(false);
     vi.mocked(userSettingsAccessor.get).mockResolvedValue({
@@ -294,16 +299,68 @@ describe('ratchet service (state-change + idle dispatch)', () => {
       action: { type: 'TRIGGERED_FIXER' },
     });
 
-    const finalUpdatePayload = vi.mocked(workspaceAccessor.update).mock.calls.at(-1)?.[1] as Record<
-      string,
-      unknown
-    >;
+    const finalUpdatePayload = vi
+      .mocked(workspaceAccessor.updateRatchetCheckIfEnabled)
+      .mock.calls.at(-1)?.[1] as Record<string, unknown>;
     expect(finalUpdatePayload.ratchetLastCiRunId).toBe('2026-01-02T00:00:00Z');
     expect(finalUpdatePayload).not.toHaveProperty('prReviewLastCheckedAt');
     expect(mockSnapshotBridge.recordReviewCheck).toHaveBeenCalledWith(
       'ws-change',
       expect.any(Date)
     );
+  });
+
+  it('stops fixer and returns disabled when active-session recording loses disable race', async () => {
+    const workspace = {
+      id: 'ws-disable-race-dispatch',
+      prUrl: 'https://github.com/example/repo/pull/40',
+      prNumber: 40,
+      prState: 'OPEN',
+      prCiStatus: CIStatus.UNKNOWN,
+      ratchetEnabled: true,
+      ratchetState: RatchetState.IDLE,
+      ratchetActiveSessionId: null,
+      ratchetLastCiRunId: 'old-snapshot',
+      prReviewLastCheckedAt: new Date('2026-01-01T00:00:00Z'),
+    };
+
+    vi.spyOn(
+      unsafeCoerce<{ fetchPRState: (...args: unknown[]) => Promise<unknown> }>(ratchetService),
+      'fetchPRState'
+    ).mockResolvedValue({
+      ciStatus: CIStatus.FAILURE,
+      snapshotKey: 'new-snapshot',
+      hasChangesRequested: false,
+      latestReviewActivityAtMs: null,
+      statusCheckRollup: null,
+      prState: 'OPEN',
+      prNumber: 40,
+    });
+
+    vi.mocked(agentSessionAccessor.findByWorkspaceId).mockResolvedValue([] as never);
+    vi.mocked(fixerSessionService.acquireAndDispatch).mockResolvedValue({
+      status: 'started',
+      sessionId: 'raced-session',
+      promptSent: true,
+    } as never);
+    vi.mocked(workspaceAccessor.setRatchetActiveSessionIfEnabled).mockResolvedValue(false);
+    vi.mocked(workspaceAccessor.updateRatchetCheckIfEnabled).mockResolvedValue(false);
+    vi.mocked(mockSessionBridge.isSessionRunning).mockReturnValue(true);
+
+    const result = await unsafeCoerce<{
+      processWorkspace: (workspaceArg: typeof workspace) => Promise<unknown>;
+    }>(ratchetService).processWorkspace(workspace);
+
+    expect(result).toMatchObject({
+      newState: RatchetState.IDLE,
+      action: { type: 'DISABLED', reason: 'Workspace ratcheting disabled' },
+    });
+    expect(workspaceAccessor.setRatchetActiveSessionIfEnabled).toHaveBeenCalledWith(
+      'ws-disable-race-dispatch',
+      'raced-session'
+    );
+    expect(mockSessionBridge.stopSession).toHaveBeenCalledWith('raced-session');
+    expect(mockSnapshotBridge.recordReviewCheck).not.toHaveBeenCalled();
   });
 
   it('dispatches when session is running but idle', async () => {
@@ -690,6 +747,55 @@ describe('ratchet service (state-change + idle dispatch)', () => {
         reason: 'PR is clean (green CI and no new review activity)',
       },
     });
+  });
+
+  it('returns disabled when stale check-state update loses disable race', async () => {
+    const recentCheck = new Date();
+    const workspace = {
+      id: 'ws-disable-race-state',
+      prUrl: 'https://github.com/example/repo/pull/41',
+      prNumber: 41,
+      prState: 'OPEN',
+      prCiStatus: CIStatus.UNKNOWN,
+      ratchetEnabled: true,
+      ratchetState: RatchetState.READY,
+      ratchetActiveSessionId: null,
+      ratchetLastCiRunId: 'old-snapshot',
+      prReviewLastCheckedAt: recentCheck,
+    };
+
+    vi.spyOn(
+      unsafeCoerce<{
+        fetchPRState: (...args: unknown[]) => Promise<unknown>;
+      }>(ratchetService),
+      'fetchPRState'
+    ).mockResolvedValue({
+      ciStatus: CIStatus.SUCCESS,
+      snapshotKey: 'new-snapshot',
+      hasChangesRequested: false,
+      latestReviewActivityAtMs: recentCheck.getTime() - 1000,
+      statusCheckRollup: null,
+      prState: 'OPEN',
+      prNumber: 41,
+    });
+    vi.mocked(workspaceAccessor.updateRatchetCheckIfEnabled).mockResolvedValue(false);
+    vi.mocked(agentSessionAccessor.findByWorkspaceId).mockResolvedValue([] as never);
+
+    const events: RatchetStateChangedEvent[] = [];
+    ratchetService.on(RATCHET_STATE_CHANGED, (event: RatchetStateChangedEvent) => {
+      events.push(event);
+    });
+
+    const result = await unsafeCoerce<{
+      processWorkspace: (workspaceArg: typeof workspace) => Promise<unknown>;
+    }>(ratchetService).processWorkspace(workspace);
+
+    expect(result).toMatchObject({
+      newState: RatchetState.IDLE,
+      action: { type: 'DISABLED', reason: 'Workspace ratcheting disabled' },
+    });
+    expect(events).toHaveLength(0);
+    ratchetService.removeAllListeners();
   });
 
   it('self-heals when review check timestamp is stale with no active session', async () => {
@@ -2049,6 +2155,39 @@ describe('ratchet service (state-change + idle dispatch)', () => {
       });
     });
 
+    it('stops already-active fixer when active-session recording loses disable race', async () => {
+      const workspace = {
+        id: 'ws-already-active-disabled',
+        prUrl: 'https://github.com/example/repo/pull/24',
+        prNumber: 24,
+        ratchetEnabled: true,
+        ratchetState: RatchetState.CI_FAILED,
+        ratchetActiveSessionId: null,
+        ratchetLastCiRunId: null,
+        prReviewLastCheckedAt: null,
+      };
+
+      vi.mocked(fixerSessionService.acquireAndDispatch).mockResolvedValue({
+        status: 'already_active',
+        sessionId: 'existing-session',
+      } as never);
+      vi.mocked(workspaceAccessor.setRatchetActiveSessionIfEnabled).mockResolvedValue(false);
+      vi.mocked(mockSessionBridge.isSessionRunning).mockReturnValue(true);
+
+      const result = await unsafeCoerce<{
+        triggerFixer: (w: unknown, prStateInfo: unknown) => Promise<unknown>;
+      }>(ratchetService).triggerFixer(workspace, {
+        ciStatus: CIStatus.FAILURE,
+        prNumber: 24,
+      });
+
+      expect(result).toMatchObject({
+        type: 'DISABLED',
+        reason: 'Workspace ratcheting disabled',
+      });
+      expect(mockSessionBridge.stopSession).toHaveBeenCalledWith('existing-session');
+    });
+
     it('handles skipped result from acquireAndDispatch', async () => {
       const workspace = {
         id: 'ws-skipped',
@@ -2154,6 +2293,35 @@ describe('ratchet service (state-change + idle dispatch)', () => {
           ratchetState: RatchetState.IDLE,
         },
       ]);
+    });
+
+    it('stops ratchet workflow sessions found after disabling workspace', async () => {
+      vi.mocked(workspaceAccessor.findById).mockResolvedValue({
+        id: 'ws-disable-raced-session',
+        ratchetState: RatchetState.CI_RUNNING,
+        ratchetActiveSessionId: null,
+      } as never);
+      vi.mocked(workspaceAccessor.update).mockResolvedValue({} as never);
+      vi.mocked(agentSessionAccessor.findByWorkspaceId).mockResolvedValue([
+        {
+          id: 'raced-ratchet-session',
+          workflow: 'ratchet',
+          status: SessionStatus.RUNNING,
+        },
+        {
+          id: 'manual-session',
+          workflow: 'default',
+          status: SessionStatus.RUNNING,
+        },
+      ] as never);
+      vi.mocked(mockSessionBridge.isSessionRunning).mockImplementation(
+        (sessionId) => sessionId === 'raced-ratchet-session'
+      );
+
+      await ratchetService.setWorkspaceRatcheting('ws-disable-raced-session', false);
+
+      expect(mockSessionBridge.stopSession).toHaveBeenCalledTimes(1);
+      expect(mockSessionBridge.stopSession).toHaveBeenCalledWith('raced-ratchet-session');
     });
   });
 

--- a/src/backend/services/ratchet/service/ratchet.service.test.ts
+++ b/src/backend/services/ratchet/service/ratchet.service.test.ts
@@ -57,6 +57,7 @@ import {
 } from './ratchet.service';
 
 const mockSessionBridge: RatchetSessionBridge = {
+  findSessionsByWorkspaceId: vi.fn(),
   isSessionRunning: vi.fn(),
   isSessionWorking: vi.fn(),
   stopSession: vi.fn(),
@@ -101,6 +102,7 @@ describe('ratchet service (state-change + idle dispatch)', () => {
     vi.mocked(workspaceAccessor.updateRatchetCheckIfEnabled).mockResolvedValue(true);
     vi.mocked(workspaceAccessor.setRatchetActiveSessionIfEnabled).mockResolvedValue(true);
     vi.mocked(agentSessionAccessor.findByWorkspaceId).mockResolvedValue([] as never);
+    vi.mocked(mockSessionBridge.findSessionsByWorkspaceId).mockResolvedValue([]);
     vi.mocked(mockGitHubBridge.getAuthenticatedUsername).mockResolvedValue(null);
     vi.mocked(mockSessionBridge.isSessionWorking).mockReturnValue(false);
     vi.mocked(userSettingsAccessor.get).mockResolvedValue({
@@ -2302,7 +2304,7 @@ describe('ratchet service (state-change + idle dispatch)', () => {
         ratchetActiveSessionId: null,
       } as never);
       vi.mocked(workspaceAccessor.update).mockResolvedValue({} as never);
-      vi.mocked(agentSessionAccessor.findByWorkspaceId).mockResolvedValue([
+      vi.mocked(mockSessionBridge.findSessionsByWorkspaceId).mockResolvedValue([
         {
           id: 'raced-ratchet-session',
           workflow: 'ratchet',

--- a/src/backend/services/ratchet/service/ratchet.service.test.ts
+++ b/src/backend/services/ratchet/service/ratchet.service.test.ts
@@ -2322,6 +2322,9 @@ describe('ratchet service (state-change + idle dispatch)', () => {
 
       await ratchetService.setWorkspaceRatcheting('ws-disable-raced-session', false);
 
+      expect(mockSessionBridge.findSessionsByWorkspaceId).toHaveBeenCalledWith(
+        'ws-disable-raced-session'
+      );
       expect(mockSessionBridge.stopSession).toHaveBeenCalledTimes(1);
       expect(mockSessionBridge.stopSession).toHaveBeenCalledWith('raced-ratchet-session');
     });

--- a/src/backend/services/ratchet/service/ratchet.service.ts
+++ b/src/backend/services/ratchet/service/ratchet.service.ts
@@ -3,8 +3,9 @@ import { toError } from '@/backend/lib/error-utils';
 import { SERVICE_INTERVAL_MS, SERVICE_TIMEOUT_MS } from '@/backend/services/constants';
 import { createLogger } from '@/backend/services/logger.service';
 import { RateLimitBackoff } from '@/backend/services/rate-limit-backoff';
+import { agentSessionAccessor } from '@/backend/services/session';
 import { workspaceAccessor } from '@/backend/services/workspace';
-import { CIStatus, RatchetState } from '@/shared/core';
+import { CIStatus, RatchetState, SessionStatus } from '@/shared/core';
 import type { RatchetGitHubBridge, RatchetPRSnapshotBridge, RatchetSessionBridge } from './bridges';
 import type {
   PRStateFetchResult,
@@ -303,6 +304,8 @@ class RatchetService extends EventEmitter {
       ratchetLastCiRunId: null,
     });
 
+    await this.stopActiveRatchetSessionsAfterDisable(workspaceId);
+
     if (workspace.ratchetState !== RatchetState.IDLE) {
       this.emit(RATCHET_STATE_CHANGED, {
         workspaceId,
@@ -415,35 +418,7 @@ class RatchetService extends EventEmitter {
 
       const action = await this.applyRatchetDecision(decisionContext, decision);
 
-      await this.updateWorkspaceAfterCheck(
-        workspace,
-        prStateInfo,
-        action,
-        decisionContext.finalState
-      );
-      if (decisionContext.previousState !== decisionContext.finalState) {
-        this.emit(RATCHET_STATE_CHANGED, {
-          workspaceId: workspace.id,
-          fromState: decisionContext.previousState,
-          toState: decisionContext.finalState,
-          prCiStatus: prStateInfo.ciStatus,
-        } satisfies RatchetStateChangedEvent);
-      }
-      this.logWorkspaceRatchetingDecision(
-        workspace,
-        decisionContext.previousState,
-        decisionContext.finalState,
-        action,
-        prStateInfo,
-        decisionContext
-      );
-
-      return {
-        workspaceId: workspace.id,
-        previousState: decisionContext.previousState,
-        newState: decisionContext.finalState,
-        action,
-      };
+      return await this.finishRatchetCheck(workspace, prStateInfo, action, decisionContext);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       logger.error('Error processing workspace in ratchet', toError(error), {
@@ -712,35 +687,53 @@ class RatchetService extends EventEmitter {
     const freshDecision = this.decideRatchetAction(freshContext);
     const freshAction = await this.applyRatchetDecision(freshContext, freshDecision);
 
-    await this.updateWorkspaceAfterCheck(
+    return await this.finishRatchetCheck(
       workspace,
       pollResult.freshPrState,
       freshAction,
-      freshContext.finalState
+      freshContext
     );
-    if (freshContext.previousState !== freshContext.finalState) {
+  }
+
+  private async finishRatchetCheck(
+    workspace: WorkspaceWithPR,
+    prStateInfo: PRStateInfo,
+    action: RatchetAction,
+    decisionContext: RatchetDecisionContext
+  ): Promise<WorkspaceRatchetResult> {
+    const updateApplied = await this.updateWorkspaceAfterCheck(
+      workspace,
+      prStateInfo,
+      action,
+      decisionContext.finalState
+    );
+    const resultAction: RatchetAction = updateApplied
+      ? action
+      : { type: 'DISABLED', reason: 'Workspace ratcheting disabled' };
+    const resultState = updateApplied ? decisionContext.finalState : RatchetState.IDLE;
+    if (updateApplied && decisionContext.previousState !== decisionContext.finalState) {
       this.emit(RATCHET_STATE_CHANGED, {
         workspaceId: workspace.id,
-        fromState: freshContext.previousState,
-        toState: freshContext.finalState,
-        prCiStatus: pollResult.freshPrState.ciStatus,
+        fromState: decisionContext.previousState,
+        toState: decisionContext.finalState,
+        prCiStatus: prStateInfo.ciStatus,
       } satisfies RatchetStateChangedEvent);
     }
 
     this.logWorkspaceRatchetingDecision(
       workspace,
-      freshContext.previousState,
-      freshContext.finalState,
-      freshAction,
-      pollResult.freshPrState,
-      freshContext
+      decisionContext.previousState,
+      resultState,
+      resultAction,
+      prStateInfo,
+      decisionContext
     );
 
     return {
       workspaceId: workspace.id,
-      previousState: freshContext.previousState,
-      newState: freshContext.finalState,
-      action: freshAction,
+      previousState: decisionContext.previousState,
+      newState: resultState,
+      action: resultAction,
     };
   }
 
@@ -775,11 +768,11 @@ class RatchetService extends EventEmitter {
     prStateInfo: PRStateInfo,
     action: RatchetAction,
     nextState: RatchetState
-  ): Promise<void> {
+  ): Promise<boolean> {
     const now = new Date();
     const dispatched = action.type === 'TRIGGERED_FIXER' && action.promptSent;
 
-    await workspaceAccessor.update(workspace.id, {
+    const updated = await workspaceAccessor.updateRatchetCheckIfEnabled(workspace.id, {
       ratchetState: nextState,
       ratchetLastCheckedAt: now,
       ...(dispatched
@@ -788,6 +781,10 @@ class RatchetService extends EventEmitter {
           }
         : {}),
     });
+
+    if (!updated) {
+      return false;
+    }
 
     if (dispatched) {
       await this.snapshot.recordReviewCheck(workspace.id, now);
@@ -800,6 +797,8 @@ class RatchetService extends EventEmitter {
         observedAt: now,
       });
     }
+
+    return true;
   }
 
   private async getActiveRatchetSession(workspace: WorkspaceWithPR): Promise<RatchetAction | null> {
@@ -909,8 +908,8 @@ class RatchetService extends EventEmitter {
     });
   }
 
-  private async setActiveSession(workspaceId: string, sessionId: string): Promise<void> {
-    await workspaceAccessor.update(workspaceId, { ratchetActiveSessionId: sessionId });
+  private async setActiveSession(workspaceId: string, sessionId: string): Promise<boolean> {
+    return await workspaceAccessor.setRatchetActiveSessionIfEnabled(workspaceId, sessionId);
   }
 
   private async clearActiveSession(workspaceId: string): Promise<void> {
@@ -922,6 +921,31 @@ class RatchetService extends EventEmitter {
       ratchetActiveSessionId: null,
       ratchetLastCiRunId: null,
     });
+  }
+
+  private async stopActiveRatchetSessionsAfterDisable(workspaceId: string): Promise<void> {
+    const sessions = await agentSessionAccessor.findByWorkspaceId(workspaceId);
+    const activeRatchetSessions = sessions.filter(
+      (session) =>
+        session.workflow === 'ratchet' &&
+        (session.status === SessionStatus.RUNNING || session.status === SessionStatus.IDLE)
+    );
+
+    for (const session of activeRatchetSessions) {
+      if (!this.session.isSessionRunning(session.id)) {
+        continue;
+      }
+
+      try {
+        await this.session.stopSession(session.id);
+      } catch (error) {
+        logger.warn('Failed to stop ratchet session after disabling ratchet', {
+          workspaceId,
+          sessionId: session.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
   }
 }
 

--- a/src/backend/services/ratchet/service/ratchet.service.ts
+++ b/src/backend/services/ratchet/service/ratchet.service.ts
@@ -3,7 +3,6 @@ import { toError } from '@/backend/lib/error-utils';
 import { SERVICE_INTERVAL_MS, SERVICE_TIMEOUT_MS } from '@/backend/services/constants';
 import { createLogger } from '@/backend/services/logger.service';
 import { RateLimitBackoff } from '@/backend/services/rate-limit-backoff';
-import { agentSessionAccessor } from '@/backend/services/session';
 import { workspaceAccessor } from '@/backend/services/workspace';
 import { CIStatus, RatchetState, SessionStatus } from '@/shared/core';
 import type { RatchetGitHubBridge, RatchetPRSnapshotBridge, RatchetSessionBridge } from './bridges';
@@ -924,7 +923,7 @@ class RatchetService extends EventEmitter {
   }
 
   private async stopActiveRatchetSessionsAfterDisable(workspaceId: string): Promise<void> {
-    const sessions = await agentSessionAccessor.findByWorkspaceId(workspaceId);
+    const sessions = await this.session.findSessionsByWorkspaceId(workspaceId);
     const activeRatchetSessions = sessions.filter(
       (session) =>
         session.workflow === 'ratchet' &&

--- a/src/backend/services/workspace/resources/workspace.accessor.test.ts
+++ b/src/backend/services/workspace/resources/workspace.accessor.test.ts
@@ -109,6 +109,60 @@ describe('workspaceAccessor', () => {
     });
   });
 
+  it('sets ratchet active session only when ratchet is enabled', async () => {
+    mockUpdateMany.mockResolvedValue({ count: 1 });
+
+    await expect(
+      workspaceAccessor.setRatchetActiveSessionIfEnabled('ws-1', 'session-1')
+    ).resolves.toBe(true);
+
+    expect(mockUpdateMany).toHaveBeenCalledWith({
+      where: { id: 'ws-1', ratchetEnabled: true },
+      data: { ratchetActiveSessionId: 'session-1' },
+    });
+  });
+
+  it('returns false when ratchet active session conditional update affects no rows', async () => {
+    mockUpdateMany.mockResolvedValue({ count: 0 });
+
+    await expect(
+      workspaceAccessor.setRatchetActiveSessionIfEnabled('ws-1', 'session-1')
+    ).resolves.toBe(false);
+  });
+
+  it('updates ratchet check state only when ratchet is enabled', async () => {
+    const checkedAt = new Date('2026-01-01T00:00:00.000Z');
+    mockUpdateMany.mockResolvedValue({ count: 1 });
+
+    await expect(
+      workspaceAccessor.updateRatchetCheckIfEnabled('ws-1', {
+        ratchetState: 'CI_FAILED',
+        ratchetLastCheckedAt: checkedAt,
+        ratchetLastCiRunId: 'snapshot-1',
+      })
+    ).resolves.toBe(true);
+
+    expect(mockUpdateMany).toHaveBeenCalledWith({
+      where: { id: 'ws-1', ratchetEnabled: true },
+      data: {
+        ratchetState: 'CI_FAILED',
+        ratchetLastCheckedAt: checkedAt,
+        ratchetLastCiRunId: 'snapshot-1',
+      },
+    });
+  });
+
+  it('returns false when ratchet check conditional update affects no rows', async () => {
+    mockUpdateMany.mockResolvedValue({ count: 0 });
+
+    await expect(
+      workspaceAccessor.updateRatchetCheckIfEnabled('ws-1', {
+        ratchetState: 'READY',
+        ratchetLastCheckedAt: new Date('2026-01-01T00:00:00.000Z'),
+      })
+    ).resolves.toBe(false);
+  });
+
   it('appends init output and skips existence check when update succeeds', async () => {
     mockExecuteRaw.mockResolvedValue(1);
 

--- a/src/backend/services/workspace/resources/workspace.accessor.ts
+++ b/src/backend/services/workspace/resources/workspace.accessor.ts
@@ -570,6 +570,34 @@ class WorkspaceAccessor {
   }
 
   /**
+   * Record a ratchet fixer session only while ratcheting is still enabled.
+   * The conditional update closes the disable-vs-dispatch race where an
+   * in-flight ratchet check could repopulate the active session after disable.
+   */
+  async setRatchetActiveSessionIfEnabled(workspaceId: string, sessionId: string): Promise<boolean> {
+    const result = await prisma.workspace.updateMany({
+      where: { id: workspaceId, ratchetEnabled: true },
+      data: { ratchetActiveSessionId: sessionId },
+    });
+    return result.count > 0;
+  }
+
+  /**
+   * Persist ratchet check output only while ratcheting remains enabled.
+   * This prevents stale in-flight checks from overwriting the disabled state.
+   */
+  async updateRatchetCheckIfEnabled(
+    workspaceId: string,
+    data: Pick<UpdateWorkspaceInput, 'ratchetState' | 'ratchetLastCheckedAt' | 'ratchetLastCiRunId'>
+  ): Promise<boolean> {
+    const result = await prisma.workspace.updateMany({
+      where: { id: workspaceId, ratchetEnabled: true },
+      data,
+    });
+    return result.count > 0;
+  }
+
+  /**
    * Append output to initOutput field during startup script execution.
    * Truncates from the beginning if output exceeds maxSize to prevent unbounded growth.
    */


### PR DESCRIPTION
## Summary
- Prevent disabled ratchet workspaces from recording or resurrecting fixer sessions after an in-flight poll.
- Guard ratchet check-state writes so stale enabled snapshots cannot overwrite the disabled IDLE state.
- Add regression coverage for dispatch, already-active fixer, disable cleanup, and accessor ownership rules.

## Changes
- **Ratchet dispatch**: Records active fixer sessions with a conditional update that only succeeds while `ratchetEnabled` is true, and stops the session when the condition fails.
- **Ratchet disable**: Performs a post-disable cleanup pass for active ratchet workflow sessions that may have raced with the disable update.
- **Workspace accessor**: Adds guarded ratchet mutators for active-session and check-state writes, with single-writer checker coverage.
- **Tests**: Covers disable races before acquisition, during active-session recording, during check-state persistence, and for already-active fixer sessions.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; backend race covered by automated regression tests.

Closes #1732

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ratchet orchestration and session lifecycle around disable races; behavior is well covered by tests but touches concurrent poll/dispatch paths.
> 
> **Overview**
> Closes the race where disabling ratchet while a poll or fixer dispatch is in flight could still record `ratchetActiveSessionId` or overwrite ratchet check state after the workspace was set to disabled IDLE.
> 
> **Conditional persistence:** `workspaceAccessor` adds `setRatchetActiveSessionIfEnabled` and `updateRatchetCheckIfEnabled` (`updateMany` with `ratchetEnabled: true`, boolean success). Ratchet check completion goes through `finishRatchetCheck`; if the guarded check-state write fails, the result is `DISABLED` / IDLE and state-change events are skipped.
> 
> **Dispatch and disable cleanup:** Fixer acquisition skips when `ratchetEnabled === false`. After starting or reusing a fixer, recording the active session uses the guarded update; on failure, running sessions are stopped and the action is `DISABLED`. On disable, ratchet lists workspace sessions via a new session bridge method and stops active `ratchet` workflow sessions that raced the disable.
> 
> **Tooling/tests:** Single-writer rules cover the new mutators; tests cover disable races, accessor behavior, and post-disable session cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee591105574d06e00140d69aa39348c93fd359e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

