### PR TITLE
Fix #1744: Preserve archive rollback cache state

### DIFF
--- a/src/client/components/kanban/kanban-context.tsx
+++ b/src/client/components/kanban/kanban-context.tsx
@@ -21,6 +21,7 @@ import { trpc } from '@/client/lib/trpc';
 import {
   removeWorkspaceFromProjectSummaryCache,
   removeWorkspacesFromProjectSummaryCache,
+  restoreWorkspacesToProjectSummaryCache,
 } from '@/client/lib/workspace-cache-helpers';
 import type { WorkspaceWithKanban } from './kanban-card';
 
@@ -253,7 +254,9 @@ export function KanbanProvider({
         utils.workspace.get.invalidate({ id: workspaceId }),
       ]);
     } catch (error) {
-      utils.workspace.getProjectSummaryState.setData({ projectId }, previousProjectSummaryState);
+      utils.workspace.getProjectSummaryState.setData({ projectId }, (old) =>
+        restoreWorkspacesToProjectSummaryCache(old, previousProjectSummaryState, [workspaceId])
+      );
       throw error;
     } finally {
       setArchivingWorkspaceIds((prev) => {
@@ -321,7 +324,13 @@ export function KanbanProvider({
         utils.workspace.getProjectSummaryState.invalidate({ projectId }),
       ]);
     } catch (error) {
-      utils.workspace.getProjectSummaryState.setData({ projectId }, previousProjectSummaryState);
+      utils.workspace.getProjectSummaryState.setData({ projectId }, (old) =>
+        restoreWorkspacesToProjectSummaryCache(
+          old,
+          previousProjectSummaryState,
+          workspaceIdsToArchive
+        )
+      );
       throw error;
     } finally {
       setArchivingWorkspaceIds((prev) => {

--- a/src/client/lib/workspace-cache-helpers.test.ts
+++ b/src/client/lib/workspace-cache-helpers.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
   removeWorkspaceFromProjectSummaryCache,
   removeWorkspacesFromProjectSummaryCache,
+  restoreWorkspacesToListCache,
+  restoreWorkspacesToProjectSummaryCache,
 } from './workspace-cache-helpers';
 
 describe('workspace-cache-helpers', () => {
@@ -42,5 +44,83 @@ describe('workspace-cache-helpers', () => {
       workspaces: [{ id: 'ws-2' }],
       reviewCount: 1,
     });
+  });
+
+  it('restores only missing optimistically removed workspaces', () => {
+    const previousCache = {
+      workspaces: [
+        { id: 'ws-1', name: 'Archived workspace' },
+        { id: 'ws-2', name: 'Removed by snapshot' },
+      ],
+      reviewCount: 4,
+    };
+    const currentCache = {
+      workspaces: [{ id: 'ws-3', name: 'Still current' }],
+      reviewCount: 2,
+    };
+
+    const updated = restoreWorkspacesToProjectSummaryCache(currentCache, previousCache, ['ws-1']);
+
+    expect(updated).toEqual({
+      workspaces: [
+        { id: 'ws-3', name: 'Still current' },
+        { id: 'ws-1', name: 'Archived workspace' },
+      ],
+      reviewCount: 2,
+    });
+  });
+
+  it('preserves concurrent updates to workspaces already in the cache', () => {
+    const previousCache = {
+      workspaces: [
+        { id: 'ws-1', name: 'Archived workspace' },
+        { id: 'ws-2', name: 'Old name' },
+      ],
+      reviewCount: 4,
+    };
+    const currentCache = {
+      workspaces: [{ id: 'ws-2', name: 'Updated by snapshot' }],
+      reviewCount: 1,
+    };
+
+    const updated = restoreWorkspacesToProjectSummaryCache(currentCache, previousCache, ['ws-1']);
+
+    expect(updated).toEqual({
+      workspaces: [
+        { id: 'ws-2', name: 'Updated by snapshot' },
+        { id: 'ws-1', name: 'Archived workspace' },
+      ],
+      reviewCount: 1,
+    });
+  });
+
+  it('does not duplicate workspaces already restored by another cache update', () => {
+    const previousCache = {
+      workspaces: [{ id: 'ws-1', name: 'Old snapshot' }],
+      reviewCount: 4,
+    };
+    const currentCache = {
+      workspaces: [{ id: 'ws-1', name: 'Fresh snapshot' }],
+      reviewCount: 3,
+    };
+
+    const updated = restoreWorkspacesToProjectSummaryCache(currentCache, previousCache, ['ws-1']);
+
+    expect(updated).toBe(currentCache);
+  });
+
+  it('restores only missing workspaces to list caches', () => {
+    const previousCache = [
+      { id: 'ws-1', name: 'Archived workspace' },
+      { id: 'ws-2', name: 'Removed by snapshot' },
+    ];
+    const currentCache = [{ id: 'ws-3', name: 'Still current' }];
+
+    const updated = restoreWorkspacesToListCache(currentCache, previousCache, ['ws-1']);
+
+    expect(updated).toEqual([
+      { id: 'ws-3', name: 'Still current' },
+      { id: 'ws-1', name: 'Archived workspace' },
+    ]);
   });
 });

--- a/src/client/lib/workspace-cache-helpers.test.ts
+++ b/src/client/lib/workspace-cache-helpers.test.ts
@@ -50,12 +50,12 @@ describe('workspace-cache-helpers', () => {
     const previousCache = {
       workspaces: [
         { id: 'ws-1', name: 'Archived workspace' },
-        { id: 'ws-2', name: 'Removed by snapshot' },
+        { id: 'ws-2', name: 'Still current' },
       ],
       reviewCount: 4,
     };
     const currentCache = {
-      workspaces: [{ id: 'ws-3', name: 'Still current' }],
+      workspaces: [{ id: 'ws-2', name: 'Still current' }],
       reviewCount: 2,
     };
 
@@ -63,8 +63,8 @@ describe('workspace-cache-helpers', () => {
 
     expect(updated).toEqual({
       workspaces: [
-        { id: 'ws-3', name: 'Still current' },
         { id: 'ws-1', name: 'Archived workspace' },
+        { id: 'ws-2', name: 'Still current' },
       ],
       reviewCount: 2,
     });
@@ -87,10 +87,41 @@ describe('workspace-cache-helpers', () => {
 
     expect(updated).toEqual({
       workspaces: [
-        { id: 'ws-2', name: 'Updated by snapshot' },
         { id: 'ws-1', name: 'Archived workspace' },
+        { id: 'ws-2', name: 'Updated by snapshot' },
       ],
       reviewCount: 1,
+    });
+  });
+
+  it('restores project summary workspaces at their previous relative position', () => {
+    const previousCache = {
+      workspaces: [
+        { id: 'ws-1', name: 'First' },
+        { id: 'ws-2', name: 'Second' },
+        { id: 'ws-3', name: 'Third' },
+      ],
+      reviewCount: 4,
+    };
+    const currentCache = {
+      workspaces: [
+        { id: 'ws-new', name: 'New snapshot item' },
+        { id: 'ws-2', name: 'Second' },
+        { id: 'ws-3', name: 'Third' },
+      ],
+      reviewCount: 2,
+    };
+
+    const updated = restoreWorkspacesToProjectSummaryCache(currentCache, previousCache, ['ws-1']);
+
+    expect(updated).toEqual({
+      workspaces: [
+        { id: 'ws-new', name: 'New snapshot item' },
+        { id: 'ws-1', name: 'First' },
+        { id: 'ws-2', name: 'Second' },
+        { id: 'ws-3', name: 'Third' },
+      ],
+      reviewCount: 2,
     });
   });
 
@@ -112,15 +143,37 @@ describe('workspace-cache-helpers', () => {
   it('restores only missing workspaces to list caches', () => {
     const previousCache = [
       { id: 'ws-1', name: 'Archived workspace' },
-      { id: 'ws-2', name: 'Removed by snapshot' },
+      { id: 'ws-2', name: 'Still current' },
     ];
-    const currentCache = [{ id: 'ws-3', name: 'Still current' }];
+    const currentCache = [{ id: 'ws-2', name: 'Still current' }];
 
     const updated = restoreWorkspacesToListCache(currentCache, previousCache, ['ws-1']);
 
     expect(updated).toEqual([
-      { id: 'ws-3', name: 'Still current' },
       { id: 'ws-1', name: 'Archived workspace' },
+      { id: 'ws-2', name: 'Still current' },
+    ]);
+  });
+
+  it('restores list cache workspaces at their previous relative position', () => {
+    const previousCache = [
+      { id: 'ws-1', name: 'First' },
+      { id: 'ws-2', name: 'Second' },
+      { id: 'ws-3', name: 'Third' },
+    ];
+    const currentCache = [
+      { id: 'ws-new', name: 'New snapshot item' },
+      { id: 'ws-2', name: 'Second' },
+      { id: 'ws-3', name: 'Third' },
+    ];
+
+    const updated = restoreWorkspacesToListCache(currentCache, previousCache, ['ws-1']);
+
+    expect(updated).toEqual([
+      { id: 'ws-new', name: 'New snapshot item' },
+      { id: 'ws-1', name: 'First' },
+      { id: 'ws-2', name: 'Second' },
+      { id: 'ws-3', name: 'Third' },
     ]);
   });
 });

--- a/src/client/lib/workspace-cache-helpers.test.ts
+++ b/src/client/lib/workspace-cache-helpers.test.ts
@@ -70,6 +70,20 @@ describe('workspace-cache-helpers', () => {
     });
   });
 
+  it('restores the previous project summary cache when the current cache is missing', () => {
+    const previousCache = {
+      workspaces: [
+        { id: 'ws-1', name: 'Archived workspace' },
+        { id: 'ws-2', name: 'Still current' },
+      ],
+      reviewCount: 4,
+    };
+
+    const updated = restoreWorkspacesToProjectSummaryCache(undefined, previousCache, ['ws-1']);
+
+    expect(updated).toBe(previousCache);
+  });
+
   it('preserves concurrent updates to workspaces already in the cache', () => {
     const previousCache = {
       workspaces: [
@@ -153,6 +167,17 @@ describe('workspace-cache-helpers', () => {
       { id: 'ws-1', name: 'Archived workspace' },
       { id: 'ws-2', name: 'Still current' },
     ]);
+  });
+
+  it('restores the previous list cache when the current cache is missing', () => {
+    const previousCache = [
+      { id: 'ws-1', name: 'Archived workspace' },
+      { id: 'ws-2', name: 'Still current' },
+    ];
+
+    const updated = restoreWorkspacesToListCache(undefined, previousCache, ['ws-1']);
+
+    expect(updated).toBe(previousCache);
   });
 
   it('restores list cache workspaces at their previous relative position', () => {

--- a/src/client/lib/workspace-cache-helpers.ts
+++ b/src/client/lib/workspace-cache-helpers.ts
@@ -39,6 +39,33 @@ export type ProjectSummaryCacheData<TWorkspace extends WorkspaceWithId> = {
   reviewCount: number;
 };
 
+function restoreWorkspacesByPreviousOrder<TWorkspace extends WorkspaceWithId>(
+  currentWorkspaces: TWorkspace[],
+  previousWorkspaces: TWorkspace[],
+  workspacesToRestore: TWorkspace[]
+): TWorkspace[] {
+  const previousIndexById = new Map(
+    previousWorkspaces.map((workspace, index) => [workspace.id, index])
+  );
+  const restoredWorkspaces = [...currentWorkspaces];
+
+  for (const workspace of workspacesToRestore) {
+    const previousIndex = previousIndexById.get(workspace.id) ?? Number.MAX_SAFE_INTEGER;
+    const insertIndex = restoredWorkspaces.findIndex((current) => {
+      const currentPreviousIndex = previousIndexById.get(current.id);
+      return currentPreviousIndex !== undefined && currentPreviousIndex > previousIndex;
+    });
+
+    if (insertIndex === -1) {
+      restoredWorkspaces.push(workspace);
+    } else {
+      restoredWorkspaces.splice(insertIndex, 0, workspace);
+    }
+  }
+
+  return restoredWorkspaces;
+}
+
 export function removeWorkspaceFromProjectSummaryCache<TWorkspace extends WorkspaceWithId>(
   cache: ProjectSummaryCacheData<TWorkspace> | undefined,
   workspaceId: string
@@ -99,7 +126,7 @@ export function restoreWorkspacesToListCache<TWorkspace extends WorkspaceWithId>
     return cache;
   }
 
-  return [...cache, ...workspacesToRestore];
+  return restoreWorkspacesByPreviousOrder(cache, previousCache, workspacesToRestore);
 }
 
 export function restoreWorkspacesToProjectSummaryCache<TWorkspace extends WorkspaceWithId>(
@@ -127,6 +154,10 @@ export function restoreWorkspacesToProjectSummaryCache<TWorkspace extends Worksp
 
   return {
     ...cache,
-    workspaces: [...cache.workspaces, ...workspacesToRestore],
+    workspaces: restoreWorkspacesByPreviousOrder(
+      cache.workspaces,
+      previousCache.workspaces,
+      workspacesToRestore
+    ),
   };
 }

--- a/src/client/lib/workspace-cache-helpers.ts
+++ b/src/client/lib/workspace-cache-helpers.ts
@@ -108,13 +108,17 @@ export function restoreWorkspacesToListCache<TWorkspace extends WorkspaceWithId>
   previousCache: TWorkspace[] | undefined,
   workspaceIds: Iterable<string>
 ): TWorkspace[] | undefined {
-  if (!(cache && previousCache)) {
+  if (!previousCache) {
     return cache;
   }
 
   const idsToRestore = new Set(workspaceIds);
   if (idsToRestore.size === 0) {
     return cache;
+  }
+
+  if (!cache) {
+    return previousCache;
   }
 
   const currentIds = new Set(cache.map((workspace) => workspace.id));
@@ -134,13 +138,17 @@ export function restoreWorkspacesToProjectSummaryCache<TWorkspace extends Worksp
   previousCache: ProjectSummaryCacheData<TWorkspace> | undefined,
   workspaceIds: Iterable<string>
 ): ProjectSummaryCacheData<TWorkspace> | undefined {
-  if (!(cache && previousCache)) {
+  if (!previousCache) {
     return cache;
   }
 
   const idsToRestore = new Set(workspaceIds);
   if (idsToRestore.size === 0) {
     return cache;
+  }
+
+  if (!cache) {
+    return previousCache;
   }
 
   const currentIds = new Set(cache.workspaces.map((workspace) => workspace.id));

--- a/src/client/lib/workspace-cache-helpers.ts
+++ b/src/client/lib/workspace-cache-helpers.ts
@@ -75,3 +75,58 @@ export function removeWorkspacesFromProjectSummaryCache<TWorkspace extends Works
 
   return { ...cache, workspaces };
 }
+
+export function restoreWorkspacesToListCache<TWorkspace extends WorkspaceWithId>(
+  cache: TWorkspace[] | undefined,
+  previousCache: TWorkspace[] | undefined,
+  workspaceIds: Iterable<string>
+): TWorkspace[] | undefined {
+  if (!(cache && previousCache)) {
+    return cache;
+  }
+
+  const idsToRestore = new Set(workspaceIds);
+  if (idsToRestore.size === 0) {
+    return cache;
+  }
+
+  const currentIds = new Set(cache.map((workspace) => workspace.id));
+  const workspacesToRestore = previousCache.filter(
+    (workspace) => idsToRestore.has(workspace.id) && !currentIds.has(workspace.id)
+  );
+
+  if (workspacesToRestore.length === 0) {
+    return cache;
+  }
+
+  return [...cache, ...workspacesToRestore];
+}
+
+export function restoreWorkspacesToProjectSummaryCache<TWorkspace extends WorkspaceWithId>(
+  cache: ProjectSummaryCacheData<TWorkspace> | undefined,
+  previousCache: ProjectSummaryCacheData<TWorkspace> | undefined,
+  workspaceIds: Iterable<string>
+): ProjectSummaryCacheData<TWorkspace> | undefined {
+  if (!(cache && previousCache)) {
+    return cache;
+  }
+
+  const idsToRestore = new Set(workspaceIds);
+  if (idsToRestore.size === 0) {
+    return cache;
+  }
+
+  const currentIds = new Set(cache.workspaces.map((workspace) => workspace.id));
+  const workspacesToRestore = previousCache.workspaces.filter(
+    (workspace) => idsToRestore.has(workspace.id) && !currentIds.has(workspace.id)
+  );
+
+  if (workspacesToRestore.length === 0) {
+    return cache;
+  }
+
+  return {
+    ...cache,
+    workspaces: [...cache.workspaces, ...workspacesToRestore],
+  };
+}

--- a/src/client/routes/projects/workspaces/use-workspace-detail.ts
+++ b/src/client/routes/projects/workspaces/use-workspace-detail.ts
@@ -2,7 +2,11 @@ import { useCallback, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router';
 import { toast } from 'sonner';
 import { trpc } from '@/client/lib/trpc';
-import { removeWorkspaceFromProjectSummaryCache } from '@/client/lib/workspace-cache-helpers';
+import {
+  removeWorkspaceFromProjectSummaryCache,
+  restoreWorkspacesToListCache,
+  restoreWorkspacesToProjectSummaryCache,
+} from '@/client/lib/workspace-cache-helpers';
 import {
   type NewSessionProviderSelection,
   resolveExplicitSessionProvider,
@@ -236,15 +240,15 @@ export function useSessionManagement({
 
       if (context?.projectId) {
         if (context.previousWorkspaceList) {
-          utils.workspace.listWithKanbanState.setData(
-            { projectId: context.projectId },
-            context.previousWorkspaceList
+          utils.workspace.listWithKanbanState.setData({ projectId: context.projectId }, (old) =>
+            restoreWorkspacesToListCache(old, context.previousWorkspaceList, [_variables.id])
           );
         }
         if (context.previousProjectSummaryState) {
-          utils.workspace.getProjectSummaryState.setData(
-            { projectId: context.projectId },
-            context.previousProjectSummaryState
+          utils.workspace.getProjectSummaryState.setData({ projectId: context.projectId }, (old) =>
+            restoreWorkspacesToProjectSummaryCache(old, context.previousProjectSummaryState, [
+              _variables.id,
+            ])
           );
         }
       }


### PR DESCRIPTION
## Summary
- Prevent failed archive rollbacks from restoring stale project summary cache snapshots.
- Preserve live snapshot removals and updates that land while archive requests are in flight.
- Apply precise rollback behavior to Kanban and workspace detail archive cache paths.

## Changes
- **Workspace cache helpers**: Added merge-based rollback helpers for project summary and list caches that restore only missing archive targets.
- **Kanban archive flow**: Replaced full-cache rollback for single and bulk archive failures with precise project summary cache restoration.
- **Workspace detail archive flow**: Replaced full-cache rollback for Kanban list and project summary caches with precise restoration.
- **Tests**: Added helper coverage for concurrent removals, concurrent updates, duplicate prevention, and list cache restoration.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Guardrails pass (`pnpm check:fix`)
- [ ] Manual testing: Not performed; cache rollback behavior is covered by unit tests and has no visual UI change.

Closes #1744

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side optimistic cache rollback only; behavior is covered by new unit tests and does not touch server or auth.
> 
> **Overview**
> Fixes failed **archive** rollbacks overwriting live tRPC cache with a stale full snapshot when snapshot sync or other updates land while the request is in flight.
> 
> Adds **`restoreWorkspacesToListCache`** and **`restoreWorkspacesToProjectSummaryCache`**, which re-insert only the optimistically removed workspace IDs from the pre-archive snapshot, keep current entries (including newer snapshot data), preserve relative ordering, and avoid duplicates. **Kanban** single/bulk archive error paths and **workspace detail** archive `onError` now use these merge helpers via functional `setData` instead of replacing the entire project summary or Kanban list cache.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6233ff1361838cbae24ca1a06a40e3a008d22e39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

