### PR TITLE
Fix #1816: Evict run-script buffers on workspace delete

### DIFF
--- a/src/backend/trpc/workspace.router.test.ts
+++ b/src/backend/trpc/workspace.router.test.ts
@@ -132,6 +132,7 @@ function createCaller(requestTrust?: {
     stopRunScript: vi.fn(
       async (): Promise<{ success: boolean; error?: string }> => ({ success: true })
     ),
+    evictWorkspaceBuffers: vi.fn(),
   };
   const terminalService = {
     destroyWorkspaceTerminals: vi.fn(),
@@ -569,6 +570,13 @@ describe('workspaceRouter', () => {
     );
     expect(sessionService.stopWorkspaceSessions).toHaveBeenCalledWith('w1');
     expect(runScriptService.stopRunScript).toHaveBeenCalledWith('w1');
+    expect(runScriptService.evictWorkspaceBuffers).toHaveBeenCalledWith('w1');
+    const evictionCallOrder = runScriptService.evictWorkspaceBuffers.mock.invocationCallOrder[0];
+    const deleteCallOrder = mockWorkspaceDataService.delete.mock.invocationCallOrder[0];
+    if (evictionCallOrder === undefined || deleteCallOrder === undefined) {
+      throw new Error('Expected buffer eviction and workspace deletion to be called');
+    }
+    expect(evictionCallOrder).toBeLessThan(deleteCallOrder);
     expect(terminalService.destroyWorkspaceTerminals).toHaveBeenCalledWith('w1');
     expect(mockClearWorkspaceActivity).toHaveBeenCalledWith('w1');
 
@@ -592,6 +600,7 @@ describe('workspaceRouter', () => {
     );
     expect(sessionService.stopWorkspaceSessions).toHaveBeenCalledWith('w1');
     expect(runScriptService.stopRunScript).toHaveBeenCalledWith('w1');
+    expect(runScriptService.evictWorkspaceBuffers).not.toHaveBeenCalled();
     expect(terminalService.destroyWorkspaceTerminals).toHaveBeenCalledWith('w1');
     expect(mockWorkspaceDataService.delete).not.toHaveBeenCalled();
   });
@@ -605,6 +614,7 @@ describe('workspaceRouter', () => {
     );
     expect(sessionService.stopWorkspaceSessions).toHaveBeenCalledWith('w1');
     expect(runScriptService.stopRunScript).toHaveBeenCalledWith('w1');
+    expect(runScriptService.evictWorkspaceBuffers).not.toHaveBeenCalled();
     expect(terminalService.destroyWorkspaceTerminals).toHaveBeenCalledWith('w1');
     expect(mockWorkspaceDataService.delete).not.toHaveBeenCalled();
   });
@@ -620,6 +630,7 @@ describe('workspaceRouter', () => {
     );
     expect(sessionService.stopWorkspaceSessions).toHaveBeenCalledWith('w1');
     expect(runScriptService.stopRunScript).toHaveBeenCalledWith('w1');
+    expect(runScriptService.evictWorkspaceBuffers).not.toHaveBeenCalled();
     expect(terminalService.destroyWorkspaceTerminals).toHaveBeenCalledWith('w1');
     expect(mockWorkspaceDataService.delete).not.toHaveBeenCalled();
   });

--- a/src/backend/trpc/workspace.trpc.ts
+++ b/src/backend/trpc/workspace.trpc.ts
@@ -462,6 +462,7 @@ export const workspaceRouter = router({
   delete: publicProcedure.input(z.object({ id: z.string() })).mutation(async ({ ctx, input }) => {
     // Clean up running sessions, terminals, and dev processes before deleting
     await cleanupWorkspaceRuntimeResources(input.id, ctx.appContext.services, 'delete');
+    ctx.appContext.services.runScriptService.evictWorkspaceBuffers(input.id);
     workspaceActivityService.clearWorkspace(input.id);
     return workspaceDataService.delete(input.id);
   }),


### PR DESCRIPTION
## Summary
- Evicts run-script log buffers when a workspace is deleted.
- Adds regression coverage that deletion evicts buffers before deleting the workspace row.
- Verifies cleanup failures do not evict buffers or delete the workspace.

## Changes
- **Workspace delete**: Call `runScriptService.evictWorkspaceBuffers` after runtime cleanup succeeds and before `workspaceDataService.delete`.
- **Tests**: Extend workspace router delete tests to cover buffer eviction order and cleanup-failure behavior.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not run; backend cleanup path covered by regression test.

Closes #1816

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to the delete mutation plus test updates; no auth or data-model changes beyond existing cleanup ordering.
> 
> **Overview**
> Workspace **delete** now drops in-memory run-script log buffers after runtime cleanup succeeds and **before** the workspace row is removed, matching the archive cleanup pattern and preventing stale buffers for deleted IDs.
> 
> Router tests assert `evictWorkspaceBuffers` runs on successful delete (before `workspaceDataService.delete`) and is **not** invoked when session, run-script stop, or terminal cleanup fails—so failed deletes neither evict nor persist deletion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4e699c4129008f97c5db15afb9af470468f160e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

