### PR TITLE
Fix #1740: Repair session startup rollback

### DIFF
--- a/src/backend/services/session/resources/agent-session.accessor.test.ts
+++ b/src/backend/services/session/resources/agent-session.accessor.test.ts
@@ -133,6 +133,30 @@ describe('agentSessionAccessor', () => {
     expect(mockCreate).not.toHaveBeenCalled();
   });
 
+  it('createWithinWorkspaceLimit does not count failed rollback sessions as active', async () => {
+    mockCount.mockResolvedValue(1);
+    mockCreate.mockResolvedValue({ id: 'session-after-failed-rollback' });
+
+    await expect(
+      agentSessionAccessor.createWithinWorkspaceLimit({
+        workspaceId: 'workspace-1',
+        workflow: 'user',
+        maxSessions: 2,
+      })
+    ).resolves.toEqual({
+      outcome: 'created',
+      session: { id: 'session-after-failed-rollback' },
+    });
+
+    expect(mockCount).toHaveBeenCalledWith({
+      where: {
+        workspaceId: 'workspace-1',
+        status: { in: [SessionStatus.RUNNING, SessionStatus.IDLE] },
+      },
+    });
+    expect(mockCreate).toHaveBeenCalled();
+  });
+
   it('findById includes workspace relation', async () => {
     mockFindUnique.mockResolvedValue({ id: 'session-1' });
 

--- a/src/backend/services/session/service/data/session-data.service.ts
+++ b/src/backend/services/session/service/data/session-data.service.ts
@@ -1,4 +1,4 @@
-import type { SessionProvider, TerminalSession } from '@prisma-gen/client';
+import type { Prisma, SessionProvider, TerminalSession } from '@prisma-gen/client';
 import {
   type AgentSessionRecord,
   agentSessionAccessor,
@@ -64,6 +64,7 @@ class SessionDataService {
       model?: string;
       status?: SessionStatus;
       provider?: SessionProvider;
+      providerMetadata?: Prisma.InputJsonValue | null;
       providerSessionId?: string | null;
       providerProjectPath?: string | null;
       providerProcessPid?: number | null;

--- a/src/backend/trpc/session.router.test.ts
+++ b/src/backend/trpc/session.router.test.ts
@@ -1,6 +1,7 @@
 import { SessionProvider } from '@prisma-gen/client';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { CLIHealthStatus } from '@/backend/orchestration/cli-health.service';
+import { SessionStatus } from '@/shared/core';
 
 const mockSessionDataService = vi.hoisted(() => ({
   findAgentSessionsByWorkspaceId: vi.fn(),
@@ -246,7 +247,7 @@ describe('sessionRouter', () => {
     expect(mockSessionDataService.deleteAgentSession).toHaveBeenCalledWith('s-orphan');
   });
 
-  it('preserves startup errors even when rollback cleanup fails', async () => {
+  it('marks the created session failed when startup rollback deletion fails', async () => {
     const startupError = new Error('Runtime failed to start');
     const { caller, sessionService, sessionDomainService } = createCaller();
     mockSessionProviderResolverService.resolveSessionProvider.mockResolvedValue(
@@ -273,6 +274,49 @@ describe('sessionRouter', () => {
 
     expect(sessionDomainService.clearSession).toHaveBeenCalledWith('s-cleanup-fails');
     expect(mockSessionDataService.deleteAgentSession).toHaveBeenCalledWith('s-cleanup-fails');
+    expect(mockSessionDataService.updateAgentSession).toHaveBeenCalledWith('s-cleanup-fails', {
+      status: SessionStatus.FAILED,
+      providerProcessPid: null,
+      providerMetadata: {
+        rollbackReason: 'startup_failed_after_create',
+      },
+    });
+  });
+
+  it('preserves startup errors even when rollback repair also fails', async () => {
+    const startupError = new Error('Runtime failed to start');
+    const { caller, sessionService, sessionDomainService } = createCaller();
+    mockSessionProviderResolverService.resolveSessionProvider.mockResolvedValue(
+      SessionProvider.CLAUDE
+    );
+    mockSessionDataService.createAgentSessionWithinWorkspaceLimit.mockResolvedValue({
+      outcome: 'created',
+      session: {
+        id: 's-repair-fails',
+        workspaceId: 'w1',
+      },
+    });
+    sessionService.startSession.mockRejectedValue(startupError);
+    mockSessionDataService.deleteAgentSession.mockRejectedValue(new Error('Delete failed'));
+    mockSessionDataService.updateAgentSession.mockRejectedValue(new Error('Update failed'));
+
+    await expect(
+      caller.createAndStartSession({
+        workspaceId: 'w1',
+        workflow: 'followup',
+        name: 'Chat 1',
+      })
+    ).rejects.toThrow('Runtime failed to start');
+
+    expect(sessionDomainService.clearSession).toHaveBeenCalledWith('s-repair-fails');
+    expect(mockSessionDataService.deleteAgentSession).toHaveBeenCalledWith('s-repair-fails');
+    expect(mockSessionDataService.updateAgentSession).toHaveBeenCalledWith('s-repair-fails', {
+      status: SessionStatus.FAILED,
+      providerProcessPid: null,
+      providerMetadata: {
+        rollbackReason: 'startup_failed_after_create',
+      },
+    });
   });
 
   it('handles start/stop/delete flows and terminal session procedures', async () => {

--- a/src/backend/trpc/session.trpc.ts
+++ b/src/backend/trpc/session.trpc.ts
@@ -59,6 +59,29 @@ async function createAgentSessionFromInput(
   return session;
 }
 
+async function rollbackCreatedSession(
+  sessionId: string,
+  sessionDomainService: Context['appContext']['services']['sessionDomainService']
+) {
+  sessionDomainService.clearSession(sessionId);
+
+  try {
+    await sessionDataService.deleteAgentSession(sessionId);
+  } catch {
+    try {
+      await sessionDataService.updateAgentSession(sessionId, {
+        status: SessionStatus.FAILED,
+        providerProcessPid: null,
+        providerMetadata: {
+          rollbackReason: 'startup_failed_after_create',
+        },
+      });
+    } catch {
+      // Preserve the startup error even if rollback cleanup cannot repair the row.
+    }
+  }
+}
+
 export const sessionRouter = router({
   // Session limits
 
@@ -140,12 +163,7 @@ export const sessionRouter = router({
           // Best-effort runtime cleanup; preserve the startup error.
         }
 
-        try {
-          sessionDomainService.clearSession(session.id);
-          await sessionDataService.deleteAgentSession(session.id);
-        } catch {
-          // Best-effort DB cleanup; preserve the startup error.
-        }
+        await rollbackCreatedSession(session.id, sessionDomainService);
 
         throw error;
       }


### PR DESCRIPTION
## Summary
- Prevent failed session startup rollback from leaving active-counted orphan sessions.
- Mark undeletable startup rollback rows as `FAILED` with cleanup metadata.
- Add regression coverage for rollback deletion failures and active-session limit counting.

## Changes
- **Session startup rollback**: Fall back to updating the newly created session to `FAILED` when rollback deletion fails, while preserving the original startup error.
- **Session data service**: Expose `providerMetadata` through `updateAgentSession` so rollback repair can annotate the record.
- **Tests**: Cover the delete-failure rollback path and assert failed rollback sessions do not count toward active workspace limits.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; backend rollback behavior covered by regression tests.

Closes #1740

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session creation failure cleanup and persisted session status/metadata, which affects workspace session limits and user-visible session state after failed startups.
> 
> **Overview**
> Fixes **orphan agent sessions** left behind when `createAndStartSession` fails after the DB row is created but rollback **delete** fails—those rows could still look “active” and block workspace session limits.
> 
> Startup failure handling now uses **`rollbackCreatedSession`**: clear in-memory state, try delete, and on delete failure **mark the row `FAILED`**, clear `providerProcessPid`, and set `providerMetadata.rollbackReason` to `startup_failed_after_create`. The original startup error is still thrown even if that repair update fails.
> 
> **`updateAgentSession`** now accepts **`providerMetadata`** so rollback can annotate the record. Tests cover delete-failure rollback, repair-failure (startup error preserved), and that active limits only count **RUNNING/IDLE** (so repaired `FAILED` rows don’t block new sessions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35e0baec19418e84fc5d6066e6f8485290387e0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->