### PR TITLE
Fix #1819: Use localhost for 0.0.0.0 CORS default

### DIFF
--- a/src/cli/serve-env.test.ts
+++ b/src/cli/serve-env.test.ts
@@ -32,8 +32,22 @@ describe('buildServeEnv', () => {
     expect(env.CORS_ALLOWED_ORIGINS).toBe('http://localhost:3504');
   });
 
+  it('uses localhost for the default CORS origin when binding production to all interfaces', () => {
+    const env = buildServeEnv({ host: '0.0.0.0' }, '/tmp/factory.db', 3000, 7001, {});
+
+    expect(env.BACKEND_HOST).toBe('0.0.0.0');
+    expect(env.CORS_ALLOWED_ORIGINS).toBe('http://localhost:7001');
+  });
+
+  it('uses localhost for the default CORS origin when binding dev mode to all interfaces', () => {
+    const env = buildServeEnv({ dev: true, host: '0.0.0.0' }, '/tmp/factory.db', 5173, 7001, {});
+
+    expect(env.BACKEND_HOST).toBe('0.0.0.0');
+    expect(env.CORS_ALLOWED_ORIGINS).toBe('http://localhost:5173');
+  });
+
   it('respects CORS_ALLOWED_ORIGINS from the base environment', () => {
-    const env = buildServeEnv({ host: 'localhost' }, '/tmp/factory.db', 3000, 3001, {
+    const env = buildServeEnv({ host: '0.0.0.0' }, '/tmp/factory.db', 3000, 3001, {
       CORS_ALLOWED_ORIGINS: 'https://home.adeesha.dev',
     });
 

--- a/src/cli/serve-env.ts
+++ b/src/cli/serve-env.ts
@@ -10,9 +10,10 @@ export function buildServeEnv(
   backendPort: number,
   baseEnv: NodeJS.ProcessEnv = process.env
 ): NodeJS.ProcessEnv {
+  const corsHost = options.host === '0.0.0.0' ? 'localhost' : options.host;
   const corsOrigins = options.dev
-    ? `http://${options.host}:${frontendPort}`
-    : `http://${options.host}:${backendPort}`;
+    ? `http://${corsHost}:${frontendPort}`
+    : `http://${corsHost}:${backendPort}`;
 
   return {
     ...baseEnv,


### PR DESCRIPTION
## Summary
- Fixes the default CORS origin when `serve --host 0.0.0.0` is used.
- Keeps the backend bind host set to `0.0.0.0` while using `localhost` for browser-origin defaults.
- Adds regression coverage for production and dev serve modes.

## Changes
- **CLI serve env**: Normalize only the generated default CORS host from `0.0.0.0` to `localhost`.
- **Tests**: Cover all-interface binding in production and dev mode, and verify explicit `CORS_ALLOWED_ORIGINS` overrides still win.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not run; behavior is covered by focused `buildServeEnv` regression tests.

Closes #1819

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI env normalization for CORS defaults only; bind host and explicit CORS overrides are unchanged.
> 
> **Overview**
> Fixes broken default **CORS** origins when `serve` is started with **`--host 0.0.0.0`**. The server still binds on `0.0.0.0`, but auto-generated `CORS_ALLOWED_ORIGINS` now use **`localhost`** (with the correct frontend port in dev or backend port in production) instead of `http://0.0.0.0:…`, which browsers do not treat as a valid page origin.
> 
> Explicit **`CORS_ALLOWED_ORIGINS`** from the environment is unchanged and still overrides the default. Regression tests cover production and dev all-interface binding plus the override case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 294599b41f4cd7479f7cf55eb55955a5177f1ae5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->