### PR TITLE
Fix #1767: Retry terminal PID cleanup

### DIFF
--- a/src/backend/orchestration/workspace-init.orchestrator.test.ts
+++ b/src/backend/orchestration/workspace-init.orchestrator.test.ts
@@ -443,7 +443,10 @@ describe('initializeWorkspaceWorktree', () => {
       createTerminalSessionDeferred.resolve(unsafeCoerce({}));
       await initializationPromise;
 
-      expect(sessionDataService.clearTerminalPid).toHaveBeenCalledWith('term-default');
+      expect(sessionDataService.clearTerminalPid).toHaveBeenCalledWith(
+        WORKSPACE_ID,
+        'term-default'
+      );
     });
   });
 
@@ -1374,7 +1377,10 @@ describe('initializeWorkspaceWorktree', () => {
 
       expect(sessionService.stopWorkspaceSessions).toHaveBeenCalledWith(WORKSPACE_ID);
       expect(terminalService.destroyTerminal).toHaveBeenCalledWith(WORKSPACE_ID, 'term-default');
-      expect(sessionDataService.clearTerminalPid).toHaveBeenCalledWith('term-default');
+      expect(sessionDataService.clearTerminalPid).toHaveBeenCalledWith(
+        WORKSPACE_ID,
+        'term-default'
+      );
       expect(workspaceStateMachine.markFailed).toHaveBeenCalledWith(WORKSPACE_ID, 'script boom');
     });
 

