### PR TITLE
Fix #1746: Refresh review badge from snapshots

### DIFF
--- a/src/backend/routers/websocket/snapshots.handler.test.ts
+++ b/src/backend/routers/websocket/snapshots.handler.test.ts
@@ -39,7 +39,7 @@ const {
 } = vi.hoisted(() => ({
   storeListeners: new Map<string, (event: unknown) => unknown>(),
   mockGetByProjectId: vi.fn(() => []),
-  mockGetCachedReviewCount: vi.fn(() => 5),
+  mockGetCachedReviewCount: vi.fn<() => number | undefined>(() => 5),
   mockRefreshReviewCountIfStale: vi.fn(),
   mockSendBadRequest: vi.fn(),
 }));
@@ -214,6 +214,41 @@ describe('createSnapshotsUpgradeHandler', () => {
     expect(mockRefreshReviewCountIfStale).toHaveBeenCalled();
   });
 
+  it('omits review count from full snapshot when cache is not populated', async () => {
+    mockGetCachedReviewCount.mockReturnValue(undefined);
+    mockGetByProjectId.mockReturnValue([
+      {
+        workspaceId: 'ws-1',
+        projectId: 'proj-1',
+        name: 'Visible',
+        status: 'READY',
+      },
+    ] as never);
+
+    const handler = createSnapshotsUpgradeHandler(createAppContextMock());
+    const ws = new MockWebSocket();
+
+    callHandler(handler, ws, 'proj-1');
+
+    await vi.waitFor(() => {
+      expect(ws.send).toHaveBeenCalledWith(
+        JSON.stringify({
+          type: 'snapshot_full',
+          projectId: 'proj-1',
+          entries: [
+            {
+              workspaceId: 'ws-1',
+              projectId: 'proj-1',
+              name: 'Visible',
+              status: 'READY',
+            },
+          ],
+        })
+      );
+    });
+    expect(mockRefreshReviewCountIfStale).toHaveBeenCalled();
+  });
+
   it('rejects connection without projectId', () => {
     const handler = createSnapshotsUpgradeHandler(createAppContextMock());
     const ws = new MockWebSocket();
@@ -275,6 +310,40 @@ describe('createSnapshotsUpgradeHandler', () => {
       })
     );
     expect(wsB.send).not.toHaveBeenCalled();
+    expect(mockRefreshReviewCountIfStale).toHaveBeenCalled();
+  });
+
+  it('omits review count from snapshot_changed when cache is not populated', async () => {
+    mockGetCachedReviewCount.mockReturnValue(undefined);
+    const handler = createSnapshotsUpgradeHandler(createAppContextMock());
+    const ws = new MockWebSocket();
+
+    callHandler(handler, ws, 'proj-1');
+    await waitForInitialSnapshot(ws);
+    ws.send.mockClear();
+
+    const changedListener = storeListeners.get('snapshot_changed');
+    expect(changedListener).toBeDefined();
+
+    const event: SnapshotChangedEvent = {
+      workspaceId: 'ws-1',
+      projectId: 'proj-1',
+      entry: {
+        workspaceId: 'ws-1',
+        projectId: 'proj-1',
+        name: 'Updated',
+        status: 'READY',
+      } as never,
+    };
+    await changedListener!(event);
+
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({
+        type: 'snapshot_changed',
+        workspaceId: 'ws-1',
+        entry: event.entry,
+      })
+    );
     expect(mockRefreshReviewCountIfStale).toHaveBeenCalled();
   });
 

--- a/src/backend/routers/websocket/snapshots.handler.test.ts
+++ b/src/backend/routers/websocket/snapshots.handler.test.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'node:events';
 import type { IncomingMessage } from 'node:http';
 import type { Duplex } from 'node:stream';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { WebSocket, WebSocketServer } from 'ws';
 import type { AppContext } from '@/backend/app-context';
 import { WS_READY_STATE } from '@/backend/constants/websocket';
@@ -30,11 +30,13 @@ class MockWebSocket extends EventEmitter {
 }
 
 // Use vi.hoisted so these are available inside hoisted vi.mock factories
