### PR TITLE
Fix #1867: Guard WebSocket fan-out sends with safeSend helper

### DIFF
--- a/src/backend/lib/websocket-send.test.ts
+++ b/src/backend/lib/websocket-send.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { WebSocket } from 'ws';
+import { WS_READY_STATE } from '@/backend/constants/websocket';
+import { safeSend } from './websocket-send';
+
+function createMockWs(readyState: number = WS_READY_STATE.OPEN) {
+  return {
+    readyState,
+    send: vi.fn(),
+  };
+}
+
+function createMockLogger() {
+  return { error: vi.fn() };
+}
+
+describe('safeSend', () => {
+  it('sends the message when the socket is OPEN and returns true', () => {
+    const ws = createMockWs();
+    const logger = createMockLogger();
+
+    const result = safeSend(ws as unknown as WebSocket, 'hello', logger);
+
+    expect(result).toBe(true);
+    expect(ws.send).toHaveBeenCalledWith('hello');
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('does not send when the socket is not OPEN and returns false', () => {
+    const ws = createMockWs(WS_READY_STATE.CLOSING);
+    const logger = createMockLogger();
+
+    const result = safeSend(ws as unknown as WebSocket, 'hello', logger);
+
+    expect(result).toBe(false);
+    expect(ws.send).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('catches a synchronous send error, logs it, and returns false', () => {
+    const ws = createMockWs();
+    ws.send.mockImplementation(() => {
+      throw new Error('socket closing');
+    });
+    const logger = createMockLogger();
+
+    const result = safeSend(ws as unknown as WebSocket, 'hello', logger, 'test message');
+
+    expect(result).toBe(false);
+    expect(logger.error).toHaveBeenCalledWith(
+      'Failed to send test message',
+      expect.objectContaining({ message: 'socket closing' })
+    );
+  });
+});

--- a/src/backend/lib/websocket-send.ts
+++ b/src/backend/lib/websocket-send.ts
@@ -1,0 +1,40 @@
+/**
+ * Safe WebSocket send helper for fan-out broadcasters.
+ *
+ * `ws.send` can throw synchronously (e.g. the socket transitions to CLOSING
+ * between a readyState check and the send). Broadcasters iterating over many
+ * clients must not let one bad socket drop the message for the remaining
+ * clients or propagate the error back into the code path that triggered the
+ * broadcast.
+ */
+
+import type { WebSocket } from 'ws';
+import { WS_READY_STATE } from '@/backend/constants/websocket';
+import { toError } from './error-utils';
+
+interface SendErrorLogger {
+  error(message: string, error: Error): void;
+}
+
+/**
+ * Send a message on a WebSocket, swallowing (and logging) synchronous send
+ * errors. Returns true if the message was sent, false if the socket was not
+ * open or the send threw.
+ */
+export function safeSend(
+  ws: WebSocket,
+  message: string,
+  logger: SendErrorLogger,
+  description = 'WebSocket message'
+): boolean {
+  if (ws.readyState !== WS_READY_STATE.OPEN) {
+    return false;
+  }
+  try {
+    ws.send(message);
+    return true;
+  } catch (error) {
+    logger.error(`Failed to send ${description}`, toError(error));
+    return false;
+  }
+}

--- a/src/backend/routers/websocket/snapshots.handler.test.ts
+++ b/src/backend/routers/websocket/snapshots.handler.test.ts
@@ -59,6 +59,10 @@ vi.mock('@/backend/services/workspace-snapshot-store.service', () => {
         originalOn(event, listener);
         return emitter;
       }),
+      off: vi.fn((event: string, listener: (event: unknown) => unknown) => {
+        emitter.off(event, listener);
+        return emitter;
+      }),
     },
   };
 });
@@ -424,6 +428,103 @@ describe('createSnapshotsUpgradeHandler', () => {
     });
 
     expect(ws.send).not.toHaveBeenCalled();
