### PR TITLE
Fix #1735: Bound workspace output buffers

### DIFF
--- a/src/components/workspace/rolling-output.test.ts
+++ b/src/components/workspace/rolling-output.test.ts
@@ -24,4 +24,22 @@ describe('rolling output', () => {
   it('trims restored output with the same bounded representation', () => {
     expect(trimRollingOutput('abcdefghijklmnop', options)).toBe('[cut]\nklmnop');
   });
+
+  it('does not exceed the cap when the truncation marker is longer than the cap', () => {
+    expect(
+      appendToRollingOutput('abc', 'def', {
+        maxChars: 4,
+        truncationMarker: '[cut]\n',
+      })
+    ).toBe('[cut');
+  });
+
+  it('returns an empty string for a non-positive cap', () => {
+    expect(
+      appendToRollingOutput('abc', 'def', {
+        maxChars: 0,
+        truncationMarker: '[cut]\n',
+      })
+    ).toBe('');
+  });
 });

--- a/src/components/workspace/rolling-output.test.ts
+++ b/src/components/workspace/rolling-output.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { appendToRollingOutput, trimRollingOutput } from './rolling-output';
+
+const options = {
+  maxChars: 12,
+  truncationMarker: '[cut]\n',
+};
+
+describe('rolling output', () => {
+  it('appends without a marker while output is below the cap', () => {
+    expect(appendToRollingOutput('abc', 'def', options)).toBe('abcdef');
+  });
+
+  it('keeps only the newest output and prepends one truncation marker', () => {
+    expect(appendToRollingOutput('abcdef', 'ghijklmnop', options)).toBe('[cut]\nklmnop');
+  });
+
+  it('does not duplicate the truncation marker on later appends', () => {
+    const truncated = appendToRollingOutput('abcdef', 'ghijklmnop', options);
+
+    expect(appendToRollingOutput(truncated, 'qrst', options)).toBe('[cut]\nopqrst');
+  });
+
+  it('trims restored output with the same bounded representation', () => {
+    expect(trimRollingOutput('abcdefghijklmnop', options)).toBe('[cut]\nklmnop');
+  });
+});

--- a/src/components/workspace/rolling-output.ts
+++ b/src/components/workspace/rolling-output.ts
@@ -1,0 +1,31 @@
+export const WORKSPACE_LOG_OUTPUT_MAX_CHARS = 512 * 1024;
+export const TERMINAL_OUTPUT_MAX_CHARS = 128 * 1024;
+
+export const WORKSPACE_LOG_TRUNCATION_MARKER = '[Earlier output truncated]\n';
+export const TERMINAL_TRUNCATION_MARKER = '\r\n[Earlier terminal output truncated]\r\n';
+
+interface RollingOutputOptions {
+  maxChars: number;
+  truncationMarker: string;
+}
+
+export function appendToRollingOutput(
+  current: string,
+  next: string,
+  { maxChars, truncationMarker }: RollingOutputOptions
+): string {
+  const wasTruncated = current.startsWith(truncationMarker);
+  const currentBody = wasTruncated ? current.slice(truncationMarker.length) : current;
+  const combinedBody = currentBody + next;
+
+  if (!wasTruncated && combinedBody.length <= maxChars) {
+    return combinedBody;
+  }
+
+  const maxBodyChars = Math.max(maxChars - truncationMarker.length, 0);
+  return truncationMarker + combinedBody.slice(-maxBodyChars);
+}
+
+export function trimRollingOutput(output: string, options: RollingOutputOptions): string {
+  return appendToRollingOutput('', output, options);
+}

