### PR TITLE
Fix #1765: Prevent duplicate PR status sync batches

### DIFF
--- a/src/backend/services/workspace/service/query/workspace-query.service.test.ts
+++ b/src/backend/services/workspace/service/query/workspace-query.service.test.ts
@@ -618,6 +618,30 @@ describe('WorkspaceQueryService', () => {
     });
   });
 
+  it('skips concurrent syncAllPRStatuses calls while the workspace lookup is pending', async () => {
+    let resolveLookup:
+      | ((workspaces: Array<{ id: string; prUrl: string | null }>) => void)
+      | undefined;
+    const lookupPromise = new Promise<Array<{ id: string; prUrl: string | null }>>((resolve) => {
+      resolveLookup = resolve;
+    });
+
+    mockFindByProjectIdWithSessions.mockReturnValueOnce(lookupPromise);
+    mockRefreshWorkspace.mockResolvedValueOnce({ success: true });
+
+    const firstSync = workspaceQueryService.syncAllPRStatuses('p1');
+    await Promise.resolve();
+
+    await expect(workspaceQueryService.syncAllPRStatuses('p1')).resolves.toEqual({ queued: 0 });
+    expect(mockFindByProjectIdWithSessions).toHaveBeenCalledTimes(1);
+
+    resolveLookup?.([{ id: 'w1', prUrl: 'https://github.com/o/r/pull/1' }]);
+    await expect(firstSync).resolves.toEqual({ queued: 1 });
+    await vi.waitFor(() => {
+      expect(mockRefreshWorkspace).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it('hasChanges checks workspace metadata and git stats safely', async () => {
     mockFindByIdWithProject.mockResolvedValueOnce(null);
     await expect(workspaceQueryService.hasChanges('w1')).resolves.toBe(false);

--- a/src/backend/services/workspace/service/query/workspace-query.service.ts
+++ b/src/backend/services/workspace/service/query/workspace-query.service.ts
@@ -439,33 +439,39 @@ class WorkspaceQueryService {
       return { queued: 0 };
     }
 
-    const workspaces = await workspaceAccessor.findByProjectIdWithSessions(projectId, {
-      excludeStatuses: [WorkspaceStatus.ARCHIVING, WorkspaceStatus.ARCHIVED],
-    });
-
-    const workspacesWithPRs = workspaces.filter(
-      (w): w is typeof w & { prUrl: string } => w.prUrl !== null
-    );
-
-    if (workspacesWithPRs.length === 0) {
-      return { queued: 0 };
-    }
-
     this.prStatusSyncInFlight = true;
 
-    // Fire-and-forget: results are pushed to clients via WebSocket as each call completes.
-    Promise.all(
-      workspacesWithPRs.map((workspace) =>
-        gitConcurrencyLimit(() => this.prSnapshot.refreshWorkspace(workspace.id, workspace.prUrl))
-      )
-    )
-      .then(() => logger.info('Batch PR status sync completed', { projectId }))
-      .catch((err) => logger.error('Batch PR status sync failed', toError(err), { projectId }))
-      .finally(() => {
-        this.prStatusSyncInFlight = false;
+    try {
+      const workspaces = await workspaceAccessor.findByProjectIdWithSessions(projectId, {
+        excludeStatuses: [WorkspaceStatus.ARCHIVING, WorkspaceStatus.ARCHIVED],
       });
 
-    return { queued: workspacesWithPRs.length };
+      const workspacesWithPRs = workspaces.filter(
+        (w): w is typeof w & { prUrl: string } => w.prUrl !== null
+      );
+
+      if (workspacesWithPRs.length === 0) {
+        this.prStatusSyncInFlight = false;
+        return { queued: 0 };
+      }
+
+      // Fire-and-forget: results are pushed to clients via WebSocket as each call completes.
+      Promise.all(
+        workspacesWithPRs.map((workspace) =>
+          gitConcurrencyLimit(() => this.prSnapshot.refreshWorkspace(workspace.id, workspace.prUrl))
+        )
+      )
+        .then(() => logger.info('Batch PR status sync completed', { projectId }))
+        .catch((err) => logger.error('Batch PR status sync failed', toError(err), { projectId }))
+        .finally(() => {
+          this.prStatusSyncInFlight = false;
+        });
+
+      return { queued: workspacesWithPRs.length };
+    } catch (error) {
+      this.prStatusSyncInFlight = false;
+      throw error;
+    }
   }
 
   async hasChanges(workspaceId: string): Promise<boolean> {


### PR DESCRIPTION
## Summary
- Fixes the PR status sync in-flight guard so concurrent calls cannot duplicate a refresh batch.
- Adds a regression test covering a second call arriving while the first workspace lookup is still pending.

## Changes
- **Workspace query service**: Claim `prStatusSyncInFlight` before the first awaited lookup, release it on lookup/no-work failures, and keep the existing fire-and-forget batch release after queued refreshes finish.
- **Workspace query tests**: Add a delayed-lookup concurrency test that verifies only one workspace lookup and one PR refresh batch are queued.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Manual testing: Not applicable; backend guard behavior is covered by the regression test.

Closes #1765

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to batch PR sync deduplication with a targeted test; no auth, data model, or API contract changes.
> 
> **Overview**
> Fixes a race in **`syncAllPRStatuses`** where the in-flight guard ran only after the workspace lookup finished, so overlapping triggers could each start a full PR refresh batch.
> 
> **`prStatusSyncInFlight`** is now set immediately after the early skip check, before **`findByProjectIdWithSessions`**. The flag is cleared when the lookup finds no PRs, when the lookup throws (re-thrown after reset), and still in the existing **`finally`** after the fire-and-forget refresh batch completes.
> 
> A regression test simulates a slow lookup and asserts a second concurrent call returns **`{ queued: 0 }`** with a single lookup and one refresh batch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d0edca4c05063c77d5c0892395afe6ed3e155a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

