### PR TITLE
Fix #1751: Bound Codex history lookup

### DIFF
--- a/src/backend/services/session/service/data/codex-session-history-loader.service.test.ts
+++ b/src/backend/services/session/service/data/codex-session-history-loader.service.test.ts
@@ -714,6 +714,81 @@ describe('codexSessionHistoryLoaderService', () => {
     });
   });
 
+  it('does not reuse a positive cache entry whose session_meta id changed', async () => {
+    const providerSessionId = 'session-positive-cache-id-validation';
+    const cwd = '/Users/test/project';
+    const cachedPath = writeSessionFile({
+      codexHomeDir: tempDir,
+      relativeDir: '2026/02/14',
+      fileName: `rollout-2026-02-14T00-00-00-${providerSessionId}.jsonl`,
+      entries: [
+        {
+          type: 'session_meta',
+          payload: { id: providerSessionId, cwd },
+        },
+        {
+          timestamp: '2026-02-14T00:00:01.000Z',
+          type: 'event_msg',
+          payload: { type: 'user_message', message: 'first cached file' },
+        },
+      ],
+    });
+
+    const firstResult = await codexSessionHistoryLoaderService.loadSessionHistory({
+      providerSessionId,
+      workingDir: cwd,
+    });
+    expect(firstResult).toMatchObject({ status: 'loaded', filePath: cachedPath });
+
+    writeSessionFile({
+      codexHomeDir: tempDir,
+      relativeDir: '2026/02/14',
+      fileName: `rollout-2026-02-14T00-00-00-${providerSessionId}.jsonl`,
+      entries: [
+        {
+          type: 'session_meta',
+          payload: { id: 'different-session-id', cwd },
+        },
+        {
+          timestamp: '2026-02-14T00:00:02.000Z',
+          type: 'event_msg',
+          payload: { type: 'user_message', message: 'wrong replaced file' },
+        },
+      ],
+    });
+    const replacementPath = writeSessionFile({
+      codexHomeDir: tempDir,
+      relativeDir: '2026/02/15',
+      fileName: `rollout-2026-02-15T00-00-00-${providerSessionId}.jsonl`,
+      entries: [
+        {
+          type: 'session_meta',
+          payload: { id: providerSessionId, cwd },
+        },
+        {
+          timestamp: '2026-02-15T00:00:01.000Z',
+          type: 'event_msg',
+          payload: { type: 'user_message', message: 'replacement original session' },
+        },
+      ],
+    });
+
+    const secondResult = await codexSessionHistoryLoaderService.loadSessionHistory({
+      providerSessionId,
+      workingDir: cwd,
+    });
+
+    expect(secondResult).toMatchObject({ status: 'loaded', filePath: replacementPath });
+    if (secondResult.status !== 'loaded') {
+      return;
+    }
+    expect(secondResult.history).toHaveLength(1);
+    expect(secondResult.history[0]).toMatchObject({
+      type: 'user',
+      content: 'replacement original session',
+    });
+  });
+
   it('loads history when providerSessionId includes sess_ prefix but file/meta use unprefixed id', async () => {
     const unprefixedSessionId = '019c620a-8a8d-7b33-9b20-f9bd7c6512a7';
     const providerSessionId = `sess_${unprefixedSessionId}`;

--- a/src/backend/services/session/service/data/codex-session-history-loader.service.test.ts
+++ b/src/backend/services/session/service/data/codex-session-history-loader.service.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -201,6 +201,71 @@ describe('codexSessionHistoryLoaderService', () => {
     ]);
   });
 