+  });
+
+  it('continues snapshot_changed fan-out when one client send throws', async () => {
+    const handler = createSnapshotsUpgradeHandler(createAppContextMock());
+    const throwingWs = new MockWebSocket();
+    const healthyWs = new MockWebSocket();
+
+    callHandler(handler, throwingWs, 'proj-1');
+    callHandler(handler, healthyWs, 'proj-1');
+
+    await waitForInitialSnapshot(throwingWs);
+    await waitForInitialSnapshot(healthyWs);
+    throwingWs.send.mockClear();
+    healthyWs.send.mockClear();
+
+    throwingWs.send.mockImplementation(() => {
+      throw new Error('socket closing');
+    });
+
+    const changedListener = storeListeners.get('snapshot_changed');
+    expect(changedListener).toBeDefined();
+
+    const event: SnapshotChangedEvent = {
+      workspaceId: 'ws-1',
+      projectId: 'proj-1',
+      entry: {
+        workspaceId: 'ws-1',
+        projectId: 'proj-1',
+        name: 'Updated',
+        status: 'READY',
+      } as never,
+    };
+    expect(() => changedListener!(event)).not.toThrow();
+
+    expect(healthyWs.send).toHaveBeenCalledWith(
+      JSON.stringify({
+        type: 'snapshot_changed',
+        workspaceId: 'ws-1',
+        entry: event.entry,
+        reviewCount: 5,
+      })
+    );
+  });
+
+  it('continues snapshot_removed fan-out when one client send throws', async () => {
+    const handler = createSnapshotsUpgradeHandler(createAppContextMock());
+    const throwingWs = new MockWebSocket();
+    const healthyWs = new MockWebSocket();
+
+    callHandler(handler, throwingWs, 'proj-1');
+    callHandler(handler, healthyWs, 'proj-1');
+
+    await waitForInitialSnapshot(throwingWs);
+    await waitForInitialSnapshot(healthyWs);
+    throwingWs.send.mockClear();
+    healthyWs.send.mockClear();
+
+    throwingWs.send.mockImplementation(() => {
+      throw new Error('socket closing');
+    });
+
+    const removedListener = storeListeners.get('snapshot_removed');
+    expect(removedListener).toBeDefined();
+
+    const event: SnapshotRemovedEvent = {
+      workspaceId: 'ws-1',
+      projectId: 'proj-1',
+    };
+    expect(() => removedListener!(event)).not.toThrow();
+
+    expect(healthyWs.send).toHaveBeenCalledWith(
+      JSON.stringify({
+        type: 'snapshot_removed',
+        workspaceId: 'ws-1',
+        reviewCount: 5,
+      })
+    );
+  });
+
+  it('does not throw out of the upgrade callback when the initial snapshot send throws', () => {
+    mockGetByProjectId.mockReturnValue([
+      {
+        workspaceId: 'ws-1',
+        projectId: 'proj-1',
+        name: 'Visible',
+        status: 'READY',
+      },
+    ] as never);
+
+    const handler = createSnapshotsUpgradeHandler(createAppContextMock());
+    const ws = new MockWebSocket();
+    ws.send.mockImplementation(() => {
+      throw new Error('socket closing');
+    });
+
+    expect(() => callHandler(handler, ws, 'proj-1')).not.toThrow();
+    expect(ws.send).toHaveBeenCalled();
   });
 
   it('cleans up connection set on close', () => {

--- a/src/backend/routers/websocket/snapshots.handler.ts
+++ b/src/backend/routers/websocket/snapshots.handler.ts
@@ -11,6 +11,7 @@ import type { Duplex } from 'node:stream';
 import type { WebSocket, WebSocketServer } from 'ws';
 import type { AppContext } from '@/backend/app-context';
 import { WS_READY_STATE } from '@/backend/constants/websocket';
+import { safeSend } from '@/backend/lib/websocket-send';
 import { snapshotReconciliationService } from '@/backend/orchestration/snapshot-reconciliation.orchestrator';
 import { workspaceQueryService } from '@/backend/services/workspace';
 import {
@@ -85,9 +86,7 @@ class SnapshotStoreSubscriptionState {
       );
 
       for (const ws of projectClients) {
-        if (ws.readyState === WS_READY_STATE.OPEN) {
-          ws.send(message);
-        }
+        safeSend(ws, message, logger, 'snapshot delta');
       }
     };
 
@@ -105,9 +104,7 @@ class SnapshotStoreSubscriptionState {
       });
 
       for (const ws of projectClients) {
-        if (ws.readyState === WS_READY_STATE.OPEN) {
-          ws.send(message);
-        }
+        safeSend(ws, message, logger, 'snapshot removal');
       }
     };
 
@@ -232,13 +229,16 @@ export function createSnapshotsUpgradeHandler(
         const entries = workspaceSnapshotStore
           .getByProjectId(projectId)
           .filter((entry) => !isHiddenWorkspaceStatus(entry.status));
-        ws.send(
+        safeSend(
+          ws,
           JSON.stringify({
             type: 'snapshot_full',
             projectId,
             entries,
             reviewCount,
-          })
+          }),
+          logger,
+          'full snapshot'
         );
       };
 

--- a/src/backend/services/session/service/chat/chat-connection.service.test.ts
+++ b/src/backend/services/session/service/chat/chat-connection.service.test.ts
@@ -232,6 +232,33 @@ describe('ChatConnectionService', () => {
       expect(mockWs.send).not.toHaveBeenCalled();
     });
 
