### PR TITLE
Fix #1841: Restore workspace slash command precedence

### DIFF
--- a/src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.test.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.test.ts
@@ -1340,7 +1340,7 @@ describe('createLoadSessionHandler', () => {
     });
   });
 
-  it('emits cached Claude commands plus a fresh workspace command scan on passive load', async () => {
+  it('prefers fresh workspace Claude commands over cached globals on passive load', async () => {
     const worktreePath = mkdtempSync(join(tmpdir(), 'ff-slash-commands-'));
     tempDirs.push(worktreePath);
     const commandsDir = join(worktreePath, '.claude', 'commands');
@@ -1364,7 +1364,7 @@ describe('createLoadSessionHandler', () => {
     });
     mocks.getCachedCommands.mockResolvedValue([
       { name: '/global-only', description: 'Global only' },
-      { name: '/project:duplicate', description: 'Cached duplicate' },
+      { name: '/duplicate', description: 'Cached global duplicate' },
     ]);
 
     const handler = createLoadSessionHandler({
@@ -1383,9 +1383,9 @@ describe('createLoadSessionHandler', () => {
     expect(mocks.emitDelta).toHaveBeenCalledWith('session-1', {
       type: 'slash_commands',
       slashCommands: [
-        { name: '/global-only', description: 'Global only' },
-        { name: '/project:duplicate', description: 'Cached duplicate' },
+        { name: 'duplicate', description: 'Workspace duplicate' },
         { name: 'workspace-only', description: 'Workspace only' },
+        { name: '/global-only', description: 'Global only' },
       ],
     });
   });

--- a/src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.ts
@@ -521,8 +521,8 @@ function buildClaudeSlashCommandsForLoad(
   worktreePath: string | null
 ): CommandInfo[] {
   const seen = new Set<string>();
+  const commands = scanClaudeWorkspaceCommandsFromDisk(worktreePath, seen);
   if (cached) {
-    const commands: CommandInfo[] = [];
     for (const command of cached) {
       const key = commandNameKey(command.name);
       if (seen.has(key)) {
@@ -531,11 +531,9 @@ function buildClaudeSlashCommandsForLoad(
       seen.add(key);
       commands.push(command);
     }
-    commands.push(...scanClaudeWorkspaceCommandsFromDisk(worktreePath, seen));
     return commands;
   }
 
-  const commands = scanClaudeGlobalCommandsFromDisk(seen);
-  commands.push(...scanClaudeWorkspaceCommandsFromDisk(worktreePath, seen));
+  commands.push(...scanClaudeGlobalCommandsFromDisk(seen));
   return commands;
 }


### PR DESCRIPTION
## Summary
- Make active workspace Claude slash commands override same-named cached globals
- Apply the same workspace-first precedence to the global disk fallback
- Add regression coverage for cross-workspace cached command collisions

## Changes
- **Session loading**: Scan workspace command files before merging cached or global Claude commands so workspace keys are reserved first
- **Regression tests**: Verify a workspace `duplicate.md` replaces a cached global `/duplicate` while unique commands remain available

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting passes (`pnpm check:fix`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; backend merge precedence is covered by the regression and full test suites

Closes #1841

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