--- a/src/backend/orchestration/workspace-init.orchestrator.ts
+++ b/src/backend/orchestration/workspace-init.orchestrator.ts
@@ -126,7 +126,7 @@ async function handleWorkspaceInitFailure(
       });
     }
     try {
-      await sessionDataService.clearTerminalPid(autoCreatedTerminalId);
+      await sessionDataService.clearTerminalPid(workspaceId, autoCreatedTerminalId);
     } catch (clearPidError) {
       logger.warn('Failed to clear default terminal PID after init failure', {
         workspaceId,
@@ -466,7 +466,7 @@ async function startDefaultTerminal(
     let terminalSessionPersisted = false;
     const clearPersistedTerminalPid = async () => {
       try {
-        await sessionDataService.clearTerminalPid(terminalId);
+        await sessionDataService.clearTerminalPid(workspaceId, terminalId);
       } catch (error) {
         logger.warn('Failed to clear terminal PID after default terminal exit', {
           workspaceId,

--- a/src/backend/routers/websocket/terminal.handler.test.ts
+++ b/src/backend/routers/websocket/terminal.handler.test.ts
@@ -509,7 +509,7 @@ describe('createTerminalUpgradeHandler', () => {
     expect(ws.send).toHaveBeenCalledWith(
       JSON.stringify({ type: 'exit', terminalId: 'terminal-1', exitCode: 0 })
     );
-    expect(mockClearTerminalPid).toHaveBeenCalledWith('terminal-1');
+    expect(mockClearTerminalPid).toHaveBeenCalledWith(workspaceId, 'terminal-1');
 
     ws.emit('message', JSON.stringify({ type: 'destroy', terminalId: 'terminal-1' }));
     await Promise.resolve();
@@ -607,6 +607,60 @@ describe('createTerminalUpgradeHandler', () => {
         })
       );
     });
+  });
+
+  it('retries clearing the persisted pid when terminal exit cleanup transiently fails', async () => {
+    const workspaceId = 'workspace-1';
+    const terminalId = 'terminal-1';
+    const { terminalService, exitListeners } = createTerminalService();
+    terminalService.getTerminalsForWorkspace.mockReturnValue([
+      {
+        id: terminalId,
+        createdAt: new Date('2026-07-15T00:00:00.000Z'),
+        outputBuffer: '',
+      },
+    ]);
+    mockClearTerminalPid
+      .mockRejectedValueOnce(new Error('database locked'))
+      .mockResolvedValueOnce(undefined);
+
+    const logger = createLogger();
+    const appContext = {
+      services: {
+        terminalService,
+        configService: {
+          getCorsConfig: vi.fn(() => ({ allowedOrigins: [allowedOrigin] })),
+        },
+        createLogger: vi.fn(() => logger),
+      },
+    } as unknown as AppContext;
+    const handler = createTerminalUpgradeHandler(appContext);
+    const ws = new MockWebSocket();
+    const wss = createWss(ws);
+
+    handler(
+      createRequest(),
+      { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex,
+      Buffer.alloc(0),
+      new URL(`http://localhost/terminal?workspaceId=${workspaceId}`),
+      wss,
+      new WeakMap<WebSocket, boolean>()
+    );
+
+    await vi.waitFor(() => {
+      expect(exitListeners.get(terminalId)?.size).toBe(1);
+    });
+
+    for (const callback of exitListeners.get(terminalId) ?? []) {
+      callback(0);
+    }
+
+    await vi.waitFor(() => {
+      expect(mockClearTerminalPid).toHaveBeenCalledTimes(2);
+    });
+    expect(mockClearTerminalPid).toHaveBeenNthCalledWith(1, workspaceId, terminalId);
+    expect(mockClearTerminalPid).toHaveBeenNthCalledWith(2, workspaceId, terminalId);
+    expect(logger.warn).not.toHaveBeenCalledWith('Failed to clear terminal PID', expect.anything());
   });
 
   it('destroys a newly created terminal when session persistence fails', async () => {

--- a/src/backend/routers/websocket/terminal.handler.ts
+++ b/src/backend/routers/websocket/terminal.handler.ts
@@ -42,6 +42,8 @@ const terminalListenerCleanup = new WeakMap<WebSocket, Map<string, (() => void)[
 
 type TerminalUnsubscribers = (() => void)[];
 
+const TERMINAL_PID_CLEAR_RETRY_DELAYS_MS = [100, 500] as const;
+
 // ============================================================================
 // Helper Functions
 // ============================================================================
@@ -106,7 +108,7 @@ function sendExistingTerminals(
 
   const cleanupMap = terminalListenerCleanup.get(ws);
   for (const terminal of existingTerminals) {
-    attachTerminalListeners(ws, terminal.id, terminalService, logger, cleanupMap);
+    attachTerminalListeners(ws, workspaceId, terminal.id, terminalService, logger, cleanupMap);
   }
 }
 
@@ -178,7 +180,7 @@ async function handleCreateMessage(
   }
 
   const cleanupMap = terminalListenerCleanup.get(ws);
-  attachTerminalListeners(ws, terminalId, terminalService, logger, cleanupMap);
+  attachTerminalListeners(ws, workspaceId, terminalId, terminalService, logger, cleanupMap);
 
   logger.info('Sending created message to client', { terminalId, requestId: message.requestId });
   ws.send(JSON.stringify({ type: 'created', terminalId, requestId: message.requestId }));
@@ -186,6 +188,7 @@ async function handleCreateMessage(
 
 function attachTerminalListeners(
   ws: WebSocket,
+  workspaceId: string,
   terminalId: string,
   terminalService: AppContext['services']['terminalService'],
   logger: ReturnType<AppContext['services']['createLogger']>,
@@ -207,11 +210,45 @@ function attachTerminalListeners(
       ws.send(JSON.stringify({ type: 'exit', terminalId, exitCode }));
     }
     terminalListenerCleanup.get(ws)?.delete(terminalId);
-    sessionDataService.clearTerminalPid(terminalId).catch((err) => {
-      logger.warn('Failed to clear terminal PID', { terminalId, error: err });
-    });
+    void clearTerminalPidWithRetry(workspaceId, terminalId, logger);
   });
   unsubscribers.push(unsubExit);
+}
+
+async function clearTerminalPidWithRetry(
+  workspaceId: string,
+  terminalId: string,
+  logger: ReturnType<AppContext['services']['createLogger']>
+): Promise<void> {
+  const maxAttempts = TERMINAL_PID_CLEAR_RETRY_DELAYS_MS.length + 1;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      await sessionDataService.clearTerminalPid(workspaceId, terminalId);
+      return;
+    } catch (error) {
+      const retryDelayMs = TERMINAL_PID_CLEAR_RETRY_DELAYS_MS[attempt - 1];
+      if (retryDelayMs === undefined) {
+        logger.warn('Failed to clear terminal PID', {
+          workspaceId,
+          terminalId,
+          attempts: maxAttempts,
+          error,
+        });
+        return;
+      }
+
+      logger.warn('Failed to clear terminal PID; retrying', {
+        workspaceId,
+        terminalId,
+        attempt,
+        maxAttempts,
+        retryDelayMs,
+        error,
+      });
+      await new Promise<void>((resolve) => setTimeout(resolve, retryDelayMs));
+    }
+  }
 }
 
 function handleInputMessage(

--- a/src/backend/services/resources.integration.test.ts
+++ b/src/backend/services/resources.integration.test.ts
@@ -609,26 +609,34 @@ describe('resource accessors integration', () => {
   });
 
   describe('terminalSessionAccessor', () => {
-    it('clears pid for all matching terminal names', async () => {
+    it('clears pid only for matching terminal names in the requested workspace', async () => {
       const project = await createProjectFixture();
       const workspace = await createWorkspaceFixture(project.id);
+      const otherWorkspace = await createWorkspaceFixture(project.id);
 
       await prisma.terminalSession.createMany({
         data: [
           { workspaceId: workspace.id, name: 'terminal-a', pid: 1001 },
           { workspaceId: workspace.id, name: 'terminal-a', pid: 2002 },
           { workspaceId: workspace.id, name: 'terminal-b', pid: 3003 },
+          { workspaceId: otherWorkspace.id, name: 'terminal-a', pid: 4004 },
         ],
       });
 
-      await terminalSessionAccessor.clearPid('terminal-a');
+      await terminalSessionAccessor.clearPid(workspace.id, 'terminal-a');
 
       const all = await prisma.terminalSession.findMany({ orderBy: { name: 'asc' } });
-      const target = all.filter((session) => session.name === 'terminal-a');
-      const untouched = all.find((session) => session.name === 'terminal-b');
+      const target = all.filter(
+        (session) => session.workspaceId === workspace.id && session.name === 'terminal-a'
+      );
+      const untouchedName = all.find((session) => session.name === 'terminal-b');
+      const untouchedWorkspace = all.find(
+        (session) => session.workspaceId === otherWorkspace.id && session.name === 'terminal-a'
+      );
 
       expect(target.every((session) => session.pid === null)).toBe(true);
-      expect(untouched?.pid).toBe(3003);
+      expect(untouchedName?.pid).toBe(3003);
+      expect(untouchedWorkspace?.pid).toBe(4004);
     });
 
     it('finds only terminal sessions with a live pid', async () => {

--- a/src/backend/services/session/service/data/session-data.service.ts
+++ b/src/backend/services/session/service/data/session-data.service.ts
@@ -131,8 +131,8 @@ class SessionDataService {
     return terminalSessionAccessor.findWithPid();
   }
 
-  clearTerminalPid(name: string): Promise<void> {
-    return terminalSessionAccessor.clearPid(name);
+  clearTerminalPid(workspaceId: string, name: string): Promise<void> {
+    return terminalSessionAccessor.clearPid(workspaceId, name);
   }
 }
 

--- a/src/backend/services/terminal/resources/terminal-session.accessor.ts
+++ b/src/backend/services/terminal/resources/terminal-session.accessor.ts
@@ -67,9 +67,9 @@ class TerminalSessionAccessor {
     });
   }
 
-  async clearPid(name: string): Promise<void> {
+  async clearPid(workspaceId: string, name: string): Promise<void> {
     await prisma.terminalSession.updateMany({
-      where: { name },
+      where: { workspaceId, name },
       data: { pid: null },
     });
   }

--- a/src/backend/services/workspace/service/worktree/worktree-init.test.ts
+++ b/src/backend/services/workspace/service/worktree/worktree-init.test.ts
@@ -312,7 +312,7 @@ describe('initializeWorkspaceWorktree orchestrator', () => {
     });
     expect(mocks.stopWorkspaceSessions).toHaveBeenCalledWith('workspace-1');
     expect(mocks.destroyTerminal).toHaveBeenCalledWith('workspace-1', 'term-default');
-    expect(mocks.clearTerminalPid).toHaveBeenCalledWith('term-default');
+    expect(mocks.clearTerminalPid).toHaveBeenCalledWith('workspace-1', 'term-default');
     expect(mocks.markFailed).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- Retry terminal PID cleanup after transient database failures on process exit
- Scope PID clearing by workspace and terminal name to prevent cross-workspace collisions
- Add focused retry and persistence-isolation regression coverage

## Changes
- **Terminal WebSocket lifecycle**: Retain workspace context and retry failed PID cleanup after 100 ms and 500 ms delays before logging final failure
- **Session persistence**: Require `(workspaceId, name)` when clearing terminal PIDs
- **Tests**: Simulate a rejected exit cleanup followed by success and verify matching terminal names in other workspaces remain untouched

## Testing
- [x] Tests pass (`pnpm test` — 3,485 passed, 3 skipped)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Formatting/lint completed (`pnpm check:fix`)
- [ ] Manual testing: Not performed; automated WebSocket exit and database integration tests cover the changed behavior

Closes #1767

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 69c0cc8e982069ffa1429a95daa06072200cc522. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

