### PR TITLE
Fix #1734: Bound file autocomplete search

### DIFF
--- a/src/backend/lib/file-helpers.test.ts
+++ b/src/backend/lib/file-helpers.test.ts
@@ -1,19 +1,21 @@
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getLanguageFromPath } from '@/lib/language-detection';
-import { isBinaryContent, isPathSafe, pathExists } from './file-helpers';
+import { isBinaryContent, isPathSafe, pathExists, searchFilesRecursive } from './file-helpers';
 
 // Mock fs/promises
 vi.mock('node:fs/promises', () => ({
   lstat: vi.fn(),
+  readdir: vi.fn(),
   readlink: vi.fn(),
   realpath: vi.fn(),
   stat: vi.fn(),
 }));
 
-import { lstat, readlink, realpath, stat } from 'node:fs/promises';
+import { lstat, readdir, readlink, realpath, stat } from 'node:fs/promises';
 
 const mockedLstat = vi.mocked(lstat);
+const mockedReaddir = vi.mocked(readdir);
 const mockedReadlink = vi.mocked(readlink);
 const mockedRealpath = vi.mocked(realpath);
 const mockedStat = vi.mocked(stat);
@@ -21,6 +23,10 @@ const createErrno = (code: string): NodeJS.ErrnoException => {
   const error = new Error(code) as NodeJS.ErrnoException;
   error.code = code;
   return error;
+};
+type TestDirent = {
+  name: string;
+  isDirectory: () => boolean;
 };
 
 describe('file-helpers', () => {
@@ -289,6 +295,103 @@ describe('file-helpers', () => {
         const result = await isPathSafe(symlinkWorktree, 'src/index.ts');
         expect(result).toBe(true);
       });
+    });
+  });
+
+  describe('searchFilesRecursive', () => {
+    const createDirent = (name: string, type: 'file' | 'directory'): TestDirent => ({
+      name,
+      isDirectory: () => type === 'directory',
+    });
+
+    const mockDirectoryTree = (entries: Map<string, TestDirent[]>) => {
+      mockedReaddir.mockImplementation(((targetPath: unknown) => {
+        const dirents = entries.get(String(targetPath));
+        if (dirents) {
+          return Promise.resolve(dirents);
+        }
+        return Promise.reject(createErrno('ENOENT'));
+      }) as never);
+    };
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('returns a bounded deterministic list while ignoring hidden and generated paths', async () => {
+      mockDirectoryTree(
+        new Map([
+          [
+            '/repo',
+            [
+              createDirent('src', 'directory'),
+              createDirent('node_modules', 'directory'),
+              createDirent('.env', 'file'),
+              createDirent('README.md', 'file'),
+            ],
+          ],
+          ['/repo/src', [createDirent('index.ts', 'file')]],
+          ['/repo/node_modules', [createDirent('ignored.js', 'file')]],
+        ])
+      );
+
+      await expect(searchFilesRecursive('/repo', { limit: 10 })).resolves.toEqual([
+        'README.md',
+        path.join('src', 'index.ts'),
+      ]);
+      expect(mockedReaddir).not.toHaveBeenCalledWith('/repo/node_modules', expect.anything());
+    });
+
+    it('filters case-insensitively and sorts bounded candidates by relevance', async () => {
+      mockDirectoryTree(
+        new Map([
+          ['/repo', [createDirent('src', 'directory'), createDirent('docs', 'directory')]],
+          [
+            '/repo/src',
+            [
+              createDirent('my-button.ts', 'file'),
+              createDirent('Button.tsx', 'file'),
+              createDirent('button', 'file'),
+            ],
+          ],
+          ['/repo/docs', [createDirent('notes.md', 'file')]],
+        ])
+      );
+
+      await expect(searchFilesRecursive('/repo', { query: 'BUTTON', limit: 10 })).resolves.toEqual([
+        path.join('src', 'button'),
+        path.join('src', 'Button.tsx'),
+        path.join('src', 'my-button.ts'),
+      ]);
+    });
+
+    it('stops walking once enough matches are found', async () => {
+      mockDirectoryTree(
+        new Map([
+          ['/repo', [createDirent('a', 'directory'), createDirent('z', 'directory')]],
+          ['/repo/a', [createDirent('target.ts', 'file')]],
+          ['/repo/z', [createDirent('target-later.ts', 'file')]],
+        ])
+      );
+
+      await expect(searchFilesRecursive('/repo', { query: 'target', limit: 1 })).resolves.toEqual([
+        path.join('a', 'target.ts'),
+      ]);
+      expect(mockedReaddir).toHaveBeenCalledTimes(2);
+      expect(mockedReaddir).not.toHaveBeenCalledWith('/repo/z', expect.anything());
+    });
+
+    it('respects the max depth bound', async () => {
+      mockDirectoryTree(
+        new Map([
+          ['/repo', [createDirent('level1', 'directory')]],
+          ['/repo/level1', [createDirent('level2', 'directory')]],
+          ['/repo/level1/level2', [createDirent('deep.ts', 'file')]],
+        ])
+      );
+
+      await expect(searchFilesRecursive('/repo', { limit: 10, maxDepth: 2 })).resolves.toEqual([]);
+      expect(mockedReaddir).not.toHaveBeenCalledWith('/repo/level1/level2', expect.anything());
     });
   });
 