--- a/src/components/workspace/rolling-output.ts
+++ b/src/components/workspace/rolling-output.ts
@@ -14,6 +14,10 @@ export function appendToRollingOutput(
   next: string,
   { maxChars, truncationMarker }: RollingOutputOptions
 ): string {
+  if (maxChars <= 0) {
+    return '';
+  }
+
   const wasTruncated = current.startsWith(truncationMarker);
   const currentBody = wasTruncated ? current.slice(truncationMarker.length) : current;
   const combinedBody = currentBody + next;
@@ -22,8 +26,13 @@ export function appendToRollingOutput(
     return combinedBody;
   }
 
-  const maxBodyChars = Math.max(maxChars - truncationMarker.length, 0);
-  return truncationMarker + combinedBody.slice(-maxBodyChars);
+  const boundedMarker = truncationMarker.slice(0, maxChars);
+  const maxBodyChars = maxChars - boundedMarker.length;
+  if (maxBodyChars <= 0) {
+    return boundedMarker;
+  }
+
+  return boundedMarker + combinedBody.slice(-maxBodyChars);
 }
 
 export function trimRollingOutput(output: string, options: RollingOutputOptions): string {

--- a/src/components/workspace/terminal-instance.test.tsx
+++ b/src/components/workspace/terminal-instance.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+
+import { createElement } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TerminalInstance } from './terminal-instance';
+
+const mocks = vi.hoisted(() => ({
+  fit: vi.fn(),
+  clear: vi.fn(),
+  dispose: vi.fn(),
+  focus: vi.fn(),
+  loadAddon: vi.fn(),
+  onData: vi.fn(),
+  open: vi.fn(),
+  write: vi.fn(),
+}));
+
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: vi.fn(function FitAddon() {
+    return {
+      fit: mocks.fit,
+    };
+  }),
+}));
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: vi.fn(function Terminal() {
+    return {
+      clear: mocks.clear,
+      cols: 80,
+      dispose: mocks.dispose,
+      focus: mocks.focus,
+      loadAddon: mocks.loadAddon,
+      onData: mocks.onData,
+      open: mocks.open,
+      rows: 24,
+      write: mocks.write,
+    };
+  }),
+}));
+
+vi.mock('@xterm/xterm/css/xterm.css', () => ({}));
+
+class MockResizeObserver {
+  observe = vi.fn();
+  disconnect = vi.fn();
+}
+
+describe('TerminalInstance', () => {
+  beforeEach(() => {
+    vi.stubGlobal('ResizeObserver', MockResizeObserver);
+    mocks.fit.mockReset();
+    mocks.clear.mockReset();
+    mocks.dispose.mockReset();
+    mocks.focus.mockReset();
+    mocks.loadAddon.mockReset();
+    mocks.onData.mockReset();
+    mocks.open.mockReset();
+    mocks.write.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.body.innerHTML = '';
+  });
+
+  it('appends only the new suffix when output grows', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    flushSync(() => {
+      root.render(
+        createElement(TerminalInstance, {
+          onData: vi.fn(),
+          onResize: vi.fn(),
+          output: 'abc',
+        })
+      );
+    });
+
+    flushSync(() => {
+      root.render(
+        createElement(TerminalInstance, {
+          onData: vi.fn(),
+          onResize: vi.fn(),
+          output: 'abcdef',
+        })
+      );
+    });
+
+    expect(mocks.clear).not.toHaveBeenCalled();
+    expect(mocks.write.mock.calls).toEqual([['abc'], ['def']]);
+
+    root.unmount();
+  });
+
+  it('repaints when rolling output is rewritten without growing', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    flushSync(() => {
+      root.render(
+        createElement(TerminalInstance, {
+          onData: vi.fn(),
+          onResize: vi.fn(),
+          output: '[cut]\nklmnop',
+        })
+      );
+    });
+
+    flushSync(() => {
+      root.render(
+        createElement(TerminalInstance, {
+          onData: vi.fn(),
+          onResize: vi.fn(),
+          output: '[cut]\nopqrst',
+        })
+      );
+    });
+
+    expect(mocks.clear).toHaveBeenCalledTimes(1);
+    expect(mocks.write.mock.calls).toEqual([['[cut]\nklmnop'], ['[cut]\nopqrst']]);
+
+    root.unmount();
+  });
+});

