### PR TITLE
Fix #1809: Skip non-file slash commands

### DIFF
--- a/src/backend/services/session/service/store/slash-command-disk-scanner.test.ts
+++ b/src/backend/services/session/service/store/slash-command-disk-scanner.test.ts
@@ -1,8 +1,16 @@
+import { spawnSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { scanClaudeWorkspaceCommandsFromDisk } from './slash-command-disk-scanner';
+
+function mkfifo(path: string): void {
+  const result = spawnSync('mkfifo', [path], { encoding: 'utf-8' });
+  if (result.status !== 0) {
+    throw new Error(result.stderr || result.error?.message || 'Failed to create FIFO');
+  }
+}
 
 describe('slash command disk scanner', () => {
   const tempDirs: string[] = [];
@@ -23,5 +31,35 @@ describe('slash command disk scanner', () => {
     symlinkSync(escapedCommandsPath, join(worktreePath, '.claude', 'commands'));
 
     expect(scanClaudeWorkspaceCommandsFromDisk(worktreePath)).toEqual([]);
+  });
+
+  it('skips non-regular command files before reading descriptions', () => {
+    const worktreePath = mkdtempSync(join(tmpdir(), 'ff-worktree-commands-'));
+    tempDirs.push(worktreePath);
+
+    const commandsPath = join(worktreePath, '.claude', 'commands');
+    mkdirSync(commandsPath, { recursive: true });
+    writeFileSync(join(commandsPath, 'valid.md'), '---\ndescription: Regular command\n---\n');
+    mkfifo(join(commandsPath, 'pipe.md'));
+
+    const commands = scanClaudeWorkspaceCommandsFromDisk(worktreePath);
+
+    expect(commands).toEqual([{ name: 'valid', description: 'Regular command' }]);
+  });
+
+  it('skips symlinked command files that resolve to non-regular targets', () => {
+    const worktreePath = mkdtempSync(join(tmpdir(), 'ff-worktree-commands-'));
+    tempDirs.push(worktreePath);
+
+    const commandsPath = join(worktreePath, '.claude', 'commands');
+    const fifoPath = join(worktreePath, 'command-target');
+    mkdirSync(commandsPath, { recursive: true });
+    writeFileSync(join(commandsPath, 'valid.md'), '---\ndescription: Regular command\n---\n');
+    mkfifo(fifoPath);
+    symlinkSync(fifoPath, join(commandsPath, 'linked.md'));
+
+    const commands = scanClaudeWorkspaceCommandsFromDisk(worktreePath);
+
+    expect(commands).toEqual([{ name: 'valid', description: 'Regular command' }]);
   });
 });

--- a/src/backend/services/session/service/store/slash-command-disk-scanner.ts
+++ b/src/backend/services/session/service/store/slash-command-disk-scanner.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, realpathSync } from 'node:fs';
+import { readdirSync, readFileSync, realpathSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { basename, isAbsolute, join, relative } from 'node:path';
 import type { CommandInfo } from '@/shared/acp-protocol';
@@ -22,12 +22,18 @@ function isRealPathContainedInRoot(rootReal: string, targetReal: string): boolea
   return !(rel.startsWith('..') || isAbsolute(rel));
 }
 
