### PR TITLE
Fix #1840: Bound GitHub review request pagination

### DIFF
--- a/src/backend/services/github/service/github-cli.service.test.ts
+++ b/src/backend/services/github/service/github-cli.service.test.ts
@@ -1261,6 +1261,40 @@ describe('GitHubCLIService', () => {
       );
     });
 
+    it('caps review request pagination at 20 pages', async () => {
+      const continuingPage = {
+        stdout: JSON.stringify({
+          data: {
+            search: {
+              pageInfo: { hasNextPage: true, endCursor: 'repeated-cursor' },
+              nodes: [],
+            },
+          },
+        }),
+        stderr: '',
+      };
+
+      for (let page = 0; page < 20; page++) {
+        mockExecFile.mockResolvedValueOnce(continuingPage);
+      }
+      mockExecFile.mockRejectedValueOnce(new Error('unexpected 21st page request'));
+
+      try {
+        await expect(githubCLIService.listReviewRequests()).resolves.toEqual([]);
+
+        expect(mockExecFile).toHaveBeenCalledTimes(20);
+        expect(mockLoggerWarn).toHaveBeenCalledWith(
+          'listReviewRequests: reached MAX_PAGES limit, results may be incomplete',
+          {
+            totalFetched: 0,
+            maxPages: 20,
+          }
+        );
+      } finally {
+        mockExecFile.mockReset();
+      }
+    });
+
     it('falls back to empty array when GraphQL response is malformed', async () => {
       mockExecFile.mockResolvedValueOnce({
         stdout: JSON.stringify({ data: { search: { nodes: 'not-an-array' } } }),

--- a/src/backend/services/github/service/github-cli.service.ts
+++ b/src/backend/services/github/service/github-cli.service.ts
@@ -318,11 +318,12 @@ class GitHubCLIService {
    * Uses paginated GraphQL search calls to fetch all matching PRs.
    */
   async listReviewRequests(): Promise<ReviewRequestedPR[]> {
+    const MAX_PAGES = 20;
     const prs: ReviewRequestedPR[] = [];
     let afterCursor: string | null = null;
     let hasNextPage = true;
 
-    while (hasNextPage) {
+    for (let page = 1; page <= MAX_PAGES && hasNextPage; page++) {
       const afterClause = afterCursor ? `, after: ${JSON.stringify(afterCursor)}` : '';
       const query = `
         query {
@@ -377,6 +378,13 @@ class GitHubCLIService {
       if (hasNextPage && !afterCursor) {
         logger.warn('GitHub review request page is missing an end cursor');
         return prs;
+      }
+
+      if (page === MAX_PAGES && hasNextPage) {
+        logger.warn('listReviewRequests: reached MAX_PAGES limit, results may be incomplete', {
+          totalFetched: prs.length,
+          maxPages: MAX_PAGES,
+        });
       }
     }
 


### PR DESCRIPTION
## Summary
- Cap GitHub review-request pagination at 20 GraphQL pages.
- Warn when additional pages remain after the cap and return the results already fetched.
- Add regression coverage that prevents a 21st API request.

## Changes
- **GitHub service**: Replace the unbounded review-request pagination loop with the established 20-page defensive bound.
- **Tests**: Simulate a pathological continuing cursor, verify exactly 20 calls, and assert the truncation warning.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting/lint pass (`pnpm check:fix`)
- [x] Build succeeds (`pnpm build`)
- [x] Manual testing: Verified the regression test fails on the pre-fix behavior by attempting page 21, then passes with the cap.

Closes #1840

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive pagination bound on a read-only GitHub listing path; behavior only changes for unusually large review queues (partial results + warning instead of unbounded calls).
> 
> **Overview**
> **`listReviewRequests`** no longer paginates indefinitely through GitHub GraphQL search. Pagination is capped at **20 pages** (same defensive bound as **`getReviewComments`**), using a bounded `for` loop instead of an unbounded `while`.
> 
> When the cap is hit but GitHub still reports a next page, the service **logs a warning** with `totalFetched` and `maxPages`, then returns whatever PRs were already collected—no extra API call.
> 
> A regression test simulates a stuck “always has next page” cursor, asserts **exactly 20** `gh` calls, and checks the truncation warning so a 21st request cannot happen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcdd87c3266f6bb4e613df24513d0fb8296960c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

