### PR TITLE
Fix #1769: Prevent overlapping terminal resource scans

### DIFF
--- a/src/backend/services/terminal/service/terminal.service.test.ts
+++ b/src/backend/services/terminal/service/terminal.service.test.ts
@@ -452,7 +452,7 @@ describe('TerminalService', () => {
       expect(mockPidusage).toHaveBeenCalledTimes(2);
     });
 
-    it('does not let an unresolved update from a stopped monitor block restarted monitoring', async () => {
+    it('does not let an unresolved update from the last terminal block restarted monitoring', async () => {
       vi.useFakeTimers();
       const firstPendingUsage = createDeferred<ReturnType<typeof createPidUsageStat>>();
       const secondPendingUsage = createDeferred<ReturnType<typeof createPidUsageStat>>();
@@ -466,9 +466,8 @@ describe('TerminalService', () => {
       expect(mockPidusage).toHaveBeenCalledTimes(1);
 
       service.destroyTerminal(defaultOpts.workspaceId, terminalId);
-      await vi.advanceTimersByTimeAsync(5000);
-
       await service.createTerminal(defaultOpts);
+
       await vi.advanceTimersByTimeAsync(5000);
       expect(mockPidusage).toHaveBeenCalledTimes(2);
 

--- a/src/backend/services/terminal/service/terminal.service.test.ts
+++ b/src/backend/services/terminal/service/terminal.service.test.ts
@@ -451,6 +451,41 @@ describe('TerminalService', () => {
       await vi.advanceTimersByTimeAsync(5000);
       expect(mockPidusage).toHaveBeenCalledTimes(2);
     });
+
+    it('does not let an unresolved update from a stopped monitor block restarted monitoring', async () => {
+      vi.useFakeTimers();
+      const firstPendingUsage = createDeferred<ReturnType<typeof createPidUsageStat>>();
+      const secondPendingUsage = createDeferred<ReturnType<typeof createPidUsageStat>>();
+      mockPidusage
+        .mockReturnValueOnce(firstPendingUsage.promise)
+        .mockReturnValueOnce(secondPendingUsage.promise);
+
+      const { terminalId } = await service.createTerminal(defaultOpts);
+
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(mockPidusage).toHaveBeenCalledTimes(1);
+
+      service.destroyTerminal(defaultOpts.workspaceId, terminalId);
+      await vi.advanceTimersByTimeAsync(5000);
+
+      await service.createTerminal(defaultOpts);
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(mockPidusage).toHaveBeenCalledTimes(2);
+
+      firstPendingUsage.resolve(createPidUsageStat(3.5, 2048));
+      await firstPendingUsage.promise;
+      await vi.advanceTimersByTimeAsync(0);
+
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(mockPidusage).toHaveBeenCalledTimes(2);
+
+      secondPendingUsage.resolve(createPidUsageStat(4.5, 4096));
+      await secondPendingUsage.promise;
+      await vi.advanceTimersByTimeAsync(0);
+
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(mockPidusage).toHaveBeenCalledTimes(3);
+    });
   });
 
   // =========================================================================

--- a/src/backend/services/terminal/service/terminal.service.test.ts
+++ b/src/backend/services/terminal/service/terminal.service.test.ts
@@ -8,6 +8,18 @@ const mockPtyWrite = vi.fn();
 const mockPtyResize = vi.fn();
 const mockPtyKill = vi.fn();
 
+interface MockPidUsageStat {
+  cpu: number;
+  memory: number;
+  ppid: number;
+  pid: number;
+  ctime: number;
+  elapsed: number;
+  timestamp: number;
+}
+
+const mockPidusage = vi.hoisted(() => vi.fn<(pid: number | string) => Promise<MockPidUsageStat>>());
+
 let onDataCallback: ((data: string) => void) | null = null;
 let onExitCallback: ((e: { exitCode: number }) => void) | null = null;
 
@@ -40,7 +52,7 @@ vi.mock('node:module', () => ({
 }));
 
 vi.mock('pidusage', () => ({
-  default: vi.fn().mockResolvedValue({ cpu: 1.5, memory: 1024 }),
+  default: mockPidusage,
 }));
 
 vi.mock('@/backend/services/logger.service', () => ({
@@ -72,6 +84,7 @@ describe('TerminalService', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockPidusage.mockResolvedValue(createPidUsageStat());
     onDataCallback = null;
     onExitCallback = null;
     service = new TerminalService();
@@ -79,7 +92,31 @@ describe('TerminalService', () => {
 
   afterEach(() => {
     service.cleanup();
+    vi.useRealTimers();
   });
+
+  function createPidUsageStat(cpu = 1.5, memory = 1024): MockPidUsageStat {
+    return {
+      cpu,
+      memory,
+      ppid: 1,
+      pid: 12_345,
+      ctime: 0,
+      elapsed: 0,
+      timestamp: Date.now(),
+    };
+  }
+
+  function createDeferred<T>() {
+    let resolve!: (value: T) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+      resolve = resolvePromise;
+      reject = rejectPromise;
+    });
+
+    return { promise, resolve, reject };
+  }
 
   // =========================================================================
   // createTerminal
@@ -371,6 +408,48 @@ describe('TerminalService', () => {
           rows: 24,
         })
       );
+    });
+  });
+
+  // =========================================================================
+  // resource monitoring
+  // =========================================================================
+  describe('resource monitoring', () => {
+    it('stores cached resource usage for admin terminal snapshots', async () => {
+      vi.useFakeTimers();
+      mockPidusage.mockResolvedValueOnce(createPidUsageStat(7.25, 4096));
+
+      await service.createTerminal(defaultOpts);
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(service.getAllTerminals()[0]?.resourceUsage).toEqual(
+        expect.objectContaining({
+          cpu: 7.25,
+          memory: 4096,
+          timestamp: expect.any(Date),
+        })
+      );
+    });
+
+    it('skips interval ticks while a resource update is still running', async () => {
+      vi.useFakeTimers();
+      const pendingUsage = createDeferred<ReturnType<typeof createPidUsageStat>>();
+      mockPidusage.mockReturnValueOnce(pendingUsage.promise);
+
+      await service.createTerminal(defaultOpts);
+
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(mockPidusage).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(mockPidusage).toHaveBeenCalledTimes(1);
+
+      pendingUsage.resolve(createPidUsageStat(3.5, 2048));
+      await pendingUsage.promise;
+      await vi.advanceTimersByTimeAsync(0);
+
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(mockPidusage).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/src/backend/services/terminal/service/terminal.service.ts
+++ b/src/backend/services/terminal/service/terminal.service.ts
@@ -208,7 +208,8 @@ export class TerminalService {
 
   // Resource monitoring interval
   private monitoringInterval: NodeJS.Timeout | null = null;
-  private resourceUpdateInFlight = false;
+  private resourceUpdateInFlightGeneration: number | null = null;
+  private resourceMonitoringGeneration = 0;
   private static readonly MONITORING_INTERVAL_MS = 5000; // 5 seconds
 
   /**
@@ -256,6 +257,10 @@ export class TerminalService {
     }
 
     logger.debug('Starting terminal resource monitoring');
+    const monitoringGeneration = this.resourceMonitoringGeneration + 1;
+    this.resourceMonitoringGeneration = monitoringGeneration;
+    this.resourceUpdateInFlightGeneration = null;
+
     this.monitoringInterval = setInterval(async () => {
       // Stop monitoring if no terminals
       if (this.getActiveTerminalCount() === 0) {
@@ -263,12 +268,12 @@ export class TerminalService {
         return;
       }
 
-      if (this.resourceUpdateInFlight) {
+      if (this.resourceUpdateInFlightGeneration === monitoringGeneration) {
         logger.debug('Skipping terminal resource update; previous update still running');
         return;
       }
 
-      this.resourceUpdateInFlight = true;
+      this.resourceUpdateInFlightGeneration = monitoringGeneration;
       try {
         await this.updateAllTerminalResources();
       } catch (error) {
@@ -276,7 +281,9 @@ export class TerminalService {
           error: error instanceof Error ? error.message : String(error),
         });
       } finally {
-        this.resourceUpdateInFlight = false;
+        if (this.resourceUpdateInFlightGeneration === monitoringGeneration) {
+          this.resourceUpdateInFlightGeneration = null;
+        }
       }
     }, TerminalService.MONITORING_INTERVAL_MS);
   }
@@ -285,10 +292,12 @@ export class TerminalService {
    * Update resource usage for all terminals.
    */
   private async updateAllTerminalResources(): Promise<void> {
-    for (const workspaceTerminals of this.terminals.values()) {
-      for (const instance of workspaceTerminals.values()) {
-        await this.updateTerminalResource(instance);
-      }
+    const terminalInstances = Array.from(this.terminals.values()).flatMap((workspaceTerminals) =>
+      Array.from(workspaceTerminals.values())
+    );
+
+    for (const instance of terminalInstances) {
+      await this.updateTerminalResource(instance);
     }
   }
 
@@ -326,6 +335,7 @@ export class TerminalService {
       logger.debug('Stopping terminal resource monitoring');
       clearInterval(this.monitoringInterval);
       this.monitoringInterval = null;
+      this.resourceUpdateInFlightGeneration = null;
     }
   }
 

--- a/src/backend/services/terminal/service/terminal.service.ts
+++ b/src/backend/services/terminal/service/terminal.service.ts
@@ -514,6 +514,10 @@ export class TerminalService {
       this.activeTerminals.delete(workspaceId);
     }
 
+    if (this.getActiveTerminalCount() === 0) {
+      this.stopResourceMonitoring();
+    }
+
     // Dispose PTY event listeners before killing
     for (const dispose of instance.disposables) {
       try {

--- a/src/backend/services/terminal/service/terminal.service.ts
+++ b/src/backend/services/terminal/service/terminal.service.ts
@@ -208,6 +208,7 @@ export class TerminalService {
 
   // Resource monitoring interval
   private monitoringInterval: NodeJS.Timeout | null = null;
+  private resourceUpdateInFlight = false;
   private static readonly MONITORING_INTERVAL_MS = 5000; // 5 seconds
 
   /**
@@ -262,12 +263,20 @@ export class TerminalService {
         return;
       }
 
+      if (this.resourceUpdateInFlight) {
+        logger.debug('Skipping terminal resource update; previous update still running');
+        return;
+      }
+
+      this.resourceUpdateInFlight = true;
       try {
         await this.updateAllTerminalResources();
       } catch (error) {
         logger.error('Failed to update terminal resources', {
           error: error instanceof Error ? error.message : String(error),
         });
+      } finally {
+        this.resourceUpdateInFlight = false;
       }
     }, TerminalService.MONITORING_INTERVAL_MS);
   }


### PR DESCRIPTION
## Summary
- Prevent terminal resource monitor ticks from overlapping when a scan is still running.
- Preserve cached CPU/memory snapshots for the admin active-processes view.
- Add regression coverage for slow `pidusage` calls and cached resource snapshots.

## Changes
- **Terminal service**: Added an in-flight guard around `updateAllTerminalResources()` so later interval ticks skip while the previous scan is unresolved.
- **Terminal tests**: Added timer-based tests for cached snapshot updates and non-overlapping polling behavior.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; backend polling behavior covered by automated tests.

Closes #1769

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to informational terminal resource polling and admin snapshots; no PTY lifecycle or auth changes.
> 
> **Overview**
> Fixes **overlapping 5s `pidusage` scans** in `TerminalService` when a full-terminal resource update runs longer than the polling interval.
> 
> The monitor now tracks a **monitoring generation** and an **in-flight flag**: interval ticks skip while the current generation’s update is still running, and the flag is cleared in `finally` and when monitoring stops. **Restarting monitoring** (e.g. after destroy + create) bumps generation so a stale in-flight update from the previous session cannot block new ticks. **`destroyTerminal`** also stops the interval when the last terminal is removed.
> 
> Tests add a hoisted `pidusage` mock, deferred promises, and fake timers to cover cached CPU/memory on `getAllTerminals()`, non-overlapping polls, and the destroy/recreate stale-update case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be3281a61c8a78a5e0dea9db55481873c0b39e44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

