### PR TITLE
Fix #1743: Prevent orphaned recycle sessions

### DIFF
--- a/src/backend/orchestration/domain-bridges.orchestrator.test.ts
+++ b/src/backend/orchestration/domain-bridges.orchestrator.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AutoIterationSessionBridge } from '@/backend/services/auto-iteration';
 
 // --- Module mocks (inline vi.fn() - no top-level variable references) ---
 
@@ -125,6 +126,18 @@ import { initializeWorkspaceWorktree } from './workspace-init.orchestrator';
 // Helper to extract bridge argument from a mocked configure call.
 function getBridge<T>(mockFn: (arg: T) => void): T {
   return vi.mocked(mockFn).mock.calls[0]![0];
+}
+
+type ConfigureDomainBridgeServices = NonNullable<Parameters<typeof configureDomainBridges>[0]>;
+type AutoIterationServiceBridge = NonNullable<
+  ConfigureDomainBridgeServices['autoIterationService']
+>;
+
+function createAutoIterationServiceMock(): AutoIterationServiceBridge {
+  return {
+    configure: vi.fn(),
+    onSessionDeath: vi.fn(),
+  } as unknown as AutoIterationServiceBridge;
 }
 
 describe('configureDomainBridges', () => {
@@ -464,6 +477,79 @@ describe('configureDomainBridges', () => {
       });
       expect(sessionService.isSessionRunning).toHaveBeenCalledWith('session-1');
       expect(sessionDomainService.getQueueLength).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('auto-iteration session bridge', () => {
+    it('cleans up a recycled session when handoff send fails', async () => {
+      const autoIterationServiceMock = createAutoIterationServiceMock();
+      const sendError = new Error('prompt failed');
+      vi.mocked(workspaceAccessor.findRawById)
+        .mockResolvedValueOnce({
+          autoIterationSessionId: 'old-session',
+        } as Awaited<ReturnType<typeof workspaceAccessor.findRawById>>)
+        .mockResolvedValueOnce({
+          autoIterationSessionId: 'new-session',
+        } as Awaited<ReturnType<typeof workspaceAccessor.findRawById>>);
+      vi.mocked(sessionDataService.createAgentSession).mockResolvedValue({
+        id: 'new-session',
+      } as Awaited<ReturnType<typeof sessionDataService.createAgentSession>>);
+      vi.mocked(sessionService.sendAcpMessage).mockRejectedValue(sendError);
+
+      configureDomainBridges({ autoIterationService: autoIterationServiceMock });
+      const sessionBridge = vi.mocked(autoIterationServiceMock.configure).mock
+        .calls[0]![0] as AutoIterationSessionBridge;
+
+      await expect(sessionBridge.recycleSession('ws-1', 'handoff prompt')).rejects.toThrow(
+        sendError
+      );
+
+      expect(sessionService.stopSession).toHaveBeenCalledWith('old-session');
+      expect(sessionService.startSession).toHaveBeenCalledWith('new-session', {
+        startupModePreset: 'non_interactive',
+      });
+      expect(workspaceAccessor.update).toHaveBeenNthCalledWith(1, 'ws-1', {
+        autoIterationSessionId: 'new-session',
+      });
+      expect(sessionService.sendAcpMessage).toHaveBeenCalledWith('new-session', [
+        { type: 'text', text: 'handoff prompt' },
+      ]);
+      expect(sessionService.stopSession).toHaveBeenCalledWith('new-session');
+      expect(workspaceAccessor.update).toHaveBeenNthCalledWith(2, 'ws-1', {
+        autoIterationSessionId: null,
+      });
+      expect(vi.mocked(workspaceAccessor.update).mock.invocationCallOrder[0]).toBeLessThan(
+        vi.mocked(sessionService.sendAcpMessage).mock.invocationCallOrder[0]!
+      );
+    });
+
+    it('does not clear a newer auto-iteration session after recycle cleanup', async () => {
+      const autoIterationServiceMock = createAutoIterationServiceMock();
+      vi.mocked(workspaceAccessor.findRawById)
+        .mockResolvedValueOnce({
+          autoIterationSessionId: 'old-session',
+        } as Awaited<ReturnType<typeof workspaceAccessor.findRawById>>)
+        .mockResolvedValueOnce({
+          autoIterationSessionId: 'newer-session',
+        } as Awaited<ReturnType<typeof workspaceAccessor.findRawById>>);
+      vi.mocked(sessionDataService.createAgentSession).mockResolvedValue({
+        id: 'new-session',
+      } as Awaited<ReturnType<typeof sessionDataService.createAgentSession>>);
+      vi.mocked(sessionService.sendAcpMessage).mockRejectedValue(new Error('prompt failed'));
+
+      configureDomainBridges({ autoIterationService: autoIterationServiceMock });
+      const sessionBridge = vi.mocked(autoIterationServiceMock.configure).mock
+        .calls[0]![0] as AutoIterationSessionBridge;
+
+      await expect(sessionBridge.recycleSession('ws-1', 'handoff prompt')).rejects.toThrow(
+        'prompt failed'
+      );
+
+      expect(sessionService.stopSession).toHaveBeenCalledWith('new-session');
+      expect(workspaceAccessor.update).toHaveBeenCalledTimes(1);
+      expect(workspaceAccessor.update).toHaveBeenCalledWith('ws-1', {
+        autoIterationSessionId: 'new-session',
+      });
     });
   });
 

--- a/src/backend/orchestration/domain-bridges.orchestrator.ts
+++ b/src/backend/orchestration/domain-bridges.orchestrator.ts
@@ -54,6 +54,9 @@ import { initializeWorkspaceWorktree } from './workspace-init.orchestrator';
 
 const logger = createLogger('domain-bridges');
 
+type SessionService = typeof sessionService;
+type WorkspaceAccessor = typeof workspaceAccessor;
+
 type BridgeServices = {
   autoIterationService: typeof autoIterationService;
   chatEventForwarderService: typeof chatEventForwarderService;
@@ -101,6 +104,56 @@ const defaultServices: BridgeServices = {
   workspaceSnapshotStore,
   workspaceStateMachine,
 };
+
+async function stopSessionBestEffort(
+  sessionService: SessionService,
+  sessionId: string
+): Promise<void> {
+  try {
+    await sessionService.stopSession(sessionId);
+  } catch {
+    // Best-effort cleanup
+  }
+}
+
+async function stopPreviousAutoIterationSession(
+  sessionService: SessionService,
+  sessionId: string
+): Promise<void> {
+  try {
+    await sessionService.stopSession(sessionId);
+  } catch (error) {
+    if (!(error instanceof Error && /already stopped|not found/i.test(error.message))) {
+      throw error;
+    }
+    // Session may already be stopped
+  }
+}
+
+async function clearAutoIterationSessionIfMatching(
+  workspaceAccessor: WorkspaceAccessor,
+  workspaceId: string,
+  sessionId: string
+): Promise<void> {
+  try {
+    const latestWorkspace = await workspaceAccessor.findRawById(workspaceId);
+    if (latestWorkspace?.autoIterationSessionId === sessionId) {
+      await workspaceAccessor.update(workspaceId, { autoIterationSessionId: null });
+    }
+  } catch {
+    // Preserve the original handoff or persistence error
+  }
+}
+
+async function cleanupRecycledAutoIterationSession(
+  sessionService: SessionService,
+  workspaceAccessor: WorkspaceAccessor,
+  workspaceId: string,
+  sessionId: string
+): Promise<void> {
+  await stopSessionBestEffort(sessionService, sessionId);
+  await clearAutoIterationSessionIfMatching(workspaceAccessor, workspaceId, sessionId);
+}
 
 export function configureDomainBridges(services: Partial<BridgeServices> = {}): void {
   const resolved = { ...defaultServices, ...services };
@@ -344,14 +397,7 @@ export function configureDomainBridges(services: Partial<BridgeServices> = {}): 
     async recycleSession(workspaceId, handoffPrompt) {
       const ws = await workspaceAccessor.findRawById(workspaceId);
       if (ws?.autoIterationSessionId) {
-        try {
-          await sessionService.stopSession(ws.autoIterationSessionId);
-        } catch (error) {
-          if (!(error instanceof Error && /already stopped|not found/i.test(error.message))) {
-            throw error;
-          }
-          // Session may already be stopped
-        }
+        await stopPreviousAutoIterationSession(sessionService, ws.autoIterationSessionId);
       }
       const newSession = await sessionDataService.createAgentSession({
         workspaceId,
@@ -361,14 +407,21 @@ export function configureDomainBridges(services: Partial<BridgeServices> = {}): 
       try {
         await sessionService.startSession(newSession.id, { startupModePreset: 'non_interactive' });
       } catch (err) {
-        try {
-          await sessionService.stopSession(newSession.id);
-        } catch {
-          // Best-effort cleanup
-        }
+        await stopSessionBestEffort(sessionService, newSession.id);
         throw err;
       }
-      await sessionService.sendAcpMessage(newSession.id, [{ type: 'text', text: handoffPrompt }]);
+      try {
+        await workspaceAccessor.update(workspaceId, { autoIterationSessionId: newSession.id });
+        await sessionService.sendAcpMessage(newSession.id, [{ type: 'text', text: handoffPrompt }]);
+      } catch (err) {
+        await cleanupRecycledAutoIterationSession(
+          sessionService,
+          workspaceAccessor,
+          workspaceId,
+          newSession.id
+        );
+        throw err;
+      }
       return newSession.id;
     },
   };


### PR DESCRIPTION
## Summary
- Persists the replacement auto-iteration session as soon as recycle startup succeeds.
- Stops and clears the replacement session if handoff delivery fails, preventing orphaned auto-iteration sessions.
- Adds regression coverage for failed handoff cleanup and newer-session preservation.

## Changes
- **Auto-iteration orchestration**: Update `recycleSession` to record the new `autoIterationSessionId` before sending the handoff prompt, and clean up the replacement session on persistence or handoff failure.
- **Tests**: Cover `sendAcpMessage` failure after replacement startup, including a guard that does not clear a newer workspace session pointer.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; backend lifecycle regression covered by unit tests.

Closes #1743

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workspace/session lifecycle ordering for auto-iteration recycle; mistakes could clear the wrong session pointer or leave sessions running, though behavior is guarded and regression-tested.
> 
> **Overview**
> Fixes **auto-iteration session recycle** so a failed handoff does not leave a running session or a stale workspace pointer (#1743).
> 
> `recycleSession` now **writes `autoIterationSessionId` before** sending the handoff prompt. If startup, persistence, or `sendAcpMessage` fails, it **stops the replacement session** and **clears the workspace pointer only when it still matches** that session (so a concurrent newer session is not wiped). Session stop/cleanup logic is factored into small helpers (`stopSessionBestEffort`, `clearAutoIterationSessionIfMatching`, etc.).
> 
> **Tests** cover handoff failure cleanup (including persist-before-send ordering) and the case where cleanup must not null out a newer `autoIterationSessionId`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6f2398e606c47e9faa6f4f85eb2e98ea7d6a8c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

