### PR TITLE
Fix #1733: Bound shell command execution

### DIFF
--- a/src/backend/lib/constants.ts
+++ b/src/backend/lib/constants.ts
@@ -4,6 +4,8 @@
 export const LIB_LIMITS = Object.freeze({
   maxFileReadBytes: 1024 * 1024,
   shellDefaultMaxBufferBytes: 10 * 1024 * 1024,
+  execCommandDefaultMaxBufferBytes: 10 * 1024 * 1024,
+  execCommandDefaultTimeoutMs: 5 * 60 * 1000,
   osascriptEscapedMaxChars: 200,
 } as const);
 

--- a/src/backend/lib/shell.test.ts
+++ b/src/backend/lib/shell.test.ts
@@ -95,6 +95,38 @@ describe('execCommand', () => {
     expect(result.aborted).toBe(true);
     expect(result.stderr).toContain('was aborted');
   });
+
+  it('kills the process and truncates stdout when maxBuffer is exceeded', async () => {
+    const script = `
+      process.stdout.write('a'.repeat(1024));
+      setTimeout(() => {}, 5000);
+    `;
+
+    const result = await execCommand(process.execPath, ['-e', script], { maxBuffer: 16 });
+
+    expect(result.code).not.toBe(0);
+    expect(result.stdout).toBe('a'.repeat(16));
+    expect(result.maxBufferExceeded).toBe(true);
+    expect(result.stdoutOverflowed).toBe(true);
+    expect(result.stderrOverflowed).toBe(false);
+    expect(result.stderr).toContain('exceeded maxBuffer of 16 bytes');
+  });
+
+  it('kills the process and truncates stderr when maxBuffer is exceeded', async () => {
+    const script = `
+      process.stderr.write('b'.repeat(1024));
+      setTimeout(() => {}, 5000);
+    `;
+
+    const result = await execCommand(process.execPath, ['-e', script], { maxBuffer: 16 });
+
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain('b'.repeat(16));
+    expect(result.maxBufferExceeded).toBe(true);
+    expect(result.stdoutOverflowed).toBe(false);
+    expect(result.stderrOverflowed).toBe(true);
+    expect(result.stderr).toContain('exceeded maxBuffer of 16 bytes');
+  });
 });
 
 describe('escapeForOsascript', () => {

--- a/src/backend/lib/shell.ts
+++ b/src/backend/lib/shell.ts
@@ -29,6 +29,9 @@ export interface ExecResult {
   signal?: NodeJS.Signals | null;
   timedOut?: boolean;
   aborted?: boolean;
+  maxBufferExceeded?: boolean;
+  stdoutOverflowed?: boolean;
+  stderrOverflowed?: boolean;
 }
 
 export interface ExecShellOptions {
@@ -39,6 +42,7 @@ export interface ExecShellOptions {
 }
 
 export interface ExecCommandOptions extends SpawnOptions {
+  maxBuffer?: number;
   timeout?: number;
   killSignal?: NodeJS.Signals | number;
   forceKillAfterTimeout?: number;
@@ -142,20 +146,31 @@ export function execCommand(
     const {
       forceKillAfterTimeout = 5000,
       killSignal = 'SIGTERM',
+      maxBuffer = LIB_LIMITS.execCommandDefaultMaxBufferBytes,
       signal,
-      timeout,
+      timeout = LIB_LIMITS.execCommandDefaultTimeoutMs,
       ...spawnOptions
     } = options ?? {};
     const proc = spawn(command, args, { ...spawnOptions, shell: false });
 
-    let stdout = '';
-    let stderr = '';
     let timedOut = false;
     let aborted = false;
+    let maxBufferExceeded = false;
     let settled = false;
     let forceKillTimeout: NodeJS.Timeout | undefined;
-    const stdoutDecoder = new StringDecoder('utf8');
-    const stderrDecoder = new StringDecoder('utf8');
+    const stdoutOutput = {
+      text: '',
+      bytes: 0,
+      overflowed: false,
+      decoder: new StringDecoder('utf8'),
+    };
+    const stderrOutput = {
+      text: '',
+      bytes: 0,
+      overflowed: false,
+      decoder: new StringDecoder('utf8'),
+    };
+    const maxBufferEnabled = typeof maxBuffer === 'number' && maxBuffer > 0;
 
     const cleanupCallbacks: Array<() => void> = [];
 
@@ -171,6 +186,35 @@ export function execCommand(
           forceKillTimeout.unref?.();
         }
       }
+    };
+
+    const appendOutput = (
+      output: {
+        text: string;
+        bytes: number;
+        overflowed: boolean;
+        decoder: StringDecoder;
+      },
+      data: Buffer
+    ): void => {
+      if (output.overflowed) {
+        return;
+      }
+
+      if (!(maxBufferEnabled && output.bytes + data.length > maxBuffer)) {
+        output.text += output.decoder.write(data);
+        output.bytes += data.length;
+        return;
+      }
+
+      const remainingBytes = Math.max(maxBuffer - output.bytes, 0);
+      if (remainingBytes > 0) {
+        output.text += output.decoder.write(data.subarray(0, remainingBytes));
+      }
+      output.bytes = maxBuffer;
+      output.overflowed = true;
+      maxBufferExceeded = true;
+      terminate();
     };
     cleanupCallbacks.push(() => {
       if (forceKillTimeout) {
@@ -204,13 +248,9 @@ export function execCommand(
       }
     }
 
-    proc.stdout?.on('data', (data: Buffer) => {
-      stdout += stdoutDecoder.write(data);
-    });
+    proc.stdout?.on('data', (data: Buffer) => appendOutput(stdoutOutput, data));
 
-    proc.stderr?.on('data', (data: Buffer) => {
-      stderr += stderrDecoder.write(data);
-    });
+    proc.stderr?.on('data', (data: Buffer) => appendOutput(stderrOutput, data));
 
     proc.on('error', (error) => {
       for (const cleanup of cleanupCallbacks) {
@@ -232,10 +272,17 @@ export function execCommand(
       }
       settled = true;
 
-      const finalStdout = stdout + stdoutDecoder.end();
-      let finalStderr = stderr + stderrDecoder.end();
+      const finalStdout = stdoutOutput.text + stdoutOutput.decoder.end();
+      let finalStderr = stderrOutput.text + stderrOutput.decoder.end();
       if (timedOut) {
         finalStderr = [finalStderr, `${command} timed out after ${timeout}ms`]
+          .filter(Boolean)
+          .join('\n');
+      } else if (maxBufferExceeded) {
+        finalStderr = [
+          finalStderr,
+          `${command} exceeded maxBuffer of ${maxBuffer} bytes; output was truncated`,
+        ]
           .filter(Boolean)
           .join('\n');
       } else if (aborted) {
@@ -249,6 +296,9 @@ export function execCommand(
         signal: signalCode,
         timedOut,
         aborted,
+        maxBufferExceeded,
+        stdoutOverflowed: stdoutOutput.overflowed,
+        stderrOverflowed: stderrOutput.overflowed,
       });
     });
   });


### PR DESCRIPTION
## Summary
- Adds default bounded execution to the shared `execCommand` wrapper.
- Caps captured stdout/stderr to prevent unbounded heap growth.
- Adds tests for output overflow handling on both streams.

## Changes
- **Shell library**: Added default timeout and max-buffer limits for spawned commands, with per-call overrides.
- **Exec result metadata**: Added `maxBufferExceeded`, `stdoutOverflowed`, and `stderrOverflowed` flags so callers can identify truncated results.
- **Tests**: Covered process termination and truncation when stdout or stderr exceeds the configured buffer.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; backend shell wrapper behavior is covered by automated tests.

Closes #1733

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Widely used `execCommand` now defaults to a 5-minute timeout and kills processes on large output, which may change behavior for long-running or very chatty child commands that previously had no timeout and unbounded buffering.
> 
> **Overview**
> **`execCommand`** now applies **default limits** (10 MB captured output per stream, **5 minute** timeout) via new `LIB_LIMITS` constants, with per-call overrides still supported.
> 
> When stdout or stderr exceeds **`maxBuffer`**, the child process is **terminated**, output is **truncated** at the limit, stderr gets an explanatory message, and the result exposes **`maxBufferExceeded`**, **`stdoutOverflowed`**, and **`stderrOverflowed`** so callers can tell truncation happened.
> 
> Tests cover overflow on both streams. **`execShell`** is unchanged; only the spawn-based **`execCommand`** path gains this behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b13b4a59c518d1ab02be8c5dd24505f2eb6c6e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

