### PR TITLE
Fix #1756: Block ACP creation during shutdown

### DIFF
--- a/src/backend/services/session/service/acp/acp-runtime-manager.test.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-manager.test.ts
@@ -1144,6 +1144,98 @@ describe('AcpRuntimeManager', () => {
     });
   });
 
+  describe('stopAllClients', () => {
+    it('rejects new client creation after shutdown begins', async () => {
+      await manager.stopAllClients();
+
+      await expect(
+        manager.getOrCreateClient(
+          'session-after-shutdown',
+          defaultOptions(),
+          defaultHandlers(),
+          defaultContext()
+        )
+      ).rejects.toThrow('ACP runtime manager is shutting down');
+
+      expect(mockSpawn).not.toHaveBeenCalled();
+    });
+
+    it('aborts in-flight client creation and kills the spawned subprocess', async () => {
+      const child = createMockChildProcess();
+      mockSpawn.mockReturnValue(child);
+      mockInitialize.mockImplementation(
+        () =>
+          new Promise(() => {
+            // Keep creation pending until shutdown aborts it.
+          })
+      );
+
+      const createPromise = manager.getOrCreateClient(
+        'session-1',
+        defaultOptions(),
+        defaultHandlers(),
+        defaultContext()
+      );
+      const createRejection = createPromise.catch((error: unknown) => error);
+
+      await vi.waitFor(() => {
+        expect(mockSpawn).toHaveBeenCalledTimes(1);
+      });
+
+      await manager.stopAllClients(50);
+
+      await expect(createRejection).resolves.toMatchObject({
+        message: expect.stringContaining('ACP runtime manager is shutting down'),
+      });
+      expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+      expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+      expect(manager.getClient('session-1')).toBeUndefined();
+      expect(manager.getPendingClient('session-1')).toBeUndefined();
+    });
+
+    it('rejects queued creation requests after an in-flight creation is aborted', async () => {
+      const child = createMockChildProcess();
+      mockSpawn.mockReturnValue(child);
+      mockInitialize.mockImplementation(
+        () =>
+          new Promise(() => {
+            // Keep the first creation holding the per-session lock.
+          })
+      );
+
+      const firstCreate = manager.getOrCreateClient(
+        'session-1',
+        defaultOptions(),
+        defaultHandlers(),
+        defaultContext()
+      );
+      const firstRejection = firstCreate.catch((error: unknown) => error);
+
+      await vi.waitFor(() => {
+        expect(mockSpawn).toHaveBeenCalledTimes(1);
+      });
+
+      const secondCreate = manager.getOrCreateClient(
+        'session-1',
+        defaultOptions(),
+        defaultHandlers(),
+        defaultContext()
+      );
+      const secondRejection = secondCreate.catch((error: unknown) => error);
+
+      await manager.stopAllClients(50);
+
+      await expect(firstRejection).resolves.toMatchObject({
+        message: expect.stringContaining('ACP runtime manager is shutting down'),
+      });
+      await expect(secondRejection).resolves.toMatchObject({
+        message: expect.stringContaining('ACP runtime manager is shutting down'),
+      });
+      expect(mockSpawn).toHaveBeenCalledTimes(1);
+      expect(manager.getClient('session-1')).toBeUndefined();
+    });
+  });
+
   describe('sendPrompt', () => {
     it('sets isPromptInFlight, calls connection.prompt, clears flag on resolve', async () => {
       setupSuccessfulSpawn();

--- a/src/backend/services/session/service/acp/acp-runtime-manager.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-manager.ts
@@ -108,6 +108,8 @@ export class AcpRuntimeManager {
   private readonly managedStopChildren = new WeakSet<ChildProcess>();
   private readonly creationLocks = new Map<string, ReturnType<typeof pLimit>>();
   private readonly lockRefCounts = new Map<string, number>();
+  private readonly shutdownWaiters = new Set<() => void>();
+  private isShuttingDown = false;
   private onClientCreatedCallback: AcpRuntimeCreatedCallback | null = null;
   private acpStartupTimeoutMs = DEFAULT_ACP_STARTUP_TIMEOUT_MS;
   private preferSourceEntrypoint = true;
@@ -156,6 +158,10 @@ export class AcpRuntimeManager {
     handlers: AcpRuntimeEventHandlers,
     context: { workspaceId: string; workingDir: string }
   ): Promise<AcpProcessHandle> {
+    if (this.isShuttingDown) {
+      return Promise.reject(this.createShutdownError(sessionId));
+    }
+
     let lock = this.creationLocks.get(sessionId);
     if (!lock) {
       lock = pLimit(1);
@@ -168,6 +174,10 @@ export class AcpRuntimeManager {
 
     return lock(async () => {
       try {
+        if (this.isShuttingDown) {
+          throw this.createShutdownError(sessionId);
+        }
+
         const existing = this.sessions.get(sessionId);
         if (existing?.isRunning()) {
           logger.debug('Returning existing running ACP client', { sessionId });
@@ -208,6 +218,10 @@ export class AcpRuntimeManager {
     handlers: AcpRuntimeEventHandlers,
     context: { workspaceId: string; workingDir: string }
   ): Promise<AcpProcessHandle> {
+    if (this.isShuttingDown) {
+      throw this.createShutdownError(sessionId);
+    }
+
     if (!hasUsableWorkingDir(options.workingDir)) {
       throw new Error('ACP working directory is required before spawning adapter process');
     }
@@ -317,6 +331,11 @@ export class AcpRuntimeManager {
     let sessionInfo: Awaited<ReturnType<AcpRuntimeManager['createOrResumeSession']>>;
     const startupTimeoutMs = this.acpStartupTimeoutMs;
     const startupErrorSettled = startupError.catch(() => undefined);
+    const shutdownSignal = this.createShutdownSignal(sessionId);
+    const startupCancelOn = Promise.race([
+      startupErrorSettled,
+      shutdownSignal.promise.catch(() => undefined),
+    ]);
 
     try {
       // Initialize handshake
@@ -333,9 +352,10 @@ export class AcpRuntimeManager {
           }),
           timeoutMs: startupTimeoutMs,
           description: 'initialize handshake',
-          cancelOn: startupErrorSettled,
+          cancelOn: startupCancelOn,
         }),
         startupError,
+        shutdownSignal.promise,
       ]);
 
       logger.info('ACP connection initialized', {
@@ -350,18 +370,25 @@ export class AcpRuntimeManager {
           promise: this.createOrResumeSession(connection, sessionId, options, agentCapabilities),
           timeoutMs: startupTimeoutMs,
           description: 'session creation',
-          cancelOn: startupErrorSettled,
+          cancelOn: startupCancelOn,
         }),
         startupError,
+        shutdownSignal.promise,
       ]);
     } catch (error) {
       this.cleanupFailedClientCreation(child, sessionId);
       throw error;
     } finally {
+      shutdownSignal.dispose();
       if (startupErrorListener) {
         child.removeListener('error', startupErrorListener);
         startupErrorListener = null;
       }
+    }
+
+    if (this.isShuttingDown) {
+      this.cleanupFailedClientCreation(child, sessionId);
+      throw this.createShutdownError(sessionId);
     }
 
     // Build handle
@@ -402,6 +429,45 @@ export class AcpRuntimeManager {
       sessionId,
       pid: child.pid,
     });
+  }
+
+  private createShutdownError(sessionId: string): Error {
+    return new Error(`ACP runtime manager is shutting down; cannot create client ${sessionId}`);
+  }
+
+  private beginShutdown(): void {
+    if (this.isShuttingDown) {
+      return;
+    }
+
+    this.isShuttingDown = true;
+    for (const rejectShutdown of this.shutdownWaiters) {
+      rejectShutdown();
+    }
+    this.shutdownWaiters.clear();
+  }
+
+  private createShutdownSignal(sessionId: string): {
+    promise: Promise<never>;
+    dispose: () => void;
+  } {
+    let rejectShutdown!: () => void;
+    const promise = new Promise<never>((_resolve, reject) => {
+      rejectShutdown = () => reject(this.createShutdownError(sessionId));
+    });
+
+    if (this.isShuttingDown) {
+      rejectShutdown();
+    } else {
+      this.shutdownWaiters.add(rejectShutdown);
+    }
+
+    return {
+      promise,
+      dispose: () => {
+        this.shutdownWaiters.delete(rejectShutdown);
+      },
+    };
   }
 
   private wireChildExitHandler(
@@ -839,23 +905,43 @@ export class AcpRuntimeManager {
   }
 
   async stopAllClients(timeoutMs = 5000): Promise<void> {
-    const stopPromises: Promise<void>[] = [];
+    this.beginShutdown();
 
-    for (const sessionId of this.sessions.keys()) {
-      const stopPromise = Promise.race([
-        this.stopClient(sessionId),
-        new Promise<void>((resolve) => setTimeout(resolve, timeoutMs)),
-      ]);
-      stopPromises.push(stopPromise);
-    }
-
-    await Promise.all(stopPromises);
+    await this.stopCurrentClients(timeoutMs);
+    await this.waitForPendingCreations(timeoutMs);
+    await this.stopCurrentClients(timeoutMs);
 
     this.sessions.clear();
+    this.pendingCreation.clear();
     this.creationLocks.clear();
     this.lockRefCounts.clear();
+    this.shutdownWaiters.clear();
 
     logger.info('All ACP clients stopped and cleaned up');
+  }
+
+  private async stopCurrentClients(timeoutMs: number): Promise<void> {
+    const sessionIds = [...this.sessions.keys()];
+    const stopPromises = sessionIds.map((sessionId) =>
+      Promise.race([
+        this.stopClient(sessionId),
+        new Promise<void>((resolve) => setTimeout(resolve, timeoutMs)),
+      ])
+    );
+
+    await Promise.all(stopPromises);
+  }
+
+  private async waitForPendingCreations(timeoutMs: number): Promise<void> {
+    const pendingCreations = [...this.pendingCreation.values()];
+    if (pendingCreations.length === 0) {
+      return;
+    }
+
+    await Promise.race([
+      Promise.allSettled(pendingCreations),
+      new Promise<void>((resolve) => setTimeout(resolve, timeoutMs)),
+    ]);
   }
 
   getAllClients(): IterableIterator<[string, AcpProcessHandle]> {


### PR DESCRIPTION
## Summary
- Prevent ACP clients from being created once runtime manager shutdown begins
- Abort in-flight ACP startup during shutdown so spawned adapter subprocesses are killed
- Add regression coverage for post-shutdown, in-flight, and queued creation races

## Changes
- **ACP Runtime Manager**: Added a manager-level shutdown barrier, shutdown signal, pending-creation wait, and final stop sweep in `stopAllClients()`.
- **Tests**: Covered late creation rejection, in-flight spawn cleanup, and queued creation rejection after shutdown starts.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; runtime shutdown behavior is covered by regression tests

Closes #1756

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches process lifecycle and shutdown ordering for spawned ACP adapters; mistakes could leave orphan processes or reject legitimate clients during server stop, but scope is localized and covered by new tests.
> 
> **Overview**
> Adds a **manager-level shutdown barrier** so `stopAllClients()` can’t race with new or in-progress ACP adapter spawns.
> 
> Once shutdown starts, **`getOrCreateClient`** rejects immediately (including after acquiring the per-session lock), and **`createClient`** wires a **shutdown signal** into the initialize/session startup `Promise.race` so hung handshakes abort and spawned children are cleaned up via existing failure cleanup (SIGTERM/SIGKILL). **`stopAllClients`** now calls `beginShutdown()` first, stops running clients, **waits for pending creations**, runs a second stop sweep, then clears sessions, `pendingCreation`, locks, and shutdown waiters.
> 
> Regression tests cover post-shutdown creation rejection, in-flight spawn kill on shutdown, and queued same-session creations failing without a second spawn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45431ca01a375104ca3fa72a986478a2d1b2329c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

