### PR TITLE
Fix #1750: Bound chat renderer transcript

### DIFF
--- a/src/backend/services/session/service/store/session-replay-builder.test.ts
+++ b/src/backend/services/session/service/store/session-replay-builder.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { type ChatMessage, DEFAULT_RENDERER_TRANSCRIPT_LIMIT } from '@/shared/acp-protocol';
 import { buildReplayEvents, buildSnapshotMessages } from './session-replay-builder';
 import type { SessionStore } from './session-store.types';
 
@@ -58,6 +59,38 @@ function createStore(): SessionStore {
       updatedAt: '2026-02-01T00:00:04.000Z',
     },
     nextOrder: 2,
+  };
+}
+
+function createUserMessage(id: string, order: number): ChatMessage {
+  return {
+    id,
+    source: 'user',
+    text: `message ${order}`,
+    timestamp: '2026-02-01T00:00:00.000Z',
+    order,
+  };
+}
+
+function createToolResultMessage(id: string, toolUseId: string, order: number): ChatMessage {
+  return {
+    id,
+    source: 'agent',
+    message: {
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: toolUseId,
+            content: 'Tool output',
+          },
+        ],
+      },
+    },
+    timestamp: '2026-02-01T00:00:00.000Z',
+    order,
   };
 }
 
@@ -135,5 +168,68 @@ describe('session-replay-builder', () => {
         }),
       ])
     );
+  });
+
+  it('builds snapshots from a bounded recent transcript window without mutating the store', () => {
+    const store = createStore();
+    store.transcript = Array.from({ length: DEFAULT_RENDERER_TRANSCRIPT_LIMIT + 5 }, (_, order) =>
+      createUserMessage(`m-${order}`, order)
+    );
+    store.queue = [
+      {
+        id: 'queued-visible',
+        text: 'queued',
+        timestamp: '2026-02-01T00:00:02.000Z',
+        settings: {
+          selectedModel: null,
+          reasoningEffort: null,
+          thinkingEnabled: false,
+          planModeEnabled: false,
+        },
+      },
+    ];
+
+    const snapshot = buildSnapshotMessages(store);
+
+    expect(store.transcript).toHaveLength(DEFAULT_RENDERER_TRANSCRIPT_LIMIT + 5);
+    expect(snapshot).toHaveLength(DEFAULT_RENDERER_TRANSCRIPT_LIMIT + 1);
+    expect(snapshot[0]!.id).toBe('m-5');
+    expect(snapshot.at(-1)?.id).toBe('queued-visible');
+  });
+
+  it('starts bounded snapshots at a render-safe boundary', () => {
+    const store = createStore();
+    store.transcript = [
+      createUserMessage('too-old', 0),
+      createToolResultMessage('orphaned-tool-result', 'tool-too-old', 1),
+      ...Array.from({ length: DEFAULT_RENDERER_TRANSCRIPT_LIMIT - 1 }, (_, index) =>
+        createUserMessage(`m-${index + 2}`, index + 2)
+      ),
+    ];
+    store.queue = [];
+
+    const snapshot = buildSnapshotMessages(store);
+
+    expect(snapshot).toHaveLength(DEFAULT_RENDERER_TRANSCRIPT_LIMIT - 1);
+    expect(snapshot[0]!.id).toBe('m-2');
+    expect(snapshot.some((message) => message.id === 'orphaned-tool-result')).toBe(false);
+  });
+
+  it('builds replay batches from a bounded recent transcript window', () => {
+    const store = createStore();
+    store.transcript = Array.from({ length: DEFAULT_RENDERER_TRANSCRIPT_LIMIT + 3 }, (_, order) =>
+      createUserMessage(`m-${order}`, order)
+    );
+    store.queue = [];
+    store.pendingInteractiveRequest = null;
+
+    const replayEvents = buildReplayEvents(store);
+    const acceptedMessageIds = replayEvents
+      .filter((event) => event.type === 'message_state_changed' && event.newState === 'ACCEPTED')
+      .map((event) => event.id);
+
+    expect(acceptedMessageIds).toHaveLength(DEFAULT_RENDERER_TRANSCRIPT_LIMIT);
+    expect(acceptedMessageIds[0]).toBe('m-3');
+    expect(acceptedMessageIds.at(-1)).toBe(`m-${DEFAULT_RENDERER_TRANSCRIPT_LIMIT + 2}`);
   });
 });

