### PR TITLE
Fix #1868: Apply trusted-local validation to all WebSocket channels

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,6 +112,8 @@ PR_REVIEW_TIMEOUT_MINUTES=60
 CORS_ALLOWED_ORIGINS=http://localhost:4000,http://localhost:4001
 
 # Additional trusted local gateway CIDRs for published Docker ports (comma-separated).
+# All WebSocket channels (terminal, chat, setup-terminal, dev-logs, post-run-logs,
+# snapshots) require a loopback or trusted-local client address at upgrade time.
 # Keep empty unless the app is bound behind a local-only bridge/proxy you control.
 # TRUSTED_LOCAL_CIDRS=172.17.0.1/32
 

--- a/src/backend/routers/websocket/chat.handler.test.ts
+++ b/src/backend/routers/websocket/chat.handler.test.ts
@@ -125,7 +125,10 @@ describe('createChatUpgradeHandler', () => {
     const { appContext, chatMessageHandlerService } = createTestContext(tempRootDir);
     const handler = createChatUpgradeHandler(appContext);
 
-    const request = { headers: { origin: allowedOrigin } } as IncomingMessage;
+    const request = {
+      headers: { origin: allowedOrigin },
+      socket: { remoteAddress: '127.0.0.1' },
+    } as unknown as IncomingMessage;
     const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
     const wss = { handleUpgrade: vi.fn() } as unknown as WebSocketServer;
     const wsAliveMap = new WeakMap<WebSocket, boolean>();
@@ -160,6 +163,50 @@ describe('createChatUpgradeHandler', () => {
     expect(wss.handleUpgrade).not.toHaveBeenCalled();
   });
 
+  it('rejects untrusted remote addresses before opening a WebSocket', () => {
+    const { appContext } = createTestContext(tempRootDir);
+    const handler = createChatUpgradeHandler(appContext);
+
+    const request = {
+      headers: { origin: allowedOrigin },
+      socket: { remoteAddress: '203.0.113.10' },
+    } as unknown as IncomingMessage;
+    const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
+    const wss = { handleUpgrade: vi.fn() } as unknown as WebSocketServer;
+    const wsAliveMap = new WeakMap<WebSocket, boolean>();
+    const url = new URL('http://localhost/chat');
+
+    handler(request, socket, Buffer.alloc(0), url, wss, wsAliveMap);
+
+    expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('403 Forbidden'));
+    expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('Untrusted remote address'));
+    expect(socket.destroy).toHaveBeenCalledTimes(1);
+    expect(wss.handleUpgrade).not.toHaveBeenCalled();
+  });
+
+  it('rejects forwarded local upgrades before opening a WebSocket', () => {
+    const { appContext } = createTestContext(tempRootDir);
+    const handler = createChatUpgradeHandler(appContext);
+
+    const request = {
+      headers: { origin: allowedOrigin, 'x-forwarded-for': '203.0.113.10' },
+      socket: { remoteAddress: '127.0.0.1' },
+    } as unknown as IncomingMessage;
+    const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
+    const wss = { handleUpgrade: vi.fn() } as unknown as WebSocketServer;
+    const wsAliveMap = new WeakMap<WebSocket, boolean>();
+    const url = new URL('http://localhost/chat');
+
+    handler(request, socket, Buffer.alloc(0), url, wss, wsAliveMap);
+
+    expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('403 Forbidden'));
+    expect(socket.write).toHaveBeenCalledWith(
+      expect.stringContaining('Forwarded WebSocket upgrades are not trusted')
+    );
+    expect(socket.destroy).toHaveBeenCalledTimes(1);
+    expect(wss.handleUpgrade).not.toHaveBeenCalled();
+  });
+
   it('registers a connection, dispatches valid messages, and cleans up on close', async () => {
     const workingDir = join(tempRootDir, 'workspace-1');
     mkdirSync(workingDir, { recursive: true });
@@ -185,7 +232,10 @@ describe('createChatUpgradeHandler', () => {
       ),
     } as unknown as WebSocketServer;
 
-    const request = { headers: { origin: allowedOrigin } } as IncomingMessage;
+    const request = {
+      headers: { origin: allowedOrigin },
+      socket: { remoteAddress: '127.0.0.1' },
+    } as unknown as IncomingMessage;
     const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
     const wsAliveMap = new WeakMap<WebSocket, boolean>();
     const url = new URL(
@@ -237,7 +287,10 @@ describe('createChatUpgradeHandler', () => {
       ),
     } as unknown as WebSocketServer;
 
-    const request = { headers: { origin: allowedOrigin } } as IncomingMessage;
+    const request = {
+      headers: { origin: allowedOrigin },
+      socket: { remoteAddress: '127.0.0.1' },
+    } as unknown as IncomingMessage;
     const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
     const wsAliveMap = new WeakMap<WebSocket, boolean>();
     const url = new URL('http://localhost/chat?connectionId=conn-1&sessionId=session-1');
@@ -270,7 +323,10 @@ describe('createChatUpgradeHandler', () => {
       ),
     } as unknown as WebSocketServer;
 
-    const request = { headers: { origin: allowedOrigin } } as IncomingMessage;
+    const request = {
+      headers: { origin: allowedOrigin },
+      socket: { remoteAddress: '127.0.0.1' },
+    } as unknown as IncomingMessage;
     const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
     const wsAliveMap = new WeakMap<WebSocket, boolean>();
     const url = new URL('http://localhost/chat?connectionId=conn-1&sessionId=session-1');
@@ -307,7 +363,10 @@ describe('createChatUpgradeHandler', () => {
       ),
     } as unknown as WebSocketServer;
 
-    const request = { headers: { origin: allowedOrigin } } as IncomingMessage;
+    const request = {
+      headers: { origin: allowedOrigin },
+      socket: { remoteAddress: '127.0.0.1' },
+    } as unknown as IncomingMessage;
     const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
     const wsAliveMap = new WeakMap<WebSocket, boolean>();
     const url = new URL('http://localhost/chat?connectionId=conn-1&sessionId=session-1');
@@ -356,7 +415,10 @@ describe('createChatUpgradeHandler', () => {
       ),
     } as unknown as WebSocketServer;
 
-    const request = { headers: { origin: allowedOrigin } } as IncomingMessage;
+    const request = {
+      headers: { origin: allowedOrigin },
+      socket: { remoteAddress: '127.0.0.1' },
+    } as unknown as IncomingMessage;
     const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
     const wsAliveMap = new WeakMap<WebSocket, boolean>();
     const url = new URL('http://localhost/chat?connectionId=conn-1&sessionId=session-1');
@@ -395,7 +457,10 @@ describe('createChatUpgradeHandler', () => {
       ),
     } as unknown as WebSocketServer;
 
-    const request = { headers: { origin: allowedOrigin } } as IncomingMessage;
+    const request = {
+      headers: { origin: allowedOrigin },
+      socket: { remoteAddress: '127.0.0.1' },
+    } as unknown as IncomingMessage;
     const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
     const wsAliveMap = new WeakMap<WebSocket, boolean>();
     const url = new URL('http://localhost/chat?connectionId=conn-1&sessionId=session-1');

--- a/src/backend/routers/websocket/chat.handler.ts
+++ b/src/backend/routers/websocket/chat.handler.ts
@@ -22,7 +22,12 @@ import { toError } from '@/backend/lib/error-utils';
 import { type ChatMessageInput, ChatMessageSchema } from '@/backend/schemas/websocket';
 import type { ConnectionInfo } from '@/backend/services/session';
 import { toMessageString } from './message-utils';
-import { markWebSocketAlive, sendBadRequest, validateWebSocketOrigin } from './upgrade-utils';
+import {
+  markWebSocketAlive,
+  sendBadRequest,
+  validateTrustedLocalWebSocketRequest,
+  validateWebSocketOrigin,
+} from './upgrade-utils';
 
 // ============================================================================
 // Chat Upgrade Handler Factory
@@ -171,6 +176,18 @@ export function createChatUpgradeHandler(appContext: AppContext) {
 
     if (
       !validateWebSocketOrigin({
+        request,
+        socket,
+        configService,
+        logger,
+        connectionName: 'chat WebSocket',
+      })
+    ) {
+      return;
+    }
+
+    if (
+      !validateTrustedLocalWebSocketRequest({
         request,
         socket,
         configService,

--- a/src/backend/routers/websocket/dev-logs.handler.test.ts
+++ b/src/backend/routers/websocket/dev-logs.handler.test.ts
@@ -59,6 +59,94 @@ describe('createDevLogsUpgradeHandler', () => {
     expect(wss.handleUpgrade).not.toHaveBeenCalled();
   });
 
+  it('rejects untrusted remote addresses before opening a WebSocket', () => {
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    const appContext = {
+      services: {
+        configService: {
+          getCorsConfig: vi.fn(() => ({ allowedOrigins: [allowedOrigin], trustedLocalCidrs: [] })),
+        },
+        createLogger: vi.fn(() => logger),
+        runScriptService: {
+          getOutputBuffer: vi.fn(() => ''),
+          subscribeToOutput: vi.fn(),
+        },
+      },
+    } as unknown as AppContext;
+
+    const handler = createDevLogsUpgradeHandler(appContext);
+    const request = {
+      headers: { origin: allowedOrigin },
+      socket: { remoteAddress: '203.0.113.10' },
+    } as unknown as IncomingMessage;
+    const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
+    const wss = { handleUpgrade: vi.fn() } as unknown as WebSocketServer;
+
+    handler(
+      request,
+      socket,
+      Buffer.alloc(0),
+      new URL('http://localhost/dev-logs?workspaceId=workspace-1'),
+      wss,
+      new WeakMap<WebSocket, boolean>()
+    );
+
+    expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('403 Forbidden'));
+    expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('Untrusted remote address'));
+    expect(wss.handleUpgrade).not.toHaveBeenCalled();
+  });
+
+  it('rejects forwarded local upgrades before opening a WebSocket', () => {
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    const appContext = {
+      services: {
+        configService: {
+          getCorsConfig: vi.fn(() => ({ allowedOrigins: [allowedOrigin], trustedLocalCidrs: [] })),
+        },
+        createLogger: vi.fn(() => logger),
+        runScriptService: {
+          getOutputBuffer: vi.fn(() => ''),
+          subscribeToOutput: vi.fn(),
+        },
+      },
+    } as unknown as AppContext;
+
+    const handler = createDevLogsUpgradeHandler(appContext);
+    const request = {
+      headers: { origin: allowedOrigin, 'x-forwarded-for': '203.0.113.10' },
+      socket: { remoteAddress: '127.0.0.1' },
+    } as unknown as IncomingMessage;
+    const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
+    const wss = { handleUpgrade: vi.fn() } as unknown as WebSocketServer;
+
+    handler(
+      request,
+      socket,
+      Buffer.alloc(0),
+      new URL('http://localhost/dev-logs?workspaceId=workspace-1'),
+      wss,
+      new WeakMap<WebSocket, boolean>()
+    );
+
+    expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('403 Forbidden'));
+    expect(socket.write).toHaveBeenCalledWith(
+      expect.stringContaining('Forwarded WebSocket upgrades are not trusted')
+    );
+    expect(wss.handleUpgrade).not.toHaveBeenCalled();
+  });
+
   it('streams buffered and live output only while socket is open', () => {
     const workspaceId = 'workspace-1';
 
@@ -98,7 +186,10 @@ describe('createDevLogsUpgradeHandler', () => {
       ),
     } as unknown as WebSocketServer;
 
-    const request = { headers: { origin: allowedOrigin } } as IncomingMessage;
+    const request = {
+      headers: { origin: allowedOrigin },
+      socket: { remoteAddress: '127.0.0.1' },
+    } as unknown as IncomingMessage;
     const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
     const wsAliveMap = new WeakMap<WebSocket, boolean>();
     const url = new URL(`http://localhost/dev-logs?workspaceId=${workspaceId}`);

--- a/src/backend/routers/websocket/dev-logs.handler.ts
+++ b/src/backend/routers/websocket/dev-logs.handler.ts
@@ -13,6 +13,7 @@ import {
   getOrCreateConnectionSet,
   markWebSocketAlive,
   sendBadRequest,
+  validateTrustedLocalWebSocketRequest,
   validateWebSocketOrigin,
 } from './upgrade-utils';
 
@@ -52,6 +53,18 @@ export function createDevLogsUpgradeHandler(appContext: AppContext) {
   ): void {
     if (
       !validateWebSocketOrigin({
+        request,
+        socket,
+        configService,
+        logger,
+        connectionName: 'dev logs WebSocket',
+      })
+    ) {
+      return;
+    }
+
+    if (
+      !validateTrustedLocalWebSocketRequest({
         request,
         socket,
         configService,

--- a/src/backend/routers/websocket/post-run-logs.handler.test.ts
+++ b/src/backend/routers/websocket/post-run-logs.handler.test.ts
@@ -65,7 +65,10 @@ describe('createPostRunLogsUpgradeHandler', () => {
     } as unknown as AppContext;
 
     const handler = createPostRunLogsUpgradeHandler(appContext);
-    const request = { headers: { origin: allowedOrigin } } as IncomingMessage;
+    const request = {
+      headers: { origin: allowedOrigin },
+      socket: { remoteAddress: '127.0.0.1' },
+    } as unknown as IncomingMessage;
     const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
     const wss = { handleUpgrade: vi.fn() } as unknown as WebSocketServer;
 
@@ -119,6 +122,84 @@ describe('createPostRunLogsUpgradeHandler', () => {
     expect(wss.handleUpgrade).not.toHaveBeenCalled();
   });
 
+  it('rejects untrusted remote addresses before opening a WebSocket', () => {
+    const logger = createLogger();
+    const runScriptService = {
+      getPostRunOutputBuffer: vi.fn(() => ''),
+      subscribeToPostRunOutput: vi.fn(),
+    };
+    const appContext = {
+      services: {
+        configService: {
+          getCorsConfig: vi.fn(() => ({ allowedOrigins: [allowedOrigin], trustedLocalCidrs: [] })),
+        },
+        createLogger: vi.fn(() => logger),
+        runScriptService,
+      },
+    } as unknown as AppContext;
+
+    const handler = createPostRunLogsUpgradeHandler(appContext);
+    const request = {
+      headers: { origin: allowedOrigin },
+      socket: { remoteAddress: '203.0.113.10' },
+    } as unknown as IncomingMessage;
+    const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
+    const wss = { handleUpgrade: vi.fn() } as unknown as WebSocketServer;
+
+    handler(
+      request,
+      socket,
+      Buffer.alloc(0),
+      new URL('http://localhost/post-run-logs?workspaceId=workspace-1'),
+      wss,
+      new WeakMap<WebSocket, boolean>()
+    );
+
+    expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('403 Forbidden'));
+    expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('Untrusted remote address'));
+    expect(wss.handleUpgrade).not.toHaveBeenCalled();
+  });
+
+  it('rejects forwarded local upgrades before opening a WebSocket', () => {
+    const logger = createLogger();
+    const runScriptService = {
+      getPostRunOutputBuffer: vi.fn(() => ''),
+      subscribeToPostRunOutput: vi.fn(),
+    };
+    const appContext = {
+      services: {
+        configService: {
+          getCorsConfig: vi.fn(() => ({ allowedOrigins: [allowedOrigin], trustedLocalCidrs: [] })),
+        },
+        createLogger: vi.fn(() => logger),
+        runScriptService,
+      },
+    } as unknown as AppContext;
+
+    const handler = createPostRunLogsUpgradeHandler(appContext);
+    const request = {
+      headers: { origin: allowedOrigin, 'x-forwarded-for': '203.0.113.10' },
+      socket: { remoteAddress: '127.0.0.1' },
+    } as unknown as IncomingMessage;
+    const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
+    const wss = { handleUpgrade: vi.fn() } as unknown as WebSocketServer;
+
+    handler(
+      request,
+      socket,
+      Buffer.alloc(0),
+      new URL('http://localhost/post-run-logs?workspaceId=workspace-1'),
+      wss,
+      new WeakMap<WebSocket, boolean>()
+    );
+
+    expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('403 Forbidden'));
+    expect(socket.write).toHaveBeenCalledWith(
+      expect.stringContaining('Forwarded WebSocket upgrades are not trusted')
+    );
+    expect(wss.handleUpgrade).not.toHaveBeenCalled();
+  });
+
   it('streams buffered/live output and cleans up subscription on close', () => {
     const workspaceId = 'workspace-1';
     const logger = createLogger();
@@ -143,7 +224,10 @@ describe('createPostRunLogsUpgradeHandler', () => {
 
     const ws = new MockWebSocket();
     const handler = createPostRunLogsUpgradeHandler(appContext);
-    const request = { headers: { origin: allowedOrigin } } as IncomingMessage;
+    const request = {
+      headers: { origin: allowedOrigin },
+      socket: { remoteAddress: '127.0.0.1' },
+    } as unknown as IncomingMessage;
     const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
     const wss = createWssFromQueue([ws]);
     const wsAliveMap = new WeakMap<WebSocket, boolean>();
@@ -216,7 +300,10 @@ describe('createPostRunLogsUpgradeHandler', () => {
     const ws1 = new MockWebSocket();
     const ws2 = new MockWebSocket();
     const handler = createPostRunLogsUpgradeHandler(appContext);
-    const request = { headers: { origin: allowedOrigin } } as IncomingMessage;
+    const request = {
+      headers: { origin: allowedOrigin },
+      socket: { remoteAddress: '127.0.0.1' },
+    } as unknown as IncomingMessage;
     const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
     const wss = createWssFromQueue([ws1, ws2]);
     const wsAliveMap = new WeakMap<WebSocket, boolean>();

--- a/src/backend/routers/websocket/post-run-logs.handler.ts
+++ b/src/backend/routers/websocket/post-run-logs.handler.ts
@@ -13,6 +13,7 @@ import {
   getOrCreateConnectionSet,
   markWebSocketAlive,
   sendBadRequest,
+  validateTrustedLocalWebSocketRequest,
   validateWebSocketOrigin,
 } from './upgrade-utils';
 
@@ -52,6 +53,18 @@ export function createPostRunLogsUpgradeHandler(appContext: AppContext) {
   ): void {
     if (
       !validateWebSocketOrigin({
+        request,
+        socket,
+        configService,
+        logger,
+        connectionName: 'post-run logs WebSocket',
+      })
+    ) {
+      return;
+    }
+
+    if (
+      !validateTrustedLocalWebSocketRequest({
         request,
         socket,
         configService,

--- a/src/backend/routers/websocket/setup-terminal.handler.test.ts
+++ b/src/backend/routers/websocket/setup-terminal.handler.test.ts
@@ -154,6 +154,82 @@ describe('createSetupTerminalUpgradeHandler', () => {
     );
   });
 
+  it('rejects untrusted remote addresses before opening a WebSocket', () => {
+    const logger = createLogger();
+    const configService = {
+      getCorsConfig: vi.fn(() => ({ allowedOrigins: [allowedOrigin], trustedLocalCidrs: [] })),
+    };
+    const appContext = {
+      services: {
+        createLogger: vi.fn(() => logger),
+        configService,
+      },
+    } as unknown as AppContext;
+
+    const handler = createSetupTerminalUpgradeHandler(appContext);
+    const ws = new MockWebSocket();
+    const wss = createWss(ws);
+    const request = {
+      headers: { origin: allowedOrigin },
+      socket: { remoteAddress: '203.0.113.10' },
+    } as unknown as IncomingMessage;
+    const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
+    const wsAliveMap = new WeakMap<WebSocket, boolean>();
+
+    handler(
+      request,
+      socket,
+      Buffer.alloc(0),
+      new URL('http://localhost/setup-terminal'),
+      wss,
+      wsAliveMap
+    );
+
+    expect(wss.handleUpgrade).not.toHaveBeenCalled();
+    expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('403 Forbidden'));
+    expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('Untrusted remote address'));
+    expect(socket.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects forwarded local upgrades before opening a WebSocket', () => {
+    const logger = createLogger();
+    const configService = {
+      getCorsConfig: vi.fn(() => ({ allowedOrigins: [allowedOrigin], trustedLocalCidrs: [] })),
+    };
+    const appContext = {
+      services: {
+        createLogger: vi.fn(() => logger),
+        configService,
+      },
+    } as unknown as AppContext;
+
+    const handler = createSetupTerminalUpgradeHandler(appContext);
+    const ws = new MockWebSocket();
+    const wss = createWss(ws);
+    const request = {
+      headers: { origin: allowedOrigin, 'x-forwarded-for': '203.0.113.10' },
+      socket: { remoteAddress: '127.0.0.1' },
+    } as unknown as IncomingMessage;
+    const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
+    const wsAliveMap = new WeakMap<WebSocket, boolean>();
+
+    handler(
+      request,
+      socket,
+      Buffer.alloc(0),
+      new URL('http://localhost/setup-terminal'),
+      wss,
+      wsAliveMap
+    );
+
+    expect(wss.handleUpgrade).not.toHaveBeenCalled();
+    expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('403 Forbidden'));
+    expect(socket.write).toHaveBeenCalledWith(
+      expect.stringContaining('Forwarded WebSocket upgrades are not trusted')
+    );
+    expect(socket.destroy).toHaveBeenCalledTimes(1);
+  });
+
   it('accepts upgrades from configured allowed origins', () => {
     const logger = createLogger();
     const configService = {
@@ -173,7 +249,8 @@ describe('createSetupTerminalUpgradeHandler', () => {
     const wss = createWss(ws);
     const request = {
       headers: { origin: allowedOrigin },
-    } as IncomingMessage;
+      socket: { remoteAddress: '127.0.0.1' },
+    } as unknown as IncomingMessage;
     const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
     const wsAliveMap = new WeakMap<WebSocket, boolean>();
 
@@ -210,7 +287,8 @@ describe('createSetupTerminalUpgradeHandler', () => {
     const wss = createWss(ws);
     const request = {
       headers: { origin: allowedOrigin },
-    } as IncomingMessage;
+      socket: { remoteAddress: '127.0.0.1' },
+    } as unknown as IncomingMessage;
     const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
     const wsAliveMap = new WeakMap<WebSocket, boolean>();
 
@@ -286,7 +364,8 @@ describe('createSetupTerminalUpgradeHandler', () => {
     const wss = createWss(ws);
     const request = {
       headers: { origin: allowedOrigin },
-    } as IncomingMessage;
+      socket: { remoteAddress: '127.0.0.1' },
+    } as unknown as IncomingMessage;
     const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
     const wsAliveMap = new WeakMap<WebSocket, boolean>();
 
@@ -328,7 +407,8 @@ describe('createSetupTerminalUpgradeHandler', () => {
     const wss = createWss(ws);
     const request = {
       headers: { origin: allowedOrigin },
-    } as IncomingMessage;
+      socket: { remoteAddress: '127.0.0.1' },
+    } as unknown as IncomingMessage;
     const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
     const wsAliveMap = new WeakMap<WebSocket, boolean>();
 

--- a/src/backend/routers/websocket/setup-terminal.handler.ts
+++ b/src/backend/routers/websocket/setup-terminal.handler.ts
@@ -20,7 +20,11 @@ import {
   SetupTerminalMessageSchema,
 } from '@/backend/schemas/websocket';
 import { toMessageString } from './message-utils';
-import { markWebSocketAlive, validateWebSocketOrigin } from './upgrade-utils';
+import {
+  markWebSocketAlive,
+  validateTrustedLocalWebSocketRequest,
+  validateWebSocketOrigin,
+} from './upgrade-utils';
 
 const require = createRequire(import.meta.url);
 
@@ -145,6 +149,18 @@ export function createSetupTerminalUpgradeHandler(appContext: AppContext) {
   ): void {
     if (
       !validateWebSocketOrigin({
+        request,
+        socket,
+        configService,
+        logger,
+        connectionName: 'setup terminal',
+      })
+    ) {
+      return;
+    }
+
+    if (
+      !validateTrustedLocalWebSocketRequest({
         request,
         socket,
         configService,

--- a/src/backend/routers/websocket/snapshots.handler.test.ts
+++ b/src/backend/routers/websocket/snapshots.handler.test.ts
@@ -14,7 +14,7 @@ import {
   resetSnapshotsHandlerStateForTests,
   snapshotConnections,
 } from './snapshots.handler';
-import { validateWebSocketOrigin } from './upgrade-utils';
+import { validateTrustedLocalWebSocketRequest, validateWebSocketOrigin } from './upgrade-utils';
 
 const allowedOrigin = 'http://localhost:3000';
 
@@ -90,6 +90,7 @@ vi.mock('./upgrade-utils', () => ({
   markWebSocketAlive: vi.fn(),
   sendBadRequest: mockSendBadRequest,
   validateWebSocketOrigin: vi.fn(() => true),
+  validateTrustedLocalWebSocketRequest: vi.fn(() => true),
 }));
 
 vi.mock('@/backend/app-context', () => ({
@@ -180,6 +181,7 @@ describe('createSnapshotsUpgradeHandler', () => {
     resetSnapshotsHandlerStateForTests();
     storeListeners.clear();
     vi.mocked(validateWebSocketOrigin).mockReturnValue(true);
+    vi.mocked(validateTrustedLocalWebSocketRequest).mockReturnValue(true);
   });
 
   it('sends full snapshot with review count on connect', async () => {
@@ -266,6 +268,17 @@ describe('createSnapshotsUpgradeHandler', () => {
 
     expect(storeListeners.size).toBe(0);
     expect(mockSendBadRequest).not.toHaveBeenCalled();
+    expect(wss.handleUpgrade).not.toHaveBeenCalled();
+    expect(ws.send).not.toHaveBeenCalled();
+  });
+
+  it('rejects untrusted local requests before subscription setup', () => {
+    vi.mocked(validateTrustedLocalWebSocketRequest).mockReturnValueOnce(false);
+    const handler = createSnapshotsUpgradeHandler(createAppContextMock());
+    const ws = new MockWebSocket();
+    const { wss } = callHandler(handler, ws, 'proj-1');
+
+    expect(storeListeners.size).toBe(0);
     expect(wss.handleUpgrade).not.toHaveBeenCalled();
     expect(ws.send).not.toHaveBeenCalled();
   });

--- a/src/backend/routers/websocket/snapshots.handler.ts
+++ b/src/backend/routers/websocket/snapshots.handler.ts
@@ -25,6 +25,7 @@ import {
   getOrCreateConnectionSet,
   markWebSocketAlive,
   sendBadRequest,
+  validateTrustedLocalWebSocketRequest,
   validateWebSocketOrigin,
 } from './upgrade-utils';
 
@@ -192,6 +193,18 @@ export function createSnapshotsUpgradeHandler(
   ): void {
     if (
       !validateWebSocketOrigin({
+        request,
+        socket,
+        configService,
+        logger,
+        connectionName: 'snapshots WebSocket',
+      })
+    ) {
+      return;
+    }
+
+    if (
+      !validateTrustedLocalWebSocketRequest({
         request,
         socket,
         configService,

--- a/src/backend/routers/websocket/upgrade-utils.ts
+++ b/src/backend/routers/websocket/upgrade-utils.ts
@@ -3,18 +3,10 @@ import type { Duplex } from 'node:stream';
 import type { WebSocket } from 'ws';
 import type { AppServices } from '@/backend/app-context';
 import { isOriginAllowed, isTrustedLocalAddress } from '@/backend/lib/request-trust';
+import { FORWARDED_CLIENT_ADDRESS_HEADERS } from '@/shared/proxy-utils';
 
 type WebSocketOriginLogger = Pick<ReturnType<AppServices['createLogger']>, 'warn'>;
 type WebSocketOriginConfigService = Pick<AppServices['configService'], 'getCorsConfig'>;
-
-const FORWARDED_CLIENT_ADDRESS_HEADERS = [
-  'forwarded',
-  'x-forwarded-for',
-  'x-real-ip',
-  'x-client-ip',
-  'cf-connecting-ip',
-  'true-client-ip',
-] as const;
 
 function getForwardedClientAddressHeaders(request: IncomingMessage): string[] {
   return FORWARDED_CLIENT_ADDRESS_HEADERS.filter((header) => request.headers[header] !== undefined);

--- a/src/shared/proxy-utils.test.ts
+++ b/src/shared/proxy-utils.test.ts
@@ -92,7 +92,7 @@ describe('proxy-utils', () => {
     const serverSockets: import('node:net').Socket[] = [];
     const server = createNetServer((socket) => {
       serverSockets.push(socket);
-      socket.on('data', (chunk) => received.push(chunk));
+      socket.on('data', (chunk) => received.push(Buffer.from(chunk)));
     });
     await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
     const upstreamPort = (server.address() as AddressInfo).port;

--- a/src/shared/proxy-utils.test.ts
+++ b/src/shared/proxy-utils.test.ts
@@ -1,9 +1,13 @@
-import type { IncomingMessage } from 'node:http';
-import { describe, expect, it } from 'vitest';
+import { createServer as createHttpServer, type IncomingMessage } from 'node:http';
+import { type AddressInfo, createServer as createNetServer } from 'node:net';
+import { PassThrough } from 'node:stream';
+import { describe, expect, it, vi } from 'vitest';
 import {
   authenticateRequest,
   createSessionValue,
   parseCookieHeader,
+  proxyAuthenticatedHttpRequest,
+  proxyAuthenticatedWebSocketUpgrade,
   sanitizePathWithoutToken,
 } from './proxy-utils';
 
@@ -81,6 +85,118 @@ describe('proxy-utils', () => {
       invalidToken: false,
       sanitizedPath: '/bar?next=1',
     });
+  });
+
+  it('does not forward client-address headers on WebSocket upgrades', async () => {
+    const received: Buffer[] = [];
+    const serverSockets: import('node:net').Socket[] = [];
+    const server = createNetServer((socket) => {
+      serverSockets.push(socket);
+      socket.on('data', (chunk) => received.push(chunk));
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const upstreamPort = (server.address() as AddressInfo).port;
+
+    try {
+      const req = {
+        method: 'GET',
+        httpVersion: '1.1',
+        headers: {
+          host: 'public.example.com',
+          origin: 'http://localhost:3000',
+          upgrade: 'websocket',
+          connection: 'Upgrade',
+          'sec-websocket-key': 'abc123',
+          forwarded: 'for=203.0.113.10',
+          'x-forwarded-for': '203.0.113.10',
+          'x-real-ip': '203.0.113.10',
+          'x-client-ip': '203.0.113.10',
+          'cf-connecting-ip': '203.0.113.10',
+          'true-client-ip': '203.0.113.10',
+        },
+      } as unknown as IncomingMessage;
+
+      proxyAuthenticatedWebSocketUpgrade({
+        req,
+        socket: new PassThrough(),
+        head: Buffer.alloc(0),
+        upstreamPort,
+        sanitizedPath: '/chat',
+        sessionCookieName: 'session',
+      });
+
+      await vi.waitFor(() => {
+        expect(Buffer.concat(received).toString()).toContain('GET /chat HTTP/1.1');
+      });
+
+      const rawUpstreamRequest = Buffer.concat(received).toString().toLowerCase();
+      expect(rawUpstreamRequest).not.toContain('forwarded');
+      expect(rawUpstreamRequest).not.toContain('x-real-ip');
+      expect(rawUpstreamRequest).not.toContain('x-client-ip');
+      expect(rawUpstreamRequest).not.toContain('cf-connecting-ip');
+      expect(rawUpstreamRequest).not.toContain('true-client-ip');
+      expect(rawUpstreamRequest).toContain('origin: http://localhost:3000');
+      expect(rawUpstreamRequest).toContain('sec-websocket-key: abc123');
+    } finally {
+      for (const socket of serverSockets) {
+        socket.destroy();
+      }
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it('does not forward client-address headers on HTTP requests', async () => {
+    let upstreamHeaders: IncomingMessage['headers'] | undefined;
+    const server = createHttpServer((req, res) => {
+      upstreamHeaders = req.headers;
+      res.end('ok');
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const upstreamPort = (server.address() as AddressInfo).port;
+
+    try {
+      const req = new PassThrough() as unknown as IncomingMessage & PassThrough;
+      req.method = 'GET';
+      req.headers = {
+        host: 'public.example.com',
+        origin: 'http://localhost:3000',
+        forwarded: 'for=203.0.113.10',
+        'x-forwarded-for': '203.0.113.10',
+        'x-real-ip': '203.0.113.10',
+        'x-client-ip': '203.0.113.10',
+        'cf-connecting-ip': '203.0.113.10',
+        'true-client-ip': '203.0.113.10',
+      };
+      const res = new PassThrough() as unknown as Parameters<
+        typeof proxyAuthenticatedHttpRequest
+      >[0]['res'];
+      res.getHeader = vi.fn(() => undefined);
+      res.setHeader = vi.fn();
+      res.writeHead = vi.fn();
+      req.end();
+
+      proxyAuthenticatedHttpRequest({
+        req,
+        res,
+        upstreamPort,
+        path: '/api/health',
+        sessionCookieName: 'session',
+      });
+
+      await vi.waitFor(() => {
+        expect(upstreamHeaders).toBeDefined();
+      });
+
+      expect(upstreamHeaders).not.toHaveProperty('forwarded');
+      expect(upstreamHeaders).not.toHaveProperty('x-forwarded-for');
+      expect(upstreamHeaders).not.toHaveProperty('x-real-ip');
+      expect(upstreamHeaders).not.toHaveProperty('x-client-ip');
+      expect(upstreamHeaders).not.toHaveProperty('cf-connecting-ip');
+      expect(upstreamHeaders).not.toHaveProperty('true-client-ip');
+      expect(upstreamHeaders?.origin).toBe('http://localhost:3000');
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
   });
 
   it('returns null-prototype cookie maps for empty and parsed headers', () => {

--- a/src/shared/proxy-utils.ts
+++ b/src/shared/proxy-utils.ts
@@ -223,6 +223,44 @@ export function authenticateRequest(params: {
   };
 }
 
+/**
+ * Headers that claim to carry the original client address. The authenticated
+ * proxy is the trust boundary for remote clients, so these must not reach the
+ * upstream server: the backend rejects WebSocket upgrades that carry them
+ * (see validateTrustedLocalWebSocketRequest), and tunnels like cloudflared
+ * add them to every request.
+ */
+export const FORWARDED_CLIENT_ADDRESS_HEADERS = [
+  'forwarded',
+  'x-forwarded-for',
+  'x-real-ip',
+  'x-client-ip',
+  'cf-connecting-ip',
+  'true-client-ip',
+] as const;
+
+const FORWARDED_CLIENT_ADDRESS_HEADER_SET: ReadonlySet<string> = new Set(
+  FORWARDED_CLIENT_ADDRESS_HEADERS
+);
+
+/**
+ * Builds the header set an authenticated proxy forwards upstream: strips
+ * hop-by-hop headers, the proxy's own session cookie, and client-address
+ * headers added by tunnels or the remote client.
+ */
+export function buildAuthenticatedProxyHeaders(
+  headers: IncomingHttpHeaders,
+  sessionCookieName?: string
+): Record<string, string | string[] | undefined> {
+  const cleaned = removeHopByHopHeaders(headers, sessionCookieName);
+  for (const key of Object.keys(cleaned)) {
+    if (FORWARDED_CLIENT_ADDRESS_HEADER_SET.has(key.toLowerCase())) {
+      delete cleaned[key];
+    }
+  }
+  return cleaned;
+}
+
 export function removeHopByHopHeaders(
   headers: IncomingHttpHeaders,
   sessionCookieName?: string
@@ -298,7 +336,10 @@ export function proxyAuthenticatedHttpRequest(params: {
     );
   }
 
-  const upstreamHeaders = removeHopByHopHeaders(params.req.headers, params.sessionCookieName);
+  const upstreamHeaders = buildAuthenticatedProxyHeaders(
+    params.req.headers,
+    params.sessionCookieName
+  );
 
   const upstreamRequest = httpRequest(
     {
@@ -361,7 +402,7 @@ export function proxyAuthenticatedWebSocketUpgrade(params: {
 
   const upstreamSocket = createConnection(params.upstreamPort, localHost, () => {
     const headers: Record<string, string | string[] | undefined> = {
-      ...removeHopByHopHeaders(params.req.headers, params.sessionCookieName),
+      ...buildAuthenticatedProxyHeaders(params.req.headers, params.sessionCookieName),
       host: `localhost:${params.upstreamPort}`,
       connection: 'Upgrade',
       upgrade: params.req.headers.upgrade,


### PR DESCRIPTION
Fixes #1868.

## Decision

Trusted-local validation (`validateTrustedLocalWebSocketRequest`) is now applied **uniformly to all six WebSocket channels**, not just `/terminal`. Rationale:

- `/chat` (agent session with filesystem access) and `/setup-terminal` (real shell via `node-pty`) are at least as sensitive as `/terminal`, and `Origin` alone is trivially spoofable by non-browser clients.
- The push-only channels (`/dev-logs`, `/post-run-logs`, `/snapshots`) leak workspace/log data, and a uniform policy is easier to reason about than a per-channel exception list.
- The supported remote-access path is unaffected: the CLI auth proxy (`src/cli/proxy.ts`) authenticates remotely and connects to the upstream server **from loopback** without adding forwarded-address headers, so it passes the check exactly as it already does for `/terminal`. Direct LAN/Docker-bridge setups keep working via the existing `TRUSTED_LOCAL_CIDRS` knob (loopback is always trusted).

The declarative `withUpgrade({ trustedLocal })` home for this policy remains #1870; this PR just closes the gap with the same hand-assembled check `/terminal` uses today.

## Changes

- Added `validateTrustedLocalWebSocketRequest` immediately after origin validation in `chat.handler.ts`, `setup-terminal.handler.ts`, `dev-logs.handler.ts`, `post-run-logs.handler.ts`, and `snapshots.handler.ts` (same ordering as `terminal.handler.ts`).
- Documented the policy next to `TRUSTED_LOCAL_CIDRS` in `.env.example`.

## Tests

Written first and verified failing (9 new tests):

- Per handler (chat, setup-terminal, dev-logs, post-run-logs): rejects untrusted remote addresses with 403, and rejects loopback upgrades carrying forwarded-address headers (`x-forwarded-for` etc.) — mirroring the existing `/terminal` tests.
- Snapshots: rejection happens before store subscription setup and before `handleUpgrade` (via the file's existing upgrade-utils mocking pattern).
- Existing handler tests updated to include a loopback `remoteAddress` on their mock requests.
- The real-socket integration suite (`websocket.integration.test.ts`) passes unchanged since it connects over loopback.

`pnpm test` (3585 passed), `pnpm check:fix`, and `pnpm check` pass. `pnpm typecheck` has pre-existing `NODE_ENV`/`ProcessEnv` failures on `main` unrelated to this change (same as noted on #1875).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-sensitive WebSocket upgrade policy changes across chat, terminals, and log/snapshot streams; misconfiguration of TRUSTED_LOCAL_CIDRS or proxy header stripping could block legitimate clients or leave gaps if bypassed.
> 
> **Overview**
> **All WebSocket upgrade handlers** (chat, setup-terminal, dev-logs, post-run-logs, snapshots) now run **`validateTrustedLocalWebSocketRequest`** right after origin checks—the same policy `/terminal` already used. Upgrades from non–trusted-local peers get **403**, and loopback upgrades that include forwarded client-address headers (`x-forwarded-for`, etc.) are rejected before `handleUpgrade`.
> 
> The **authenticated CLI proxy** now strips those forwarded-address headers on upstream **HTTP and WebSocket** via shared **`buildAuthenticatedProxyHeaders`**, so tunnel-injected headers do not trip the backend check. **`FORWARDED_CLIENT_ADDRESS_HEADERS`** lives in `proxy-utils` and is reused by `upgrade-utils`. **`.env.example`** documents that every WebSocket channel requires loopback or `TRUSTED_LOCAL_CIDRS` at upgrade time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8821c50fecbf4c4c9e5849c458c4cf2c109709c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

