### PR TITLE
Add Fable to Default Claude model options

### DIFF
--- a/src/backend/lib/session-model.ts
+++ b/src/backend/lib/session-model.ts
@@ -1,6 +1,6 @@
 import type { SessionProvider } from '@prisma-gen/client';
 
-const CLAUDE_MODEL_ALIASES = new Set(['opus', 'sonnet', 'haiku']);
+const CLAUDE_MODEL_ALIASES = new Set(['opus', 'sonnet', 'haiku', 'fable']);
 
 export const DEFAULT_SESSION_MODEL_BY_PROVIDER: Record<SessionProvider, string> = {
   CLAUDE: 'sonnet',

--- a/src/backend/trpc/user-settings.router.test.ts
+++ b/src/backend/trpc/user-settings.router.test.ts
@@ -163,6 +163,7 @@ describe('userSettingsRouter', () => {
           { value: 'sonnet', label: 'Sonnet' },
           { value: 'opus', label: 'Opus' },
           { value: 'haiku', label: 'Haiku' },
+          { value: 'fable', label: 'Fable' },
         ],
         efforts: [
           { value: 'low', label: 'Low' },

--- a/src/backend/trpc/user-settings.trpc.ts
+++ b/src/backend/trpc/user-settings.trpc.ts
@@ -36,6 +36,7 @@ const CLAUDE_FALLBACK_OPTIONS: ProviderOptions = {
     { value: 'sonnet', label: 'Sonnet' },
     { value: 'opus', label: 'Opus' },
     { value: 'haiku', label: 'Haiku' },
+    { value: 'fable', label: 'Fable' },
   ],
   efforts: [
     { value: 'low', label: 'Low' },


### PR DESCRIPTION
## Summary

Adds **Fable** as a selectable option in the Admin → Chat Defaults → **Default Claude model** dropdown.

The dropdown sources its Claude options from a hardcoded fallback list (`CLAUDE_FALLBACK_OPTIONS` in `user-settings.trpc.ts`) — unlike Codex, whose options are fetched dynamically from the CLI. That list only contained `sonnet`/`opus`/`haiku`, so Fable could never appear even though `claude-agent-acp` was already bumped to 0.55.0 for Fable support (#1845).

## Changes

- `src/backend/trpc/user-settings.trpc.ts` — add `{ value: 'fable', label: 'Fable' }` to `CLAUDE_FALLBACK_OPTIONS.models`
- `src/backend/lib/session-model.ts` — add `'fable'` to `CLAUDE_MODEL_ALIASES` so it normalizes/validates alongside the other Claude aliases (the setting's save path runs through `normalizeSessionModelForProvider`)
- `src/backend/trpc/user-settings.router.test.ts` — update the expected provider-options list

## Notes

- The **live per-session** chat model dropdown is unaffected/unchanged: it is fully dynamic and reflects whatever `configOptions` the `claude-agent-acp` subprocess reports at session start, so no app-side change is needed there — Fable will appear automatically once the runtime reports it.

## Testing

- `pnpm test` (affected files: `chat-capabilities`, `session-model`, `user-settings.router`, `admin-page`) ✅
- `pnpm typecheck` ✅
- Pre-commit hooks (biome, deps-check, knip) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