+  it('resolves UUIDv7 sessions from the expected date directory before unrelated trees', async () => {
+    const providerSessionId = '019c5dad-78c4-7d02-8f3a-e5cb6f68ae5b';
+    const cwd = '/Users/test/project';
+    const expectedPath = writeSessionFile({
+      codexHomeDir: tempDir,
+      relativeDir: '2026/02/14',
+      fileName: `rollout-2026-02-14T19-42-55-${providerSessionId}.jsonl`,
+      entries: [
+        {
+          type: 'session_meta',
+          payload: { id: providerSessionId, cwd },
+        },
+        {
+          timestamp: '2026-02-14T19:42:56.000Z',
+          type: 'event_msg',
+          payload: { type: 'user_message', message: 'from expected date dir' },
+        },
+      ],
+    });
+    const unrelatedPath = writeSessionFile({
+      codexHomeDir: tempDir,
+      relativeDir: 'archive/not/date/tree',
+      fileName: `rollout-2026-02-14T19-42-55-${providerSessionId}.jsonl`,
+      entries: [
+        {
+          type: 'session_meta',
+          payload: { id: providerSessionId, cwd },
+        },
+        {
+          timestamp: '2026-02-14T19:42:57.000Z',
+          type: 'event_msg',
+          payload: { type: 'user_message', message: 'from unrelated tree' },
+        },
+      ],
+    });
+    utimesSync(
+      expectedPath,
+      new Date('2026-02-14T19:42:56.000Z'),
+      new Date('2026-02-14T19:42:56.000Z')
+    );
+    utimesSync(
+      unrelatedPath,
+      new Date('2026-02-14T19:43:56.000Z'),
+      new Date('2026-02-14T19:43:56.000Z')
+    );
+
+    const result = await codexSessionHistoryLoaderService.loadSessionHistory({
+      providerSessionId,
+      workingDir: cwd,
+    });
+
+    expect(result).toMatchObject({ status: 'loaded', filePath: expectedPath });
+    if (result.status !== 'loaded') {
+      return;
+    }
+
+    expect(result.history).toEqual([
+      {
+        type: 'user',
+        content: 'from expected date dir',
+        timestamp: '2026-02-14T19:42:56.000Z',
+      },
+    ]);
+  });
+
   it('records raw function args when response_item arguments are not valid JSON objects', async () => {
     const providerSessionId = 'session-fn-args';
     const cwd = '/Users/test/project';
@@ -384,6 +449,42 @@ describe('codexSessionHistoryLoaderService', () => {
     });
 
     expect(result).toEqual({ status: 'not_found' });
+  });
+
+  it('caches negative lookups for missing session files', async () => {
+    const providerSessionId = 'session-negative-cache';
+    const cwd = '/Users/test/missing';
+    mkdirSync(join(tempDir, 'sessions'), { recursive: true });
+
+    const firstResult = await codexSessionHistoryLoaderService.loadSessionHistory({
+      providerSessionId,
+      workingDir: cwd,
+    });
+    expect(firstResult).toEqual({ status: 'not_found' });
+
+    writeSessionFile({
+      codexHomeDir: tempDir,
+      relativeDir: '2026/02/14',
+      fileName: `rollout-2026-02-14T00-00-00-${providerSessionId}.jsonl`,
+      entries: [
+        {
+          type: 'session_meta',
+          payload: { id: providerSessionId, cwd },
+        },
+        {
+          timestamp: '2026-02-14T00:00:01.000Z',
+          type: 'event_msg',
+          payload: { type: 'user_message', message: 'created after miss' },
+        },
+      ],
+    });
+
+    const secondResult = await codexSessionHistoryLoaderService.loadSessionHistory({
+      providerSessionId,
+      workingDir: cwd,
+    });
+
+    expect(secondResult).toEqual({ status: 'not_found' });
   });
 
   it('loads history when providerSessionId includes sess_ prefix but file/meta use unprefixed id', async () => {

--- a/src/backend/services/session/service/data/codex-session-history-loader.service.test.ts
+++ b/src/backend/services/session/service/data/codex-session-history-loader.service.test.ts
@@ -21,6 +21,13 @@ function writeSessionFile(params: {
   return sessionFilePath;
 }
 
+function formatRelativeDateDir(date: Date): string {
+  const year = String(date.getUTCFullYear());
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  return `${year}/${month}/${day}`;
+}
+
 describe('codexSessionHistoryLoaderService', () => {
   let tempDir: string;
   let originalCodexHome: string | undefined;
@@ -415,6 +422,107 @@ describe('codexSessionHistoryLoaderService', () => {
     });
   });
 
+  it('checks recent date directories for cwd matches before using an expected-date id-only fallback', async () => {
+    const providerSessionId = '019c5dad-78c4-7d02-8f3a-e5cb6f68ae5b';
+    const expectedWrongCwdPath = writeSessionFile({
+      codexHomeDir: tempDir,
+      relativeDir: '2026/02/14',
+      fileName: `rollout-2026-02-14T19-42-55-${providerSessionId}.jsonl`,
+      entries: [
+        {
+          type: 'session_meta',
+          payload: { id: providerSessionId, cwd: '/Users/test/other' },
+        },
+        {
+          timestamp: '2026-02-14T19:42:55.000Z',
+          type: 'event_msg',
+          payload: { type: 'user_message', message: 'from expected wrong cwd' },
+        },
+      ],
+    });
+    const matchingCwdPath = writeSessionFile({
+      codexHomeDir: tempDir,
+      relativeDir: '2026/02/20',
+      fileName: `rollout-2026-02-20T19-42-55-${providerSessionId}.jsonl`,
+      entries: [
+        {
+          type: 'session_meta',
+          payload: { id: providerSessionId, cwd: '/Users/test/match' },
+        },
+        {
+          timestamp: '2026-02-20T19:42:55.000Z',
+          type: 'event_msg',
+          payload: { type: 'user_message', message: 'from recent matching cwd' },
+        },
+      ],
+    });
+    utimesSync(
+      expectedWrongCwdPath,
+      new Date('2026-02-20T20:42:55.000Z'),
+      new Date('2026-02-20T20:42:55.000Z')
+    );
+    utimesSync(
+      matchingCwdPath,
+      new Date('2026-02-20T19:42:55.000Z'),
+      new Date('2026-02-20T19:42:55.000Z')
+    );
+
+    const result = await codexSessionHistoryLoaderService.loadSessionHistory({
+      providerSessionId,
+      workingDir: '/Users/test/match',
+    });
+
+    expect(result).toMatchObject({ status: 'loaded', filePath: matchingCwdPath });
+    if (result.status !== 'loaded') {
+      return;
+    }
+    expect(result.history).toHaveLength(1);
+    expect(result.history[0]).toMatchObject({
+      type: 'user',
+      content: 'from recent matching cwd',
+    });
+  });
+
+  it('does not scan beyond the bounded recent date directory window', async () => {
+    const providerSessionId = 'session-beyond-recent-cap';
+    const cwd = '/Users/test/project';
+    const newestDate = Date.UTC(2026, 5, 1);
+    const oneDayMs = 24 * 60 * 60 * 1000;
+
+    for (let offset = 0; offset < 120; offset += 1) {
+      mkdirSync(
+        join(tempDir, 'sessions', formatRelativeDateDir(new Date(newestDate - offset * oneDayMs))),
+        {
+          recursive: true,
+        }
+      );
+    }
+
+    writeSessionFile({
+      codexHomeDir: tempDir,
+      relativeDir: formatRelativeDateDir(new Date(newestDate - 120 * oneDayMs)),
+      fileName: `rollout-2026-02-01T00-00-00-${providerSessionId}.jsonl`,
+      entries: [
+        {
+          type: 'session_meta',
+          payload: { id: providerSessionId, cwd },
+        },
+        {
+          timestamp: '2026-02-01T00:00:01.000Z',
+          type: 'event_msg',
+          payload: { type: 'user_message', message: 'outside bounded scan' },
+        },
+      ],
+    });
+
+    const result = await codexSessionHistoryLoaderService.loadSessionHistory({
+      providerSessionId,
+      workingDir: cwd,
+    });
+
+    expect(result).toEqual({ status: 'not_found' });
+  });
+
   it('returns not_found when candidate filename matches but session_meta id does not', async () => {
     const providerSessionId = 'session-meta-mismatch';
     writeSessionFile({
@@ -485,6 +593,66 @@ describe('codexSessionHistoryLoaderService', () => {
     });
 
     expect(secondResult).toEqual({ status: 'not_found' });
+  });
+
+  it('ignores stale positive cache entries when the cached session file was removed', async () => {
+    const providerSessionId = 'session-stale-positive-cache';
+    const cwd = '/Users/test/project';
+    const firstPath = writeSessionFile({
+      codexHomeDir: tempDir,
+      relativeDir: '2026/02/14',
+      fileName: `rollout-2026-02-14T00-00-00-${providerSessionId}.jsonl`,
+      entries: [
+        {
+          type: 'session_meta',
+          payload: { id: providerSessionId, cwd },
+        },
+        {
+          timestamp: '2026-02-14T00:00:01.000Z',
+          type: 'event_msg',
+          payload: { type: 'user_message', message: 'first cached file' },
+        },
+      ],
+    });
+
+    const firstResult = await codexSessionHistoryLoaderService.loadSessionHistory({
+      providerSessionId,
+      workingDir: cwd,
+    });
+    expect(firstResult).toMatchObject({ status: 'loaded', filePath: firstPath });
+
+    rmSync(firstPath, { force: true });
+    const secondPath = writeSessionFile({
+      codexHomeDir: tempDir,
+      relativeDir: '2026/02/15',
+      fileName: `rollout-2026-02-15T00-00-00-${providerSessionId}.jsonl`,
+      entries: [
+        {
+          type: 'session_meta',
+          payload: { id: providerSessionId, cwd },
+        },
+        {
+          timestamp: '2026-02-15T00:00:01.000Z',
+          type: 'event_msg',
+          payload: { type: 'user_message', message: 'replacement file' },
+        },
+      ],
+    });
+
+    const secondResult = await codexSessionHistoryLoaderService.loadSessionHistory({
+      providerSessionId,
+      workingDir: cwd,
+    });
+
+    expect(secondResult).toMatchObject({ status: 'loaded', filePath: secondPath });
+    if (secondResult.status !== 'loaded') {
+      return;
+    }
+    expect(secondResult.history).toHaveLength(1);
+    expect(secondResult.history[0]).toMatchObject({
+      type: 'user',
+      content: 'replacement file',
+    });
   });
 
   it('loads history when providerSessionId includes sess_ prefix but file/meta use unprefixed id', async () => {

--- a/src/backend/services/session/service/data/codex-session-history-loader.service.test.ts
+++ b/src/backend/services/session/service/data/codex-session-history-loader.service.test.ts
@@ -655,6 +655,65 @@ describe('codexSessionHistoryLoaderService', () => {
     });
   });
 
+  it('does not reuse an id-only positive cache entry when a cwd match appears later', async () => {
+    const providerSessionId = 'session-id-only-positive-cache';
+    const requestedCwd = '/Users/test/project';
+    const idOnlyPath = writeSessionFile({
+      codexHomeDir: tempDir,
+      relativeDir: '2026/02/14',
+      fileName: `rollout-2026-02-14T00-00-00-${providerSessionId}.jsonl`,
+      entries: [
+        {
+          type: 'session_meta',
+          payload: { id: providerSessionId, cwd: '/Users/test/other' },
+        },
+        {
+          timestamp: '2026-02-14T00:00:01.000Z',
+          type: 'event_msg',
+          payload: { type: 'user_message', message: 'id-only cached file' },
+        },
+      ],
+    });
+
+    const firstResult = await codexSessionHistoryLoaderService.loadSessionHistory({
+      providerSessionId,
+      workingDir: requestedCwd,
+    });
+    expect(firstResult).toMatchObject({ status: 'loaded', filePath: idOnlyPath });
+
+    const matchingCwdPath = writeSessionFile({
+      codexHomeDir: tempDir,
+      relativeDir: '2026/02/15',
+      fileName: `rollout-2026-02-15T00-00-00-${providerSessionId}.jsonl`,
+      entries: [
+        {
+          type: 'session_meta',
+          payload: { id: providerSessionId, cwd: requestedCwd },
+        },
+        {
+          timestamp: '2026-02-15T00:00:01.000Z',
+          type: 'event_msg',
+          payload: { type: 'user_message', message: 'later cwd match' },
+        },
+      ],
+    });
+
+    const secondResult = await codexSessionHistoryLoaderService.loadSessionHistory({
+      providerSessionId,
+      workingDir: requestedCwd,
+    });
+
+    expect(secondResult).toMatchObject({ status: 'loaded', filePath: matchingCwdPath });
+    if (secondResult.status !== 'loaded') {
+      return;
+    }
+    expect(secondResult.history).toHaveLength(1);
+    expect(secondResult.history[0]).toMatchObject({
+      type: 'user',
+      content: 'later cwd match',
+    });
+  });
+
   it('loads history when providerSessionId includes sess_ prefix but file/meta use unprefixed id', async () => {
     const unprefixedSessionId = '019c620a-8a8d-7b33-9b20-f9bd7c6512a7';
     const providerSessionId = `sess_${unprefixedSessionId}`;

--- a/src/backend/services/session/service/data/codex-session-history-loader.service.ts
+++ b/src/backend/services/session/service/data/codex-session-history-loader.service.ts
@@ -119,6 +119,7 @@ function buildSessionFileLookupCacheKey(params: {
 
 async function getCachedSessionFilePath(params: {
   cacheKey: string;
+  providerSessionId: string;
   workingDir: string;
 }): Promise<string | null | undefined> {
   const cached = sessionFileLookupCache.get(params.cacheKey);
@@ -139,7 +140,11 @@ async function getCachedSessionFilePath(params: {
     }
 
     const meta = await parseSessionMeta(cached.filePath);
-    if (meta?.cwd !== params.workingDir) {
+    if (
+      typeof meta?.id !== 'string' ||
+      !isMatchingProviderSessionId(meta.id, params.providerSessionId) ||
+      meta.cwd !== params.workingDir
+    ) {
       sessionFileLookupCache.delete(params.cacheKey);
       return undefined;
     }
@@ -693,7 +698,11 @@ async function resolveSessionFilePath(
   }
 
   const cacheKey = buildSessionFileLookupCacheKey({ sessionsDir, workingDir, providerSessionId });
-  const cachedFilePath = await getCachedSessionFilePath({ cacheKey, workingDir });
+  const cachedFilePath = await getCachedSessionFilePath({
+    cacheKey,
+    providerSessionId,
+    workingDir,
+  });
   if (cachedFilePath !== undefined) {
     return cachedFilePath;
   }

--- a/src/backend/services/session/service/data/codex-session-history-loader.service.ts
+++ b/src/backend/services/session/service/data/codex-session-history-loader.service.ts
@@ -50,6 +50,10 @@ type DateSessionDirectoryCandidate = {
   mtimeMs: number;
   dateKey: string;
 };
+type SessionFileSelection = {
+  cwdMatch: string | null;
+  idOnlyMatch: string | null;
+};
 
 const sessionFileLookupCache = new Map<string, SessionFileLookupCacheEntry>();
 
@@ -113,7 +117,7 @@ function buildSessionFileLookupCacheKey(params: {
   });
 }
 
-function getCachedSessionFilePath(cacheKey: string): string | null | undefined {
+async function getCachedSessionFilePath(cacheKey: string): Promise<string | null | undefined> {
   const cached = sessionFileLookupCache.get(cacheKey);
   if (!cached) {
     return undefined;
@@ -122,6 +126,14 @@ function getCachedSessionFilePath(cacheKey: string): string | null | undefined {
   if (cached.expiresAtMs <= Date.now()) {
     sessionFileLookupCache.delete(cacheKey);
     return undefined;
+  }
+
+  if (cached.filePath !== null) {
+    const stats = await stat(cached.filePath).catch(() => null);
+    if (!stats?.isFile()) {
+      sessionFileLookupCache.delete(cacheKey);
+      return undefined;
+    }
   }
 
   sessionFileLookupCache.delete(cacheKey);
@@ -546,7 +558,7 @@ async function collectRecentDateSessionDirs(
     isDateDirectoryPart(year, 4)
   );
 
-  for (const year of years) {
+  yearLoop: for (const year of years) {
     const yearDir = join(sessionsDir, year);
     const months = (await listSubdirectories(yearDir)).filter((month) =>
       isDateDirectoryPart(month, 2)
@@ -566,6 +578,10 @@ async function collectRecentDateSessionDirs(
           mtimeMs: stats?.mtimeMs ?? Number.NEGATIVE_INFINITY,
           dateKey: `${year}-${month}-${day}`,
         });
+
+        if (candidates.length >= MAX_RECENT_SESSION_DATE_DIRS) {
+          break yearLoop;
+        }
       }
     }
   }
@@ -573,16 +589,16 @@ async function collectRecentDateSessionDirs(
   candidates.sort(
     (left, right) => right.mtimeMs - left.mtimeMs || right.dateKey.localeCompare(left.dateKey)
   );
-  return candidates.slice(0, MAX_RECENT_SESSION_DATE_DIRS);
+  return candidates;
 }
 
 async function selectMatchingSessionFilePath(params: {
   candidates: string[];
   providerSessionId: string;
   workingDir: string;
-}): Promise<string | null> {
+}): Promise<SessionFileSelection> {
   if (params.candidates.length === 0) {
-    return null;
+    return { cwdMatch: null, idOnlyMatch: null };
   }
 
   const withMtime = await Promise.all(
@@ -606,7 +622,7 @@ async function selectMatchingSessionFilePath(params: {
       isMatchingProviderSessionId(meta.id, params.providerSessionId) &&
       meta.cwd === params.workingDir
     ) {
-      return candidate.candidatePath;
+      return { cwdMatch: candidate.candidatePath, idOnlyMatch: null };
     }
   }
 
@@ -616,11 +632,11 @@ async function selectMatchingSessionFilePath(params: {
       typeof meta?.id === 'string' &&
       isMatchingProviderSessionId(meta.id, params.providerSessionId)
     ) {
-      return candidate.candidatePath;
+      return { cwdMatch: null, idOnlyMatch: candidate.candidatePath };
     }
   }
 
-  return null;
+  return { cwdMatch: null, idOnlyMatch: null };
 }
 
 async function resolveUncachedSessionFilePath(
@@ -634,13 +650,13 @@ async function resolveUncachedSessionFilePath(
     expectedDateDirs,
     fileSuffixes
   );
-  const expectedMatch = await selectMatchingSessionFilePath({
+  const expectedSelection = await selectMatchingSessionFilePath({
     candidates: expectedCandidates,
     providerSessionId,
     workingDir,
   });
-  if (expectedMatch) {
-    return expectedMatch;
+  if (expectedSelection.cwdMatch) {
+    return expectedSelection.cwdMatch;
   }
 
   const recentDateDirs = await collectRecentDateSessionDirs(sessionsDir);
@@ -648,11 +664,12 @@ async function resolveUncachedSessionFilePath(
     recentDateDirs.map((candidate) => candidate.directoryPath),
     fileSuffixes
   );
-  return await selectMatchingSessionFilePath({
+  const recentSelection = await selectMatchingSessionFilePath({
     candidates: recentCandidates,
     providerSessionId,
     workingDir,
   });
+  return recentSelection.cwdMatch ?? expectedSelection.idOnlyMatch ?? recentSelection.idOnlyMatch;
 }
 
 async function resolveSessionFilePath(
@@ -667,7 +684,7 @@ async function resolveSessionFilePath(
   }
 
   const cacheKey = buildSessionFileLookupCacheKey({ sessionsDir, workingDir, providerSessionId });
-  const cachedFilePath = getCachedSessionFilePath(cacheKey);
+  const cachedFilePath = await getCachedSessionFilePath(cacheKey);
   if (cachedFilePath !== undefined) {
     return cachedFilePath;
   }

--- a/src/backend/services/session/service/data/codex-session-history-loader.service.ts
+++ b/src/backend/services/session/service/data/codex-session-history-loader.service.ts
@@ -11,7 +11,13 @@ import { readNonEmptyJsonlLines } from './session-history-jsonl-reader';
 
 const logger = createLogger('codex-session-history-loader');
 const SAFE_PROVIDER_SESSION_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
-const MAX_SESSION_FILE_SEARCH_DEPTH = 5;
+const UUID_V7_SESSION_ID_PATTERN =
+  /^([0-9a-f]{8})-([0-9a-f]{4})-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const MAX_DATE_SESSION_FILE_SEARCH_DEPTH = 3;
+const MAX_RECENT_SESSION_DATE_DIRS = 120;
+const SESSION_FILE_LOOKUP_CACHE_LIMIT = 1024;
+const POSITIVE_SESSION_FILE_LOOKUP_CACHE_TTL_MS = 5 * 60 * 1000;
+const NEGATIVE_SESSION_FILE_LOOKUP_CACHE_TTL_MS = 30 * 1000;
 const JsonObjectSchema = z.record(z.string(), z.unknown());
 
 const CodexHistoryEntrySchema = z
@@ -35,6 +41,17 @@ const CodexSessionMetaEntrySchema = z
   .passthrough();
 
 type CodexHistoryEntry = z.infer<typeof CodexHistoryEntrySchema>;
+type SessionFileLookupCacheEntry = {
+  filePath: string | null;
+  expiresAtMs: number;
+};
+type DateSessionDirectoryCandidate = {
+  directoryPath: string;
+  mtimeMs: number;
+  dateKey: string;
+};
+
+const sessionFileLookupCache = new Map<string, SessionFileLookupCacheEntry>();
 
 export type CodexSessionHistoryLoadResult =
   | { status: 'loaded'; history: HistoryMessage[]; filePath: string }
@@ -82,6 +99,104 @@ function getProviderSessionIdCandidates(providerSessionId: string): string[] {
 
 function isMatchingProviderSessionId(candidateId: string, providerSessionId: string): boolean {
   return normalizeProviderSessionId(candidateId) === normalizeProviderSessionId(providerSessionId);
+}
+
+function buildSessionFileLookupCacheKey(params: {
+  sessionsDir: string;
+  workingDir: string;
+  providerSessionId: string;
+}): string {
+  return JSON.stringify({
+    sessionsDir: params.sessionsDir,
+    workingDir: params.workingDir,
+    providerSessionId: normalizeProviderSessionId(params.providerSessionId),
+  });
+}
+
+function getCachedSessionFilePath(cacheKey: string): string | null | undefined {
+  const cached = sessionFileLookupCache.get(cacheKey);
+  if (!cached) {
+    return undefined;
+  }
+
+  if (cached.expiresAtMs <= Date.now()) {
+    sessionFileLookupCache.delete(cacheKey);
+    return undefined;
+  }
+
+  sessionFileLookupCache.delete(cacheKey);
+  sessionFileLookupCache.set(cacheKey, cached);
+  return cached.filePath;
+}
+
+function setCachedSessionFilePath(cacheKey: string, filePath: string | null): void {
+  const ttlMs =
+    filePath === null
+      ? NEGATIVE_SESSION_FILE_LOOKUP_CACHE_TTL_MS
+      : POSITIVE_SESSION_FILE_LOOKUP_CACHE_TTL_MS;
+  sessionFileLookupCache.set(cacheKey, {
+    filePath,
+    expiresAtMs: Date.now() + ttlMs,
+  });
+
+  while (sessionFileLookupCache.size > SESSION_FILE_LOOKUP_CACHE_LIMIT) {
+    const oldestKey = sessionFileLookupCache.keys().next().value;
+    if (typeof oldestKey !== 'string') {
+      break;
+    }
+    sessionFileLookupCache.delete(oldestKey);
+  }
+}
+
+function getUuidV7TimestampMs(providerSessionId: string): number | null {
+  const normalizedSessionId = normalizeProviderSessionId(providerSessionId);
+  const match = UUID_V7_SESSION_ID_PATTERN.exec(normalizedSessionId);
+  if (!match) {
+    return null;
+  }
+
+  const timestampMs = Number.parseInt(`${match[1]}${match[2]}`, 16);
+  if (!Number.isSafeInteger(timestampMs)) {
+    return null;
+  }
+
+  return timestampMs;
+}
+
+function formatUtcDateSessionDir(sessionsDir: string, timestampMs: number): string {
+  const date = new Date(timestampMs);
+  const year = String(date.getUTCFullYear());
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  return join(sessionsDir, year, month, day);
+}
+
+function getExpectedDateSessionDirs(sessionsDir: string, providerSessionId: string): string[] {
+  const timestampMs = getUuidV7TimestampMs(providerSessionId);
+  if (timestampMs === null) {
+    return [];
+  }
+
+  const oneDayMs = 24 * 60 * 60 * 1000;
+  return [
+    formatUtcDateSessionDir(sessionsDir, timestampMs),
+    formatUtcDateSessionDir(sessionsDir, timestampMs - oneDayMs),
+    formatUtcDateSessionDir(sessionsDir, timestampMs + oneDayMs),
+  ];
+}
+
+function isDateDirectoryPart(entryName: string, digits: number): boolean {
+  return entryName.length === digits && /^\d+$/.test(entryName);
+}
+
+function buildSessionFileSuffixes(providerSessionId: string): string[] {
+  return getProviderSessionIdCandidates(providerSessionId).map(
+    (sessionIdCandidate) => `${sessionIdCandidate}.jsonl`
+  );
+}
+
+function isCandidateSessionFile(fileName: string, fileSuffixes: string[]): boolean {
+  return fileSuffixes.some((fileSuffix) => fileName.endsWith(fileSuffix));
 }
 
 function truncateForLog(value: string, maxLength = 200): string {
@@ -358,12 +473,12 @@ async function parseSessionMeta(filePath: string): Promise<{ id?: string; cwd?: 
   return null;
 }
 
-async function collectCandidateSessionFiles(
+async function collectCandidateSessionFilesInDateDir(
   directoryPath: string,
-  fileSuffix: string,
+  fileSuffixes: string[],
   depth = 0
 ): Promise<string[]> {
-  if (depth > MAX_SESSION_FILE_SEARCH_DEPTH) {
+  if (depth > MAX_DATE_SESSION_FILE_SEARCH_DEPTH) {
     return [];
   }
 
@@ -376,12 +491,12 @@ async function collectCandidateSessionFiles(
   for (const entry of entries) {
     const fullPath = join(directoryPath, entry.name);
     if (entry.isDirectory()) {
-      const nested = await collectCandidateSessionFiles(fullPath, fileSuffix, depth + 1);
+      const nested = await collectCandidateSessionFilesInDateDir(fullPath, fileSuffixes, depth + 1);
       candidatePaths.push(...nested);
       continue;
     }
 
-    if (entry.isFile() && entry.name.endsWith(fileSuffix)) {
+    if (entry.isFile() && isCandidateSessionFile(entry.name, fileSuffixes)) {
       candidatePaths.push(fullPath);
     }
   }
@@ -389,35 +504,89 @@ async function collectCandidateSessionFiles(
   return candidatePaths;
 }
 
-async function resolveSessionFilePath(
-  workingDir: string,
-  providerSessionId: string
-): Promise<string | null> {
-  const sessionsDir = getCodexSessionsDir();
-  try {
-    await access(sessionsDir);
-  } catch {
-    return null;
-  }
-
-  const sessionIdCandidates = getProviderSessionIdCandidates(providerSessionId);
+async function collectCandidateSessionFilesFromDirs(
+  directoryPaths: string[],
+  fileSuffixes: string[]
+): Promise<string[]> {
   const candidateSet = new Set<string>();
-  for (const sessionIdCandidate of sessionIdCandidates) {
-    const discovered = await collectCandidateSessionFiles(
-      sessionsDir,
-      `${sessionIdCandidate}.jsonl`
-    );
+  const visitedDirectoryPaths = new Set<string>();
+
+  for (const directoryPath of directoryPaths) {
+    if (visitedDirectoryPaths.has(directoryPath)) {
+      continue;
+    }
+    visitedDirectoryPaths.add(directoryPath);
+
+    const discovered = await collectCandidateSessionFilesInDateDir(directoryPath, fileSuffixes);
     for (const candidatePath of discovered) {
       candidateSet.add(candidatePath);
     }
   }
-  const candidates = [...candidateSet];
-  if (candidates.length === 0) {
+
+  return [...candidateSet];
+}
+
+async function listSubdirectories(directoryPath: string): Promise<string[]> {
+  const entries = await readdir(directoryPath, { withFileTypes: true }).catch(() => null);
+  if (!entries) {
+    return [];
+  }
+
+  return entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort((left, right) => right.localeCompare(left));
+}
+
+async function collectRecentDateSessionDirs(
+  sessionsDir: string
+): Promise<DateSessionDirectoryCandidate[]> {
+  const candidates: DateSessionDirectoryCandidate[] = [];
+  const years = (await listSubdirectories(sessionsDir)).filter((year) =>
+    isDateDirectoryPart(year, 4)
+  );
+
+  for (const year of years) {
+    const yearDir = join(sessionsDir, year);
+    const months = (await listSubdirectories(yearDir)).filter((month) =>
+      isDateDirectoryPart(month, 2)
+    );
+
+    for (const month of months) {
+      const monthDir = join(yearDir, month);
+      const days = (await listSubdirectories(monthDir)).filter((day) =>
+        isDateDirectoryPart(day, 2)
+      );
+
+      for (const day of days) {
+        const directoryPath = join(monthDir, day);
+        const stats = await stat(directoryPath).catch(() => null);
+        candidates.push({
+          directoryPath,
+          mtimeMs: stats?.mtimeMs ?? Number.NEGATIVE_INFINITY,
+          dateKey: `${year}-${month}-${day}`,
+        });
+      }
+    }
+  }
+
+  candidates.sort(
+    (left, right) => right.mtimeMs - left.mtimeMs || right.dateKey.localeCompare(left.dateKey)
+  );
+  return candidates.slice(0, MAX_RECENT_SESSION_DATE_DIRS);
+}
+
+async function selectMatchingSessionFilePath(params: {
+  candidates: string[];
+  providerSessionId: string;
+  workingDir: string;
+}): Promise<string | null> {
+  if (params.candidates.length === 0) {
     return null;
   }
 
   const withMtime = await Promise.all(
-    candidates.map(async (candidatePath) => {
+    params.candidates.map(async (candidatePath) => {
       try {
         const stats = await stat(candidatePath);
         return { candidatePath, mtimeMs: stats.mtimeMs };
@@ -434,8 +603,8 @@ async function resolveSessionFilePath(
     metaByPath.set(candidate.candidatePath, meta);
     if (
       typeof meta?.id === 'string' &&
-      isMatchingProviderSessionId(meta.id, providerSessionId) &&
-      meta.cwd === workingDir
+      isMatchingProviderSessionId(meta.id, params.providerSessionId) &&
+      meta.cwd === params.workingDir
     ) {
       return candidate.candidatePath;
     }
@@ -443,12 +612,69 @@ async function resolveSessionFilePath(
 
   for (const candidate of withMtime) {
     const meta = metaByPath.get(candidate.candidatePath) ?? null;
-    if (typeof meta?.id === 'string' && isMatchingProviderSessionId(meta.id, providerSessionId)) {
+    if (
+      typeof meta?.id === 'string' &&
+      isMatchingProviderSessionId(meta.id, params.providerSessionId)
+    ) {
       return candidate.candidatePath;
     }
   }
 
   return null;
+}
+
+async function resolveUncachedSessionFilePath(
+  sessionsDir: string,
+  workingDir: string,
+  providerSessionId: string
+): Promise<string | null> {
+  const fileSuffixes = buildSessionFileSuffixes(providerSessionId);
+  const expectedDateDirs = getExpectedDateSessionDirs(sessionsDir, providerSessionId);
+  const expectedCandidates = await collectCandidateSessionFilesFromDirs(
+    expectedDateDirs,
+    fileSuffixes
+  );
+  const expectedMatch = await selectMatchingSessionFilePath({
+    candidates: expectedCandidates,
+    providerSessionId,
+    workingDir,
+  });
+  if (expectedMatch) {
+    return expectedMatch;
+  }
+
+  const recentDateDirs = await collectRecentDateSessionDirs(sessionsDir);
+  const recentCandidates = await collectCandidateSessionFilesFromDirs(
+    recentDateDirs.map((candidate) => candidate.directoryPath),
+    fileSuffixes
+  );
+  return await selectMatchingSessionFilePath({
+    candidates: recentCandidates,
+    providerSessionId,
+    workingDir,
+  });
+}
+
+async function resolveSessionFilePath(
+  workingDir: string,
+  providerSessionId: string
+): Promise<string | null> {
+  const sessionsDir = getCodexSessionsDir();
+  try {
+    await access(sessionsDir);
+  } catch {
+    return null;
+  }
+
+  const cacheKey = buildSessionFileLookupCacheKey({ sessionsDir, workingDir, providerSessionId });
+  const cachedFilePath = getCachedSessionFilePath(cacheKey);
+  if (cachedFilePath !== undefined) {
+    return cachedFilePath;
+  }
+
+  const filePath = await resolveUncachedSessionFilePath(sessionsDir, workingDir, providerSessionId);
+  setCachedSessionFilePath(cacheKey, filePath);
+  return filePath;
 }
 
 class CodexSessionHistoryLoaderService {

--- a/src/backend/services/session/service/data/codex-session-history-loader.service.ts
+++ b/src/backend/services/session/service/data/codex-session-history-loader.service.ts
@@ -117,27 +117,36 @@ function buildSessionFileLookupCacheKey(params: {
   });
 }
 
-async function getCachedSessionFilePath(cacheKey: string): Promise<string | null | undefined> {
-  const cached = sessionFileLookupCache.get(cacheKey);
+async function getCachedSessionFilePath(params: {
+  cacheKey: string;
+  workingDir: string;
+}): Promise<string | null | undefined> {
+  const cached = sessionFileLookupCache.get(params.cacheKey);
   if (!cached) {
     return undefined;
   }
 
   if (cached.expiresAtMs <= Date.now()) {
-    sessionFileLookupCache.delete(cacheKey);
+    sessionFileLookupCache.delete(params.cacheKey);
     return undefined;
   }
 
   if (cached.filePath !== null) {
     const stats = await stat(cached.filePath).catch(() => null);
     if (!stats?.isFile()) {
-      sessionFileLookupCache.delete(cacheKey);
+      sessionFileLookupCache.delete(params.cacheKey);
+      return undefined;
+    }
+
+    const meta = await parseSessionMeta(cached.filePath);
+    if (meta?.cwd !== params.workingDir) {
+      sessionFileLookupCache.delete(params.cacheKey);
       return undefined;
     }
   }
 
-  sessionFileLookupCache.delete(cacheKey);
-  sessionFileLookupCache.set(cacheKey, cached);
+  sessionFileLookupCache.delete(params.cacheKey);
+  sessionFileLookupCache.set(params.cacheKey, cached);
   return cached.filePath;
 }
 
@@ -684,7 +693,7 @@ async function resolveSessionFilePath(
   }
 
   const cacheKey = buildSessionFileLookupCacheKey({ sessionsDir, workingDir, providerSessionId });
-  const cachedFilePath = await getCachedSessionFilePath(cacheKey);
+  const cachedFilePath = await getCachedSessionFilePath({ cacheKey, workingDir });
   if (cachedFilePath !== undefined) {
     return cachedFilePath;
   }


### PR DESCRIPTION
## Summary
- Bound Codex JSONL history discovery to expected UUIDv7 date paths and recent date directories.
- Added short-lived positive/negative lookup caching for provider session ID resolution.
- Added regression coverage for avoiding unrelated session-tree traversal and repeated misses.

## Changes
- **Codex history loader**: Replaced root-wide recursive discovery with UUIDv7 date-path probing plus a bounded recent date-directory fallback, while preserving metadata validation and cwd preference.
- **Lookup cache**: Added an LRU-style in-memory cache for resolved paths and misses to keep repeated passive loads cheap.
- **Tests**: Added focused coverage for date-derived lookup precedence and negative lookup caching.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Manual testing: Ran `pnpm typecheck && pnpm check:fix && pnpm test && pnpm build`

Closes #1751

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which on-disk session file is chosen when duplicates exist and adds caching that could briefly hide new files; behavior is heavily tested but affects session history hydration.
> 
> **Overview**
> Replaces **root-wide recursive** Codex session JSONL discovery with a **bounded** strategy: probe **UUIDv7-derived** `YYYY/MM/DD` directories (±1 day), then scan at most **120 recent date folders** with shallow nesting, while still preferring **cwd** matches over id-only fallbacks.
> 
> Adds an **in-memory LRU-style lookup cache** (short TTL for hits and misses) with **revalidation** on positive hits (file still exists, `session_meta` id and cwd still match) so repeated passive loads stay cheap without serving stale wrong files.
> 
> **Tests** cover expected-date precedence over unrelated trees, recent-dir cwd wins over expected-date id-only fallback, scan cap, and cache behavior (negative hits, deleted files, later cwd matches, tampered meta).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32d350bbd269fe67bb6f13ad3f2acd702de2b6cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

