### PR TITLE
Fix #1810: shut down on unhandled rejections

### DIFF
--- a/src/backend/fatal-error-handlers.test.ts
+++ b/src/backend/fatal-error-handlers.test.ts
@@ -1,0 +1,110 @@
+import { EventEmitter } from 'node:events';
+import { describe, expect, it, vi } from 'vitest';
+import { registerFatalErrorHandlers } from './fatal-error-handlers';
+
+type FatalEvent = 'uncaughtException' | 'unhandledRejection';
+type FatalHandler = (value: unknown) => Promise<void>;
+
+function createHandlerHarness() {
+  const logger = {
+    error: vi.fn(),
+  };
+  const server = {
+    stop: vi.fn().mockResolvedValue(undefined),
+  };
+  const process = Object.assign(new EventEmitter(), {
+    exit: vi.fn(),
+  });
+
+  registerFatalErrorHandlers({ logger, process, server });
+
+  const getHandler = (event: FatalEvent): FatalHandler => {
+    const [handler] = process.rawListeners(event);
+    expect(handler).toBeDefined();
+    return handler as FatalHandler;
+  };
+
+  return { getHandler, logger, process, server };
+}
+
+describe('backend fatal error handlers', () => {
+  it('logs an Error rejection, waits for cleanup, and exits with failure', async () => {
+    const { getHandler, logger, process, server } = createHandlerHarness();
+    let finishCleanup: (() => void) | undefined;
+    server.stop.mockReturnValue(
+      new Promise<void>((resolve) => {
+        finishCleanup = resolve;
+      })
+    );
+    const error = new Error('async failure');
+
+    const handling = getHandler('unhandledRejection')(error);
+
+    expect(logger.error).toHaveBeenCalledWith('Unhandled rejection at promise', {
+      message: error.message,
+      stack: error.stack,
+      name: error.name,
+    });
+    expect(server.stop).toHaveBeenCalledTimes(1);
+    expect(process.exit).not.toHaveBeenCalled();
+
+    finishCleanup?.();
+    await handling;
+
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
+  it('logs a non-Error rejection reason before shutting down', async () => {
+    const { getHandler, logger, process } = createHandlerHarness();
+
+    await getHandler('unhandledRejection')('connection lost');
+
+    expect(logger.error).toHaveBeenCalledWith('Unhandled rejection at promise', {
+      reason: 'connection lost',
+    });
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
+  it('exits when server cleanup fails', async () => {
+    const { getHandler, process, server } = createHandlerHarness();
+    server.stop.mockRejectedValue(new Error('cleanup failed'));
+
+    await getHandler('unhandledRejection')(new Error('async failure'));
+
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
+  it('runs cleanup and exits only once for concurrent fatal events', async () => {
+    const { getHandler, process, server } = createHandlerHarness();
+    let finishCleanup: (() => void) | undefined;
+    server.stop.mockReturnValue(
+      new Promise<void>((resolve) => {
+        finishCleanup = resolve;
+      })
+    );
+
+    const firstHandling = getHandler('unhandledRejection')(new Error('first failure'));
+    const secondHandling = getHandler('uncaughtException')(new Error('second failure'));
+    await secondHandling;
+
+    expect(server.stop).toHaveBeenCalledTimes(1);
+    expect(process.exit).not.toHaveBeenCalled();
+
+    finishCleanup?.();
+    await firstHandling;
+
+    expect(process.exit).toHaveBeenCalledTimes(1);
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
+  it('preserves uncaught exception logging and fatal shutdown', async () => {
+    const { getHandler, logger, process, server } = createHandlerHarness();
+    const error = new Error('synchronous failure');
+
+    await getHandler('uncaughtException')(error);
+
+    expect(logger.error).toHaveBeenCalledWith('Uncaught exception', error);
+    expect(server.stop).toHaveBeenCalledTimes(1);
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/src/backend/fatal-error-handlers.test.ts
+++ b/src/backend/fatal-error-handlers.test.ts
@@ -65,6 +65,23 @@ describe('backend fatal error handlers', () => {
     expect(process.exit).toHaveBeenCalledWith(1);
   });
 
+  it('shuts down when a non-Error rejection reason cannot be stringified', async () => {
+    const { getHandler, logger, process, server } = createHandlerHarness();
+    const reason = {
+      [Symbol.toPrimitive]() {
+        throw new Error('coercion failed');
+      },
+    };
+
+    await getHandler('unhandledRejection')(reason);
+
+    expect(logger.error).toHaveBeenCalledWith('Unhandled rejection at promise', {
+      reason: '[unstringifiable rejection reason]',
+    });
+    expect(server.stop).toHaveBeenCalledTimes(1);
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
   it('exits when server cleanup fails', async () => {
     const { getHandler, process, server } = createHandlerHarness();
     server.stop.mockRejectedValue(new Error('cleanup failed'));

--- a/src/backend/fatal-error-handlers.ts
+++ b/src/backend/fatal-error-handlers.ts
@@ -1,0 +1,56 @@
+interface FatalErrorLogger {
+  error(message: string, errorInfo: unknown): void;
+}
+
+interface FatalErrorProcess {
+  on(event: 'uncaughtException', listener: (error: Error) => void | Promise<void>): this;
+  on(event: 'unhandledRejection', listener: (reason: unknown) => void | Promise<void>): this;
+  exit(code: number): void;
+}
+
+interface FatalErrorServer {
+  stop(): Promise<void>;
+}
+
+interface FatalErrorHandlerDependencies {
+  logger: FatalErrorLogger;
+  process: FatalErrorProcess;
+  server: FatalErrorServer;
+}
+
+export function registerFatalErrorHandlers({
+  logger,
+  process,
+  server,
+}: FatalErrorHandlerDependencies): void {
+  let isShuttingDown = false;
+
+  const shutdown = async (): Promise<void> => {
+    if (isShuttingDown) {
+      return;
+    }
+    isShuttingDown = true;
+
+    try {
+      await server.stop();
+    } catch {
+      // Ignore cleanup errors
+    }
+    process.exit(1);
+  };
+
+  process.on('uncaughtException', async (error) => {
+    logger.error('Uncaught exception', error);
+    await shutdown();
+  });
+
+  process.on('unhandledRejection', async (reason) => {
+    const errorInfo =
+      reason instanceof Error
+        ? { message: reason.message, stack: reason.stack, name: reason.name }
+        : { reason: String(reason) };
+
+    logger.error('Unhandled rejection at promise', errorInfo);
+    await shutdown();
+  });
+}

--- a/src/backend/fatal-error-handlers.ts
+++ b/src/backend/fatal-error-handlers.ts
@@ -45,10 +45,18 @@ export function registerFatalErrorHandlers({
   });
 
   process.on('unhandledRejection', async (reason) => {
-    const errorInfo =
-      reason instanceof Error
-        ? { message: reason.message, stack: reason.stack, name: reason.name }
-        : { reason: String(reason) };
+    let errorInfo: Record<string, unknown>;
+    if (reason instanceof Error) {
+      errorInfo = { message: reason.message, stack: reason.stack, name: reason.name };
+    } else {
+      let stringifiedReason = '[unstringifiable rejection reason]';
+      try {
+        stringifiedReason = String(reason);
+      } catch {
+        // Keep the fatal path reliable even when the rejection reason cannot be coerced.
+      }
+      errorInfo = { reason: stringifiedReason };
+    }
 
     logger.error('Unhandled rejection at promise', errorInfo);
     await shutdown();

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -14,6 +14,7 @@
 
 import 'dotenv/config';
 import { createAppContext } from './app-context';
+import { registerFatalErrorHandlers } from './fatal-error-handlers';
 import { toError } from './lib/error-utils';
 import { createServer } from './server';
 
@@ -44,24 +45,4 @@ process.on('SIGINT', async () => {
   process.exit(0);
 });
 
-// Handle uncaught exceptions
-process.on('uncaughtException', async (error) => {
-  logger.error('Uncaught exception', error);
-  try {
-    await serverInstance.stop();
-  } catch {
-    // Ignore cleanup errors
-  }
-  process.exit(1);
-});
-
-// Handle unhandled promise rejections
-process.on('unhandledRejection', (reason) => {
-  // Extract meaningful error information from reason
-  const errorInfo =
-    reason instanceof Error
-      ? { message: reason.message, stack: reason.stack, name: reason.name }
-      : { reason: String(reason) };
-
-  logger.error('Unhandled rejection at promise', errorInfo);
-});
+registerFatalErrorHandlers({ logger, process, server: serverInstance });


### PR DESCRIPTION
## Summary
- Treat backend unhandled promise rejections as fatal runtime errors.
- Attempt graceful server cleanup before exiting with status 1.
- Add regression coverage for cleanup ordering, failures, and concurrent fatal events.

## Changes
- **Backend lifecycle**: Extract process-level fatal handlers into a dependency-injected registrar and wire it from the standalone entry point.
- **Shutdown safety**: Share a single fatal-shutdown guard across unhandled rejections and uncaught exceptions so cleanup and exit run once.
- **Tests**: Cover Error and non-Error rejection logging, cleanup failures, cleanup-before-exit ordering, and concurrent fatal events.

## Testing
- [x] Tests pass (`pnpm test` — 3,489 passed, 3 skipped)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting completes (`pnpm check:fix`)
- [x] Build succeeds (`pnpm build`)
- [x] Targeted regression tests pass (`pnpm exec vitest run src/backend/fatal-error-handlers.test.ts`)
- [ ] Manual testing: Not performed; behavior is covered by focused process-handler tests.

Closes #1810

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes process lifecycle and exit behavior on unhandled rejections, which can affect availability and orchestration restarts, though scope is limited to the standalone backend entry point and is well covered by tests.
> 
> **Overview**
> **Unhandled promise rejections** on the standalone backend entry point now follow the same fatal path as uncaught exceptions: log, attempt `server.stop()`, then `process.exit(1)`. Previously, rejections were only logged and the process could keep running.
> 
> Process-level handling is moved into **`registerFatalErrorHandlers`**, wired from `index.ts` with injectable `logger`, `process`, and `server`. A single shutdown guard ensures concurrent `uncaughtException` / `unhandledRejection` events trigger one cleanup and one exit. Non-`Error` rejection reasons are logged with safe stringification (including unstringifiable values). Regression tests cover cleanup ordering, failed cleanup, and concurrent fatals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be40be74a71bf0e6919aca5b79764941b8fef549. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->