-const { storeListeners, mockGetByProjectId, mockSendBadRequest } = vi.hoisted(() => ({
-  storeListeners: new Map<string, (event: unknown) => void>(),
-  mockGetByProjectId: vi.fn(() => []),
-  mockSendBadRequest: vi.fn(),
-}));
+const { storeListeners, mockGetByProjectId, mockRefreshReviewCount, mockSendBadRequest } =
+  vi.hoisted(() => ({
+    storeListeners: new Map<string, (event: unknown) => unknown>(),
+    mockGetByProjectId: vi.fn(() => []),
+    mockRefreshReviewCount: vi.fn(async () => 5),
+    mockSendBadRequest: vi.fn(),
+  }));
 
 vi.mock('@/backend/services/workspace-snapshot-store.service', () => {
   const { EventEmitter } = require('node:events');
@@ -46,11 +48,22 @@ vi.mock('@/backend/services/workspace-snapshot-store.service', () => {
     SNAPSHOT_REMOVED: 'snapshot_removed',
     workspaceSnapshotStore: {
       getByProjectId: mockGetByProjectId,
-      on: vi.fn((event: string, listener: (event: unknown) => void) => {
+      on: vi.fn((event: string, listener: (event: unknown) => unknown) => {
         storeListeners.set(event, listener);
         originalOn(event, listener);
         return emitter;
       }),
+    },
+  };
+});
+
+vi.mock('@/backend/services/workspace', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/backend/services/workspace')>();
+  return {
+    ...actual,
+    workspaceQueryService: {
+      ...actual.workspaceQueryService,
+      refreshReviewCount: mockRefreshReviewCount,
     },
   };
 });
@@ -139,11 +152,21 @@ function callHandler(
   return { wss, socket, wsAliveMap };
 }
 
+async function waitForInitialSnapshot(ws: MockWebSocket): Promise<void> {
+  await vi.waitFor(() => {
+    expect(ws.send).toHaveBeenCalled();
+  });
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
 
 describe('createSnapshotsUpgradeHandler', () => {
+  beforeEach(() => {
+    mockRefreshReviewCount.mockResolvedValue(5);
+  });
+
   afterEach(() => {
     // Clean up connection map between tests
     snapshotConnections.clear();
@@ -152,7 +175,7 @@ describe('createSnapshotsUpgradeHandler', () => {
     vi.mocked(validateWebSocketOrigin).mockReturnValue(true);
   });
 
-  it('sends full snapshot on connect', () => {
+  it('sends full snapshot with review count on connect', async () => {
     const visibleEntry = {
       workspaceId: 'ws-1',
       projectId: 'proj-1',
@@ -171,13 +194,16 @@ describe('createSnapshotsUpgradeHandler', () => {
 
     callHandler(handler, ws, 'proj-1');
 
-    expect(ws.send).toHaveBeenCalledWith(
-      JSON.stringify({
-        type: 'snapshot_full',
-        projectId: 'proj-1',
-        entries: [visibleEntry],
-      })
-    );
+    await vi.waitFor(() => {
+      expect(ws.send).toHaveBeenCalledWith(
+        JSON.stringify({
+          type: 'snapshot_full',
+          projectId: 'proj-1',
+          entries: [visibleEntry],
+          reviewCount: 5,
+        })
+      );
+    });
   });
 
   it('rejects connection without projectId', () => {
@@ -201,7 +227,7 @@ describe('createSnapshotsUpgradeHandler', () => {
     expect(ws.send).not.toHaveBeenCalled();
   });
 
-  it('routes snapshot_changed to correct project clients', () => {
+  it('routes snapshot_changed with review count to correct project clients', async () => {
     const handler = createSnapshotsUpgradeHandler(createAppContextMock());
 
     const wsA = new MockWebSocket();
@@ -209,6 +235,9 @@ describe('createSnapshotsUpgradeHandler', () => {
 
     callHandler(handler, wsA, 'proj-A');
     callHandler(handler, wsB, 'proj-B');
+
+    await waitForInitialSnapshot(wsA);
+    await waitForInitialSnapshot(wsB);
 
     // Clear send calls from full snapshot on connect
     wsA.send.mockClear();
@@ -227,23 +256,25 @@ describe('createSnapshotsUpgradeHandler', () => {
         status: 'READY',
       } as never,
     };
-    changedListener!(event);
+    await changedListener!(event);
 
     expect(wsA.send).toHaveBeenCalledWith(
       JSON.stringify({
         type: 'snapshot_changed',
         workspaceId: 'ws-1',
         entry: event.entry,
+        reviewCount: 5,
       })
     );
     expect(wsB.send).not.toHaveBeenCalled();
   });
 
-  it('routes ARCHIVING snapshot_changed as snapshot_removed', () => {
+  it('routes ARCHIVING snapshot_changed as snapshot_removed with review count', async () => {
     const handler = createSnapshotsUpgradeHandler(createAppContextMock());
     const ws = new MockWebSocket();
 
     callHandler(handler, ws, 'proj-1');
+    await waitForInitialSnapshot(ws);
     ws.send.mockClear();
 
     const changedListener = storeListeners.get('snapshot_changed');
@@ -259,21 +290,23 @@ describe('createSnapshotsUpgradeHandler', () => {
         status: 'ARCHIVING',
       } as never,
     };
-    changedListener!(event);
+    await changedListener!(event);
 
     expect(ws.send).toHaveBeenCalledWith(
       JSON.stringify({
         type: 'snapshot_removed',
         workspaceId: 'ws-1',
+        reviewCount: 5,
       })
     );
   });
 
-  it('sends snapshot_removed to project clients', () => {
+  it('sends snapshot_removed with review count to project clients', async () => {
     const handler = createSnapshotsUpgradeHandler(createAppContextMock());
     const ws = new MockWebSocket();
 
     callHandler(handler, ws, 'proj-1');
+    await waitForInitialSnapshot(ws);
     ws.send.mockClear();
 
     const removedListener = storeListeners.get('snapshot_removed');
@@ -283,28 +316,30 @@ describe('createSnapshotsUpgradeHandler', () => {
       workspaceId: 'ws-1',
       projectId: 'proj-1',
     };
-    removedListener!(event);
+    await removedListener!(event);
 
     expect(ws.send).toHaveBeenCalledWith(
       JSON.stringify({
         type: 'snapshot_removed',
         workspaceId: 'ws-1',
+        reviewCount: 5,
       })
     );
   });
 
-  it('does not send to non-OPEN sockets', () => {
+  it('does not send to non-OPEN sockets', async () => {
     const handler = createSnapshotsUpgradeHandler(createAppContextMock());
     const ws = new MockWebSocket();
 
     callHandler(handler, ws, 'proj-1');
+    await waitForInitialSnapshot(ws);
     ws.send.mockClear();
 
     // Set socket to CLOSED state
     ws.readyState = WS_READY_STATE.CLOSED;
 
     const changedListener = storeListeners.get('snapshot_changed');
-    changedListener!({
+    await changedListener!({
       workspaceId: 'ws-1',
       projectId: 'proj-1',
       entry: { workspaceId: 'ws-1', status: 'READY' },

--- a/src/backend/routers/websocket/snapshots.handler.test.ts
+++ b/src/backend/routers/websocket/snapshots.handler.test.ts
@@ -30,13 +30,19 @@ class MockWebSocket extends EventEmitter {
 }
 
 // Use vi.hoisted so these are available inside hoisted vi.mock factories
-const { storeListeners, mockGetByProjectId, mockRefreshReviewCount, mockSendBadRequest } =
-  vi.hoisted(() => ({
-    storeListeners: new Map<string, (event: unknown) => unknown>(),
-    mockGetByProjectId: vi.fn(() => []),
-    mockRefreshReviewCount: vi.fn(async () => 5),
-    mockSendBadRequest: vi.fn(),
-  }));
+const {
+  storeListeners,
+  mockGetByProjectId,
+  mockGetCachedReviewCount,
+  mockRefreshReviewCountIfStale,
+  mockSendBadRequest,
+} = vi.hoisted(() => ({
+  storeListeners: new Map<string, (event: unknown) => unknown>(),
+  mockGetByProjectId: vi.fn(() => []),
+  mockGetCachedReviewCount: vi.fn(() => 5),
+  mockRefreshReviewCountIfStale: vi.fn(),
+  mockSendBadRequest: vi.fn(),
+}));
 
 vi.mock('@/backend/services/workspace-snapshot-store.service', () => {
   const { EventEmitter } = require('node:events');
@@ -63,7 +69,8 @@ vi.mock('@/backend/services/workspace', async (importOriginal) => {
     ...actual,
     workspaceQueryService: {
       ...actual.workspaceQueryService,
-      refreshReviewCount: mockRefreshReviewCount,
+      getCachedReviewCount: mockGetCachedReviewCount,
+      refreshReviewCountIfStale: mockRefreshReviewCountIfStale,
     },
   };
 });
@@ -164,7 +171,7 @@ async function waitForInitialSnapshot(ws: MockWebSocket): Promise<void> {
 
 describe('createSnapshotsUpgradeHandler', () => {
   beforeEach(() => {
-    mockRefreshReviewCount.mockResolvedValue(5);
+    mockGetCachedReviewCount.mockReturnValue(5);
   });
 
   afterEach(() => {
@@ -204,6 +211,7 @@ describe('createSnapshotsUpgradeHandler', () => {
         })
       );
     });
+    expect(mockRefreshReviewCountIfStale).toHaveBeenCalled();
   });
 
   it('rejects connection without projectId', () => {
@@ -267,6 +275,7 @@ describe('createSnapshotsUpgradeHandler', () => {
       })
     );
     expect(wsB.send).not.toHaveBeenCalled();
+    expect(mockRefreshReviewCountIfStale).toHaveBeenCalled();
   });
 
   it('routes ARCHIVING snapshot_changed as snapshot_removed with review count', async () => {

--- a/src/backend/routers/websocket/snapshots.handler.ts
+++ b/src/backend/routers/websocket/snapshots.handler.ts
@@ -62,13 +62,13 @@ class SnapshotStoreSubscriptionState {
       return;
     }
 
-    const changedListener = async (event: SnapshotChangedEvent) => {
+    const changedListener = (event: SnapshotChangedEvent) => {
       const projectClients = connections.get(event.projectId);
       if (!projectClients || projectClients.size === 0) {
         return;
       }
 
-      const reviewCount = await getSnapshotReviewCount(logger);
+      const reviewCount = getSnapshotReviewCount(logger);
       const message = JSON.stringify(
         isHiddenWorkspaceStatus(event.entry.status)
           ? {
@@ -91,13 +91,13 @@ class SnapshotStoreSubscriptionState {
       }
     };
 
-    const removedListener = async (event: SnapshotRemovedEvent) => {
+    const removedListener = (event: SnapshotRemovedEvent) => {
       const projectClients = connections.get(event.projectId);
       if (!projectClients || projectClients.size === 0) {
         return;
       }
 
-      const reviewCount = await getSnapshotReviewCount(logger);
+      const reviewCount = getSnapshotReviewCount(logger);
       const message = JSON.stringify({
         type: 'snapshot_removed',
         workspaceId: event.workspaceId,
@@ -146,13 +146,15 @@ function isHiddenWorkspaceStatus(status: WorkspaceStatus): boolean {
   return status === WorkspaceStatus.ARCHIVING || status === WorkspaceStatus.ARCHIVED;
 }
 
-async function getSnapshotReviewCount(
+function getSnapshotReviewCount(
   logger: ReturnType<AppContext['services']['createLogger']>
-): Promise<number | undefined> {
+): number | undefined {
   try {
-    return await workspaceQueryService.refreshReviewCount();
+    const reviewCount = workspaceQueryService.getCachedReviewCount();
+    workspaceQueryService.refreshReviewCountIfStale();
+    return reviewCount;
   } catch (error) {
-    logger.debug('Failed to refresh review count for snapshot message', {
+    logger.debug('Failed to read review count for snapshot message', {
       error: error instanceof Error ? error.message : String(error),
     });
     return undefined;
@@ -222,11 +224,11 @@ export function createSnapshotsUpgradeHandler(
       // If a startup reconciliation is in progress and the store has no entries
       // yet for this project, wait for it before sending snapshot_full so the
       // client receives populated data rather than an empty array.
-      const sendSnapshot = async () => {
+      const sendSnapshot = () => {
         if (ws.readyState !== WS_READY_STATE.OPEN) {
           return;
         }
-        const reviewCount = await getSnapshotReviewCount(logger);
+        const reviewCount = getSnapshotReviewCount(logger);
         if (ws.readyState !== WS_READY_STATE.OPEN) {
           return;
         }

--- a/src/backend/routers/websocket/snapshots.handler.ts
+++ b/src/backend/routers/websocket/snapshots.handler.ts
@@ -229,9 +229,6 @@ export function createSnapshotsUpgradeHandler(
           return;
         }
         const reviewCount = getSnapshotReviewCount(logger);
-        if (ws.readyState !== WS_READY_STATE.OPEN) {
-          return;
-        }
         const entries = workspaceSnapshotStore
           .getByProjectId(projectId)
           .filter((entry) => !isHiddenWorkspaceStatus(entry.status));

--- a/src/backend/routers/websocket/snapshots.handler.ts
+++ b/src/backend/routers/websocket/snapshots.handler.ts
@@ -12,6 +12,7 @@ import type { WebSocket, WebSocketServer } from 'ws';
 import type { AppContext } from '@/backend/app-context';
 import { WS_READY_STATE } from '@/backend/constants/websocket';
 import { snapshotReconciliationService } from '@/backend/orchestration/snapshot-reconciliation.orchestrator';
+import { workspaceQueryService } from '@/backend/services/workspace';
 import {
   SNAPSHOT_CHANGED,
   SNAPSHOT_REMOVED,
@@ -48,8 +49,10 @@ export const snapshotConnections: SnapshotConnectionsMap = new Map();
 
 class SnapshotStoreSubscriptionState {
   private active = false;
-  private snapshotChangedListener: ((event: SnapshotChangedEvent) => void) | null = null;
-  private snapshotRemovedListener: ((event: SnapshotRemovedEvent) => void) | null = null;
+  private snapshotChangedListener: ((event: SnapshotChangedEvent) => void | Promise<void>) | null =
+    null;
+  private snapshotRemovedListener: ((event: SnapshotRemovedEvent) => void | Promise<void>) | null =
+    null;
 
   ensure(
     connections: SnapshotConnectionsMap,
@@ -59,22 +62,25 @@ class SnapshotStoreSubscriptionState {
       return;
     }
 
-    const changedListener = (event: SnapshotChangedEvent) => {
+    const changedListener = async (event: SnapshotChangedEvent) => {
       const projectClients = connections.get(event.projectId);
       if (!projectClients || projectClients.size === 0) {
         return;
       }
 
+      const reviewCount = await getSnapshotReviewCount(logger);
       const message = JSON.stringify(
         isHiddenWorkspaceStatus(event.entry.status)
           ? {
               type: 'snapshot_removed',
               workspaceId: event.workspaceId,
+              reviewCount,
             }
           : {
               type: 'snapshot_changed',
               workspaceId: event.workspaceId,
               entry: event.entry,
+              reviewCount,
             }
       );
 
@@ -85,15 +91,17 @@ class SnapshotStoreSubscriptionState {
       }
     };
 
-    const removedListener = (event: SnapshotRemovedEvent) => {
+    const removedListener = async (event: SnapshotRemovedEvent) => {
       const projectClients = connections.get(event.projectId);
       if (!projectClients || projectClients.size === 0) {
         return;
       }
 
+      const reviewCount = await getSnapshotReviewCount(logger);
       const message = JSON.stringify({
         type: 'snapshot_removed',
         workspaceId: event.workspaceId,
+        reviewCount,
       });
 
       for (const ws of projectClients) {
@@ -136,6 +144,19 @@ const defaultSnapshotStoreSubscriptionState = new SnapshotStoreSubscriptionState
 
 function isHiddenWorkspaceStatus(status: WorkspaceStatus): boolean {
   return status === WorkspaceStatus.ARCHIVING || status === WorkspaceStatus.ARCHIVED;
+}
+
+async function getSnapshotReviewCount(
+  logger: ReturnType<AppContext['services']['createLogger']>
+): Promise<number | undefined> {
+  try {
+    return await workspaceQueryService.refreshReviewCount();
+  } catch (error) {
+    logger.debug('Failed to refresh review count for snapshot message', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
+  }
 }
 
 export function resetSnapshotsHandlerStateForTests(): void {
@@ -201,7 +222,11 @@ export function createSnapshotsUpgradeHandler(
       // If a startup reconciliation is in progress and the store has no entries
       // yet for this project, wait for it before sending snapshot_full so the
       // client receives populated data rather than an empty array.
-      const sendSnapshot = () => {
+      const sendSnapshot = async () => {
+        if (ws.readyState !== WS_READY_STATE.OPEN) {
+          return;
+        }
+        const reviewCount = await getSnapshotReviewCount(logger);
         if (ws.readyState !== WS_READY_STATE.OPEN) {
           return;
         }
@@ -213,18 +238,19 @@ export function createSnapshotsUpgradeHandler(
             type: 'snapshot_full',
             projectId,
             entries,
+            reviewCount,
           })
         );
       };
 
       const storeHasEntries = workspaceSnapshotStore.getByProjectId(projectId).length > 0;
       if (storeHasEntries) {
-        sendSnapshot();
+        void sendSnapshot();
       } else {
         snapshotReconciliationService
           .waitForInProgress()
           .then(sendSnapshot)
-          .catch(() => sendSnapshot());
+          .catch(() => void sendSnapshot());
       }
 
       ws.on('close', () => {

--- a/src/backend/routers/websocket/websocket.integration.test.ts
+++ b/src/backend/routers/websocket/websocket.integration.test.ts
@@ -534,11 +534,13 @@ describe('websocket integration', () => {
     openSockets.add(ws);
 
     await vi.waitFor(() => {
-      expect(messages).toContainEqual({
-        type: 'snapshot_full',
-        projectId,
-        entries: expect.arrayContaining([expect.objectContaining({ workspaceId })]),
-      });
+      expect(messages).toContainEqual(
+        expect.objectContaining({
+          type: 'snapshot_full',
+          projectId,
+          entries: expect.arrayContaining([expect.objectContaining({ workspaceId })]),
+        })
+      );
     });
 
     workspaceSnapshotStore.upsert(
@@ -553,19 +555,23 @@ describe('websocket integration', () => {
     );
 
     await vi.waitFor(() => {
-      expect(messages).toContainEqual({
-        type: 'snapshot_changed',
-        workspaceId,
-        entry: expect.objectContaining({
-          prUrl: 'https://github.com/acme/repo/pull/123',
-        }),
-      });
+      expect(messages).toContainEqual(
+        expect.objectContaining({
+          type: 'snapshot_changed',
+          workspaceId,
+          entry: expect.objectContaining({
+            prUrl: 'https://github.com/acme/repo/pull/123',
+          }),
+        })
+      );
     });
 
     workspaceSnapshotStore.remove(workspaceId);
 
     await vi.waitFor(() => {
-      expect(messages).toContainEqual({ type: 'snapshot_removed', workspaceId });
+      expect(messages).toContainEqual(
+        expect.objectContaining({ type: 'snapshot_removed', workspaceId })
+      );
     });
   });
 

--- a/src/backend/services/workspace/service/query/workspace-query.service.ts
+++ b/src/backend/services/workspace/service/query/workspace-query.service.ts
@@ -35,7 +35,6 @@ const REVIEW_CACHE_TTL_MS = 60_000; // 1 minute cache
 class WorkspaceQueryService {
   /** Cached GitHub review count (DOM-04: moved from module scope to instance field) */
   private cachedReviewCount: { count: number; fetchedAt: number } | null = null;
-  private reviewCountRefreshInFlight = false;
   private reviewCountRefreshPromise: Promise<number> | null = null;
   private prStatusSyncInFlight = false;
 
@@ -95,7 +94,6 @@ class WorkspaceQueryService {
       return this.reviewCountRefreshPromise;
     }
 
-    this.reviewCountRefreshInFlight = true;
     const refreshPromise = Promise.resolve()
       .then(() => this.github.checkHealth())
       .then(async (health) => {
@@ -118,12 +116,24 @@ class WorkspaceQueryService {
         return this.cachedReviewCount?.count ?? 0;
       })
       .finally(() => {
-        this.reviewCountRefreshInFlight = false;
         this.reviewCountRefreshPromise = null;
       });
 
     this.reviewCountRefreshPromise = refreshPromise;
     return refreshPromise;
+  }
+
+  getCachedReviewCount(): number {
+    return this.cachedReviewCount?.count ?? 0;
+  }
+
+  refreshReviewCountIfStale(): void {
+    const now = Date.now();
+    const isStale =
+      !this.cachedReviewCount || now - this.cachedReviewCount.fetchedAt >= REVIEW_CACHE_TTL_MS;
+    if (isStale) {
+      void this.refreshReviewCount();
+    }
   }
 
   async getProjectSummaryState(projectId: string) {
@@ -189,13 +199,8 @@ class WorkspaceQueryService {
     );
 
     // Stale-while-revalidate: return cached count immediately, refresh in background if stale.
-    const reviewCount = this.cachedReviewCount?.count ?? 0;
-    const now = Date.now();
-    const isStale =
-      !this.cachedReviewCount || now - this.cachedReviewCount.fetchedAt >= REVIEW_CACHE_TTL_MS;
-    if (isStale && !this.reviewCountRefreshInFlight) {
-      void this.refreshReviewCount();
-    }
+    const reviewCount = this.getCachedReviewCount();
+    this.refreshReviewCountIfStale();
 
     return {
       workspaces: workspaces.map((w) => {

--- a/src/backend/services/workspace/service/query/workspace-query.service.ts
+++ b/src/backend/services/workspace/service/query/workspace-query.service.ts
@@ -36,6 +36,7 @@ class WorkspaceQueryService {
   /** Cached GitHub review count (DOM-04: moved from module scope to instance field) */
   private cachedReviewCount: { count: number; fetchedAt: number } | null = null;
   private reviewCountRefreshInFlight = false;
+  private reviewCountRefreshPromise: Promise<number> | null = null;
   private prStatusSyncInFlight = false;
 
   private sessionBridge: WorkspaceQuerySessionBridge | null = null;
@@ -87,6 +88,42 @@ class WorkspaceQueryService {
       );
     }
     return this.prSnapshotBridge;
+  }
+
+  refreshReviewCount(): Promise<number> {
+    if (this.reviewCountRefreshPromise !== null) {
+      return this.reviewCountRefreshPromise;
+    }
+
+    this.reviewCountRefreshInFlight = true;
+    const refreshPromise = Promise.resolve()
+      .then(() => this.github.checkHealth())
+      .then(async (health) => {
+        if (!(health.isInstalled && health.isAuthenticated)) {
+          return this.cachedReviewCount?.count ?? 0;
+        }
+
+        const prs = await this.github.listReviewRequests();
+        const count = prs.filter((pr) => pr.reviewDecision !== 'APPROVED').length;
+        this.cachedReviewCount = {
+          count,
+          fetchedAt: Date.now(),
+        };
+        return count;
+      })
+      .catch((error) => {
+        logger.debug('Failed to fetch review count', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return this.cachedReviewCount?.count ?? 0;
+      })
+      .finally(() => {
+        this.reviewCountRefreshInFlight = false;
+        this.reviewCountRefreshPromise = null;
+      });
+
+    this.reviewCountRefreshPromise = refreshPromise;
+    return refreshPromise;
   }
 
   async getProjectSummaryState(projectId: string) {
@@ -157,26 +194,7 @@ class WorkspaceQueryService {
     const isStale =
       !this.cachedReviewCount || now - this.cachedReviewCount.fetchedAt >= REVIEW_CACHE_TTL_MS;
     if (isStale && !this.reviewCountRefreshInFlight) {
-      this.reviewCountRefreshInFlight = true;
-      this.github
-        .checkHealth()
-        .then(async (health) => {
-          if (health.isInstalled && health.isAuthenticated) {
-            const prs = await this.github.listReviewRequests();
-            this.cachedReviewCount = {
-              count: prs.filter((pr) => pr.reviewDecision !== 'APPROVED').length,
-              fetchedAt: Date.now(),
-            };
-          }
-        })
-        .catch((error) => {
-          logger.debug('Failed to fetch review count', {
-            error: error instanceof Error ? error.message : String(error),
-          });
-        })
-        .finally(() => {
-          this.reviewCountRefreshInFlight = false;
-        });
+      void this.refreshReviewCount();
     }
 
     return {

--- a/src/backend/services/workspace/service/query/workspace-query.service.ts
+++ b/src/backend/services/workspace/service/query/workspace-query.service.ts
@@ -123,8 +123,8 @@ class WorkspaceQueryService {
     return refreshPromise;
   }
 
-  getCachedReviewCount(): number {
-    return this.cachedReviewCount?.count ?? 0;
+  getCachedReviewCount(): number | undefined {
+    return this.cachedReviewCount?.count;
   }
 
   refreshReviewCountIfStale(): void {
@@ -199,7 +199,7 @@ class WorkspaceQueryService {
     );
 
     // Stale-while-revalidate: return cached count immediately, refresh in background if stale.
-    const reviewCount = this.getCachedReviewCount();
+    const reviewCount = this.getCachedReviewCount() ?? 0;
     this.refreshReviewCountIfStale();
 
     return {

--- a/src/client/hooks/use-project-snapshot-sync.test.ts
+++ b/src/client/hooks/use-project-snapshot-sync.test.ts
@@ -152,7 +152,7 @@ describe('useProjectSnapshotSync', () => {
   // ===========================================================================
 
   describe('snapshot_full message (sidebar)', () => {
-    it('calls setData with mapped entries and preserves reviewCount from prev', () => {
+    it('calls setData with mapped entries and preserves reviewCount from prev when omitted', () => {
       useProjectSnapshotSync('proj-1');
       const onMessage = capturedOptions!.onMessage!;
 
@@ -173,6 +173,23 @@ describe('useProjectSnapshotSync', () => {
       expect(result.workspaces[0].id).toBe('ws-1');
       expect(result.workspaces[0].name).toBe('alpha');
       expect(result.reviewCount).toBe(5);
+    });
+
+    it('uses reviewCount from the snapshot_full message when provided', () => {
+      useProjectSnapshotSync('proj-1');
+      const onMessage = capturedOptions!.onMessage!;
+
+      onMessage({
+        type: 'snapshot_full',
+        projectId: 'proj-1',
+        entries: [],
+        reviewCount: 9,
+      });
+
+      const [, updater] = mockSetData.mock.calls[0]!;
+      const result = updater({ workspaces: [], reviewCount: 5 });
+      expect(result.reviewCount).toBe(9);
+      expect(result.workspaces).toHaveLength(0);
     });
 
     it('preserves existing stateComputedAt and sets snapshotComputedAt', () => {
@@ -243,6 +260,27 @@ describe('useProjectSnapshotSync', () => {
       expect(result.workspaces[0].name).toBe('updated-name');
       expect(result.workspaces[1].name).toBe('other');
       expect(result.reviewCount).toBe(3);
+    });
+
+    it('updates reviewCount from the snapshot_changed message when provided', () => {
+      useProjectSnapshotSync('proj-1');
+      const onMessage = capturedOptions!.onMessage!;
+
+      const entry = makeEntry({ workspaceId: 'ws-1' });
+      onMessage({
+        type: 'snapshot_changed',
+        workspaceId: 'ws-1',
+        entry,
+        reviewCount: 4,
+      });
+
+      const [, updater] = mockSetData.mock.calls[0]!;
+      const result = updater({
+        workspaces: [{ id: 'ws-1', name: 'existing' }],
+        reviewCount: 8,
+      });
+      expect(result.reviewCount).toBe(4);
+      expect(result.workspaces).toHaveLength(1);
     });
 
     it('does not overwrite existing stateComputedAt during upsert', () => {
@@ -332,6 +370,25 @@ describe('useProjectSnapshotSync', () => {
       expect(result.workspaces).toHaveLength(1);
       expect(result.workspaces[0].name).toBe('stays');
       expect(result.reviewCount).toBe(7);
+    });
+
+    it('updates reviewCount from the snapshot_removed message when provided', () => {
+      useProjectSnapshotSync('proj-1');
+      const onMessage = capturedOptions!.onMessage!;
+
+      onMessage({
+        type: 'snapshot_removed',
+        workspaceId: 'ws-1',
+        reviewCount: 2,
+      });
+
+      const [, updater] = mockSetData.mock.calls[0]!;
+      const result = updater({
+        workspaces: [{ id: 'ws-1', name: 'gone' }],
+        reviewCount: 7,
+      });
+      expect(result.reviewCount).toBe(2);
+      expect(result.workspaces).toHaveLength(0);
     });
 
     it('returns prev unchanged when prev is null', () => {

--- a/src/client/hooks/use-project-snapshot-sync.ts
+++ b/src/client/hooks/use-project-snapshot-sync.ts
@@ -197,7 +197,7 @@ function applySnapshotFullMessage(
       workspaces: message.entries.map((e) =>
         mapSnapshotEntryToServerWorkspace(e, existingById.get(e.workspaceId))
       ),
-      reviewCount: prev?.reviewCount ?? 0,
+      reviewCount: message.reviewCount ?? prev?.reviewCount ?? 0,
     };
   }) as never);
 
@@ -228,7 +228,7 @@ function applySnapshotChangedMessage(
     if (!prev) {
       return {
         workspaces: [mapSnapshotEntryToServerWorkspace(message.entry)],
-        reviewCount: 0,
+        reviewCount: message.reviewCount ?? 0,
       };
     }
 
@@ -243,7 +243,7 @@ function applySnapshotChangedMessage(
       workspaces.push(mapped);
     }
 
-    return { workspaces, reviewCount: prev.reviewCount };
+    return { workspaces, reviewCount: message.reviewCount ?? prev.reviewCount };
   }) as never);
 
   setKanbanData({ projectId }, ((prev: KanbanCacheData) =>
@@ -273,7 +273,7 @@ function applySnapshotRemovedMessage(
     }
     return {
       workspaces: prev.workspaces.filter((w) => w.id !== message.workspaceId),
-      reviewCount: prev.reviewCount,
+      reviewCount: message.reviewCount ?? prev.reviewCount,
     };
   }) as never);
 

--- a/src/client/lib/snapshot-to-sidebar.ts
+++ b/src/client/lib/snapshot-to-sidebar.ts
@@ -156,17 +156,20 @@ const SnapshotFullMessageSchema = z.object({
   type: z.literal('snapshot_full'),
   projectId: z.string(),
   entries: z.array(WorkspaceSnapshotEntrySchema),
+  reviewCount: z.number().int().nonnegative().optional(),
 });
 
 const SnapshotChangedMessageSchema = z.object({
   type: z.literal('snapshot_changed'),
   workspaceId: z.string(),
   entry: WorkspaceSnapshotEntrySchema,
+  reviewCount: z.number().int().nonnegative().optional(),
 });
 
 const SnapshotRemovedMessageSchema = z.object({
   type: z.literal('snapshot_removed'),
   workspaceId: z.string(),
+  reviewCount: z.number().int().nonnegative().optional(),
 });
 
 export const SnapshotServerMessageSchema = z.discriminatedUnion('type', [


### PR DESCRIPTION
## Summary
- Sends fresh review counts on `/snapshots` messages so the sidebar Reviews badge updates while the app is open.
- Updates client snapshot cache handling to apply `reviewCount` when present while preserving backwards compatibility.
- Adds focused backend and client tests for snapshot review-count propagation.

## Changes
- **Backend snapshots**: Refresh and attach review count to `snapshot_full`, `snapshot_changed`, and `snapshot_removed` payloads.
- **Workspace query service**: Extract review-count refresh into a coalesced public method reused by query and websocket paths.
- **Client snapshot sync**: Accept optional `reviewCount` on snapshot messages and write it into `workspace.getProjectSummaryState`.
- **Tests**: Cover websocket payloads, integration snapshot assertions, and client cache updates for changed review counts.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; live sync behavior is covered by focused snapshot/websocket tests.

Closes #1746

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional WebSocket field and cache updates; GitHub review refresh logic is refactored but still stale-while-revalidate with coalescing, with no auth or data-model changes.
> 
> **Overview**
> Fixes stale **Reviews** badge counts while the app stays open by piggybacking `reviewCount` on `/snapshots` WebSocket traffic.
> 
> **Backend:** `snapshot_full`, `snapshot_changed`, and `snapshot_removed` messages attach an optional `reviewCount` from `workspaceQueryService.getCachedReviewCount()`, with `refreshReviewCountIfStale()` fired on each send. Review-count fetching is centralized in `WorkspaceQueryService` (`refreshReviewCount` with coalesced in-flight promise, plus public cache helpers) and reused by `getProjectSummaryState`.
> 
> **Client:** Snapshot message schemas accept optional `reviewCount`; `useProjectSnapshotSync` writes it into `workspace.getProjectSummaryState` when present and keeps prior values when omitted.
> 
> **Tests:** Handler unit tests, integration expectations (`objectContaining`), and client cache tests cover propagation and backwards compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74cc7b7a660a03727464d88123c7a8dff0d4760d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

