### PR TITLE
Fix #1772: Preserve concurrent workspace order saves

### DIFF
--- a/src/backend/services/resources.integration.test.ts
+++ b/src/backend/services/resources.integration.test.ts
@@ -614,6 +614,52 @@ describe('resource accessors integration', () => {
       expect(orderA).toEqual(['ws-3', 'ws-1']);
       expect(orderB).toEqual(['ws-9']);
     });
+
+    it('retries stale workspace order writes and preserves concurrent project entries', async () => {
+      const projectA = await createProjectFixture();
+      const projectB = await createProjectFixture();
+      await userSettingsAccessor.get();
+
+      type UserSettingsUpdateManyResult = ReturnType<typeof prisma.userSettings.updateMany>;
+      const originalUpdateMany = prisma.userSettings.updateMany.bind(prisma.userSettings);
+      let injectedConcurrentUpdate = false;
+      const updateManySpy = vi
+        .spyOn(prisma.userSettings, 'updateMany')
+        .mockImplementation((args): UserSettingsUpdateManyResult => {
+          if (!injectedConcurrentUpdate) {
+            injectedConcurrentUpdate = true;
+
+            return prisma.userSettings
+              .findUniqueOrThrow({
+                where: { userId: 'default' },
+              })
+              .then((currentSettings) =>
+                prisma.userSettings.update({
+                  where: { userId: 'default' },
+                  data: {
+                    workspaceOrder: { [projectB.id]: ['ws-9'] },
+                    updatedAt: new Date(currentSettings.updatedAt.getTime() + 1000),
+                  },
+                })
+              )
+              .then(() => originalUpdateMany(args)) as UserSettingsUpdateManyResult;
+          }
+
+          return originalUpdateMany(args);
+        });
+
+      await userSettingsAccessor.updateWorkspaceOrder(projectA.id, ['ws-3', 'ws-1']);
+
+      const settings = await prisma.userSettings.findUniqueOrThrow({
+        where: { userId: 'default' },
+      });
+
+      expect(updateManySpy).toHaveBeenCalledTimes(2);
+      expect(settings.workspaceOrder).toEqual({
+        [projectB.id]: ['ws-9'],
+        [projectA.id]: ['ws-3', 'ws-1'],
+      });
+    });
   });
 
   describe('decisionLogAccessor', () => {

--- a/src/backend/services/settings/resources/user-settings.accessor.ts
+++ b/src/backend/services/settings/resources/user-settings.accessor.ts
@@ -25,6 +25,8 @@ interface UpdateUserSettingsInput {
 // Type for workspace order storage: { [projectId]: workspaceId[] }
 export type WorkspaceOrderMap = Record<string, string[]>;
 
+const WORKSPACE_ORDER_UPDATE_MAX_ATTEMPTS = 5;
+
 function parseWorkspaceOrderMap(value: Prisma.JsonValue | null): WorkspaceOrderMap {
   const parsed = workspaceOrderMapSchema.safeParse(value);
   return parsed.success ? parsed.data : {};
@@ -174,18 +176,35 @@ class UserSettingsAccessor {
    */
   async updateWorkspaceOrder(projectId: string, workspaceIds: string[]): Promise<UserSettings> {
     const userId = 'default';
-    const settings = await this.get();
-    const orderMap = parseWorkspaceOrderMap(settings.workspaceOrder);
 
-    // Update the order for this project
-    orderMap[projectId] = workspaceIds;
+    for (let attempt = 0; attempt < WORKSPACE_ORDER_UPDATE_MAX_ATTEMPTS; attempt += 1) {
+      const settings = await this.get();
+      const orderMap = parseWorkspaceOrderMap(settings.workspaceOrder);
+      const nextOrderMap = {
+        ...orderMap,
+        [projectId]: workspaceIds,
+      };
 
-    return await prisma.userSettings.update({
-      where: { userId },
-      data: {
-        workspaceOrder: orderMap,
-      },
-    });
+      const result = await prisma.userSettings.updateMany({
+        where: {
+          userId,
+          updatedAt: settings.updatedAt,
+        },
+        data: {
+          workspaceOrder: nextOrderMap,
+        },
+      });
+
+      if (result.count === 1) {
+        return await prisma.userSettings.findUniqueOrThrow({
+          where: { userId },
+        });
+      }
+    }
+
+    throw new Error(
+      `Failed to update workspace order for project ${projectId} after ${WORKSPACE_ORDER_UPDATE_MAX_ATTEMPTS} attempts`
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds optimistic concurrency retry for per-project workspace order saves.
- Preserves unrelated project order entries when concurrent saves update the shared JSON cache.
- Covers the stale-write retry path with an integration test.

## Changes
- **Settings accessor**: Replaces full-blob blind updates with `updatedAt`-guarded `updateMany` retries before returning the refreshed settings row.
- **Integration tests**: Simulates a concurrent workspace order update between read and write, then verifies both project order entries are retained.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; backend data integrity change covered by integration test.

Closes #1772

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persistence semantics for user settings JSON under concurrency; failure after five retries is a new error path, though scope is limited to workspace ordering.
> 
> **Overview**
> Fixes a race where concurrent per-project workspace order updates could overwrite each other because `updateWorkspaceOrder` read the shared `workspaceOrder` JSON, mutated one project key, and wrote the whole blob back blindly.
> 
> **`userSettingsAccessor.updateWorkspaceOrder`** now loops up to five times: each attempt re-reads settings, builds `nextOrderMap` by spreading the existing map and setting only the target `projectId`, then applies the change with `updateMany` where `userId` and `updatedAt` still match the row read. A successful write (`count === 1`) returns the refreshed row; repeated stale writes retry until success or an error is thrown.
> 
> An integration test injects a concurrent `workspaceOrder` update between the first guarded write and a retry, and asserts `updateMany` runs twice and both projects’ order entries remain in the final JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad4137686535c1b179d9c9f46494f2edf09bfb16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

