### PR TITLE
Fix #1762: Clear workspace activity on delete

### DIFF
--- a/src/backend/routers/websocket/websocket.integration.test.ts
+++ b/src/backend/routers/websocket/websocket.integration.test.ts
@@ -66,7 +66,7 @@ beforeAll(async () => {
   ({ workspaceSnapshotStore } = await vi.importActual<
     typeof import('@/backend/services/workspace-snapshot-store.service')
   >('@/backend/services/workspace-snapshot-store.service'));
-});
+}, 30_000);
 
 afterEach(async () => {
   for (const ws of openSockets) {

--- a/src/backend/services/resources.integration.test.ts
+++ b/src/backend/services/resources.integration.test.ts
@@ -61,7 +61,7 @@ beforeAll(async () => {
     '@/backend/clients/git.client'
   );
   ({ GitClientFactory } = gitClientModule);
-});
+}, 30_000);
 
 afterEach(async () => {
   await clearIntegrationDatabase(prisma);

--- a/src/backend/trpc/workspace.router.test.ts
+++ b/src/backend/trpc/workspace.router.test.ts
@@ -22,6 +22,7 @@ const mockWorkspaceQueryService = vi.hoisted(() => ({
 
 const mockDeriveFlowState = vi.hoisted(() => vi.fn());
 const mockWorkspaceCreationCreate = vi.hoisted(() => vi.fn());
+const mockClearWorkspaceActivity = vi.hoisted(() => vi.fn());
 const mockArchiveWorkspace = vi.hoisted(() => vi.fn());
 const mockInitializeWorkspaceWorktree = vi.hoisted(() => vi.fn());
 const mockBuildSessionSummaries = vi.hoisted(() => vi.fn());
@@ -40,6 +41,9 @@ const mockResolveProviderForWorkspaceCreation = vi.hoisted(() =>
 vi.mock('@/backend/services/workspace', () => ({
   workspaceDataService: mockWorkspaceDataService,
   workspaceQueryService: mockWorkspaceQueryService,
+  workspaceActivityService: {
+    clearWorkspace: (...args: unknown[]) => mockClearWorkspaceActivity(...args),
+  },
   deriveWorkspaceFlowStateFromWorkspace: (...args: unknown[]) => mockDeriveFlowState(...args),
   computeKanbanColumn: (...args: unknown[]) => mockComputeKanbanColumn(...args),
   computePendingRequestType: (...args: unknown[]) => mockComputePendingRequestType(...args),
@@ -522,6 +526,7 @@ describe('workspaceRouter', () => {
     expect(sessionService.stopWorkspaceSessions).toHaveBeenCalledWith('w1');
     expect(runScriptService.stopRunScript).toHaveBeenCalledWith('w1');
     expect(terminalService.destroyWorkspaceTerminals).toHaveBeenCalledWith('w1');
+    expect(mockClearWorkspaceActivity).toHaveBeenCalledWith('w1');
 
     await expect(caller.refreshFactoryConfigs({ projectId: 'p1' })).resolves.toEqual({
       refreshed: 3,

--- a/src/backend/trpc/workspace.trpc.ts
+++ b/src/backend/trpc/workspace.trpc.ts
@@ -32,6 +32,7 @@ import {
   deriveWorkspaceFlowStateFromWorkspace,
   WorkspaceCreationService,
   workspaceAccessor,
+  workspaceActivityService,
   workspaceDataService,
   workspaceNotificationAccessor,
   workspaceQueryService,
@@ -469,6 +470,7 @@ export const workspaceRouter = router({
         error: error instanceof Error ? error.message : String(error),
       });
     }
+    workspaceActivityService.clearWorkspace(input.id);
     return workspaceDataService.delete(input.id);
   }),
 


### PR DESCRIPTION
## Summary
- Clears in-memory workspace activity state when a workspace is directly deleted.
- Adds regression coverage for the direct delete cleanup path.
- Gives integration database setup hooks enough time to complete under full-suite load.

## Changes
- **Workspace delete**: Calls `workspaceActivityService.clearWorkspace` after stopping sessions/scripts/terminals and before deleting the workspace record.
- **Router tests**: Verifies direct workspace deletion clears activity state.
- **Integration tests**: Uses explicit 30s setup timeouts for suites that run database migrations during `beforeAll`.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; backend cleanup path covered by automated regression test.

Closes #1762

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 2dd3b319eadaf166af5e26ec139b1ca2d1fd0607. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

