### PR TITLE
Fix #1739: Add Codex RPC request timeouts

### DIFF
--- a/src/backend/services/session/service/acp/codex-app-server-adapter/codex-rpc-client.test.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/codex-rpc-client.test.ts
@@ -239,6 +239,40 @@ describe('CodexRpcClient', () => {
     }
   });
 
+  it('falls back to the configured client timeout for invalid per-request overrides', async () => {
+    vi.useFakeTimers();
+    try {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+      const client = new CodexRpcClient({
+        cwd: '/tmp/workspace',
+        env: {},
+        requestTimeoutMs: 25,
+      });
+
+      client.start();
+      const responsePromise = client.request(
+        'turn/start',
+        { threadId: 'thread_1' },
+        { timeoutMs: 0 }
+      );
+      const rejection = responsePromise.catch((error: unknown) => error);
+
+      await vi.advanceTimersByTimeAsync(25);
+
+      const error = await rejection;
+      expect(error).toBeInstanceOf(CodexRequestTimeoutError);
+      expect(error).toMatchObject({
+        id: 1,
+        method: 'turn/start',
+        timeoutMs: 25,
+      });
+      expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('clears request timeout state when a response arrives before the deadline', async () => {
     vi.useFakeTimers();
     try {

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/codex-rpc-client.test.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/codex-rpc-client.test.ts
@@ -10,7 +10,7 @@ vi.mock('node:child_process', () => ({
   spawn: (...args: unknown[]) => mockSpawn(...args),
 }));
 
-import { CodexRequestError, CodexRpcClient } from './codex-rpc-client';
+import { CodexRequestError, CodexRequestTimeoutError, CodexRpcClient } from './codex-rpc-client';
 
 type MockChild = EventEmitter & {
   stdin: PassThrough;
@@ -203,6 +203,68 @@ describe('CodexRpcClient', () => {
     );
 
     expect((client as unknown as { pending: Map<number, unknown> }).pending.size).toBe(0);
+  });
+
+  it('rejects unresponsive requests with a timeout and stops codex', async () => {
+    vi.useFakeTimers();
+    try {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+      const client = new CodexRpcClient({
+        cwd: '/tmp/workspace',
+        env: {},
+      });
+
+      client.start();
+      const responsePromise = client.request(
+        'turn/start',
+        { threadId: 'thread_1' },
+        { timeoutMs: 50 }
+      );
+      const rejection = responsePromise.catch((error: unknown) => error);
+
+      await vi.advanceTimersByTimeAsync(50);
+
+      const error = await rejection;
+      expect(error).toBeInstanceOf(CodexRequestTimeoutError);
+      expect(error).toMatchObject({
+        id: 1,
+        method: 'turn/start',
+        timeoutMs: 50,
+      });
+      expect((client as unknown as { pending: Map<number, unknown> }).pending.size).toBe(0);
+      expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('clears request timeout state when a response arrives before the deadline', async () => {
+    vi.useFakeTimers();
+    try {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+      const client = new CodexRpcClient({
+        cwd: '/tmp/workspace',
+        env: {},
+      });
+
+      client.start();
+      const responsePromise = client.request<{ ok: boolean }>(
+        'turn/start',
+        { threadId: 'thread_1' },
+        { timeoutMs: 50 }
+      );
+      child.stdout.write('{"id":1,"result":{"ok":true}}\n');
+
+      await expect(responsePromise).resolves.toEqual({ ok: true });
+      await vi.advanceTimersByTimeAsync(50);
+
+      expect((client as unknown as { pending: Map<number, unknown> }).pending.size).toBe(0);
+      expect(child.kill).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('stops the subprocess gracefully', async () => {

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/codex-rpc-client.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/codex-rpc-client.ts
@@ -10,6 +10,7 @@ import {
 type PendingRequest = {
   resolve: (value: unknown) => void;
   reject: (reason?: unknown) => void;
+  timeout: NodeJS.Timeout;
 };
 
 type CodexJsonRpcError = {
@@ -36,9 +37,32 @@ export class CodexRequestError extends Error {
   }
 }
 
+export class CodexRequestTimeoutError extends Error {
+  readonly id: number;
+  readonly method: string;
+  readonly timeoutMs: number;
+
+  constructor(params: { id: number; method: string; timeoutMs: number }) {
+    super(
+      `Codex app-server request "${params.method}" (id=${params.id}) timed out after ${params.timeoutMs}ms`
+    );
+    this.name = 'CodexRequestTimeoutError';
+    this.id = params.id;
+    this.method = params.method;
+    this.timeoutMs = params.timeoutMs;
+  }
+}
+
+export const DEFAULT_CODEX_RPC_REQUEST_TIMEOUT_MS = 120_000;
+
+export type CodexRpcRequestOptions = {
+  timeoutMs?: number;
+};
+
 export type CodexRpcClientOptions = {
   cwd: string;
   env: NodeJS.ProcessEnv;
+  requestTimeoutMs?: number;
   onStderr?: (line: string) => void;
   onNotification?: (notification: { method: string; params: unknown }) => void;
   onRequest?: (request: CodexRpcServerRequest) => void;
@@ -67,6 +91,7 @@ function toRequestErrorPayload(error: unknown): CodexJsonRpcError {
 
 export class CodexRpcClient {
   private readonly options: CodexRpcClientOptions;
+  private readonly requestTimeoutMs: number;
   private child: ChildProcess | null = null;
   private lineReader: ReadlineInterface | null = null;
   private nextId = 1;
@@ -74,6 +99,7 @@ export class CodexRpcClient {
 
   constructor(options: CodexRpcClientOptions) {
     this.options = options;
+    this.requestTimeoutMs = normalizeRequestTimeoutMs(options.requestTimeoutMs);
   }
 
   start(): void {
@@ -157,7 +183,6 @@ export class CodexRpcClient {
       return;
     }
 
-    child.kill('SIGTERM');
     await new Promise<void>((resolve) => {
       const timeout = setTimeout(() => {
         if (child.exitCode === null) {
@@ -170,12 +195,18 @@ export class CodexRpcClient {
         clearTimeout(timeout);
         resolve();
       });
+      child.kill('SIGTERM');
     });
   }
 
-  async request<TResponse>(method: string, params?: unknown): Promise<TResponse> {
+  async request<TResponse>(
+    method: string,
+    params?: unknown,
+    requestOptions?: CodexRpcRequestOptions
+  ): Promise<TResponse> {
     const id = this.nextId;
     this.nextId += 1;
+    const timeoutMs = normalizeRequestTimeoutMs(requestOptions?.timeoutMs ?? this.requestTimeoutMs);
 
     const payload: Record<string, unknown> = {
       id,
@@ -184,18 +215,35 @@ export class CodexRpcClient {
     };
 
     const responsePromise = new Promise<TResponse>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        const pending = this.takePending(id);
+        if (!pending) {
+          return;
+        }
+
+        const error = new CodexRequestTimeoutError({ id, method, timeoutMs });
+        pending.reject(error);
+        void this.stop().catch((stopError: unknown) => {
+          this.options.onProtocolError?.({
+            reason: 'request_timeout_stop_failed',
+            payload: stopError instanceof Error ? stopError.message : String(stopError),
+          });
+        });
+      }, timeoutMs);
+      timeout.unref?.();
+
       this.pending.set(id, {
         resolve: (value) => resolve(value as TResponse),
         reject,
+        timeout,
       });
     });
 
     try {
       this.write(payload);
     } catch (error) {
-      const pending = this.pending.get(id);
+      const pending = this.takePending(id);
       if (pending) {
-        this.pending.delete(id);
         pending.reject(error);
       }
     }
@@ -221,9 +269,21 @@ export class CodexRpcClient {
 
   private rejectPending(error: unknown): void {
     for (const [, pending] of this.pending) {
+      clearTimeout(pending.timeout);
       pending.reject(error);
     }
     this.pending.clear();
+  }
+
+  private takePending(id: number): PendingRequest | undefined {
+    const pending = this.pending.get(id);
+    if (!pending) {
+      return undefined;
+    }
+
+    this.pending.delete(id);
+    clearTimeout(pending.timeout);
+    return pending;
   }
 
   private write(payload: unknown): void {
@@ -314,12 +374,11 @@ export class CodexRpcClient {
       return;
     }
 
-    const pending = this.pending.get(response.id);
+    const pending = this.takePending(response.id);
     if (!pending) {
       return;
     }
 
-    this.pending.delete(response.id);
     if (response.error) {
       pending.reject(
         new CodexRequestError({
@@ -333,4 +392,12 @@ export class CodexRpcClient {
 
     pending.resolve(response.result);
   }
+}
+
+function normalizeRequestTimeoutMs(timeoutMs: number | undefined): number {
+  if (!Number.isFinite(timeoutMs) || timeoutMs === undefined || timeoutMs <= 0) {
+    return DEFAULT_CODEX_RPC_REQUEST_TIMEOUT_MS;
+  }
+
+  return Math.floor(timeoutMs);
 }

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/codex-rpc-client.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/codex-rpc-client.ts
@@ -206,7 +206,10 @@ export class CodexRpcClient {
   ): Promise<TResponse> {
     const id = this.nextId;
     this.nextId += 1;
-    const timeoutMs = normalizeRequestTimeoutMs(requestOptions?.timeoutMs ?? this.requestTimeoutMs);
+    const timeoutMs =
+      requestOptions?.timeoutMs === undefined
+        ? this.requestTimeoutMs
+        : normalizeRequestTimeoutMs(requestOptions.timeoutMs, this.requestTimeoutMs);
 
     const payload: Record<string, unknown> = {
       id,
@@ -394,9 +397,12 @@ export class CodexRpcClient {
   }
 }
 
-function normalizeRequestTimeoutMs(timeoutMs: number | undefined): number {
+function normalizeRequestTimeoutMs(
+  timeoutMs: number | undefined,
+  fallbackMs = DEFAULT_CODEX_RPC_REQUEST_TIMEOUT_MS
+): number {
   if (!Number.isFinite(timeoutMs) || timeoutMs === undefined || timeoutMs <= 0) {
-    return DEFAULT_CODEX_RPC_REQUEST_TIMEOUT_MS;
+    return fallbackMs;
   }
 
   return Math.floor(timeoutMs);


### PR DESCRIPTION
## Summary
- Adds bounded timeouts for Codex app-server JSON-RPC requests so callers cannot hang indefinitely.
- Rejects stale requests with a typed timeout error that includes the method, request id, and timeout.
- Cleans up pending request timers and stops the app-server after a timeout to avoid continuing with uncertain protocol state.

## Changes
- **Codex RPC client**: Added default 120s request timeout support with per-request overrides and pending-map cleanup on resolve, reject, write failure, process exit, and timeout.
- **Process lifecycle**: Starts subprocess exit waiting before sending SIGTERM during stop, avoiding missed synchronous exit notifications in tests.
- **Tests**: Added coverage for unresponsive requests timing out, pending cleanup, process stop on timeout, and successful responses clearing timeout timers.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; backend stability fix covered by unit tests.

Closes #1739

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core session Codex IPC behavior: hung RPCs now fail and kill the app-server, which can end an in-flight turn but prevents indefinite hangs.
> 
> **Overview**
> **Codex RPC requests no longer hang indefinitely** — each `request()` now runs with a **120s default** timeout, optional client-level `requestTimeoutMs`, and per-call `timeoutMs` overrides (invalid or non-positive values fall back to the configured default).
> 
> When a deadline hits, the promise rejects with **`CodexRequestTimeoutError`** (method, id, timeout), the pending entry and timer are cleared, and **`stop()`** tears down the `codex app-server` subprocess so the client does not keep using uncertain protocol state. Timers are also cleared on normal responses, write failures, and bulk pending rejection on process exit.
> 
> **`stop()`** now attaches the exit listener before sending **SIGTERM**, avoiding races where a synchronous exit could be missed in tests.
> 
> Unit tests cover timeout rejection, invalid override fallback, early response clearing timers, and SIGTERM on timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f7e887cde1948b18e743c01ba72be8637750da4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

