### PR TITLE
Potential fix for code scanning alert no. 15: CORS misconfiguration for credentials transfer

### DIFF
--- a/src/backend/middleware/cors.middleware.ts
+++ b/src/backend/middleware/cors.middleware.ts
@@ -14,15 +14,19 @@ export function createCorsMiddleware(appContext: AppContext) {
     const ALLOWED_ORIGINS = appContext.services.configService.getCorsConfig().allowedOrigins;
 
     const origin = req.headers.origin;
-    if (origin && isOriginAllowed(origin, ALLOWED_ORIGINS)) {
+    const allowCredentials = Boolean(
+      origin && origin !== 'null' && isOriginAllowed(origin, ALLOWED_ORIGINS)
+    );
+
+    if (allowCredentials && origin) {
       res.header('Access-Control-Allow-Origin', origin);
+      res.header('Access-Control-Allow-Credentials', 'true');
     }
     res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
     res.header(
       'Access-Control-Allow-Headers',
       'Origin, X-Requested-With, Content-Type, Accept, Authorization, X-Project-Id, X-Top-Level-Task-Id'
     );
-    res.header('Access-Control-Allow-Credentials', 'true');
 
     if (req.method === 'OPTIONS') {
       res.sendStatus(200);


### PR DESCRIPTION
Potential fix for [https://github.com/purplefish-ai/factory-factory/security/code-scanning/15](https://github.com/purplefish-ai/factory-factory/security/code-scanning/15)

General fix: when `Access-Control-Allow-Credentials` is `true`, only set `Access-Control-Allow-Origin` for strictly validated, trusted origins; never allow `"null"`; and avoid sending `Access-Control-Allow-Credentials` unless an allowed origin is actually being granted.

Best concrete fix in `src/backend/middleware/cors.middleware.ts`:
1. Add an explicit local guard to reject `"null"` origin.
2. Compute an `allowCredentials` boolean based on:
   - origin exists,
   - origin is not `"null"`,
   - origin passes `isOriginAllowed(...)`.
3. Set `Access-Control-Allow-Origin` only when `allowCredentials` is true.
4. Set `Access-Control-Allow-Credentials: true` only when `allowCredentials` is true (instead of unconditionally).

This preserves existing functionality for valid allowlisted origins while preventing credentialed CORS from being advertised for untrusted/unsafe origins.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes security-sensitive CORS behavior for cookie/credential-bearing browser requests; allowlisted origins should behave the same, but disallowed or `null` origins no longer receive credentialed CORS headers.
> 
> **Overview**
> Addresses a code-scanning CORS misconfiguration by **only advertising credentialed cross-origin access when the request `Origin` is trusted**.
> 
> The middleware now computes `allowCredentials` only when an `Origin` header is present, is not the literal `"null"`, and passes `isOriginAllowed` against configured allowlist. **`Access-Control-Allow-Origin` and `Access-Control-Allow-Credentials: true` are set together only in that case**, instead of always sending `Allow-Credentials` on every response.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 812364564c6e006d23739a93963a93fc7e7241db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->