### PR TITLE
Fix #1738: Scan full port range

### DIFF
--- a/src/backend/services/port-allocation.service.test.ts
+++ b/src/backend/services/port-allocation.service.test.ts
@@ -45,5 +45,17 @@ describe('PortAllocationService', () => {
       );
       expect(isPortInUse).not.toHaveBeenCalled();
     });
+
+    it('rejects ports outside the valid TCP range before probing ports', async () => {
+      const isPortInUse = vi.spyOn(PortAllocationService, 'isPortInUse');
+
+      await expect(PortAllocationService.findFreePort(0, 1)).rejects.toThrow(
+        'Invalid port range 0-1'
+      );
+      await expect(PortAllocationService.findFreePort(65_535, 65_536)).rejects.toThrow(
+        'Invalid port range 65535-65536'
+      );
+      expect(isPortInUse).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/backend/services/port-allocation.service.test.ts
+++ b/src/backend/services/port-allocation.service.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PortAllocationService } from './port-allocation.service';
+
+describe('PortAllocationService', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('findFreePort', () => {
+    it('scans the full range from a randomized starting offset', async () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0.5);
+      const isPortInUse = vi
+        .spyOn(PortAllocationService, 'isPortInUse')
+        .mockImplementation(async (port) => port !== 4001);
+
+      await expect(PortAllocationService.findFreePort(4000, 4003)).resolves.toBe(4001);
+      expect(isPortInUse.mock.calls.map(([port]) => port)).toEqual([4002, 4003, 4000, 4001]);
+    });
+
+    it('does not give up before checking every candidate port', async () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0);
+      const isPortInUse = vi
+        .spyOn(PortAllocationService, 'isPortInUse')
+        .mockImplementation(async (port) => port !== 3002);
+
+      await expect(PortAllocationService.findFreePort(3000, 3002)).resolves.toBe(3002);
+      expect(isPortInUse.mock.calls.map(([port]) => port)).toEqual([3000, 3001, 3002]);
+    });
+
+    it('throws only after exhausting the full range', async () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0.8);
+      const isPortInUse = vi.spyOn(PortAllocationService, 'isPortInUse').mockResolvedValue(true);
+
+      await expect(PortAllocationService.findFreePort(5000, 5002)).rejects.toThrow(
+        'Could not find free port in range 5000-5002'
+      );
+      expect(isPortInUse.mock.calls.map(([port]) => port)).toEqual([5002, 5000, 5001]);
+    });
+
+    it('rejects invalid ranges before probing ports', async () => {
+      const isPortInUse = vi.spyOn(PortAllocationService, 'isPortInUse');
+
+      await expect(PortAllocationService.findFreePort(6001, 6000)).rejects.toThrow(
+        'Invalid port range 6001-6000'
+      );
+      expect(isPortInUse).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/backend/services/port-allocation.service.ts
+++ b/src/backend/services/port-allocation.service.ts
@@ -6,7 +6,6 @@ import { createServer } from 'node:net';
 export class PortAllocationService {
   private static readonly DEFAULT_START_PORT = 3000;
   private static readonly DEFAULT_END_PORT = 9999;
-  private static readonly MAX_ATTEMPTS = 100;
 
   /**
    * Check if a port is in use by attempting to bind to it
@@ -41,17 +40,22 @@ export class PortAllocationService {
    * @param startPort - Start of port range (default: 3000)
    * @param endPort - End of port range (default: 9999)
    * @returns Available port number
-   * @throws Error if no free port found after MAX_ATTEMPTS attempts
+   * @throws Error if no free port exists in the range
    */
   static async findFreePort(
     startPort = PortAllocationService.DEFAULT_START_PORT,
     endPort = PortAllocationService.DEFAULT_END_PORT
   ): Promise<number> {
     const range = endPort - startPort + 1;
+    if (!(Number.isInteger(startPort) && Number.isInteger(endPort)) || range <= 0) {
+      throw new Error(`Invalid port range ${startPort}-${endPort}`);
+    }
 
-    for (let attempt = 0; attempt < PortAllocationService.MAX_ATTEMPTS; attempt++) {
-      // Pick a random port in range to reduce collisions
-      const port = startPort + Math.floor(Math.random() * range);
+    // Randomize the starting point to reduce collisions, then scan without replacement.
+    const startOffset = Math.floor(Math.random() * range);
+
+    for (let offset = 0; offset < range; offset++) {
+      const port = startPort + ((startOffset + offset) % range);
 
       const inUse = await PortAllocationService.isPortInUse(port);
       if (!inUse) {
@@ -59,8 +63,6 @@ export class PortAllocationService {
       }
     }
 
-    throw new Error(
-      `Could not find free port after ${PortAllocationService.MAX_ATTEMPTS} attempts in range ${startPort}-${endPort}`
-    );
+    throw new Error(`Could not find free port in range ${startPort}-${endPort}`);
   }
 }

--- a/src/backend/services/port-allocation.service.ts
+++ b/src/backend/services/port-allocation.service.ts
@@ -4,6 +4,8 @@ import { createServer } from 'node:net';
  * Service for finding and allocating free network ports
  */
 export class PortAllocationService {
+  private static readonly MIN_PORT = 1;
+  private static readonly MAX_PORT = 65_535;
   private static readonly DEFAULT_START_PORT = 3000;
   private static readonly DEFAULT_END_PORT = 9999;
 
@@ -47,7 +49,12 @@ export class PortAllocationService {
     endPort = PortAllocationService.DEFAULT_END_PORT
   ): Promise<number> {
     const range = endPort - startPort + 1;
-    if (!(Number.isInteger(startPort) && Number.isInteger(endPort)) || range <= 0) {
+    if (
+      !(Number.isInteger(startPort) && Number.isInteger(endPort)) ||
+      startPort < PortAllocationService.MIN_PORT ||
+      endPort > PortAllocationService.MAX_PORT ||
+      range <= 0
+    ) {
       throw new Error(`Invalid port range ${startPort}-${endPort}`);
     }
 


### PR DESCRIPTION
## Summary
- Fix random port allocation so it scans every candidate port before failing.
- Preserve collision avoidance by randomizing the starting offset within the range.
- Add focused allocator tests for sparse ranges, exhaustion, and invalid ranges.

## Changes
- **Port allocation**: Replace random sampling with replacement with a randomized full-range scan.
- **Validation**: Reject invalid port ranges before attempting to probe ports.
- **Tests**: Cover wraparound scanning, late free-port discovery, exhaustion, and invalid input.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; allocator behavior is covered by unit tests.

Closes #1738

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized allocator logic change with unit tests; worst case is more bind probes when the range is nearly full, not security or data-path impact.
> 
> **Overview**
> **`findFreePort`** no longer stops after 100 random draws; it validates the range (integers, 1–65535, `start ≤ end`), picks a random starting offset, then probes every port in the range once before failing.
> 
> Failure messaging is updated to reflect full-range exhaustion instead of max attempts. New Vitest coverage asserts wraparound scan order, late discovery of a free port, exhaustion behavior, and that invalid ranges never call **`isPortInUse`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cda86a0c0a62868a4ca8ed3db57d51f1b8b5daa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