--- a/src/components/workspace/terminal-instance.tsx
+++ b/src/components/workspace/terminal-instance.tsx
@@ -31,7 +31,7 @@ export function TerminalInstance({
   const terminalRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
-  const lastOutputLengthRef = useRef(0);
+  const lastOutputRef = useRef('');
   const initialOutputRef = useRef(output);
 
   // Store callbacks in refs to avoid reinitializing terminal when they change
@@ -97,7 +97,7 @@ export function TerminalInstance({
     // Write initial output captured at mount time to avoid re-initializing on every update.
     if (initialOutputRef.current) {
       terminal.write(initialOutputRef.current);
-      lastOutputLengthRef.current = initialOutputRef.current.length;
+      lastOutputRef.current = initialOutputRef.current;
     }
 
     // Handle user input via ref to always use latest callback
@@ -132,24 +132,26 @@ export function TerminalInstance({
       return;
     }
 
-    // Handle output reset (e.g., when switching tabs or clearing)
-    if (output.length < lastOutputLengthRef.current) {
-      terminalRef.current.clear();
-      lastOutputLengthRef.current = 0;
-      // If there's new output after reset, write it
-      if (output.length > 0) {
-        terminalRef.current.write(output);
-        lastOutputLengthRef.current = output.length;
-      }
+    const lastOutput = lastOutputRef.current;
+
+    if (output === lastOutput) {
       return;
     }
 
-    // Handle new output appended
-    if (output.length > lastOutputLengthRef.current) {
-      const newOutput = output.slice(lastOutputLengthRef.current);
+    // Handle new output appended.
+    if (output.startsWith(lastOutput)) {
+      const newOutput = output.slice(lastOutput.length);
       terminalRef.current.write(newOutput);
-      lastOutputLengthRef.current = output.length;
+      lastOutputRef.current = output;
+      return;
     }
+
+    // Handle output reset or rolling-buffer rewrites after truncation.
+    terminalRef.current.clear();
+    if (output.length > 0) {
+      terminalRef.current.write(output);
+    }
+    lastOutputRef.current = output;
   }, [output]);
 
   // Focus terminal when it becomes active (e.g., tab switch)

--- a/src/components/workspace/terminal-panel.test.tsx
+++ b/src/components/workspace/terminal-panel.test.tsx
@@ -4,6 +4,7 @@ import { createElement, createRef } from 'react';
 import { flushSync } from 'react-dom';
 import { createRoot } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TERMINAL_OUTPUT_MAX_CHARS, TERMINAL_TRUNCATION_MARKER } from './rolling-output';
 import { TerminalPanel, type TerminalPanelRef } from './terminal-panel';
 
 const mocks = vi.hoisted(() => ({
@@ -12,9 +13,14 @@ const mocks = vi.hoisted(() => ({
   resize: vi.fn(),
   destroy: vi.fn(),
   setActive: vi.fn(),
+  renderedOutput: '',
   options: null as {
     onCreated?: (terminalId: string, requestId?: string) => void;
+    onOutput?: (terminalId: string, data: string) => void;
     onError?: (message: string, requestId?: string) => void;
+    onTerminalList?: (
+      terminals: Array<{ id: string; createdAt: string; outputBuffer?: string }>
+    ) => void;
   } | null,
 }));
 
@@ -23,7 +29,10 @@ vi.mock('lucide-react', () => ({
 }));
 
 vi.mock('./terminal-instance', () => ({
-  TerminalInstance: () => null,
+  TerminalInstance: ({ output }: { output: string }) => {
+    mocks.renderedOutput = output;
+    return null;
+  },
 }));
 
 vi.mock('./terminal-tab-bar', () => ({
@@ -51,6 +60,7 @@ describe('TerminalPanel', () => {
     mocks.resize.mockReset();
     mocks.destroy.mockReset();
     mocks.setActive.mockReset();
+    mocks.renderedOutput = '';
     mocks.options = null;
   });
 
@@ -116,6 +126,64 @@ describe('TerminalPanel', () => {
     expect(mocks.destroy).not.toHaveBeenCalled();
     expect(mocks.setActive).toHaveBeenCalledTimes(1);
     expect(mocks.setActive).toHaveBeenCalledWith('terminal-a');
+
+    root.unmount();
+  });
+
+  it('bounds live terminal output for associated tabs', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const panelRef = createRef<TerminalPanelRef>();
+
+    flushSync(() => {
+      root.render(createElement(TerminalPanel, { workspaceId: 'workspace-1', ref: panelRef }));
+    });
+
+    flushSync(() => {
+      panelRef.current?.createNewTerminal();
+    });
+
+    const requestId = mocks.create.mock.calls[0]?.[0] as string;
+
+    flushSync(() => {
+      mocks.options?.onCreated?.('terminal-a', requestId);
+      mocks.options?.onOutput?.('terminal-a', 'a'.repeat(TERMINAL_OUTPUT_MAX_CHARS + 100));
+    });
+    await vi.dynamicImportSettled();
+
+    expect(mocks.renderedOutput.length).toBe(TERMINAL_OUTPUT_MAX_CHARS);
+    expect(mocks.renderedOutput.startsWith(TERMINAL_TRUNCATION_MARKER)).toBe(true);
+    expect(mocks.renderedOutput.endsWith('a'.repeat(100))).toBe(true);
+
+    root.unmount();
+  });
+
+  it('bounds pending terminal output before a tab is associated', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const panelRef = createRef<TerminalPanelRef>();
+
+    flushSync(() => {
+      root.render(createElement(TerminalPanel, { workspaceId: 'workspace-1', ref: panelRef }));
+    });
+
+    flushSync(() => {
+      panelRef.current?.createNewTerminal();
+    });
+
+    const requestId = mocks.create.mock.calls[0]?.[0] as string;
+
+    flushSync(() => {
+      mocks.options?.onOutput?.('terminal-a', 'b'.repeat(TERMINAL_OUTPUT_MAX_CHARS + 100));
+      mocks.options?.onCreated?.('terminal-a', requestId);
+    });
+    await vi.dynamicImportSettled();
+
+    expect(mocks.renderedOutput.length).toBe(TERMINAL_OUTPUT_MAX_CHARS);
+    expect(mocks.renderedOutput.startsWith(TERMINAL_TRUNCATION_MARKER)).toBe(true);
+    expect(mocks.renderedOutput.endsWith('b'.repeat(100))).toBe(true);
 
     root.unmount();
   });

--- a/src/components/workspace/terminal-panel.tsx
+++ b/src/components/workspace/terminal-panel.tsx
@@ -2,6 +2,7 @@ import { Terminal } from 'lucide-react';
 import {
   forwardRef,
   lazy,
+  type SetStateAction,
   Suspense,
   useCallback,
   useEffect,
@@ -12,6 +13,12 @@ import {
 } from 'react';
 
 import { cn } from '@/lib/utils';
+import {
+  appendToRollingOutput,
+  TERMINAL_OUTPUT_MAX_CHARS,
+  TERMINAL_TRUNCATION_MARKER,
+  trimRollingOutput,
+} from './rolling-output';
 import { TerminalTabBar } from './terminal-tab-bar';
 import {
   claimPendingTerminalTab,
@@ -36,6 +43,11 @@ interface TerminalTab {
   terminalId: string | null; // Server-assigned terminal ID
   output: string;
 }
+
+const TERMINAL_ROLLING_OUTPUT_OPTIONS = {
+  maxChars: TERMINAL_OUTPUT_MAX_CHARS,
+  truncationMarker: TERMINAL_TRUNCATION_MARKER,
+};
 
 interface TerminalPanelProps {
   workspaceId: string;
@@ -66,6 +78,12 @@ export interface TerminalPanelRef {
 export const TerminalPanel = forwardRef<TerminalPanelRef, TerminalPanelProps>(
   function TerminalPanel({ workspaceId, className, hideHeader = false, onStateChange }, ref) {
     const [tabs, setTabs] = useState<TerminalTab[]>([]);
+    const tabsRef = useRef<TerminalTab[]>([]);
+    const updateTabs = useCallback((action: SetStateAction<TerminalTab[]>) => {
+      const next = typeof action === 'function' ? action(tabsRef.current) : action;
+      tabsRef.current = next;
+      setTabs(next);
+    }, []);
     const [activeTabId, setActiveTabIdState] = useState<string | null>(null);
     const activeTabIdRef = useRef<string | null>(null);
     const setActiveTabId = useCallback((tabId: string | null) => {
@@ -85,86 +103,130 @@ export const TerminalPanel = forwardRef<TerminalPanelRef, TerminalPanelProps>(
     const destroyRef = useRef<(terminalId: string) => void>(() => undefined);
 
     // Handle terminal output - route to correct tab by terminalId
-    const handleOutput = useCallback((terminalId: string, data: string) => {
-      setTabs((prev) => {
-        const tab = prev.find((t) => t.terminalId === terminalId);
-        if (tab) {
-          // Terminal is associated with a tab - append output
-          return prev.map((t) =>
-            t.terminalId === terminalId ? { ...t, output: t.output + data } : t
+    const handleOutput = useCallback(
+      (terminalId: string, data: string) => {
+        const tab = tabsRef.current.find((t) => t.terminalId === terminalId);
+        if (!tab) {
+          // Terminal not yet associated - buffer the output
+          const existingBuffer = outputBufferRef.current.get(terminalId) ?? '';
+          outputBufferRef.current.set(
+            terminalId,
+            appendToRollingOutput(existingBuffer, data, TERMINAL_ROLLING_OUTPUT_OPTIONS)
           );
-        }
-        // Terminal not yet associated - buffer the output
-        const existingBuffer = outputBufferRef.current.get(terminalId) ?? '';
-        outputBufferRef.current.set(terminalId, existingBuffer + data);
-        return prev;
-      });
-    }, []);
-
-    // Handle terminal created - associate server terminalId with its requested tab
-    const handleCreated = useCallback((terminalId: string, requestId?: string) => {
-      const pendingTabId = claimPendingTerminalTab(pendingTabIdsByRequestRef.current, requestId);
-      if (pendingTabId) {
-        // Get any buffered output for this terminal
-        const bufferedOutput = outputBufferRef.current.get(terminalId) ?? '';
-        outputBufferRef.current.delete(terminalId);
-
-        setTabs((prev) =>
-          prev.map((tab) =>
-            tab.id === pendingTabId ? { ...tab, terminalId, output: bufferedOutput } : tab
-          )
-        );
-
-        if (activeTabIdRef.current === pendingTabId) {
-          // Notify backend only when this response belongs to the selected tab.
-          setActiveRef.current(terminalId);
-        }
-      } else {
-        // The pending tab was closed before creation completed; avoid an orphaned PTY.
-        outputBufferRef.current.delete(terminalId);
-        destroyRef.current(terminalId);
-      }
-    }, []);
-
-    // Handle terminal exit
-    const handleExit = useCallback((terminalId: string, exitCode: number) => {
-      setTabs((prev) =>
-        prev.map((tab) =>
-          tab.terminalId === terminalId
-            ? { ...tab, output: `${tab.output}\r\n[Process exited with code ${exitCode}]\r\n` }
-            : tab
-        )
-      );
-    }, []);
-
-    // Handle terminal error
-    const handleError = useCallback((message: string, requestId?: string) => {
-      // Show request-scoped create errors in the tab that initiated them.
-      if (requestId) {
-        const pendingTabId = claimPendingTerminalTab(pendingTabIdsByRequestRef.current, requestId);
-        if (!pendingTabId) {
           return;
         }
 
-        setTabs((prev) =>
+        // Terminal is associated with a tab - append output
+        updateTabs((prev) =>
+          prev.map((t) =>
+            t.terminalId === terminalId
+              ? {
+                  ...t,
+                  output: appendToRollingOutput(t.output, data, TERMINAL_ROLLING_OUTPUT_OPTIONS),
+                }
+              : t
+          )
+        );
+      },
+      [updateTabs]
+    );
+
+    // Handle terminal created - associate server terminalId with its requested tab
+    const handleCreated = useCallback(
+      (terminalId: string, requestId?: string) => {
+        const pendingTabId = claimPendingTerminalTab(pendingTabIdsByRequestRef.current, requestId);
+        if (pendingTabId) {
+          // Get any buffered output for this terminal
+          const bufferedOutput = outputBufferRef.current.get(terminalId) ?? '';
+          outputBufferRef.current.delete(terminalId);
+
+          updateTabs((prev) =>
+            prev.map((tab) =>
+              tab.id === pendingTabId
+                ? {
+                    ...tab,
+                    terminalId,
+                    output: trimRollingOutput(bufferedOutput, TERMINAL_ROLLING_OUTPUT_OPTIONS),
+                  }
+                : tab
+            )
+          );
+
+          if (activeTabIdRef.current === pendingTabId) {
+            // Notify backend only when this response belongs to the selected tab.
+            setActiveRef.current(terminalId);
+          }
+        } else {
+          // The pending tab was closed before creation completed; avoid an orphaned PTY.
+          outputBufferRef.current.delete(terminalId);
+          destroyRef.current(terminalId);
+        }
+      },
+      [updateTabs]
+    );
+
+    // Handle terminal exit
+    const handleExit = useCallback(
+      (terminalId: string, exitCode: number) => {
+        updateTabs((prev) =>
           prev.map((tab) =>
-            tab.id === pendingTabId
-              ? { ...tab, output: `${tab.output}\r\n[Error: ${message}]\r\n` }
+            tab.terminalId === terminalId
+              ? {
+                  ...tab,
+                  output: appendToRollingOutput(
+                    tab.output,
+                    `\r\n[Process exited with code ${exitCode}]\r\n`,
+                    TERMINAL_ROLLING_OUTPUT_OPTIONS
+                  ),
+                }
               : tab
           )
         );
-        return;
-      }
+      },
+      [updateTabs]
+    );
 
-      // Legacy uncorrelated errors cannot be tied to one create request.
-      outputBufferRef.current.clear();
-    }, []);
+    // Handle terminal error
+    const handleError = useCallback(
+      (message: string, requestId?: string) => {
+        // Show request-scoped create errors in the tab that initiated them.
+        if (requestId) {
+          const pendingTabId = claimPendingTerminalTab(
+            pendingTabIdsByRequestRef.current,
+            requestId
+          );
+          if (!pendingTabId) {
+            return;
+          }
+
+          updateTabs((prev) =>
+            prev.map((tab) =>
+              tab.id === pendingTabId
+                ? {
+                    ...tab,
+                    output: appendToRollingOutput(
+                      tab.output,
+                      `\r\n[Error: ${message}]\r\n`,
+                      TERMINAL_ROLLING_OUTPUT_OPTIONS
+                    ),
+                  }
+                : tab
+            )
+          );
+          return;
+        }
+
+        // Legacy uncorrelated errors cannot be tied to one create request.
+        outputBufferRef.current.clear();
+      },
+      [updateTabs]
+    );
 
     // Handle terminal list restoration (after page refresh)
     const handleTerminalList = useCallback(
       (terminals: Array<{ id: string; createdAt: string; outputBuffer?: string }>) => {
         // Only restore if we don't already have tabs (avoid duplicates on reconnect)
-        setTabs((prev) => {
+        updateTabs((prev) => {
           if (prev.length > 0) {
             return prev;
           }
@@ -174,7 +236,7 @@ export const TerminalPanel = forwardRef<TerminalPanelRef, TerminalPanelProps>(
             id: `tab-${terminal.id}`,
             label: `Terminal ${index + 1}`,
             terminalId: terminal.id,
-            output: terminal.outputBuffer ?? '',
+            output: trimRollingOutput(terminal.outputBuffer ?? '', TERMINAL_ROLLING_OUTPUT_OPTIONS),
           }));
 
           // Set the first tab as active
@@ -191,7 +253,7 @@ export const TerminalPanel = forwardRef<TerminalPanelRef, TerminalPanelProps>(
           return restoredTabs;
         });
       },
-      [setActiveTabId]
+      [setActiveTabId, updateTabs]
     );
 
     const { connected, create, sendInput, resize, destroy, setActive } = useTerminalWebSocket({
@@ -213,7 +275,7 @@ export const TerminalPanel = forwardRef<TerminalPanelRef, TerminalPanelProps>(
       const id = `tab-${requestId}`;
 
       pendingTabIdsByRequestRef.current.set(requestId, id);
-      setTabs((prev) => [
+      updateTabs((prev) => [
         ...prev,
         {
           id,
@@ -224,7 +286,7 @@ export const TerminalPanel = forwardRef<TerminalPanelRef, TerminalPanelProps>(
       ]);
       setActiveTabId(id);
       create(requestId);
-    }, [create, setActiveTabId]);
+    }, [create, setActiveTabId, updateTabs]);
 
     // Expose createNewTerminal to parent via ref
     useImperativeHandle(
@@ -238,7 +300,7 @@ export const TerminalPanel = forwardRef<TerminalPanelRef, TerminalPanelProps>(
     // Close terminal tab
     const handleCloseTab = useCallback(
       (id: string) => {
-        setTabs((prev) => {
+        updateTabs((prev) => {
           // Find the tab to get its terminalId before removing it
           const tab = prev.find((t) => t.id === id);
           removePendingTerminalTab(pendingTabIdsByRequestRef.current, id);
@@ -274,7 +336,7 @@ export const TerminalPanel = forwardRef<TerminalPanelRef, TerminalPanelProps>(
           return filtered;
         });
       },
-      [activeTabId, destroy, setActive, setActiveTabId]
+      [activeTabId, destroy, setActive, setActiveTabId, updateTabs]
     );
 
     // Handle terminal input - send to the active tab's terminal

--- a/src/components/workspace/use-dev-logs.ts
+++ b/src/components/workspace/use-dev-logs.ts
@@ -2,6 +2,11 @@ import { useCallback, useRef, useState } from 'react';
 import { z } from 'zod';
 import { useWebSocketTransport } from '@/hooks/use-websocket-transport';
 import { buildWebSocketUrl } from '@/lib/websocket-config';
+import {
+  appendToRollingOutput,
+  WORKSPACE_LOG_OUTPUT_MAX_CHARS,
+  WORKSPACE_LOG_TRUNCATION_MARKER,
+} from './rolling-output';
 
 const DevLogsMessageSchema = z.object({
   type: z.literal('output'),
@@ -9,6 +14,11 @@ const DevLogsMessageSchema = z.object({
 });
 
 type DevLogsMessage = z.infer<typeof DevLogsMessageSchema>;
+
+const LOG_ROLLING_OUTPUT_OPTIONS = {
+  maxChars: WORKSPACE_LOG_OUTPUT_MAX_CHARS,
+  truncationMarker: WORKSPACE_LOG_TRUNCATION_MARKER,
+};
 
 // =============================================================================
 // Types
@@ -57,7 +67,9 @@ export function useDevLogs(workspaceId: string): UseDevLogsResult {
       const message: DevLogsMessage = parsed.data;
 
       if (message.type === 'output' && message.data) {
-        setOutput((prev) => prev + message.data);
+        setOutput((prev) =>
+          appendToRollingOutput(prev, message.data ?? '', LOG_ROLLING_OUTPUT_OPTIONS)
+        );
         // Scroll to bottom after a short delay to allow render
         setTimeout(scrollToBottom, 10);
       }
@@ -67,12 +79,20 @@ export function useDevLogs(workspaceId: string): UseDevLogsResult {
 
   const handleConnected = useCallback(() => {
     setHasDisconnected(false);
-    setOutput((prev) => (prev ? `${prev}Reconnected!\n\n` : 'Connected!\n\n'));
+    setOutput((prev) =>
+      appendToRollingOutput(
+        prev,
+        prev ? 'Reconnected!\n\n' : 'Connected!\n\n',
+        LOG_ROLLING_OUTPUT_OPTIONS
+      )
+    );
   }, []);
 
   const handleDisconnected = useCallback(() => {
     setHasDisconnected(true);
-    setOutput((prev) => `${prev}Disconnected. Reconnecting...\n`);
+    setOutput((prev) =>
+      appendToRollingOutput(prev, 'Disconnected. Reconnecting...\n', LOG_ROLLING_OUTPUT_OPTIONS)
+    );
   }, []);
 
   const { connected } = useWebSocketTransport({

--- a/src/components/workspace/use-post-run-logs.ts
+++ b/src/components/workspace/use-post-run-logs.ts
@@ -2,6 +2,11 @@ import { useCallback, useRef, useState } from 'react';
 import { z } from 'zod';
 import { useWebSocketTransport } from '@/hooks/use-websocket-transport';
 import { buildWebSocketUrl } from '@/lib/websocket-config';
+import {
+  appendToRollingOutput,
+  WORKSPACE_LOG_OUTPUT_MAX_CHARS,
+  WORKSPACE_LOG_TRUNCATION_MARKER,
+} from './rolling-output';
 
 const PostRunLogsMessageSchema = z.object({
   type: z.literal('output'),
@@ -9,6 +14,11 @@ const PostRunLogsMessageSchema = z.object({
 });
 
 type PostRunLogsMessage = z.infer<typeof PostRunLogsMessageSchema>;
+
+const LOG_ROLLING_OUTPUT_OPTIONS = {
+  maxChars: WORKSPACE_LOG_OUTPUT_MAX_CHARS,
+  truncationMarker: WORKSPACE_LOG_TRUNCATION_MARKER,
+};
 
 // =============================================================================
 // Types
@@ -52,7 +62,9 @@ export function usePostRunLogs(workspaceId: string): UsePostRunLogsResult {
       const message: PostRunLogsMessage = parsed.data;
 
       if (message.type === 'output' && message.data) {
-        setOutput((prev) => prev + message.data);
+        setOutput((prev) =>
+          appendToRollingOutput(prev, message.data ?? '', LOG_ROLLING_OUTPUT_OPTIONS)
+        );
         setTimeout(scrollToBottom, 10);
       }
     },
@@ -61,12 +73,20 @@ export function usePostRunLogs(workspaceId: string): UsePostRunLogsResult {
 
   const handleConnected = useCallback(() => {
     setHasDisconnected(false);
-    setOutput((prev) => (prev ? `${prev}Reconnected!\n\n` : 'Connected!\n\n'));
+    setOutput((prev) =>
+      appendToRollingOutput(
+        prev,
+        prev ? 'Reconnected!\n\n' : 'Connected!\n\n',
+        LOG_ROLLING_OUTPUT_OPTIONS
+      )
+    );
   }, []);
 
   const handleDisconnected = useCallback(() => {
     setHasDisconnected(true);
-    setOutput((prev) => `${prev}Disconnected. Reconnecting...\n`);
+    setOutput((prev) =>
+      appendToRollingOutput(prev, 'Disconnected. Reconnecting...\n', LOG_ROLLING_OUTPUT_OPTIONS)
+    );
   }, []);
 
   const { connected } = useWebSocketTransport({


### PR DESCRIPTION
## Summary
- Adds bounded client-side rolling buffers for workspace dev logs, post-run logs, and terminal output.
- Preserves the newest output and shows a truncation marker when older content is dropped.
- Covers live terminal output and pre-association pending output with regression tests.

## Changes
- **Workspace logs**: Apply a shared rolling buffer to dev/post-run output plus connection status messages.
- **Terminal panel**: Bound associated tab output, pending terminal buffers, restored buffers, and exit/error messages.
- **Tests**: Add rolling buffer unit tests and terminal panel tests for live and pending high-volume output.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Manual testing: Verified with focused Vitest coverage for oversized terminal output and the full requested verification sequence.

Closes #1735

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only memory/UI behavior with focused tests; no auth, persistence, or API contract changes.
> 
> **Overview**
> Adds a shared **rolling output** helper that caps in-memory strings, keeps the newest tail, and prepends a single truncation marker when older content is dropped.
> 
> **Workspace dev and post-run logs** now append through that helper (including connect/disconnect status lines) at **512 KiB**. **Terminal panel** applies a **128 KiB** cap to live tab output, pre-association pending buffers, restored server buffers, and exit/error lines. Tab updates use a ref-backed `updateTabs` so WebSocket handlers see current tabs when routing output.
> 
> **`TerminalInstance`** no longer infers updates from string length alone: it writes only new suffixes when `output` extends the previous value, and **clear + full rewrite** when truncation changes the buffer without a simple append (so xterm stays in sync). New unit and component tests cover the rolling logic and high-volume terminal paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3d70da684ee3f97e19208c1d5a39412cd6c022d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