-function isContainedInRoot(rootReal: string, filePath: string): boolean {
+function resolveContainedRegularFile(rootReal: string, filePath: string): string | null {
   try {
     const fileReal = realpathSync(filePath);
-    return isRealPathContainedInRoot(rootReal, fileReal);
+    if (!isRealPathContainedInRoot(rootReal, fileReal)) {
+      return null;
+    }
+    if (!statSync(fileReal).isFile()) {
+      return null;
+    }
+    return fileReal;
   } catch {
-    return false;
+    return null;
   }
 }
 
@@ -64,7 +70,8 @@ function scanCommandsFromDir(dir: string, seen: Set<string>, containmentRoot = d
   const commands: CommandInfo[] = [];
   for (const file of files) {
     const filePath = join(dir, file);
-    if (!isContainedInRoot(rootReal, filePath)) {
+    const fileReal = resolveContainedRegularFile(rootReal, filePath);
+    if (!fileReal) {
       continue;
     }
     const name = basename(file, '.md');
@@ -73,7 +80,7 @@ function scanCommandsFromDir(dir: string, seen: Set<string>, containmentRoot = d
       continue;
     }
     seen.add(key);
-    commands.push({ name, description: parseCommandDescription(filePath) });
+    commands.push({ name, description: parseCommandDescription(fileReal) });
   }
   return commands;
 }

--- a/src/backend/trpc/project.router.test.ts
+++ b/src/backend/trpc/project.router.test.ts
@@ -1,4 +1,5 @@
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -60,6 +61,13 @@ vi.mock('@/backend/services/git-clone.service', () => ({
 }));
 
 import { projectRouter } from './project.trpc';
+
+function mkfifo(path: string): void {
+  const result = spawnSync('mkfifo', [path], { encoding: 'utf-8' });
+  if (result.status !== 0) {
+    throw new Error(result.stderr || result.error?.message || 'Failed to create FIFO');
+  }
+}
 
 function createCaller(
   requestTrust?: {
@@ -170,6 +178,34 @@ describe('projectRouter', () => {
     expect(result.branches).not.toContainEqual(
       expect.objectContaining({ name: 'origin/main', refType: 'remote' })
     );
+  });
+
+  it('skips non-regular slash command files', async () => {
+    const commandsPath = join(tempDir, '.claude', 'commands');
+    const fifoTarget = join(tempDir, 'command-target');
+    mkdirSync(commandsPath, { recursive: true });
+    writeFileSync(
+      join(commandsPath, 'issue-1809-valid.md'),
+      '---\ndescription: Safe command\n---\n'
+    );
+    mkfifo(join(commandsPath, 'issue-1809-pipe.md'));
+    mkfifo(fifoTarget);
+    symlinkSync(fifoTarget, join(commandsPath, 'issue-1809-linked.md'));
+    mockProjectManagementService.findById.mockResolvedValue({
+      id: 'p1',
+      repoPath: tempDir,
+    });
+
+    const caller = createCaller();
+    const result = await caller.listSlashCommands({ projectId: 'p1' });
+    const commandNames = result.commands.map((command) => command.name);
+
+    expect(result.commands).toContainEqual({
+      name: 'issue-1809-valid',
+      description: 'Safe command',
+    });
+    expect(commandNames).not.toContain('issue-1809-pipe');
+    expect(commandNames).not.toContain('issue-1809-linked');
   });
 
   it('handles malformed git ref lines and git branch listing failures', async () => {

--- a/src/backend/trpc/project.trpc.ts
+++ b/src/backend/trpc/project.trpc.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, realpathSync } from 'node:fs';
+import { readdirSync, readFileSync, realpathSync, statSync } from 'node:fs';
 import { writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { basename, isAbsolute, join, relative } from 'node:path';
@@ -31,13 +31,19 @@ function parseCommandFileDescription(filePath: string): string {
   }
 }
 
-function isContainedInRoot(rootReal: string, filePath: string): boolean {
+function resolveContainedRegularFile(rootReal: string, filePath: string): string | null {
   try {
     const fileReal = realpathSync(filePath);
     const rel = relative(rootReal, fileReal);
-    return !(rel.startsWith('..') || isAbsolute(rel));
+    if (rel.startsWith('..') || isAbsolute(rel)) {
+      return null;
+    }
+    if (!statSync(fileReal).isFile()) {
+      return null;
+    }
+    return fileReal;
   } catch {
-    return false;
+    return null;
   }
 }
 
@@ -57,7 +63,8 @@ function scanSlashCommandDirs(
     }
     for (const file of files) {
       const filePath = join(dir, file);
-      if (!isContainedInRoot(rootReal, filePath)) {
+      const fileReal = resolveContainedRegularFile(rootReal, filePath);
+      if (!fileReal) {
         continue;
       }
       const name = basename(file, '.md');
@@ -65,7 +72,7 @@ function scanSlashCommandDirs(
         continue;
       }
       seen.add(name);
-      commands.push({ name, description: parseCommandFileDescription(filePath) });
+      commands.push({ name, description: parseCommandFileDescription(fileReal) });
     }
   }
   return commands;


### PR DESCRIPTION
## Summary
- Guard slash command disk scans so only resolved regular files are read.
- Skip direct FIFOs and symlinks to non-regular targets in session and project command discovery.
- Add FIFO regression tests for both scanner paths.

## Changes
- **Session slash commands**: Resolve command candidates, enforce containment, and require `statSync(...).isFile()` before reading descriptions.
- **Project slash commands**: Apply the same regular-file guard to new-workspace slash command autocomplete discovery.
- **Tests**: Add direct FIFO and symlink-to-FIFO coverage to prevent blocking reads from returning.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Manual testing: exercised focused FIFO regression tests with `pnpm exec vitest run src/backend/services/session/service/store/slash-command-disk-scanner.test.ts src/backend/trpc/project.router.test.ts`

Closes #1809

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