--- a/src/backend/services/session/service/store/session-replay-builder.ts
+++ b/src/backend/services/session/service/store/session-replay-builder.ts
@@ -5,13 +5,18 @@ import {
   QUEUED_MESSAGE_ORDER_BASE,
   type WebSocketMessage as ReplayEventMessage,
   resolveSelectedModel,
+  trimTranscriptForRenderer,
 } from '@/shared/acp-protocol';
 import { isUserQuestionRequest } from '@/shared/pending-request-types';
 import type { SessionStore } from './session-store.types';
 import { messageSort } from './session-transcript';
 
+function selectRendererTranscriptWindow(store: SessionStore): ChatMessage[] {
+  return trimTranscriptForRenderer(store.transcript);
+}
+
 export function buildSnapshotMessages(store: SessionStore): ChatMessage[] {
-  const snapshot = [...store.transcript];
+  const snapshot = selectRendererTranscriptWindow(store);
   store.queue.forEach((queued, index) => {
     snapshot.push({
       id: queued.id,
@@ -34,7 +39,7 @@ export function buildReplayEvents(store: SessionStore): ReplayEventMessage[] {
     },
   ];
 
-  const transcript = [...store.transcript].sort(messageSort);
+  const transcript = selectRendererTranscriptWindow(store);
   for (const message of transcript) {
     if (message.source === 'user') {
       replayEvents.push({

--- a/src/components/chat/chat-reducer.test.ts
+++ b/src/components/chat/chat-reducer.test.ts
@@ -15,7 +15,11 @@ import type {
   UserQuestionRequest,
   WebSocketMessage,
 } from '@/lib/chat-protocol';
-import { DEFAULT_CHAT_SETTINGS, MessageState } from '@/lib/chat-protocol';
+import {
+  DEFAULT_CHAT_SETTINGS,
+  DEFAULT_RENDERER_TRANSCRIPT_LIMIT,
+  MessageState,
+} from '@/lib/chat-protocol';
 import type { ChatBarCapabilities } from '@/shared/chat-capabilities';
 import { unsafeCoerce } from '@/test-utils/unsafe-coerce';
 import {
@@ -163,6 +167,36 @@ function createTestToolResultMessage(toolUseId: string): AgentMessage {
         },
       ],
     },
+  };
+}
+
+function createUserChatMessage(id: string, order: number): ChatMessage {
+  return {
+    id,
+    source: 'user',
+    text: `Message ${order}`,
+    timestamp: '2024-01-01T00:00:00.000Z',
+    order,
+  };
+}
+
+function createToolUseChatMessage(id: string, toolUseId: string, order: number): ChatMessage {
+  return {
+    id,
+    source: 'agent',
+    message: createTestToolUseMessage(toolUseId),
+    timestamp: '2024-01-01T00:00:00.000Z',
+    order,
+  };
+}
+
+function createToolResultChatMessage(id: string, toolUseId: string, order: number): ChatMessage {
+  return {
+    id,
+    source: 'agent',
+    message: createTestToolResultMessage(toolUseId),
+    timestamp: '2024-01-01T00:00:00.000Z',
+    order,
   };
 }
 
@@ -1540,6 +1574,151 @@ describe('chatReducer', () => {
 
       expect(newState.messages).toHaveLength(1);
       expect(newState.messages[0]).toEqual(userMessage);
+    });
+  });
+
+  describe('renderer transcript retention', () => {
+    it('caps live agent inserts to the recent renderer window and prunes rewind metadata', () => {
+      const messages = Array.from({ length: DEFAULT_RENDERER_TRANSCRIPT_LIMIT }, (_, order) =>
+        createUserChatMessage(`msg-${order}`, order)
+      );
+      const state = createInitialChatState({
+        messages,
+        messageIdToUuid: new Map([
+          ['msg-0', 'uuid-0'],
+          [`msg-${DEFAULT_RENDERER_TRANSCRIPT_LIMIT - 1}`, 'uuid-recent'],
+        ]),
+        localUserMessageIds: new Set(['msg-0', `msg-${DEFAULT_RENDERER_TRANSCRIPT_LIMIT - 1}`]),
+      });
+
+      const newState = chatReducer(state, {
+        type: 'WS_AGENT_MESSAGE',
+        payload: {
+          message: createTestAssistantMessage(),
+          order: DEFAULT_RENDERER_TRANSCRIPT_LIMIT,
+        },
+      });
+
+      expect(newState.messages).toHaveLength(DEFAULT_RENDERER_TRANSCRIPT_LIMIT);
+      expect(newState.messages[0]!.id).toBe('msg-1');
+      expect(newState.messages.at(-1)?.source).toBe('agent');
+      expect(newState.messageIdToUuid.has('msg-0')).toBe(false);
+      expect(newState.messageIdToUuid.get(`msg-${DEFAULT_RENDERER_TRANSCRIPT_LIMIT - 1}`)).toBe(
+        'uuid-recent'
+      );
+      expect(newState.localUserMessageIds.has('msg-0')).toBe(false);
+    });
+
+    it('drops recovered old user-message deltas that fall outside the recent window', () => {
+      const messages = Array.from({ length: DEFAULT_RENDERER_TRANSCRIPT_LIMIT }, (_, index) =>
+        createUserChatMessage(`msg-${index + 100}`, index + 100)
+      );
+      const state = createInitialChatState({ messages });
+
+      const newState = chatReducer(state, {
+        type: 'MESSAGE_STATE_CHANGED',
+        payload: {
+          id: 'missed-old-message',
+          newState: MessageState.DISPATCHED,
+          userMessage: {
+            text: 'Recovered but too old',
+            timestamp: '2024-01-01T00:00:00.000Z',
+            order: 0,
+          },
+        },
+      });
+
+      expect(newState.messages).toHaveLength(DEFAULT_RENDERER_TRANSCRIPT_LIMIT);
+      expect(newState.messages.some((message) => message.id === 'missed-old-message')).toBe(false);
+      expect(newState.messages[0]!.id).toBe('msg-100');
+    });
+
+    it('caps snapshot hydration and rebuilds tool indexes for retained messages', () => {
+      const messages = [
+        createToolUseChatMessage('old-tool', 'tool-old', 0),
+        ...Array.from({ length: DEFAULT_RENDERER_TRANSCRIPT_LIMIT - 1 }, (_, index) =>
+          createUserChatMessage(`msg-${index + 1}`, index + 1)
+        ),
+        createToolUseChatMessage('recent-tool', 'tool-recent', DEFAULT_RENDERER_TRANSCRIPT_LIMIT),
+      ];
+
+      const newState = chatReducer(initialState, {
+        type: 'SESSION_SNAPSHOT',
+        payload: {
+          messages,
+          queuedMessages: [],
+          sessionRuntime: {
+            phase: 'idle',
+            processState: 'alive',
+            activity: 'IDLE',
+            updatedAt: '2026-02-08T00:00:00.000Z',
+          },
+        },
+      });
+
+      expect(newState.messages).toHaveLength(DEFAULT_RENDERER_TRANSCRIPT_LIMIT);
+      expect(newState.messages[0]!.id).toBe('msg-1');
+      expect(newState.messages.at(-1)?.id).toBe('recent-tool');
+      expect(newState.toolUseIdToIndex.has('tool-old')).toBe(false);
+      expect(newState.toolUseIdToIndex.get('tool-recent')).toBe(
+        DEFAULT_RENDERER_TRANSCRIPT_LIMIT - 1
+      );
+    });
+
+    it('starts a trimmed snapshot at a render-safe boundary', () => {
+      const messages = [
+        createUserChatMessage('too-old', 0),
+        createToolResultChatMessage('orphaned-tool-result', 'tool-too-old', 1),
+        ...Array.from({ length: DEFAULT_RENDERER_TRANSCRIPT_LIMIT - 1 }, (_, index) =>
+          createUserChatMessage(`msg-${index + 2}`, index + 2)
+        ),
+      ];
+
+      const newState = chatReducer(initialState, {
+        type: 'SESSION_SNAPSHOT',
+        payload: {
+          messages,
+          queuedMessages: [],
+          sessionRuntime: {
+            phase: 'idle',
+            processState: 'alive',
+            activity: 'IDLE',
+            updatedAt: '2026-02-08T00:00:00.000Z',
+          },
+        },
+      });
+
+      expect(newState.messages).toHaveLength(DEFAULT_RENDERER_TRANSCRIPT_LIMIT - 1);
+      expect(newState.messages[0]!.id).toBe('msg-2');
+      expect(newState.messages.some((message) => message.id === 'orphaned-tool-result')).toBe(
+        false
+      );
+    });
+
+    it('drops late user-message UUIDs when there is no retained local message or pending send', () => {
+      const state = createInitialChatState({
+        pendingUserMessageUuids: ['stale-uuid'],
+      });
+
+      const newState = chatReducer(state, {
+        type: 'USER_MESSAGE_UUID_RECEIVED',
+        payload: { uuid: 'late-uuid' },
+      });
+
+      expect(newState.pendingUserMessageUuids).toEqual([]);
+    });
+
+    it('still queues early user-message UUIDs while a local send is pending', () => {
+      const state = createInitialChatState({
+        pendingMessages: new Map([['pending-message', { text: 'Pending send' }]]),
+      });
+
+      const newState = chatReducer(state, {
+        type: 'USER_MESSAGE_UUID_RECEIVED',
+        payload: { uuid: 'early-uuid' },
+      });
+
+      expect(newState.pendingUserMessageUuids).toEqual(['early-uuid']);
     });
   });
 

--- a/src/components/chat/reducer/helpers.ts
+++ b/src/components/chat/reducer/helpers.ts
@@ -6,11 +6,13 @@ import type {
   UserQuestionRequest,
 } from '@/lib/chat-protocol';
 import {
+  DEFAULT_RENDERER_TRANSCRIPT_LIMIT,
   getToolUseIdFromEvent,
   isReasoningToolCall,
   isStreamEventMessage,
   shouldPersistAgentMessage,
   shouldSuppressDuplicateResultMessage,
+  trimTranscriptForRenderer,
   updateTokenStatsFromResult,
 } from '@/lib/chat-protocol';
 import { createDebugLogger, DEBUG_CHAT_WS } from '@/lib/debug';
@@ -116,6 +118,73 @@ export function insertMessageByOrder(
   return result;
 }
 
+export function trimMessagesForRenderer(
+  messages: ChatMessage[],
+  limit = DEFAULT_RENDERER_TRANSCRIPT_LIMIT
+): ChatMessage[] {
+  return trimTranscriptForRenderer(messages, limit);
+}
+
+function buildToolUseIdToIndex(messages: ChatMessage[]): Map<string, number> {
+  const toolUseIdToIndex = new Map<string, number>();
+  messages.forEach((message, index) => {
+    if (!message.message) {
+      return;
+    }
+    const toolUseId = getToolUseIdFromMessage(message.message);
+    if (toolUseId) {
+      toolUseIdToIndex.set(toolUseId, index);
+    }
+  });
+  return toolUseIdToIndex;
+}
+
+function filterMapByIds<Value>(
+  map: Map<string, Value>,
+  retainedIds: Set<string>
+): Map<string, Value> {
+  const filtered = new Map<string, Value>();
+  for (const [id, value] of map) {
+    if (retainedIds.has(id)) {
+      filtered.set(id, value);
+    }
+  }
+  return filtered;
+}
+
+function filterSetByIds(set: Set<string>, retainedIds: Set<string>): Set<string> {
+  const filtered = new Set<string>();
+  for (const id of set) {
+    if (retainedIds.has(id)) {
+      filtered.add(id);
+    }
+  }
+  return filtered;
+}
+
+export function applyRendererMessages(state: ChatState, messages: ChatMessage[]): ChatState {
+  const retainedMessages = trimMessagesForRenderer(messages);
+  const retainedIds = new Set(retainedMessages.map((message) => message.id));
+  const hasUnmappedLocalUserMessage = retainedMessages.some(
+    (message) =>
+      message.source === 'user' &&
+      state.localUserMessageIds.has(message.id) &&
+      !state.messageIdToUuid.has(message.id)
+  );
+
+  return {
+    ...state,
+    messages: retainedMessages,
+    toolUseIdToIndex: buildToolUseIdToIndex(retainedMessages),
+    messageIdToUuid: filterMapByIds(state.messageIdToUuid, retainedIds),
+    localUserMessageIds: filterSetByIds(state.localUserMessageIds, retainedIds),
+    pendingUserMessageUuids:
+      hasUnmappedLocalUserMessage || state.pendingMessages.size > 0
+        ? state.pendingUserMessageUuids
+        : [],
+  };
+}
+
 /**
  * Checks if a message is a tool_use message with the given ID.
  */
@@ -180,11 +249,6 @@ function upsertClaudeMessageAtOrder(
   if (!existingMsg) {
     return null;
   }
-  const existingToolUseId = existingMsg.message
-    ? getToolUseIdFromMessage(existingMsg.message)
-    : null;
-  const incomingToolUseId = getToolUseIdFromMessage(claudeMsg);
-
   const updatedMessages = [...state.messages];
   updatedMessages[existingIndex] = {
     ...existingMsg,
@@ -192,25 +256,7 @@ function upsertClaudeMessageAtOrder(
     timestamp: claudeMsg.timestamp ?? existingMsg.timestamp,
   };
 
-  if (existingToolUseId !== incomingToolUseId) {
-    const nextToolUseIdToIndex = new Map(state.toolUseIdToIndex);
-    if (existingToolUseId) {
-      nextToolUseIdToIndex.delete(existingToolUseId);
-    }
-    if (incomingToolUseId) {
-      nextToolUseIdToIndex.set(incomingToolUseId, existingIndex);
-    }
-    return {
-      ...state,
-      messages: updatedMessages,
-      toolUseIdToIndex: nextToolUseIdToIndex,
-    };
-  }
-
-  return {
-    ...state,
-    messages: updatedMessages,
-  };
+  return applyRendererMessages(state, updatedMessages);
 }
 
 /**
@@ -277,17 +323,7 @@ export function handleClaudeMessage(
   // Create and add the message using order-based insertion
   const chatMessage = createClaudeMessage(claudeMsg, order);
   const newMessages = insertMessageByOrder(baseState.messages, chatMessage);
-  const newIndex = newMessages.indexOf(chatMessage);
-
-  // Track tool_use message index for O(1) updates
-  const toolUseId = getToolUseIdFromMessage(claudeMsg);
-  if (toolUseId) {
-    const newToolUseIdToIndex = new Map(baseState.toolUseIdToIndex);
-    newToolUseIdToIndex.set(toolUseId, newIndex);
-    return { ...baseState, messages: newMessages, toolUseIdToIndex: newToolUseIdToIndex };
-  }
-
-  return { ...baseState, messages: newMessages };
+  return applyRendererMessages(baseState, newMessages);
 }
 
 /**

--- a/src/components/chat/reducer/slices/messages/compact.ts
+++ b/src/components/chat/reducer/slices/messages/compact.ts
@@ -1,3 +1,4 @@
+import { applyRendererMessages } from '@/components/chat/reducer/helpers';
 import type { ChatAction, ChatState } from '@/components/chat/reducer/types';
 import type { AgentMessage, ChatMessage } from '@/lib/chat-protocol';
 
@@ -15,11 +16,13 @@ export function reduceMessageCompactSlice(state: ChatState, action: ChatAction):
         timestamp: new Date().toISOString(),
         order: maxOrder + 1,
       };
-      return {
-        ...state,
-        hasCompactBoundary: true,
-        messages: [...state.messages, compactBoundaryMessage],
-      };
+      return applyRendererMessages(
+        {
+          ...state,
+          hasCompactBoundary: true,
+        },
+        [...state.messages, compactBoundaryMessage]
+      );
     }
     default:
       return state;

--- a/src/components/chat/reducer/slices/messages/queue.ts
+++ b/src/components/chat/reducer/slices/messages/queue.ts
@@ -1,11 +1,11 @@
-import { insertMessageByOrder } from '@/components/chat/reducer/helpers';
+import { applyRendererMessages, insertMessageByOrder } from '@/components/chat/reducer/helpers';
 import type { ChatAction, ChatState } from '@/components/chat/reducer/types';
 import type { ChatMessage } from '@/lib/chat-protocol';
 
 export function reduceMessageQueueSlice(state: ChatState, action: ChatAction): ChatState {
   switch (action.type) {
     case 'USER_MESSAGE_SENT':
-      return { ...state, messages: [...state.messages, action.payload] };
+      return applyRendererMessages(state, [...state.messages, action.payload]);
     case 'ADD_TO_QUEUE': {
       const newQueuedMessages = new Map(state.queuedMessages);
       newQueuedMessages.set(action.payload.id, action.payload);
@@ -51,8 +51,7 @@ export function reduceMessageQueueSlice(state: ChatState, action: ChatAction): C
       };
 
       return {
-        ...state,
-        messages: insertMessageByOrder(state.messages, userMessage),
+        ...applyRendererMessages(state, insertMessageByOrder(state.messages, userMessage)),
         pendingMessages: newPendingMessages,
         pendingRequest: { type: 'none' },
       };

--- a/src/components/chat/reducer/slices/messages/snapshot.ts
+++ b/src/components/chat/reducer/slices/messages/snapshot.ts
@@ -1,4 +1,4 @@
-import { convertPendingRequest } from '@/components/chat/reducer/helpers';
+import { applyRendererMessages, convertPendingRequest } from '@/components/chat/reducer/helpers';
 import type { ChatAction, ChatState, PendingMessageContent } from '@/components/chat/reducer/types';
 
 export function reduceMessageSnapshotSlice(state: ChatState, action: ChatAction): ChatState {
@@ -18,20 +18,23 @@ export function reduceMessageSnapshotSlice(state: ChatState, action: ChatAction)
         action.payload.queuedMessages.map((queued) => [queued.id, queued] as const)
       );
 
-      return {
-        ...state,
-        messages: snapshotMessages,
-        queuedMessages,
-        pendingRequest,
-        sessionRuntime: action.payload.sessionRuntime,
-        toolUseIdToIndex: new Map(),
-        pendingMessages: newPendingMessages,
-        lastRejectedMessage: state.lastRejectedMessage,
-        messageIdToUuid: new Map(),
-        pendingUserMessageUuids: [],
-        localUserMessageIds: new Set(),
-        rewindPreview: null,
-      };
+      return applyRendererMessages(
+        {
+          ...state,
+          messages: [],
+          queuedMessages,
+          pendingRequest,
+          sessionRuntime: action.payload.sessionRuntime,
+          toolUseIdToIndex: new Map(),
+          pendingMessages: newPendingMessages,
+          lastRejectedMessage: state.lastRejectedMessage,
+          messageIdToUuid: new Map(),
+          pendingUserMessageUuids: [],
+          localUserMessageIds: new Set(),
+          rewindPreview: null,
+        },
+        snapshotMessages
+      );
     }
     default:
       return state;

--- a/src/components/chat/reducer/slices/messages/state-machine.ts
+++ b/src/components/chat/reducer/slices/messages/state-machine.ts
@@ -1,4 +1,8 @@
-import { debugLog, insertMessageByOrder } from '@/components/chat/reducer/helpers';
+import {
+  applyRendererMessages,
+  debugLog,
+  insertMessageByOrder,
+} from '@/components/chat/reducer/helpers';
 import type { ChatAction, ChatState } from '@/components/chat/reducer/types';
 import type { ChatMessage } from '@/lib/chat-protocol';
 import { MessageState, QUEUED_MESSAGE_ORDER_BASE } from '@/lib/chat-protocol';
@@ -127,16 +131,18 @@ function handleAcceptedState(
     }
   }
 
-  return {
-    ...state,
-    messages: insertMessageByOrder(state.messages, newMessage),
-    queuedMessages: newQueuedMessages,
-    pendingMessages: newPendingMessages,
-    latestThinking: null,
-    messageIdToUuid: newMessageIdToUuid,
-    pendingUserMessageUuids: newPendingUuids,
-    localUserMessageIds: newLocalUserMessageIds,
-  };
+  return applyRendererMessages(
+    {
+      ...state,
+      queuedMessages: newQueuedMessages,
+      pendingMessages: newPendingMessages,
+      latestThinking: null,
+      messageIdToUuid: newMessageIdToUuid,
+      pendingUserMessageUuids: newPendingUuids,
+      localUserMessageIds: newLocalUserMessageIds,
+    },
+    insertMessageByOrder(state.messages, newMessage)
+  );
 }
 
 function handleDispatchedState(
@@ -181,10 +187,7 @@ function upsertUserMessageFromStateChange(
   const existingMessageIndex = state.messages.findIndex((m) => m.id === id);
   if (existingMessageIndex === -1) {
     // If this tab missed earlier transitions (reconnect/race), recover from payload.
-    return {
-      ...state,
-      messages: insertMessageByOrder(state.messages, messageFromDelta),
-    };
+    return applyRendererMessages(state, insertMessageByOrder(state.messages, messageFromDelta));
   }
 
   // Update the message with the new order and re-insert at correct position
@@ -208,10 +211,7 @@ function upsertUserMessageFromStateChange(
   ];
   const newMessages = insertMessageByOrder(messagesWithoutOld, updatedMessage);
 
-  return {
-    ...state,
-    messages: newMessages,
-  };
+  return applyRendererMessages(state, newMessages);
 }
 
 function handleCommittedState(
@@ -231,11 +231,13 @@ function handleRemoveFromQueue(state: ChatState, id: string): ChatState {
 function handleCancelledState(state: ChatState, id: string): ChatState {
   const newQueuedMessages = new Map(state.queuedMessages);
   newQueuedMessages.delete(id);
-  return {
-    ...state,
-    messages: state.messages.filter((m) => m.id !== id),
-    queuedMessages: newQueuedMessages,
-  };
+  return applyRendererMessages(
+    {
+      ...state,
+      queuedMessages: newQueuedMessages,
+    },
+    state.messages.filter((m) => m.id !== id)
+  );
 }
 
 function handleRejectedOrFailedState(
@@ -253,18 +255,20 @@ function handleRejectedOrFailedState(
   const newPendingMessages = new Map(state.pendingMessages);
   newPendingMessages.delete(id);
 
-  return {
-    ...state,
-    messages: state.messages.filter((m) => m.id !== id),
-    queuedMessages: newQueuedMessages,
-    pendingMessages: newPendingMessages,
-    lastRejectedMessage: recoveryContent
-      ? {
-          text: queuedMessage?.text ?? pendingContent?.text ?? '',
-          attachments: recoveryContent.attachments,
-          error: errorMessage ?? 'Message failed',
-          sessionId: recoveryContent.sessionId,
-        }
-      : null,
-  };
+  return applyRendererMessages(
+    {
+      ...state,
+      queuedMessages: newQueuedMessages,
+      pendingMessages: newPendingMessages,
+      lastRejectedMessage: recoveryContent
+        ? {
+            text: queuedMessage?.text ?? pendingContent?.text ?? '',
+            attachments: recoveryContent.attachments,
+            error: errorMessage ?? 'Message failed',
+            sessionId: recoveryContent.sessionId,
+          }
+        : null,
+    },
+    state.messages.filter((m) => m.id !== id)
+  );
 }

--- a/src/components/chat/reducer/slices/messages/transport.ts
+++ b/src/components/chat/reducer/slices/messages/transport.ts
@@ -1,4 +1,8 @@
-import { generateMessageId, handleClaudeMessage } from '@/components/chat/reducer/helpers';
+import {
+  applyRendererMessages,
+  generateMessageId,
+  handleClaudeMessage,
+} from '@/components/chat/reducer/helpers';
 import type { ChatAction, ChatState } from '@/components/chat/reducer/types';
 import type { AgentMessage, ChatMessage } from '@/lib/chat-protocol';
 
@@ -23,11 +27,13 @@ export function reduceMessageTransportSlice(state: ChatState, action: ChatAction
       // Clear loading state if error occurs while loading (e.g., load_session fails)
       const sessionStatus =
         state.sessionStatus.phase === 'loading' ? { phase: 'ready' as const } : state.sessionStatus;
-      return {
-        ...state,
-        messages: [...state.messages, errorChatMessage],
-        sessionStatus,
-      };
+      return applyRendererMessages(
+        {
+          ...state,
+          sessionStatus,
+        },
+        [...state.messages, errorChatMessage]
+      );
     }
     default:
       return state;

--- a/src/components/chat/reducer/slices/messages/uuid.ts
+++ b/src/components/chat/reducer/slices/messages/uuid.ts
@@ -24,6 +24,15 @@ export function reduceMessageUuidSlice(state: ChatState, action: ChatAction): Ch
         };
       }
 
+      if (state.pendingMessages.size === 0) {
+        debugLog(
+          `[chat-reducer] UUID received with no retained local user message, dropping: ${action.payload.uuid}`
+        );
+        return state.pendingUserMessageUuids.length > 0
+          ? { ...state, pendingUserMessageUuids: [] }
+          : state;
+      }
+
       debugLog(
         `[chat-reducer] UUID received but no unmapped user message found, queueing: ${action.payload.uuid}`
       );

--- a/src/shared/acp-protocol/protocol/constants.ts
+++ b/src/shared/acp-protocol/protocol/constants.ts
@@ -3,3 +3,9 @@
  * Shared by backend snapshot generation and frontend optimistic queue rendering.
  */
 export const QUEUED_MESSAGE_ORDER_BASE = 1_000_000_000;
+
+/**
+ * Maximum number of transcript messages retained in renderer state and sent
+ * during session hydration. The backend store remains authoritative.
+ */
+export const DEFAULT_RENDERER_TRANSCRIPT_LIMIT = 1000;

--- a/src/shared/acp-protocol/protocol/index.ts
+++ b/src/shared/acp-protocol/protocol/index.ts
@@ -8,6 +8,7 @@ export * from './interaction';
 export * from './messages';
 export * from './models';
 export * from './queued';
+export * from './renderer-window';
 export * from './result-dedup';
 export * from './session';
 export * from './state-machine';

--- a/src/shared/acp-protocol/protocol/renderer-window.ts
+++ b/src/shared/acp-protocol/protocol/renderer-window.ts
@@ -1,0 +1,58 @@
+import { DEFAULT_RENDERER_TRANSCRIPT_LIMIT } from './constants';
+import type { AgentContentItem } from './content';
+import type { AgentMessage, ChatMessage } from './messages';
+
+function hasContentType(
+  content: NonNullable<AgentMessage['message']>['content'],
+  type: AgentContentItem['type']
+): boolean {
+  return Array.isArray(content) && content.some((item) => item.type === type);
+}
+
+function isToolResultMessage(message: AgentMessage): boolean {
+  if (message.type === 'stream_event') {
+    return (
+      message.event?.type === 'content_block_start' &&
+      message.event.content_block.type === 'tool_result'
+    );
+  }
+
+  return message.message ? hasContentType(message.message.content, 'tool_result') : false;
+}
+
+function isStreamFragment(message: AgentMessage): boolean {
+  return message.type === 'stream_event' && message.event?.type !== 'content_block_start';
+}
+
+function isSafeRendererWindowStart(message: ChatMessage): boolean {
+  if (message.source === 'user') {
+    return true;
+  }
+
+  if (!message.message) {
+    return false;
+  }
+
+  return !(isToolResultMessage(message.message) || isStreamFragment(message.message));
+}
+
+export function trimTranscriptForRenderer(
+  messages: ChatMessage[],
+  limit = DEFAULT_RENDERER_TRANSCRIPT_LIMIT
+): ChatMessage[] {
+  const sortedMessages = [...messages].sort((a, b) => a.order - b.order);
+  if (sortedMessages.length <= limit) {
+    return sortedMessages;
+  }
+
+  const windowStart = Math.max(0, sortedMessages.length - limit);
+  const safeStart = sortedMessages.findIndex(
+    (message, index) => index >= windowStart && isSafeRendererWindowStart(message)
+  );
+
+  if (safeStart === -1) {
+    return sortedMessages.slice(windowStart);
+  }
+
+  return sortedMessages.slice(safeStart);
+}


### PR DESCRIPTION
## Summary
- Bounds renderer transcript state and hydration payloads to a recent transcript window.
- Keeps the backend session transcript authoritative while pruning renderer-only metadata consistently.
- Adds tests for live inserts, replay/snapshot hydration, render-safe trim boundaries, and stale UUID cleanup.

## Changes
- **Shared protocol**: Added a renderer transcript window helper and default 1,000-message retention limit.
- **Chat reducer**: Routes message append/update paths through the retention helper and rebuilds tool indexes after pruning.
- **Session replay**: Sends bounded recent transcript windows for snapshots and replay batches while preserving queued messages.
- **Tests**: Covers bounded live state, recovery deltas, snapshot/replay windows, orphaned tool-result boundaries, stale UUID cleanup, and store immutability.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Manual testing: Not applicable; UI appearance is unchanged and state/replay behavior is covered by automated tests.

Closes #1750

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core chat hydration, replay, and live reducer paths for long sessions; incorrect trimming could hide messages or break tool/UUID mapping, though behavior is heavily tested and UI appearance is unchanged.
> 
> **Overview**
> Caps **renderer-only** chat transcript state and hydration/replay payloads to the most recent **1,000** messages via shared `trimTranscriptForRenderer`, while the backend session store stays fully authoritative.
> 
> **Shared protocol:** Adds `DEFAULT_RENDERER_TRANSCRIPT_LIMIT` and trimming that can shift the window start to a **render-safe** boundary (e.g. skip leading orphaned `tool_result` or stream fragments).
> 
> **Session replay:** `buildSnapshotMessages` and `buildReplayEvents` use the bounded window without mutating the store; queued messages still append on snapshots.
> 
> **Chat reducer:** Message append/update paths (snapshots, live agent/user traffic, queue, state machine, errors, compact boundary) go through `applyRendererMessages`, which trims, rebuilds `toolUseIdToIndex`, and prunes `messageIdToUuid` / `localUserMessageIds` for dropped IDs. Late `USER_MESSAGE_UUID_RECEIVED` values are dropped when nothing local is pending.
> 
> **Tests:** Cover bounded snapshots/replay, safe trim boundaries, live cap + metadata pruning, stale UUID cleanup, and store immutability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7668126a3ef23198db4b07bb7a24c673b2844902. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

