### PR TITLE
Fix #1815: Sync Kanban cache on workspace transitions

### DIFF
--- a/src/backend/services/resources.integration.test.ts
+++ b/src/backend/services/resources.integration.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   CIStatus,
+  KanbanColumn,
   PRState,
   type Prisma,
   type PrismaClient,
@@ -182,6 +183,7 @@ describe('resource accessors integration', () => {
       const project = await createProjectFixture();
       const eligible = await createWorkspaceFixture(project.id, {
         status: WorkspaceStatus.FAILED,
+        cachedKanbanColumn: KanbanColumn.WAITING,
         initRetryCount: 1,
       });
       const maxed = await createWorkspaceFixture(project.id, {
@@ -201,6 +203,7 @@ describe('resource accessors integration', () => {
       expect(eligibleResult.count).toBe(1);
       expect(maxedResult.count).toBe(0);
       expect(eligibleReloaded.status).toBe(WorkspaceStatus.PROVISIONING);
+      expect(eligibleReloaded.cachedKanbanColumn).toBe(KanbanColumn.WORKING);
       expect(eligibleReloaded.initRetryCount).toBe(2);
       expect(maxedReloaded.status).toBe(WorkspaceStatus.FAILED);
     });

--- a/src/backend/services/workspace/resources/workspace.accessor.ts
+++ b/src/backend/services/workspace/resources/workspace.accessor.ts
@@ -2,12 +2,12 @@ import type { Prisma, Workspace, WorkspaceProviderSelection } from '@prisma-gen/
 import { prisma } from '@/backend/db';
 import type {
   CIStatus,
-  KanbanColumn,
   PRState,
   RatchetState,
   RunScriptStatus,
   WorkspaceStatus,
 } from '@/shared/core';
+import { KanbanColumn } from '@/shared/core';
 
 /**
  * Threshold for considering a PROVISIONING workspace as stale.
@@ -388,6 +388,8 @@ class WorkspaceAccessor {
       },
       data: {
         status: 'PROVISIONING',
+        cachedKanbanColumn: KanbanColumn.WORKING,
+        stateComputedAt: new Date(),
         initRetryCount: { increment: 1 },
         initStartedAt: new Date(),
         initErrorMessage: null,
@@ -410,6 +412,8 @@ class WorkspaceAccessor {
       },
       data: {
         status: 'PROVISIONING',
+        cachedKanbanColumn: KanbanColumn.WORKING,
+        stateComputedAt: new Date(),
         initRetryCount: { increment: 1 },
         initStartedAt: new Date(),
         initErrorMessage: null,
@@ -431,6 +435,8 @@ class WorkspaceAccessor {
       },
       data: {
         status: 'NEW',
+        cachedKanbanColumn: KanbanColumn.WORKING,
+        stateComputedAt: new Date(),
         initRetryCount: { increment: 1 },
         initStartedAt: null,
         initCompletedAt: null,

--- a/src/backend/services/workspace/service/lifecycle/state-machine.service.test.ts
+++ b/src/backend/services/workspace/service/lifecycle/state-machine.service.test.ts
@@ -154,7 +154,7 @@ describe('WorkspaceStateMachineService', () => {
     });
 
     it('should transition from PROVISIONING to FAILED with error message', async () => {
-      const workspace = { id: 'ws-1', status: 'PROVISIONING' };
+      const workspace = { id: 'ws-1', status: 'PROVISIONING', cachedKanbanColumn: 'WAITING' };
       const updatedWorkspace = {
         ...workspace,
         status: 'FAILED',
@@ -174,8 +174,30 @@ describe('WorkspaceStateMachineService', () => {
         where: { id: 'ws-1', status: 'PROVISIONING' },
         data: expect.objectContaining({
           status: 'FAILED',
+          cachedKanbanColumn: 'WORKING',
+          stateComputedAt: expect.any(Date),
           initCompletedAt: expect.any(Date),
           initErrorMessage: 'Git clone failed',
+        }),
+      });
+    });
+
+    it('should update cached kanban column when transitioning to FAILED', async () => {
+      const workspace = { id: 'ws-1', status: 'PROVISIONING', cachedKanbanColumn: 'WAITING' };
+      const updatedWorkspace = { ...workspace, status: 'FAILED', cachedKanbanColumn: 'WORKING' };
+
+      mockFindUnique.mockResolvedValue(workspace);
+      mockUpdateMany.mockResolvedValue({ count: 1 });
+      mockFindUniqueOrThrow.mockResolvedValue(updatedWorkspace);
+
+      await workspaceStateMachine.transition('ws-1', 'FAILED');
+
+      expect(mockUpdateMany).toHaveBeenCalledWith({
+        where: { id: 'ws-1', status: 'PROVISIONING' },
+        data: expect.objectContaining({
+          status: 'FAILED',
+          cachedKanbanColumn: 'WORKING',
+          stateComputedAt: expect.any(Date),
         }),
       });
     });
@@ -264,7 +286,7 @@ describe('WorkspaceStateMachineService', () => {
     });
 
     it('should transition from READY to ARCHIVING', async () => {
-      const workspace = { id: 'ws-1', status: 'READY' };
+      const workspace = { id: 'ws-1', status: 'READY', cachedKanbanColumn: 'WAITING' };
       const updatedWorkspace = { ...workspace, status: 'ARCHIVING' };
 
       mockFindUnique.mockResolvedValue(workspace);
@@ -274,6 +296,13 @@ describe('WorkspaceStateMachineService', () => {
       const result = await workspaceStateMachine.transition('ws-1', 'ARCHIVING');
 
       expect(result.status).toBe('ARCHIVING');
+      expect(mockUpdateMany).toHaveBeenCalledWith({
+        where: { id: 'ws-1', status: 'READY' },
+        data: expect.not.objectContaining({
+          cachedKanbanColumn: expect.anything(),
+          stateComputedAt: expect.anything(),
+        }),
+      });
     });
 
     it('should transition from FAILED to ARCHIVING', async () => {
@@ -356,8 +385,18 @@ describe('WorkspaceStateMachineService', () => {
     });
 
     it('should transition from FAILED to PROVISIONING (retry)', async () => {
-      const workspace = { id: 'ws-1', status: 'FAILED', initRetryCount: 1 };
-      const updatedWorkspace = { ...workspace, status: 'PROVISIONING', initRetryCount: 2 };
+      const workspace = {
+        id: 'ws-1',
+        status: 'FAILED',
+        initRetryCount: 1,
+        cachedKanbanColumn: 'WAITING',
+      };
+      const updatedWorkspace = {
+        ...workspace,
+        status: 'PROVISIONING',
+        initRetryCount: 2,
+        cachedKanbanColumn: 'WORKING',
+      };
 
       mockFindUnique
         .mockResolvedValueOnce(workspace) // First call for status check
@@ -375,6 +414,8 @@ describe('WorkspaceStateMachineService', () => {
         },
         data: expect.objectContaining({
           status: 'PROVISIONING',
+          cachedKanbanColumn: 'WORKING',
+          stateComputedAt: expect.any(Date),
           initRetryCount: { increment: 1 },
           initStartedAt: expect.any(Date),
           initErrorMessage: null,

--- a/src/backend/services/workspace/service/lifecycle/state-machine.service.ts
+++ b/src/backend/services/workspace/service/lifecycle/state-machine.service.ts
@@ -21,6 +21,7 @@ import { EventEmitter } from 'node:events';
 import type { Prisma, Workspace } from '@prisma-gen/client';
 import { createLogger } from '@/backend/services/logger.service';
 import { workspaceAccessor } from '@/backend/services/workspace/resources/workspace.accessor';
+import { computeKanbanColumn } from '@/backend/services/workspace/service/state/kanban-state';
 import type { WorkspaceStatus } from '@/shared/core';
 
 const logger = createLogger('workspace-state-machine');
@@ -132,6 +133,33 @@ function applyTransitionData(
   }
 }
 
+function applyKanbanCacheData(
+  updateData: Prisma.WorkspaceUpdateManyMutationInput,
+  workspace: Workspace,
+  targetStatus: WorkspaceStatus,
+  now: Date
+): void {
+  if (targetStatus === 'ARCHIVING' || targetStatus === 'ARCHIVED') {
+    return;
+  }
+
+  const cachedKanbanColumn = computeKanbanColumn({
+    lifecycle: targetStatus,
+    isWorking: false,
+    prState: workspace.prState,
+    ratchetState: workspace.ratchetState,
+  });
+
+  if (cachedKanbanColumn === null) {
+    return;
+  }
+
+  updateData.cachedKanbanColumn = cachedKanbanColumn;
+  if (workspace.cachedKanbanColumn !== cachedKanbanColumn) {
+    updateData.stateComputedAt = now;
+  }
+}
+
 class WorkspaceStateMachineService extends EventEmitter {
   /**
    * Check if a state transition is valid.
@@ -170,6 +198,7 @@ class WorkspaceStateMachineService extends EventEmitter {
 
     // Apply transition-specific updates
     applyTransitionData(updateData, currentStatus, targetStatus, now, options);
+    applyKanbanCacheData(updateData, workspace, targetStatus, now);
 
     // Use compare-and-swap to prevent race conditions
     const result = await workspaceAccessor.transitionWithCas(

--- a/src/backend/services/workspace/service/query/workspace-query.service.test.ts
+++ b/src/backend/services/workspace/service/query/workspace-query.service.test.ts
@@ -261,6 +261,53 @@ describe('WorkspaceQueryService', () => {
     });
   });
 
+  it('listWithKanbanState returns FAILED workspaces from the WORKING cache bucket', async () => {
+    mockFindByProjectIdWithSessions.mockResolvedValue([
+      {
+        id: 'w1',
+        status: WorkspaceStatus.FAILED,
+        prUrl: null,
+        prState: PRState.NONE,
+        prCiStatus: CIStatus.UNKNOWN,
+        ratchetState: RatchetState.IDLE,
+        runScriptStatus: RunScriptStatus.IDLE,
+        hasHadSessions: true,
+        cachedKanbanColumn: 'WORKING',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      },
+    ]);
+
+    mockDeriveWorkspaceRuntimeState.mockReturnValue({
+      sessionIds: [],
+      isSessionWorking: false,
+      isWorking: false,
+      flowState: {
+        hasActivePr: false,
+        isWorking: false,
+        shouldAnimateRatchetButton: false,
+        phase: 'NO_PR',
+        ciObservation: 'CHECKS_UNKNOWN',
+      },
+    });
+    mockGetAllPendingRequests.mockReturnValue(new Map());
+
+    const result = await workspaceQueryService.listWithKanbanState({
+      projectId: 'proj-1',
+      kanbanColumn: 'WORKING',
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: 'w1',
+      status: WorkspaceStatus.FAILED,
+      kanbanColumn: 'WORKING',
+    });
+    expect(mockFindByProjectIdWithSessions).toHaveBeenCalledWith('proj-1', {
+      kanbanColumn: 'WORKING',
+      excludeStatuses: [WorkspaceStatus.ARCHIVING, WorkspaceStatus.ARCHIVED],
+    });
+  });
+
   it('surfaces session runtime errors in initial workspace query paths', async () => {
     const erroredWorkspace = {
       id: 'w1',


### PR DESCRIPTION
## Summary
- Keeps `cachedKanbanColumn` synchronized when workspace lifecycle status changes
- Ensures FAILED workspaces persist in the WORKING Kanban cache bucket
- Adds regression coverage for state transitions, retry accessors, and Kanban list selection

## Changes
- **Workspace lifecycle**: Derive and persist the cached Kanban column during successful status transitions while preserving cached archive columns.
- **Workspace accessors**: Mark retry/reset transitions back into NEW or PROVISIONING as WORKING in the persisted Kanban cache.
- **Tests**: Cover FAILED transition cache updates, retry cache persistence, and WORKING-column list selection for FAILED workspaces.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not run; backend cache behavior covered by automated tests.

Closes #1815

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workspace lifecycle persistence and Kanban filtering; incorrect cache values could misplace cards on the board, but behavior is covered by new unit and integration tests.
> 
> **Overview**
> Keeps **`cachedKanbanColumn`** aligned with workspace lifecycle so Kanban list queries (which filter on the cache) stay correct when status changes without a separate recompute pass.
> 
> The workspace state machine now derives the column via **`computeKanbanColumn`** on each successful transition and persists it (plus **`stateComputedAt`** when the bucket changes), while **ARCHIVING** / **ARCHIVED** transitions still leave the pre-archive cache untouched. **FAILED** workspaces are written into the **WORKING** bucket, matching the kanban model for init/retry states.
> 
> Retry/reset accessors (**`startProvisioningRetryIfAllowed`**, **`startProvisioningFromReadyIfAllowed`**, **`resetToNewIfAllowed`**) also set **WORKING** and **`stateComputedAt`** on their CAS updates. Tests cover state-machine **FAILED** cache updates, integration retry persistence, and **`listWithKanbanState`** returning **FAILED** rows from the **WORKING** filter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfb172ca1c1bcc29f393776bd08a1af7e734e489. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->