--- a/src/backend/lib/file-helpers.ts
+++ b/src/backend/lib/file-helpers.ts
@@ -31,6 +31,21 @@ const isErrnoCode = (error: unknown, code: string): boolean =>
 const isWithinPath = (targetPath: string, rootPath: string): boolean =>
   targetPath === rootPath || targetPath.startsWith(rootPath + path.sep);
 
+const DEFAULT_FILE_IGNORE_PATTERNS = [
+  '.git',
+  'node_modules',
+  '.next',
+  'dist',
+  'build',
+  '.turbo',
+  'coverage',
+  '.vscode',
+  '.idea',
+];
+
+const shouldIgnoreFileSearchEntry = (name: string, ignorePatterns: string[]): boolean =>
+  ignorePatterns.includes(name) || name.startsWith('.');
+
 const resolveSymlinkTargetPath = async (candidatePath: string): Promise<string | null> => {
   let candidateStats: Awaited<ReturnType<typeof lstat>>;
 
@@ -136,27 +151,11 @@ export async function listFilesRecursive(
   const fullPath = path.join(rootPath, currentPath);
   const files: string[] = [];
 
-  const ignorePatterns = [
-    '.git',
-    'node_modules',
-    '.next',
-    'dist',
-    'build',
-    '.turbo',
-    'coverage',
-    '.vscode',
-    '.idea',
-  ];
-
   try {
     const dirents = await readdir(fullPath, { withFileTypes: true });
 
     for (const dirent of dirents) {
-      if (ignorePatterns.includes(dirent.name)) {
-        continue;
-      }
-
-      if (dirent.name.startsWith('.')) {
+      if (shouldIgnoreFileSearchEntry(dirent.name, DEFAULT_FILE_IGNORE_PATTERNS)) {
         continue;
       }
 
@@ -179,6 +178,113 @@ export async function listFilesRecursive(
   }
 
   return files;
+}
+
+export interface SearchFilesRecursiveOptions {
+  query?: string;
+  limit?: number;
+  maxDepth?: number;
+  ignorePatterns?: string[];
+}
+
+interface PendingSearchDirectory {
+  relativePath: string;
+  depth: number;
+}
+
+interface FileSearchTraversalState {
+  directories: PendingSearchDirectory[];
+  files: string[];
+  ignorePatterns: string[];
+  limit: number;
+  queryLower: string | undefined;
+}
+
+const readSortedSearchDirents = async (directoryPath: string) => {
+  try {
+    const dirents = await readdir(directoryPath, { withFileTypes: true });
+    return dirents.sort((a, b) => a.name.localeCompare(b.name));
+  } catch (_error) {
+    return [];
+  }
+};
+
+const sortFileSearchResults = (files: string[], queryLower?: string): string[] =>
+  files.sort((a, b) => compareFilesByRelevance(a, b, queryLower));
+
+const matchesFileSearchQuery = (filePath: string, queryLower?: string): boolean =>
+  !queryLower || filePath.toLowerCase().includes(queryLower);
+
+type SearchDirent = Awaited<ReturnType<typeof readSortedSearchDirents>>[number];
+
+const collectFileSearchEntry = (
+  state: FileSearchTraversalState,
+  dirent: SearchDirent,
+  relativePath: string,
+  depth: number
+): boolean => {
+  if (shouldIgnoreFileSearchEntry(dirent.name, state.ignorePatterns)) {
+    return false;
+  }
+
+  const filePath = relativePath ? path.join(relativePath, dirent.name) : dirent.name;
+
+  if (dirent.isDirectory()) {
+    state.directories.push({ relativePath: filePath, depth: depth + 1 });
+    return false;
+  }
+
+  if (!matchesFileSearchQuery(filePath, state.queryLower)) {
+    return false;
+  }
+
+  state.files.push(filePath);
+  return state.files.length >= state.limit;
+};
+
+/**
+ * Recursively searches files with a bounded result set for autocomplete.
+ * Traversal is breadth-first and deterministic so shallow paths are considered
+ * before deep paths, then the bounded candidates are relevance-sorted.
+ */
+export async function searchFilesRecursive(
+  rootPath: string,
+  {
+    query,
+    limit = 50,
+    maxDepth = 10,
+    ignorePatterns = DEFAULT_FILE_IGNORE_PATTERNS,
+  }: SearchFilesRecursiveOptions = {}
+): Promise<string[]> {
+  if (limit <= 0) {
+    return [];
+  }
+
+  const queryLower = query?.toLowerCase();
+  const state: FileSearchTraversalState = {
+    directories: [{ relativePath: '', depth: 0 }],
+    files: [],
+    ignorePatterns,
+    limit,
+    queryLower,
+  };
+
+  for (const { relativePath, depth } of state.directories) {
+    if (depth >= maxDepth) {
+      continue;
+    }
+
+    const fullPath = path.join(rootPath, relativePath);
+    const dirents = await readSortedSearchDirents(fullPath);
+
+    for (const dirent of dirents) {
+      if (collectFileSearchEntry(state, dirent, relativePath, depth)) {
+        return sortFileSearchResults(state.files, queryLower);
+      }
+    }
+  }
+
+  return sortFileSearchResults(state.files, queryLower);
 }
 
 /**

--- a/src/backend/trpc/project.router.test.ts
+++ b/src/backend/trpc/project.router.test.ts
@@ -18,8 +18,7 @@ const mockProjectManagementService = vi.hoisted(() => ({
 const mockGitCommandC = vi.hoisted(() => vi.fn());
 const mockEncrypt = vi.hoisted(() => vi.fn((value: string) => `enc:${value}`));
 const mockReadConfig = vi.hoisted(() => vi.fn());
-const mockListFilesRecursive = vi.hoisted(() => vi.fn());
-const mockCompareFilesByRelevance = vi.hoisted(() => vi.fn());
+const mockSearchFilesRecursive = vi.hoisted(() => vi.fn());
 const mockParseGithubUrl = vi.hoisted(() => vi.fn());
 const mockCheckGithubAuth = vi.hoisted(() => vi.fn());
 const mockGetClonePath = vi.hoisted(() => vi.fn());
@@ -47,8 +46,7 @@ vi.mock('@/backend/services/factory-config.service', () => ({
 }));
 
 vi.mock('@/backend/lib/file-helpers', () => ({
-  listFilesRecursive: (...args: unknown[]) => mockListFilesRecursive(...args),
-  compareFilesByRelevance: (...args: unknown[]) => mockCompareFilesByRelevance(...args),
+  searchFilesRecursive: (...args: unknown[]) => mockSearchFilesRecursive(...args),
 }));
 
 vi.mock('@/backend/services/git-clone.service', () => ({
@@ -93,7 +91,6 @@ describe('projectRouter', () => {
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'project-router-test-'));
     vi.clearAllMocks();
-    mockCompareFilesByRelevance.mockImplementation((a: string, b: string) => a.localeCompare(b));
     mockParseGithubUrl.mockReturnValue({
       owner: 'purplefish-ai',
       repo: 'factory-factory',
@@ -209,22 +206,13 @@ describe('projectRouter', () => {
     );
   });
 
-  it('filters/sorts file listings and validates project exists', async () => {
+  it('delegates file autocomplete to bounded search and validates project exists', async () => {
     const caller = createCaller();
     mockProjectManagementService.findById.mockResolvedValueOnce({
       id: 'p1',
       repoPath: '/repo/path',
     });
-    mockListFilesRecursive.mockResolvedValueOnce([
-      'src/zeta.ts',
-      'README.md',
-      'src/alpha.ts',
-      'docs/notes.md',
-    ]);
-    mockCompareFilesByRelevance.mockImplementation((a: string, b: string, query?: string) => {
-      expect(query).toBe('src');
-      return a.localeCompare(b);
-    });
+    mockSearchFilesRecursive.mockResolvedValueOnce(['src/alpha.ts', 'src/zeta.ts']);
 
     await expect(
       caller.listAllFiles({
@@ -234,6 +222,11 @@ describe('projectRouter', () => {
       })
     ).resolves.toEqual({
       files: ['src/alpha.ts', 'src/zeta.ts'],
+    });
+
+    expect(mockSearchFilesRecursive).toHaveBeenCalledWith('/repo/path', {
+      query: 'SRC',
+      limit: 2,
     });
 
     mockProjectManagementService.findById.mockResolvedValueOnce(null);

--- a/src/backend/trpc/project.trpc.ts
+++ b/src/backend/trpc/project.trpc.ts
@@ -3,7 +3,7 @@ import { writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { basename, isAbsolute, join, relative } from 'node:path';
 import { z } from 'zod';
-import { compareFilesByRelevance, listFilesRecursive } from '@/backend/lib/file-helpers';
+import { searchFilesRecursive } from '@/backend/lib/file-helpers';
 import { gitCommandC } from '@/backend/lib/shell';
 import { cryptoService } from '@/backend/services/crypto.service';
 import { FactoryConfigService } from '@/backend/services/factory-config.service';
@@ -242,16 +242,10 @@ export const projectRouter = router({
         throw new Error(`Project not found: ${input.projectId}`);
       }
 
-      let files = await listFilesRecursive(project.repoPath);
-
-      if (input.query) {
-        const queryLower = input.query.toLowerCase();
-        files = files.filter((file) => file.toLowerCase().includes(queryLower));
-      }
-
-      const queryLower = input.query?.toLowerCase();
-      files.sort((a, b) => compareFilesByRelevance(a, b, queryLower));
-      files = files.slice(0, input.limit);
+      const files = await searchFilesRecursive(project.repoPath, {
+        query: input.query,
+        limit: input.limit,
+      });
 
       return { files };
     }),

--- a/src/backend/trpc/workspace/files.trpc.ts
+++ b/src/backend/trpc/workspace/files.trpc.ts
@@ -3,12 +3,11 @@ import path from 'node:path';
 import { z } from 'zod';
 import { toError } from '@/backend/lib/error-utils';
 import {
-  compareFilesByRelevance,
   type FileEntry,
   isBinaryContent,
   isPathSafe,
-  listFilesRecursive,
   MAX_FILE_SIZE,
+  searchFilesRecursive,
 } from '@/backend/lib/file-helpers';
 import { type Context, publicProcedure, router } from '@/backend/trpc/trpc';
 import { getLanguageFromPath } from '@/lib/language-detection';
@@ -63,21 +62,10 @@ export const workspaceFilesRouter = router({
       const { worktreePath } = result;
 
       try {
-        // Get all files recursively
-        let files = await listFilesRecursive(worktreePath);
-
-        // Filter by query if provided (case-insensitive)
-        if (input.query) {
-          const queryLower = input.query.toLowerCase();
-          files = files.filter((file) => file.toLowerCase().includes(queryLower));
-        }
-
-        // Sort by relevance (prefer shorter paths, exact matches first)
-        const queryLower = input.query?.toLowerCase();
-        files.sort((a, b) => compareFilesByRelevance(a, b, queryLower));
-
-        // Limit results
-        files = files.slice(0, input.limit);
+        const files = await searchFilesRecursive(worktreePath, {
+          query: input.query,
+          limit: input.limit,
+        });
 
         logger.info('listAllFiles returning files', {
           workspaceId: input.workspaceId,


### PR DESCRIPTION
## Summary
- Adds a bounded recursive file search helper for autocomplete.
- Uses bounded search from project and workspace file autocomplete endpoints.
- Covers filtering, relevance ordering, ignore rules, depth bounds, and early traversal stop behavior.

## Changes
- **Backend file helpers**: Added `searchFilesRecursive` with deterministic breadth-first traversal, query filtering, relevance sorting on bounded candidates, ignore handling, and early return once the requested limit is reached.
- **Project autocomplete**: Replaced collect-all/filter/sort/slice logic with bounded search using the caller-provided query and limit.
- **Workspace autocomplete**: Reused the same bounded search path to avoid the same full-repo scan pattern.
- **Tests**: Updated router delegation coverage and added helper tests for bounded traversal and edge cases.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not run; backend autocomplete behavior is covered by focused helper/router tests.

Closes #1734

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Autocomplete-only performance refactor with no auth or persistence changes; behavior is covered by new helper and router tests.
> 
> **Overview**
> Replaces **full-repo scan → filter → sort → slice** on project and workspace `listAllFiles` with a single **`searchFilesRecursive`** call that respects query and limit up front.
> 
> The new helper does **breadth-first, deterministic** traversal (sorted directory entries), skips shared ignore rules (e.g. `node_modules`, dotfiles), applies **case-insensitive** path matching, **stops early** once enough hits are collected, and sorts the bounded set with existing **`compareFilesByRelevance`**. **`listFilesRecursive`** still exists but now shares **`shouldIgnoreFileSearchEntry`** / default ignore lists.
> 
> Tests cover helper behavior (ignores, relevance, early stop, max depth) and router delegation to bounded search.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26fe0a7cf00b3400e3d83cba1913a13a59ea7f18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