+    it('should continue forwarding to remaining connections when a send throws', () => {
+      const throwingWs = new MockWebSocket();
+      throwingWs.send.mockImplementation(() => {
+        throw new Error('socket closing');
+      });
+      const healthyWs = new MockWebSocket();
+      const dbSessionId = 'session-456';
+
+      chatConnectionService.register('conn-1', {
+        ws: throwingWs as unknown as WebSocket,
+        dbSessionId,
+        workingDir: '/test/dir',
+      });
+
+      chatConnectionService.register('conn-2', {
+        ws: healthyWs as unknown as WebSocket,
+        dbSessionId,
+        workingDir: '/test/dir',
+      });
+
+      const message = { type: 'test', data: 'hello' };
+      expect(() => chatConnectionService.forwardToSession(dbSessionId, message)).not.toThrow();
+
+      expect(throwingWs.send).toHaveBeenCalled();
+      expect(healthyWs.send).toHaveBeenCalledWith(JSON.stringify(message));
+    });
+
     it('should exclude specified websocket from forwarding', () => {
       const ws1 = new MockWebSocket() as unknown as WebSocket;
       const ws2 = new MockWebSocket() as unknown as WebSocket;

--- a/src/backend/services/session/service/chat/chat-connection.service.ts
+++ b/src/backend/services/session/service/chat/chat-connection.service.ts
@@ -9,6 +9,7 @@
 
 import type { WebSocket } from 'ws';
 import { WS_READY_STATE } from '@/backend/constants/websocket';
+import { safeSend } from '@/backend/lib/websocket-send';
 import { configService } from '@/backend/services/config.service';
 import { createLogger } from '@/backend/services/logger.service';
 import { sessionFileLogger } from '@/backend/services/session/service/logging/session-file-logger.service';
@@ -134,12 +135,8 @@ export class ChatConnectionService {
 
     const json = JSON.stringify(data);
     for (const info of this.connections.values()) {
-      if (
-        info.dbSessionId === dbSessionId &&
-        info.ws.readyState === WS_READY_STATE.OPEN &&
-        info.ws !== exclude
-      ) {
-        info.ws.send(json);
+      if (info.dbSessionId === dbSessionId && info.ws !== exclude) {
+        safeSend(info.ws, json, logger, 'chat session message');
       }
     }
   }

--- a/src/backend/services/session/service/chat/chat-event-forwarder.service.ts
+++ b/src/backend/services/session/service/chat/chat-event-forwarder.service.ts
@@ -10,8 +10,7 @@
  * This service retains the workspace notification and pending request management responsibilities.
  */
 
-import { WS_READY_STATE } from '@/backend/constants/websocket';
-import { toError } from '@/backend/lib/error-utils';
+import { safeSend } from '@/backend/lib/websocket-send';
 import { createLogger } from '@/backend/services/logger.service';
 import type { SessionWorkspaceBridge } from '@/backend/services/session/service/bridges';
 import { sessionDomainService } from '@/backend/services/session/service/session-domain.service';
@@ -112,13 +111,7 @@ class ChatEventForwarderService {
       });
 
       for (const info of chatConnectionService.values()) {
-        if (info.ws.readyState === WS_READY_STATE.OPEN) {
-          try {
-            info.ws.send(message);
-          } catch (error) {
-            logger.error('Failed to send workspace notification', toError(error));
-          }
-        }
+        safeSend(info.ws, message, logger, 'workspace notification');
       }
     });
   }


### PR DESCRIPTION
Fixes #1867.

## Problem

Several WebSocket fan-out loops called `ws.send()` guarded only by a `readyState === OPEN` check, with no try/catch. `ws.send` can throw synchronously (e.g. the socket transitions to CLOSING between the readyState check and the send), so a single bad socket would:

1. Silently drop that message for every client after the failing one in the loop.
2. In the snapshot case, propagate the exception back into `WorkspaceSnapshotStore.emit(...)`, i.e. into the store-mutation code path that triggered the broadcast.

## Fix

- Added a shared `safeSend(ws, message, logger, description)` helper in `src/backend/lib/websocket-send.ts` that checks `readyState`, wraps the send in try/catch, logs failures, and returns whether the message was sent — so future broadcasters get this for free.
- Used it in all fan-out paths named in the issue:
  - `chat-connection.service.ts` `forwardToSession`
  - `snapshots.handler.ts` `changedListener`, `removedListener`, and `sendSnapshot`
- Refactored the sibling `chat-event-forwarder.service.ts` broadcaster (which already hand-rolled the identical try/catch) to use the shared helper.

## Tests

New tests (written first, verified failing against the old code):

- `websocket-send.test.ts`: sends when OPEN, skips when not OPEN, catches and logs synchronous send errors.
- `chat-connection.service.test.ts`: a throwing send doesn't prevent remaining connections from receiving the message and doesn't propagate.
- `snapshots.handler.test.ts`: throwing client doesn't block `snapshot_changed`/`snapshot_removed` fan-out to other clients; a throwing initial `snapshot_full` send doesn't escape the upgrade callback. Also added `off` to the mock store so listener cleanup between tests works (removes a MaxListeners warning).

`pnpm test` (3583 passed), `pnpm check:fix`, and `pnpm check` pass. `pnpm typecheck` has pre-existing `NODE_ENV`/`ProcessEnv` failures on `main` (verified via stash on a clean tree) unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f877f3329ccff46833e2922dd54be72855dd8b8f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

