### PR TITLE
Fix #1818: Preserve empty tool result content

### DIFF
--- a/src/backend/services/session/service/data/session-history-loader.service.test.ts
+++ b/src/backend/services/session/service/data/session-history-loader.service.test.ts
@@ -164,6 +164,47 @@ describe('claudeSessionHistoryLoaderService', () => {
     ]);
   });
 
+  it('normalizes tool_result entries with omitted content to an empty string', async () => {
+    const providerSessionId = 'provider-session-empty-tool-result';
+    const cwd = '/Users/test/project';
+    writeSessionFile({
+      claudeConfigDir: tempDir,
+      cwd,
+      providerSessionId,
+      entries: [
+        {
+          type: 'user',
+          sessionId: providerSessionId,
+          timestamp: '2026-02-14T00:00:00.000Z',
+          message: {
+            role: 'user',
+            content: [{ type: 'tool_result', tool_use_id: 'tool-1' }],
+          },
+        },
+      ],
+    });
+
+    const result = await claudeSessionHistoryLoaderService.loadSessionHistory({
+      providerSessionId,
+      workingDir: cwd,
+    });
+
+    expect(result.status).toBe('loaded');
+    if (result.status !== 'loaded') {
+      return;
+    }
+
+    expect(result.history).toEqual([
+      {
+        type: 'tool_result',
+        content: '',
+        toolId: 'tool-1',
+        timestamp: '2026-02-14T00:00:00.000Z',
+      },
+    ]);
+    expect(JSON.parse(JSON.stringify(result.history))).toEqual(result.history);
+  });
+
   it('falls back to scanning all project directories when cwd differs', async () => {
     const providerSessionId = 'provider-session-2';
     const originalCwd = '/Users/test/original';

--- a/src/backend/services/session/service/data/session-history-loader.service.ts
+++ b/src/backend/services/session/service/data/session-history-loader.service.ts
@@ -86,8 +86,12 @@ function withOptionalUuid<T extends HistoryMessage>(message: T, uuid: string | u
 }
 
 function safeJsonStringify(value: unknown): string {
+  if (value === undefined) {
+    return '';
+  }
+
   try {
-    return JSON.stringify(value);
+    return JSON.stringify(value) ?? '';
   } catch {
     return String(value);
   }


### PR DESCRIPTION
## Summary
- Prevent Claude session history tool_result entries with omitted content from reaching the frontend without a content field.
- Add regression coverage for JSONL session history containing an empty tool_result.

## Changes
- **Session History Loader**: Make safe JSON stringification return an empty string for `undefined` and other non-serializable top-level values.
- **Session Tests**: Verify omitted tool_result content normalizes to `content: ""` and survives JSON serialization.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Manual testing: Not applicable; backend history normalization regression is covered by automated loader tests.

Closes #1818

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow normalization change in session history parsing with regression tests; no auth, security, or data-mutation paths.
> 
> **Overview**
> Fixes Claude session history loading so **tool_result** messages always include a **`content`** field when the JSONL chunk omits it.
> 
> **`safeJsonStringify`** now returns **`''`** for **`undefined`** and uses **`JSON.stringify(value) ?? ''`**, so **`normalizeToolResultContent`** maps missing tool result payloads to an empty string instead of leaving **`content`** absent or non-serializable. A loader test covers JSONL with **`tool_result`** blocks that only specify **`tool_use_id`**, asserting **`content: ''`** and round-trip JSON safety.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82da6b84912fb6f1f32f0ceee89fe56f862118e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

