### PR TITLE
Fix #1757: Make user settings first read atomic

### DIFF
--- a/src/backend/services/resources.integration.test.ts
+++ b/src/backend/services/resources.integration.test.ts
@@ -592,6 +592,15 @@ describe('resource accessors integration', () => {
       expect(settings.defaultCodexModel).toBe('default');
     });
 
+    it('returns one default row for concurrent first reads', async () => {
+      const settings = await Promise.all(
+        Array.from({ length: 10 }, () => userSettingsAccessor.get())
+      );
+
+      expect(new Set(settings.map((row) => row.id)).size).toBe(1);
+      expect(await prisma.userSettings.count({ where: { userId: 'default' } })).toBe(1);
+    });
+
     it('persists workspace order by project id', async () => {
       const projectA = await createProjectFixture();
       const projectB = await createProjectFixture();

--- a/src/backend/services/settings/resources/user-settings.accessor.ts
+++ b/src/backend/services/settings/resources/user-settings.accessor.ts
@@ -1,9 +1,5 @@
-import type {
-  Prisma,
-  SessionPermissionPreset,
-  SessionProvider,
-  UserSettings,
-} from '@prisma-gen/client';
+import type { SessionPermissionPreset, SessionProvider, UserSettings } from '@prisma-gen/client';
+import { Prisma } from '@prisma-gen/client';
 import { prisma } from '@/backend/db';
 import { normalizeSessionModelForProvider } from '@/backend/lib/session-model';
 import { workspaceOrderMapSchema } from '@/shared/schemas/persisted-stores.schema';
@@ -68,6 +64,10 @@ function normalizeOptionalEffort(value: string | null | undefined): string | nul
   return normalized.length > 0 ? normalized : null;
 }
 
+function isUniqueConstraintError(error: unknown): error is Prisma.PrismaClientKnownRequestError {
+  return error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002';
+}
+
 class UserSettingsAccessor {
   /**
    * Get user settings for the default user.
@@ -76,24 +76,46 @@ class UserSettingsAccessor {
   async get(): Promise<UserSettings> {
     const userId = 'default';
 
-    return await prisma.userSettings.upsert({
+    const existing = await prisma.userSettings.findUnique({
       where: { userId },
-      update: {},
-      create: {
-        userId,
-        preferredIde: 'cursor',
-        customIdeCommand: null,
-        playSoundOnComplete: true,
-        defaultSessionProvider: 'CLAUDE',
-        defaultClaudeModel: 'sonnet',
-        defaultCodexModel: 'default',
-        defaultClaudeReasoningEffort: null,
-        defaultCodexReasoningEffort: null,
-        defaultWorkspacePermissions: 'STRICT',
-        ratchetReplyToPrComments: true,
-        ratchetPermissions: 'YOLO',
-      },
     });
+
+    if (existing) {
+      return existing;
+    }
+
+    try {
+      return await prisma.userSettings.create({
+        data: {
+          userId,
+          preferredIde: 'cursor',
+          customIdeCommand: null,
+          playSoundOnComplete: true,
+          defaultSessionProvider: 'CLAUDE',
+          defaultClaudeModel: 'sonnet',
+          defaultCodexModel: 'default',
+          defaultClaudeReasoningEffort: null,
+          defaultCodexReasoningEffort: null,
+          defaultWorkspacePermissions: 'STRICT',
+          ratchetReplyToPrComments: true,
+          ratchetPermissions: 'YOLO',
+        },
+      });
+    } catch (error) {
+      if (!isUniqueConstraintError(error)) {
+        throw error;
+      }
+
+      const settings = await prisma.userSettings.findUnique({
+        where: { userId },
+      });
+
+      if (!settings) {
+        throw error;
+      }
+
+      return settings;
+    }
   }
 
   async getDefaultSessionProvider(): Promise<SessionProvider> {

--- a/src/backend/services/settings/resources/user-settings.accessor.ts
+++ b/src/backend/services/settings/resources/user-settings.accessor.ts
@@ -76,31 +76,24 @@ class UserSettingsAccessor {
   async get(): Promise<UserSettings> {
     const userId = 'default';
 
-    let settings = await prisma.userSettings.findUnique({
+    return await prisma.userSettings.upsert({
       where: { userId },
+      update: {},
+      create: {
+        userId,
+        preferredIde: 'cursor',
+        customIdeCommand: null,
+        playSoundOnComplete: true,
+        defaultSessionProvider: 'CLAUDE',
+        defaultClaudeModel: 'sonnet',
+        defaultCodexModel: 'default',
+        defaultClaudeReasoningEffort: null,
+        defaultCodexReasoningEffort: null,
+        defaultWorkspacePermissions: 'STRICT',
+        ratchetReplyToPrComments: true,
+        ratchetPermissions: 'YOLO',
+      },
     });
-
-    // Create default settings if they don't exist
-    if (!settings) {
-      settings = await prisma.userSettings.create({
-        data: {
-          userId,
-          preferredIde: 'cursor',
-          customIdeCommand: null,
-          playSoundOnComplete: true,
-          defaultSessionProvider: 'CLAUDE',
-          defaultClaudeModel: 'sonnet',
-          defaultCodexModel: 'default',
-          defaultClaudeReasoningEffort: null,
-          defaultCodexReasoningEffort: null,
-          defaultWorkspacePermissions: 'STRICT',
-          ratchetReplyToPrComments: true,
-          ratchetPermissions: 'YOLO',
-        },
-      });
-    }
-
-    return settings;
   }
 
   async getDefaultSessionProvider(): Promise<SessionProvider> {


### PR DESCRIPTION
## Summary
- Makes the singleton user settings first-read path atomic with Prisma `upsert`.
- Adds regression coverage for concurrent first reads on an empty settings table.

## Changes
- **Settings accessor**: Replaced the `findUnique` then `create` sequence with a single `upsert` using the existing default values.
- **Integration tests**: Added concurrent first-read coverage to verify all callers receive the same singleton row and only one default row is created.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; backend data-access race fix covered by integration test.

Closes #1757

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to singleton settings bootstrap; behavior for existing rows is unchanged and concurrency is covered by an integration test.
> 
> **Overview**
> Fixes a race when multiple callers hit `userSettingsAccessor.get()` on an empty table: the old **find-then-create** path could insert more than one row for `userId: 'default'`.
> 
> **`get()`** now returns immediately if a row exists, otherwise **creates** defaults inside a **try/catch**. A **P2002** unique-constraint failure is treated as a lost race—the accessor **re-fetches** by `userId` and returns that row (or rethrows if the row is still missing). **`isUniqueConstraintError`** and a **value import** of **`Prisma`** support that handling.
> 
> Adds an integration test that runs **10 concurrent** first reads and asserts every caller gets the **same row id** and the DB has **exactly one** default settings row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b82aadb5189b4445c85850291bfec64f9bc666cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->