### PR TITLE
Fix #1766: Clear ratchet teardown state

### DIFF
--- a/src/backend/orchestration/workspace-archive.orchestrator.test.ts
+++ b/src/backend/orchestration/workspace-archive.orchestrator.test.ts
@@ -65,6 +65,9 @@ const services = unsafeCoerce<ArchiveWorkspaceDependencies>({
   githubCLIService: {
     addIssueComment: vi.fn(),
   },
+  ratchetService: {
+    clearWorkspaceState: vi.fn(),
+  },
   runScriptService: {
     stopRunScript: vi.fn(),
     evictWorkspaceBuffers: vi.fn(),
@@ -100,6 +103,7 @@ describe('archiveWorkspace', () => {
     vi.mocked(workspaceStateMachine.transition).mockResolvedValue(
       unsafeCoerce({ id: 'ws-1', status: 'READY' })
     );
+    vi.mocked(services.ratchetService.clearWorkspaceState).mockReturnValue(undefined);
     vi.mocked(workspaceAccessor.findStaleArchivingWithProject).mockResolvedValue([]);
     vi.mocked(worktreeLifecycleService.cleanupWorkspaceWorktree).mockResolvedValue(undefined);
     vi.mocked(services.sessionService.stopWorkspaceSessions).mockResolvedValue(undefined as never);
@@ -167,6 +171,13 @@ describe('archiveWorkspace', () => {
       expect(workspaceStateMachine.startArchivingWithSourceStatus).toHaveBeenCalledWith('ws-1');
       expect(workspaceStateMachine.markArchived).toHaveBeenCalledWith('ws-1');
       expect(services.runScriptService.evictWorkspaceBuffers).toHaveBeenCalledWith('ws-1');
+    });
+
+    it('clears ratchet in-memory state after successful archive', async () => {
+      const workspace = makeWorkspace();
+      await archiveWorkspace(workspace, defaultOptions);
+
+      expect(services.ratchetService.clearWorkspaceState).toHaveBeenCalledWith('ws-1');
     });
 
     it('returns the archived workspace', async () => {
@@ -261,6 +272,7 @@ describe('archiveWorkspace', () => {
 
       await expect(archiveWorkspace(workspace, defaultOptions)).rejects.toThrow();
       expect(workspaceStateMachine.markArchived).not.toHaveBeenCalled();
+      expect(services.ratchetService.clearWorkspaceState).not.toHaveBeenCalled();
     });
 
     it('rolls status back when archive fails after entering ARCHIVING', async () => {
@@ -485,6 +497,7 @@ describe('recoverStaleArchivingWorkspaces', () => {
     vi.mocked(workspaceStateMachine.transition).mockResolvedValue(
       unsafeCoerce({ id: 'ws-1', status: 'FAILED' })
     );
+    vi.mocked(services.ratchetService.clearWorkspaceState).mockReturnValue(undefined);
     vi.mocked(worktreeLifecycleService.cleanupWorkspaceWorktree).mockResolvedValue(undefined);
     vi.mocked(services.sessionService.stopWorkspaceSessions).mockResolvedValue(undefined as never);
     vi.mocked(services.runScriptService.stopRunScript).mockResolvedValue(
@@ -518,6 +531,7 @@ describe('recoverStaleArchivingWorkspaces', () => {
     });
     expect(workspaceStateMachine.markArchived).toHaveBeenCalledWith('ws-1');
     expect(services.runScriptService.evictWorkspaceBuffers).toHaveBeenCalledWith('ws-1');
+    expect(services.ratchetService.clearWorkspaceState).toHaveBeenCalledWith('ws-1');
   });
 
   it('marks a stale ARCHIVING workspace as FAILED when recovery cannot complete', async () => {

--- a/src/backend/orchestration/workspace-archive.orchestrator.ts
+++ b/src/backend/orchestration/workspace-archive.orchestrator.ts
@@ -27,6 +27,9 @@ export type ArchiveWorkspaceDependencies = {
     stopRunScript(workspaceId: string): Promise<{ success: boolean; error?: string }>;
     evictWorkspaceBuffers(workspaceId: string): void;
   };
+  ratchetService: {
+    clearWorkspaceState(workspaceId: string): void;
+  };
   sessionService: {
     stopWorkspaceSessions(workspaceId: string): Promise<void>;
   };
@@ -131,6 +134,7 @@ async function completeArchive(
 
   const archivedWorkspace = await workspaceStateMachine.markArchived(workspace.id);
   runScriptService.evictWorkspaceBuffers(workspace.id);
+  services.ratchetService.clearWorkspaceState(workspace.id);
 
   // Notify parent workspace that this child was archived (fire-and-forget)
   fireLifecycleNotification(

--- a/src/backend/services/ratchet/service/ratchet.service.test.ts
+++ b/src/backend/services/ratchet/service/ratchet.service.test.ts
@@ -1573,6 +1573,24 @@ describe('ratchet service (state-change + idle dispatch)', () => {
   });
 
   describe('shutdown behavior', () => {
+    it('clears review poll trackers on stop', async () => {
+      const trackers = unsafeCoerce<{
+        reviewPollTrackers: Map<
+          string,
+          { snapshotKey: string; lastPolledAt: number; pollCount: number }
+        >;
+      }>(ratchetService).reviewPollTrackers;
+      trackers.set('ws-poll', {
+        snapshotKey: 'snapshot-1',
+        lastPolledAt: Date.now(),
+        pollCount: 0,
+      });
+
+      await ratchetService.stop();
+
+      expect(trackers.size).toBe(0);
+    });
+
     it('stops immediately while monitor loop is sleeping', async () => {
       vi.useFakeTimers();
 
@@ -1593,6 +1611,32 @@ describe('ratchet service (state-change + idle dispatch)', () => {
     });
   });
 
+  describe('clearWorkspaceState', () => {
+    it('clears only the review poll tracker for the target workspace', () => {
+      const trackers = unsafeCoerce<{
+        reviewPollTrackers: Map<
+          string,
+          { snapshotKey: string; lastPolledAt: number; pollCount: number }
+        >;
+      }>(ratchetService).reviewPollTrackers;
+      trackers.set('ws-target', {
+        snapshotKey: 'snapshot-target',
+        lastPolledAt: Date.now(),
+        pollCount: 0,
+      });
+      trackers.set('ws-other', {
+        snapshotKey: 'snapshot-other',
+        lastPolledAt: Date.now(),
+        pollCount: 0,
+      });
+
+      ratchetService.clearWorkspaceState('ws-target');
+
+      expect(trackers.has('ws-target')).toBe(false);
+      expect(trackers.has('ws-other')).toBe(true);
+    });
+  });
+
   describe('checkWorkspaceById', () => {
     it('returns null when shutting down', async () => {
       unsafeCoerce<{ isShuttingDown: boolean }>(ratchetService).isShuttingDown = true;
@@ -1604,9 +1648,21 @@ describe('ratchet service (state-change + idle dispatch)', () => {
     it('returns null when workspace not found', async () => {
       unsafeCoerce<{ isShuttingDown: boolean }>(ratchetService).isShuttingDown = false;
       vi.mocked(workspaceAccessor.findForRatchetById).mockResolvedValue(null);
+      const trackers = unsafeCoerce<{
+        reviewPollTrackers: Map<
+          string,
+          { snapshotKey: string; lastPolledAt: number; pollCount: number }
+        >;
+      }>(ratchetService).reviewPollTrackers;
+      trackers.set('ws-nonexistent', {
+        snapshotKey: 'snapshot-1',
+        lastPolledAt: Date.now(),
+        pollCount: 0,
+      });
 
       const result = await ratchetService.checkWorkspaceById('ws-nonexistent');
       expect(result).toBeNull();
+      expect(trackers.has('ws-nonexistent')).toBe(false);
     });
 
     it('deduplicates concurrent checks for the same workspace', async () => {
@@ -2263,6 +2319,17 @@ describe('ratchet service (state-change + idle dispatch)', () => {
         ratchetActiveSessionId: null,
       } as never);
       vi.mocked(workspaceAccessor.update).mockResolvedValue({} as never);
+      const trackers = unsafeCoerce<{
+        reviewPollTrackers: Map<
+          string,
+          { snapshotKey: string; lastPolledAt: number; pollCount: number }
+        >;
+      }>(ratchetService).reviewPollTrackers;
+      trackers.set('ws-disable', {
+        snapshotKey: 'snapshot-1',
+        lastPolledAt: Date.now(),
+        pollCount: 0,
+      });
 
       const toggledEvents: RatchetToggledEvent[] = [];
       const stateEvents: RatchetStateChangedEvent[] = [];
@@ -2295,6 +2362,7 @@ describe('ratchet service (state-change + idle dispatch)', () => {
           ratchetState: RatchetState.IDLE,
         },
       ]);
+      expect(trackers.has('ws-disable')).toBe(false);
     });
 
     it('stops ratchet workflow sessions found after disabling workspace', async () => {

--- a/src/backend/services/ratchet/service/ratchet.service.ts
+++ b/src/backend/services/ratchet/service/ratchet.service.ts
@@ -137,6 +137,8 @@ class RatchetService extends EventEmitter {
       this.monitorLoop = null;
     }
 
+    this.reviewPollTrackers.clear();
+
     logger.info('Ratchet service stopped');
   }
 
@@ -234,6 +236,7 @@ class RatchetService extends EventEmitter {
 
     const workspace = await workspaceAccessor.findForRatchetById(workspaceId);
     if (!workspace) {
+      this.clearWorkspaceState(workspaceId);
       return null;
     }
 
@@ -242,6 +245,10 @@ class RatchetService extends EventEmitter {
 
   async clearRatchetActiveSessionIfMatching(workspaceId: string, sessionId: string): Promise<void> {
     await workspaceAccessor.clearRatchetActiveSession(workspaceId, sessionId);
+  }
+
+  clearWorkspaceState(workspaceId: string): void {
+    this.reviewPollTrackers.delete(workspaceId);
   }
 
   private async runWorkspaceCheckSafely(
@@ -304,6 +311,7 @@ class RatchetService extends EventEmitter {
     });
 
     await this.stopActiveRatchetSessionsAfterDisable(workspaceId);
+    this.clearWorkspaceState(workspaceId);
 
     if (workspace.ratchetState !== RatchetState.IDLE) {
       this.emit(RATCHET_STATE_CHANGED, {
@@ -401,7 +409,7 @@ class RatchetService extends EventEmitter {
       const decision = this.decideRatchetAction(decisionContext);
 
       if (prStateInfo.prState === 'MERGED') {
-        this.reviewPollTrackers.delete(workspace.id);
+        this.clearWorkspaceState(workspace.id);
       } else if (decisionContext.isCleanPrWithNoNewReviewActivity) {
         const pollDispatch = await this.processReviewCommentPoll(
           workspace,
@@ -412,7 +420,7 @@ class RatchetService extends EventEmitter {
           return pollDispatch;
         }
       } else {
-        this.reviewPollTrackers.delete(workspace.id);
+        this.clearWorkspaceState(workspace.id);
       }
 
       const action = await this.applyRatchetDecision(decisionContext, decision);


### PR DESCRIPTION
## Summary
- Adds explicit ratchet workspace-state cleanup for review-poll trackers
- Clears stale ratchet state when workspaces are archived, disabled, no longer ratchet-eligible, or the service stops
- Covers archive teardown, stale archive recovery, and ratchet cleanup paths with focused tests

## Changes
- **Ratchet service**: Added `clearWorkspaceState(workspaceId)` and reused it for tracker deletion paths; service stop now clears all review-poll trackers.
- **Archive orchestration**: Clears ratchet in-memory state immediately after a workspace is marked archived, including stale archiving recovery.
- **Tests**: Added coverage for archive cleanup, failed archive non-cleanup, recovery cleanup, direct tracker cleanup, stop cleanup, disabled ratchet cleanup, and no-longer-eligible workspace cleanup.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; backend memory cleanup only

Closes #1766

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> In-memory cleanup only; archive flow gains one post-success hook with tests ensuring failed archives do not clear ratchet state.
> 
> **Overview**
> Fixes stale **ratchet** in-memory **review-poll trackers** by centralizing cleanup in `clearWorkspaceState(workspaceId)` and calling it when a workspace is no longer ratchet-relevant.
> 
> **Ratchet service** now drops per-workspace trackers on disable, merged PR, non-clean-PR paths, missing workspace on `checkWorkspaceById`, and clears the full map on `stop()`.
> 
> **Archive orchestration** invokes `ratchetService.clearWorkspaceState` after a workspace is successfully marked archived (including stale archiving recovery), and skips cleanup when archive fails before that point.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d199fbe7a7ef9bb9e88c4367e6ad04a4084f255. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

