### PR TITLE
Add backpressure handling to WebSocket output

### DIFF
--- a/docs/superpowers/plans/2026-07-16-websocket-stream-backpressure.md
+++ b/docs/superpowers/plans/2026-07-16-websocket-stream-backpressure.md
@@ -1,0 +1,584 @@
+# WebSocket Stream Backpressure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bound queued WebSocket data for high-volume terminal and log output and log asynchronous send failures.
+
+**Architecture:** Extend the existing `websocket-send` utility with a stream-specific sender that drops output above a 1 MiB `bufferedAmount` threshold and tracks per-socket congestion warnings in a `WeakSet`. Route only live output callbacks through this helper; leave replay and low-volume control messages on their existing paths.
+
+**Tech Stack:** TypeScript, `ws`, Vitest, Express WebSocket handlers
+
+## Global Constraints
+
+- Apply backpressure only to live workspace-terminal, setup-terminal, dev-log, and post-run-log output.
+- Use a fixed 1 MiB threshold and drop chunks only when `ws.bufferedAmount` is greater than the threshold.
+- Emit at most one warning per socket congestion window and resume sends when the queued amount returns to the threshold or below.
+- Use the `ws.send` callback to log asynchronous send failures.
+- Do not add an application-level output queue or pause shared PTYs.
+- Do not introduce `TopicBroadcaster` or change the browser WebSocket protocol.
+- Keep replay payloads and low-volume create, exit, and error messages unchanged.
+
+---
+
+### Task 1: Add the stream-aware WebSocket send primitive
+
+**Files:**
+- Modify: `src/backend/lib/websocket-send.ts`
+- Test: `src/backend/lib/websocket-send.test.ts`
+
+**Interfaces:**
+- Consumes: `WebSocket.readyState`, `WebSocket.bufferedAmount`, and `WebSocket.send(data, callback)` from `ws`
+- Produces: `MAX_WEBSOCKET_STREAM_BUFFERED_BYTES: number` and `sendStreamOutput(ws, message, logger, description?): boolean`
+
+- [ ] **Step 1: Add failing tests for threshold, recovery, and send errors**
+
+Update the test imports and mock:
+
+```ts
+import {
+  MAX_WEBSOCKET_STREAM_BUFFERED_BYTES,
+  safeSend,
+  sendStreamOutput,
+} from './websocket-send';
+
+function createMockWs(
+  readyState: number = WS_READY_STATE.OPEN,
+  bufferedAmount = 0
+) {
+  return {
+    readyState,
+    bufferedAmount,
+    send: vi.fn(),
+  };
+}
+
+function createMockLogger() {
+  return { error: vi.fn(), warn: vi.fn() };
+}
+```
+
+Add these tests:
+
+```ts
+describe('sendStreamOutput', () => {
+  it('sends stream output with a callback at or below the threshold', () => {
+    const ws = createMockWs(
+      WS_READY_STATE.OPEN,
+      MAX_WEBSOCKET_STREAM_BUFFERED_BYTES
+    );
+    const logger = createMockLogger();
+
+    expect(
+      sendStreamOutput(
+        ws as unknown as WebSocket,
+        'output',
+        logger,
+        'terminal output'
+      )
+    ).toBe(true);
+
+    expect(ws.send).toHaveBeenCalledWith('output', expect.any(Function));
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('drops output and warns once while a socket remains congested', () => {
+    const ws = createMockWs(
+      WS_READY_STATE.OPEN,
+      MAX_WEBSOCKET_STREAM_BUFFERED_BYTES + 1
+    );
+    const logger = createMockLogger();
+
+    expect(
+      sendStreamOutput(ws as unknown as WebSocket, 'first', logger, 'log output')
+    ).toBe(false);
+    expect(
+      sendStreamOutput(ws as unknown as WebSocket, 'second', logger, 'log output')
+    ).toBe(false);
+
+    expect(ws.send).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Dropping log output because WebSocket send buffer is congested',
+      {
+        bufferedAmount: MAX_WEBSOCKET_STREAM_BUFFERED_BYTES + 1,
+        maxBufferedAmount: MAX_WEBSOCKET_STREAM_BUFFERED_BYTES,
+      }
+    );
+  });
+
+  it('resumes output and allows a new warning after the socket drains', () => {
+    const ws = createMockWs(
+      WS_READY_STATE.OPEN,
+      MAX_WEBSOCKET_STREAM_BUFFERED_BYTES + 1
+    );
+    const logger = createMockLogger();
+
+    sendStreamOutput(ws as unknown as WebSocket, 'dropped', logger);
+    ws.bufferedAmount = MAX_WEBSOCKET_STREAM_BUFFERED_BYTES;
+    expect(
+      sendStreamOutput(ws as unknown as WebSocket, 'resumed', logger)
+    ).toBe(true);
+
+    ws.bufferedAmount = MAX_WEBSOCKET_STREAM_BUFFERED_BYTES + 1;
+    expect(
+      sendStreamOutput(ws as unknown as WebSocket, 'dropped again', logger)
+    ).toBe(false);
+
+    expect(ws.send).toHaveBeenCalledWith('resumed', expect.any(Function));
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+  });
+
+  it('logs asynchronous send callback errors', () => {
+    const ws = createMockWs();
+    ws.send.mockImplementation(
+      (_message: string, callback: (error?: Error) => void) => {
+        callback(new Error('write failed'));
+      }
+    );
+    const logger = createMockLogger();
+
+    expect(
+      sendStreamOutput(
+        ws as unknown as WebSocket,
+        'output',
+        logger,
+        'terminal output'
+      )
+    ).toBe(true);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'Failed to send terminal output',
+      expect.objectContaining({ message: 'write failed' })
+    );
+  });
+
+  it('catches synchronous stream send errors and ignores closed sockets', () => {
+    const throwingWs = createMockWs();
+    throwingWs.send.mockImplementation(() => {
+      throw new Error('socket closing');
+    });
+    const logger = createMockLogger();
+
+    expect(
+      sendStreamOutput(
+        throwingWs as unknown as WebSocket,
+        'output',
+        logger,
+        'terminal output'
+      )
+    ).toBe(false);
+    expect(logger.error).toHaveBeenCalledWith(
+      'Failed to send terminal output',
+      expect.objectContaining({ message: 'socket closing' })
+    );
+
+    const closedWs = createMockWs(WS_READY_STATE.CLOSED);
+    expect(
+      sendStreamOutput(closedWs as unknown as WebSocket, 'output', logger)
+    ).toBe(false);
+    expect(closedWs.send).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the utility test and verify it fails for the missing API**
+
+Run:
+
+```bash
+pnpm vitest run src/backend/lib/websocket-send.test.ts
+```
+
+Expected: FAIL because `MAX_WEBSOCKET_STREAM_BUFFERED_BYTES` and `sendStreamOutput` are not exported.
+
+- [ ] **Step 3: Implement the minimal stream sender**
+
+Add the stream logger, constant, state, and function to `websocket-send.ts`:
+
+```ts
+interface StreamSendLogger extends SendErrorLogger {
+  warn(message: string, data: Record<string, unknown>): void;
+}
+
+export const MAX_WEBSOCKET_STREAM_BUFFERED_BYTES = 1024 * 1024;
+
+const congestedStreamSockets = new WeakSet<WebSocket>();
+
+export function sendStreamOutput(
+  ws: WebSocket,
+  message: string,
+  logger: StreamSendLogger,
+  description = 'WebSocket stream output'
+): boolean {
+  if (ws.readyState !== WS_READY_STATE.OPEN) {
+    return false;
+  }
+
+  if (ws.bufferedAmount > MAX_WEBSOCKET_STREAM_BUFFERED_BYTES) {
+    if (!congestedStreamSockets.has(ws)) {
+      congestedStreamSockets.add(ws);
+      logger.warn(`Dropping ${description} because WebSocket send buffer is congested`, {
+        bufferedAmount: ws.bufferedAmount,
+        maxBufferedAmount: MAX_WEBSOCKET_STREAM_BUFFERED_BYTES,
+      });
+    }
+    return false;
+  }
+
+  congestedStreamSockets.delete(ws);
+
+  try {
+    ws.send(message, (error) => {
+      if (error) {
+        logger.error(`Failed to send ${description}`, toError(error));
+      }
+    });
+    return true;
+  } catch (error) {
+    logger.error(`Failed to send ${description}`, toError(error));
+    return false;
+  }
+}
+```
+
+- [ ] **Step 4: Run the utility test and verify it passes**
+
+Run:
+
+```bash
+pnpm vitest run src/backend/lib/websocket-send.test.ts
+```
+
+Expected: PASS with all `safeSend` and `sendStreamOutput` tests green.
+
+- [ ] **Step 5: Commit the primitive**
+
+```bash
+git add src/backend/lib/websocket-send.ts src/backend/lib/websocket-send.test.ts
+git commit -m "Add WebSocket stream backpressure helper"
+```
+
+### Task 2: Route high-volume handler output through the primitive
+
+**Files:**
+- Modify: `src/backend/routers/websocket/push-channel.handler.ts`
+- Modify: `src/backend/routers/websocket/terminal.handler.ts`
+- Modify: `src/backend/routers/websocket/setup-terminal.handler.ts`
+- Test: `src/backend/routers/websocket/dev-logs.handler.test.ts`
+- Test: `src/backend/routers/websocket/terminal.handler.test.ts`
+- Test: `src/backend/routers/websocket/setup-terminal.handler.test.ts`
+
+**Interfaces:**
+- Consumes: `sendStreamOutput(ws, serializedOutput, logger, description)` from Task 1
+- Produces: bounded live output sends for both shared log channels, workspace terminals, and setup terminals
+
+- [ ] **Step 1: Add `bufferedAmount` to handler WebSocket mocks**
+
+Add this property to each `MockWebSocket` class in the three handler test files:
+
+```ts
+bufferedAmount = 0;
+```
+
+- [ ] **Step 2: Add a failing shared push-channel regression test**
+
+Import the threshold in `dev-logs.handler.test.ts`:
+
+```ts
+import { MAX_WEBSOCKET_STREAM_BUFFERED_BYTES } from '@/backend/lib/websocket-send';
+```
+
+Extend `streams buffered and live output only while socket is open` after obtaining `outputSubscriber`:
+
+```ts
+ws.send.mockClear();
+ws.bufferedAmount = MAX_WEBSOCKET_STREAM_BUFFERED_BYTES + 1;
+outputSubscriber('dropped logs\n');
+expect(ws.send).not.toHaveBeenCalled();
+
+ws.bufferedAmount = MAX_WEBSOCKET_STREAM_BUFFERED_BYTES;
+outputSubscriber('resumed logs\n');
+expect(ws.send).toHaveBeenCalledWith(
+  JSON.stringify({ type: 'output', data: 'resumed logs\n' }),
+  expect.any(Function)
+);
+```
+
+- [ ] **Step 3: Add a failing workspace-terminal regression test**
+
+Import the threshold in `terminal.handler.test.ts`:
+
+```ts
+import { MAX_WEBSOCKET_STREAM_BUFFERED_BYTES } from '@/backend/lib/websocket-send';
+```
+
+Add:
+
+```ts
+it('drops live terminal output while the socket is congested and resumes after drain', async () => {
+  const workspaceId = 'workspace-1';
+  const terminalId = 'terminal-1';
+  const { terminalService, outputListeners } = createTerminalService();
+  terminalService.getTerminalsForWorkspace.mockReturnValue([
+    {
+      id: terminalId,
+      createdAt: new Date('2026-07-16T00:00:00.000Z'),
+      outputBuffer: '',
+    },
+  ]);
+  const logger = createLogger();
+  const appContext = {
+    services: {
+      terminalService,
+      configService: {
+        getCorsConfig: vi.fn(() => ({ allowedOrigins: [allowedOrigin] })),
+      },
+      createLogger: vi.fn(() => logger),
+    },
+  } as unknown as AppContext;
+  const ws = new MockWebSocket();
+  const handler = createTerminalUpgradeHandler(appContext);
+
+  handler(
+    createRequest(),
+    { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex,
+    Buffer.alloc(0),
+    new URL(`http://localhost/terminal?workspaceId=${workspaceId}`),
+    createWss(ws),
+    new WeakMap<WebSocket, boolean>()
+  );
+
+  await vi.waitFor(() => {
+    expect(outputListeners.get(terminalId)?.size).toBe(1);
+  });
+  const listener = Array.from(outputListeners.get(terminalId) ?? [])[0];
+  if (!listener) {
+    throw new Error('Expected terminal output listener');
+  }
+
+  ws.send.mockClear();
+  ws.bufferedAmount = MAX_WEBSOCKET_STREAM_BUFFERED_BYTES + 1;
+  listener('dropped output');
+  expect(ws.send).not.toHaveBeenCalled();
+
+  ws.bufferedAmount = MAX_WEBSOCKET_STREAM_BUFFERED_BYTES;
+  listener('resumed output');
+  expect(ws.send).toHaveBeenCalledWith(
+    JSON.stringify({
+      type: 'output',
+      terminalId,
+      data: 'resumed output',
+    }),
+    expect.any(Function)
+  );
+});
+```
+
+- [ ] **Step 4: Add a failing setup-terminal regression assertion**
+
+Import the threshold in `setup-terminal.handler.test.ts`:
+
+```ts
+import { MAX_WEBSOCKET_STREAM_BUFFERED_BYTES } from '@/backend/lib/websocket-send';
+```
+
+In the existing creation/routing test, replace the immediate `onDataCallback` assertion with:
+
+```ts
+ws.send.mockClear();
+ws.bufferedAmount = MAX_WEBSOCKET_STREAM_BUFFERED_BYTES + 1;
+onDataCallback?.('dropped shell output');
+expect(ws.send).not.toHaveBeenCalled();
+
+ws.bufferedAmount = MAX_WEBSOCKET_STREAM_BUFFERED_BYTES;
+onDataCallback?.('hello from shell');
+expect(ws.send).toHaveBeenCalledWith(
+  JSON.stringify({ type: 'output', data: 'hello from shell' }),
+  expect.any(Function)
+);
+```
+
+- [ ] **Step 5: Run the handler tests and verify they fail because output still bypasses the helper**
+
+Run:
+
+```bash
+pnpm vitest run \
+  src/backend/routers/websocket/dev-logs.handler.test.ts \
+  src/backend/routers/websocket/terminal.handler.test.ts \
+  src/backend/routers/websocket/setup-terminal.handler.test.ts
+```
+
+Expected: FAIL because congested live output is still sent.
+
+- [ ] **Step 6: Route live log output through the helper**
+
+Change the import in `push-channel.handler.ts`:
+
+```ts
+import { safeSend, sendStreamOutput } from '@/backend/lib/websocket-send';
+```
+
+Change only the live subscription:
+
+```ts
+const unsubscribe = subscribeToOutput(workspaceId, (data) => {
+  sendStreamOutput(
+    ws,
+    JSON.stringify({ type: 'output', data }),
+    logger,
+    'log output'
+  );
+});
+```
+
+Keep the initial output-buffer replay on `safeSend`.
+
+- [ ] **Step 7: Route live workspace-terminal output through the helper**
+
+Add:
+
+```ts
+import { sendStreamOutput } from '@/backend/lib/websocket-send';
+```
+
+Replace the output listener body with:
+
+```ts
+const unsubOutput = terminalService.onOutput(terminalId, (output) => {
+  sendStreamOutput(
+    ws,
+    JSON.stringify({ type: 'output', terminalId, data: output }),
+    logger,
+    'terminal output'
+  );
+});
+```
+
+Keep the exit path unchanged.
+
+- [ ] **Step 8: Route live setup-terminal output through the helper**
+
+Add:
+
+```ts
+import { sendStreamOutput } from '@/backend/lib/websocket-send';
+```
+
+Replace the PTY data callback body with:
+
+```ts
+state.pty.onData((output: string) => {
+  sendStreamOutput(
+    ws,
+    JSON.stringify({ type: 'output', data: output }),
+    logger,
+    'setup terminal output'
+  );
+});
+```
+
+Keep create and exit messages unchanged.
+
+- [ ] **Step 9: Update existing live-output call-shape assertions**
+
+Any existing assertion for live terminal, setup-terminal, dev-log, or post-run-log output must expect the callback argument:
+
+```ts
+expect(ws.send).toHaveBeenCalledWith(
+  JSON.stringify({ type: 'output', data: expectedData }),
+  expect.any(Function)
+);
+```
+
+Replay payloads and control-message assertions must continue expecting one argument.
+
+- [ ] **Step 10: Run all affected WebSocket tests**
+
+Run:
+
+```bash
+pnpm vitest run \
+  src/backend/lib/websocket-send.test.ts \
+  src/backend/routers/websocket/dev-logs.handler.test.ts \
+  src/backend/routers/websocket/post-run-logs.handler.test.ts \
+  src/backend/routers/websocket/terminal.handler.test.ts \
+  src/backend/routers/websocket/setup-terminal.handler.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 11: Commit the handler integration**
+
+```bash
+git add \
+  src/backend/routers/websocket/push-channel.handler.ts \
+  src/backend/routers/websocket/terminal.handler.ts \
+  src/backend/routers/websocket/setup-terminal.handler.ts \
+  src/backend/routers/websocket/dev-logs.handler.test.ts \
+  src/backend/routers/websocket/post-run-logs.handler.test.ts \
+  src/backend/routers/websocket/terminal.handler.test.ts \
+  src/backend/routers/websocket/setup-terminal.handler.test.ts
+git commit -m "Bound high-volume WebSocket output buffering"
+```
+
+### Task 3: Verify repository guardrails
+
+**Files:**
+- Verify: all changed files
+
+**Interfaces:**
+- Consumes: completed Tasks 1 and 2
+- Produces: evidence that the issue is fixed without type, lint, boundary, or test regressions
+
+- [ ] **Step 1: Run formatting and apply any mechanical changes**
+
+Run:
+
+```bash
+pnpm check:fix
+```
+
+Expected: exit 0. If files change, inspect and commit only formatting changes related to this issue.
+
+- [ ] **Step 2: Run TypeScript checks**
+
+Run:
+
+```bash
+pnpm typecheck
+```
+
+Expected: exit 0.
+
+- [ ] **Step 3: Run repository checks**
+
+Run:
+
+```bash
+pnpm check
+```
+
+Expected: exit 0.
+
+- [ ] **Step 4: Run the complete test suite**
+
+Run:
+
+```bash
+pnpm test
+```
+
+Expected: exit 0 with no failing Vitest files.
+
+- [ ] **Step 5: Inspect the final diff and worktree**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+git log --oneline -3
+```
+
+Expected: no whitespace errors; only intentional issue files are modified or committed.

--- a/docs/superpowers/plans/2026-07-16-websocket-stream-backpressure.md
+++ b/docs/superpowers/plans/2026-07-16-websocket-stream-backpressure.md
@@ -4,15 +4,15 @@
 
 **Goal:** Bound queued WebSocket data for high-volume terminal and log output and log asynchronous send failures.
 
-**Architecture:** Extend the existing `websocket-send` utility with a stream-specific sender that drops output above a 1 MiB `bufferedAmount` threshold and tracks per-socket congestion warnings in a `WeakSet`. Route only live output callbacks through this helper; leave replay and low-volume control messages on their existing paths.
+**Architecture:** Extend the existing `websocket-send` utility with a stream-specific sender that drops output when the current `bufferedAmount` plus the UTF-8 message size would exceed 1 MiB, and tracks per-socket congestion warnings in a `WeakSet`. Route only live output callbacks through this helper; leave replay and low-volume control messages on their existing paths.
 
 **Tech Stack:** TypeScript, `ws`, Vitest, Express WebSocket handlers
 
 ## Global Constraints
 
 - Apply backpressure only to live workspace-terminal, setup-terminal, dev-log, and post-run-log output.
-- Use a fixed 1 MiB threshold and drop chunks only when `ws.bufferedAmount` is greater than the threshold.
-- Emit at most one warning per socket congestion window and resume sends when the queued amount returns to the threshold or below.
+- Use a fixed 1 MiB threshold and drop chunks when `ws.bufferedAmount + Buffer.byteLength(message)` is greater than the threshold.
+- Emit at most one warning per socket congestion window and resume sends when the current buffer has enough capacity for the next message.
 - Use the `ws.send` callback to log asynchronous send failures.
 - Do not add an application-level output queue or pause shared PTYs.
 - Do not introduce `TopicBroadcaster` or change the browser WebSocket protocol.
@@ -27,7 +27,7 @@
 - Test: `src/backend/lib/websocket-send.test.ts`
 
 **Interfaces:**
-- Consumes: `WebSocket.readyState`, `WebSocket.bufferedAmount`, and `WebSocket.send(data, callback)` from `ws`
+- Consumes: `WebSocket.readyState`, `WebSocket.bufferedAmount`, `WebSocket.send(data, callback)` from `ws`, and `Buffer.byteLength(message)` for UTF-8 payload size
 - Produces: `MAX_WEBSOCKET_STREAM_BUFFERED_BYTES: number` and `sendStreamOutput(ws, message, logger, description?): boolean`
 
 - [ ] **Step 1: Add failing tests for threshold, recovery, and send errors**
@@ -61,24 +61,39 @@ Add these tests:
 
 ```ts
 describe('sendStreamOutput', () => {
-  it('sends stream output with a callback at or below the threshold', () => {
+  it('sends stream output when the projected buffer is at the threshold', () => {
+    const message = 'output';
     const ws = createMockWs(
       WS_READY_STATE.OPEN,
-      MAX_WEBSOCKET_STREAM_BUFFERED_BYTES
+      MAX_WEBSOCKET_STREAM_BUFFERED_BYTES - Buffer.byteLength(message)
     );
     const logger = createMockLogger();
 
     expect(
       sendStreamOutput(
         ws as unknown as WebSocket,
-        'output',
+        message,
         logger,
         'terminal output'
       )
     ).toBe(true);
 
-    expect(ws.send).toHaveBeenCalledWith('output', expect.any(Function));
+    expect(ws.send).toHaveBeenCalledWith(message, expect.any(Function));
     expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('drops output when its UTF-8 bytes would push the buffer above the threshold', () => {
+    const message = 'éé';
+    const ws = createMockWs(
+      WS_READY_STATE.OPEN,
+      MAX_WEBSOCKET_STREAM_BUFFERED_BYTES - Buffer.byteLength(message) + 1
+    );
+    const logger = createMockLogger();
+
+    expect(
+      sendStreamOutput(ws as unknown as WebSocket, message, logger, 'log output')
+    ).toBe(false);
+    expect(ws.send).not.toHaveBeenCalled();
   });
 
   it('drops output and warns once while a socket remains congested', () => {
@@ -114,7 +129,8 @@ describe('sendStreamOutput', () => {
     const logger = createMockLogger();
 
     sendStreamOutput(ws as unknown as WebSocket, 'dropped', logger);
-    ws.bufferedAmount = MAX_WEBSOCKET_STREAM_BUFFERED_BYTES;
+    ws.bufferedAmount =
+      MAX_WEBSOCKET_STREAM_BUFFERED_BYTES - Buffer.byteLength('resumed');
     expect(
       sendStreamOutput(ws as unknown as WebSocket, 'resumed', logger)
     ).toBe(true);
@@ -214,7 +230,10 @@ export function sendStreamOutput(
     return false;
   }
 
-  if (ws.bufferedAmount > MAX_WEBSOCKET_STREAM_BUFFERED_BYTES) {
+  if (
+    ws.bufferedAmount + Buffer.byteLength(message) >
+    MAX_WEBSOCKET_STREAM_BUFFERED_BYTES
+  ) {
     if (!congestedStreamSockets.has(ws)) {
       congestedStreamSockets.add(ws);
       logger.warn(`Dropping ${description} because WebSocket send buffer is congested`, {
@@ -296,7 +315,7 @@ ws.bufferedAmount = MAX_WEBSOCKET_STREAM_BUFFERED_BYTES + 1;
 outputSubscriber('dropped logs\n');
 expect(ws.send).not.toHaveBeenCalled();
 
-ws.bufferedAmount = MAX_WEBSOCKET_STREAM_BUFFERED_BYTES;
+ws.bufferedAmount = 0;
 outputSubscriber('resumed logs\n');
 expect(ws.send).toHaveBeenCalledWith(
   JSON.stringify({ type: 'output', data: 'resumed logs\n' }),
@@ -361,7 +380,7 @@ it('drops live terminal output while the socket is congested and resumes after d
   listener('dropped output');
   expect(ws.send).not.toHaveBeenCalled();
 
-  ws.bufferedAmount = MAX_WEBSOCKET_STREAM_BUFFERED_BYTES;
+  ws.bufferedAmount = 0;
   listener('resumed output');
   expect(ws.send).toHaveBeenCalledWith(
     JSON.stringify({
@@ -390,7 +409,7 @@ ws.bufferedAmount = MAX_WEBSOCKET_STREAM_BUFFERED_BYTES + 1;
 onDataCallback?.('dropped shell output');
 expect(ws.send).not.toHaveBeenCalled();
 
-ws.bufferedAmount = MAX_WEBSOCKET_STREAM_BUFFERED_BYTES;
+ws.bufferedAmount = 0;
 onDataCallback?.('hello from shell');
 expect(ws.send).toHaveBeenCalledWith(
   JSON.stringify({ type: 'output', data: 'hello from shell' }),

--- a/docs/superpowers/specs/2026-07-16-websocket-stream-backpressure-design.md
+++ b/docs/superpowers/specs/2026-07-16-websocket-stream-backpressure-design.md
@@ -1,0 +1,88 @@
+# WebSocket Stream Backpressure Design
+
+## Goal
+
+Bound server-side WebSocket buffering for high-volume terminal and log streams,
+while preserving existing connection and replay behavior and making asynchronous
+send failures visible.
+
+## Scope
+
+Apply the policy to live output messages from:
+
+- workspace terminals
+- setup terminals
+- dev-server logs
+- post-run logs
+
+The policy does not apply to low-volume control messages such as terminal
+creation, exit, errors, or restoration payloads. It also does not introduce the
+larger `TopicBroadcaster` abstraction proposed in issue #1872.
+
+## Design
+
+Extend the shared WebSocket send utilities with a high-volume stream sender.
+Before sending, the helper checks that the socket is open and compares
+`ws.bufferedAmount` with a fixed 1 MiB threshold. If the queued amount is above
+the threshold, the new output chunk is dropped instead of being added to the
+socket's send queue.
+
+Dropping is tracked per socket as a congestion window. The helper logs one
+warning when it first begins dropping chunks, suppresses repeated warnings
+while the socket remains congested, and clears the congestion state when a
+later send observes that the queued amount has fallen to or below the
+threshold. This bounds log volume as well as socket buffering.
+
+Successful sends use the `ws.send` callback. Callback errors are normalized and
+logged, covering asynchronous failures that the existing synchronous
+`try/catch` helper cannot observe. Synchronous exceptions remain caught and
+logged.
+
+The shared dev-log and post-run-log handler factory uses the new helper for live
+output. The workspace terminal and setup-terminal handlers use it only in their
+PTY output callbacks. Existing `safeSend` behavior for other fan-out paths is
+unchanged.
+
+## Recovery Behavior
+
+The server does not build a second application-level queue for dropped output:
+
+- Workspace terminals already retain bounded rolling output and replay it when
+  the client reconnects.
+- Dev and post-run logs already retain bounded output buffers and send them on
+  reconnect.
+- Setup terminals are connection-scoped and have no replay buffer, so a slow
+  client may miss output while congested. This is preferable to unbounded
+  process memory growth for an auxiliary setup flow.
+
+The helper resumes live streaming automatically once `bufferedAmount` returns
+to the threshold or below. No browser protocol changes are required.
+
+## Error Handling
+
+- Non-open sockets do not receive output.
+- Synchronous `ws.send` failures are logged and reported as unsuccessful.
+- Asynchronous send callback failures are logged.
+- A congested socket produces at most one warning until it recovers.
+- Congestion on one connection does not pause a PTY or affect healthy
+  connections subscribed to the same terminal or log stream.
+
+## Testing
+
+Add unit tests for the shared helper that verify:
+
+- normal stream output is sent with a callback
+- output is dropped above 1 MiB
+- only one warning is emitted during a congestion window
+- sending resumes after the socket drains
+- synchronous and callback send errors are logged
+- closed sockets are ignored
+
+Add handler regression tests proving that terminal, setup-terminal, and the
+shared push-channel path do not send live output while the socket is above the
+threshold and resume after it drains. Because dev and post-run logs share the
+factory, one focused factory-path integration test plus the existing channel
+tests is sufficient to cover both log channels.
+
+Run the focused Vitest files, then `pnpm typecheck`, `pnpm check`, and the full
+`pnpm test` suite.

--- a/docs/superpowers/specs/2026-07-16-websocket-stream-backpressure-design.md
+++ b/docs/superpowers/specs/2026-07-16-websocket-stream-backpressure-design.md
@@ -22,10 +22,11 @@ larger `TopicBroadcaster` abstraction proposed in issue #1872.
 ## Design
 
 Extend the shared WebSocket send utilities with a high-volume stream sender.
-Before sending, the helper checks that the socket is open and compares
-`ws.bufferedAmount` with a fixed 1 MiB threshold. If the queued amount is above
-the threshold, the new output chunk is dropped instead of being added to the
-socket's send queue.
+Before sending, the helper checks that the socket is open and compares the
+projected queued bytes (`ws.bufferedAmount` plus the UTF-8 message byte length)
+with a fixed 1 MiB threshold. If the projected amount is above the threshold,
+the new output chunk is dropped instead of being added to the socket's send
+queue.
 
 Dropping is tracked per socket as a congestion window. The helper logs one
 warning when it first begins dropping chunks, suppresses repeated warnings
@@ -55,8 +56,9 @@ The server does not build a second application-level queue for dropped output:
   client may miss output while congested. This is preferable to unbounded
   process memory growth for an auxiliary setup flow.
 
-The helper resumes live streaming automatically once `bufferedAmount` returns
-to the threshold or below. No browser protocol changes are required.
+The helper resumes live streaming automatically once the current buffer has
+enough capacity for the next output message. No browser protocol changes are
+required.
 
 ## Error Handling
 
@@ -72,7 +74,7 @@ to the threshold or below. No browser protocol changes are required.
 Add unit tests for the shared helper that verify:
 
 - normal stream output is sent with a callback
-- output is dropped above 1 MiB
+- output is dropped when its UTF-8 bytes would push the queue above 1 MiB
 - only one warning is emitted during a congestion window
 - sending resumes after the socket drains
 - synchronous and callback send errors are logged

--- a/src/backend/lib/websocket-send.test.ts
+++ b/src/backend/lib/websocket-send.test.ts
@@ -56,16 +56,33 @@ describe('safeSend', () => {
 });
 
 describe('sendStreamOutput', () => {
-  it('sends stream output with a callback at or below the threshold', () => {
-    const ws = createMockWs(WS_READY_STATE.OPEN, MAX_WEBSOCKET_STREAM_BUFFERED_BYTES);
+  it('sends stream output when the projected buffer is at the threshold', () => {
+    const message = 'output';
+    const ws = createMockWs(
+      WS_READY_STATE.OPEN,
+      MAX_WEBSOCKET_STREAM_BUFFERED_BYTES - Buffer.byteLength(message)
+    );
     const logger = createMockLogger();
 
-    expect(sendStreamOutput(ws as unknown as WebSocket, 'output', logger, 'terminal output')).toBe(
+    expect(sendStreamOutput(ws as unknown as WebSocket, message, logger, 'terminal output')).toBe(
       true
     );
 
-    expect(ws.send).toHaveBeenCalledWith('output', expect.any(Function));
+    expect(ws.send).toHaveBeenCalledWith(message, expect.any(Function));
     expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('drops output when its UTF-8 bytes would push the buffer above the threshold', () => {
+    const message = 'éé';
+    const ws = createMockWs(
+      WS_READY_STATE.OPEN,
+      MAX_WEBSOCKET_STREAM_BUFFERED_BYTES - Buffer.byteLength(message) + 1
+    );
+    const logger = createMockLogger();
+
+    expect(sendStreamOutput(ws as unknown as WebSocket, message, logger, 'log output')).toBe(false);
+
+    expect(ws.send).not.toHaveBeenCalled();
   });
 
   it('drops output and warns once while a socket remains congested', () => {
@@ -93,7 +110,7 @@ describe('sendStreamOutput', () => {
     const logger = createMockLogger();
 
     sendStreamOutput(ws as unknown as WebSocket, 'dropped', logger);
-    ws.bufferedAmount = MAX_WEBSOCKET_STREAM_BUFFERED_BYTES;
+    ws.bufferedAmount = MAX_WEBSOCKET_STREAM_BUFFERED_BYTES - Buffer.byteLength('resumed');
     expect(sendStreamOutput(ws as unknown as WebSocket, 'resumed', logger)).toBe(true);
 
     ws.bufferedAmount = MAX_WEBSOCKET_STREAM_BUFFERED_BYTES + 1;

--- a/src/backend/lib/websocket-send.test.ts
+++ b/src/backend/lib/websocket-send.test.ts
@@ -1,17 +1,18 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { WebSocket } from 'ws';
 import { WS_READY_STATE } from '@/backend/constants/websocket';
-import { safeSend } from './websocket-send';
+import { MAX_WEBSOCKET_STREAM_BUFFERED_BYTES, safeSend, sendStreamOutput } from './websocket-send';
 
-function createMockWs(readyState: number = WS_READY_STATE.OPEN) {
+function createMockWs(readyState: number = WS_READY_STATE.OPEN, bufferedAmount = 0) {
   return {
     readyState,
+    bufferedAmount,
     send: vi.fn(),
   };
 }
 
 function createMockLogger() {
-  return { error: vi.fn() };
+  return { error: vi.fn(), warn: vi.fn() };
 }
 
 describe('safeSend', () => {
@@ -51,5 +52,91 @@ describe('safeSend', () => {
       'Failed to send test message',
       expect.objectContaining({ message: 'socket closing' })
     );
+  });
+});
+
+describe('sendStreamOutput', () => {
+  it('sends stream output with a callback at or below the threshold', () => {
+    const ws = createMockWs(WS_READY_STATE.OPEN, MAX_WEBSOCKET_STREAM_BUFFERED_BYTES);
+    const logger = createMockLogger();
+
+    expect(sendStreamOutput(ws as unknown as WebSocket, 'output', logger, 'terminal output')).toBe(
+      true
+    );
+
+    expect(ws.send).toHaveBeenCalledWith('output', expect.any(Function));
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('drops output and warns once while a socket remains congested', () => {
+    const ws = createMockWs(WS_READY_STATE.OPEN, MAX_WEBSOCKET_STREAM_BUFFERED_BYTES + 1);
+    const logger = createMockLogger();
+
+    expect(sendStreamOutput(ws as unknown as WebSocket, 'first', logger, 'log output')).toBe(false);
+    expect(sendStreamOutput(ws as unknown as WebSocket, 'second', logger, 'log output')).toBe(
+      false
+    );
+
+    expect(ws.send).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Dropping log output because WebSocket send buffer is congested',
+      {
+        bufferedAmount: MAX_WEBSOCKET_STREAM_BUFFERED_BYTES + 1,
+        maxBufferedAmount: MAX_WEBSOCKET_STREAM_BUFFERED_BYTES,
+      }
+    );
+  });
+
+  it('resumes output and allows a new warning after the socket drains', () => {
+    const ws = createMockWs(WS_READY_STATE.OPEN, MAX_WEBSOCKET_STREAM_BUFFERED_BYTES + 1);
+    const logger = createMockLogger();
+
+    sendStreamOutput(ws as unknown as WebSocket, 'dropped', logger);
+    ws.bufferedAmount = MAX_WEBSOCKET_STREAM_BUFFERED_BYTES;
+    expect(sendStreamOutput(ws as unknown as WebSocket, 'resumed', logger)).toBe(true);
+
+    ws.bufferedAmount = MAX_WEBSOCKET_STREAM_BUFFERED_BYTES + 1;
+    expect(sendStreamOutput(ws as unknown as WebSocket, 'dropped again', logger)).toBe(false);
+
+    expect(ws.send).toHaveBeenCalledWith('resumed', expect.any(Function));
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+  });
+
+  it('logs asynchronous send callback errors', () => {
+    const ws = createMockWs();
+    ws.send.mockImplementation((_message: string, callback: (error?: Error) => void) => {
+      callback(new Error('write failed'));
+    });
+    const logger = createMockLogger();
+
+    expect(sendStreamOutput(ws as unknown as WebSocket, 'output', logger, 'terminal output')).toBe(
+      true
+    );
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'Failed to send terminal output',
+      expect.objectContaining({ message: 'write failed' })
+    );
+  });
+
+  it('catches synchronous stream send errors and ignores closed sockets', () => {
+    const throwingWs = createMockWs();
+    throwingWs.send.mockImplementation(() => {
+      throw new Error('socket closing');
+    });
+    const logger = createMockLogger();
+
+    expect(
+      sendStreamOutput(throwingWs as unknown as WebSocket, 'output', logger, 'terminal output')
+    ).toBe(false);
+    expect(logger.error).toHaveBeenCalledWith(
+      'Failed to send terminal output',
+      expect.objectContaining({ message: 'socket closing' })
+    );
+
+    const closedWs = createMockWs(WS_READY_STATE.CLOSED);
+    expect(sendStreamOutput(closedWs as unknown as WebSocket, 'output', logger)).toBe(false);
+    expect(closedWs.send).not.toHaveBeenCalled();
   });
 });

--- a/src/backend/lib/websocket-send.ts
+++ b/src/backend/lib/websocket-send.ts
@@ -16,6 +16,14 @@ interface SendErrorLogger {
   error(message: string, error: Error): void;
 }
 
+interface StreamSendLogger extends SendErrorLogger {
+  warn(message: string, data: Record<string, unknown>): void;
+}
+
+export const MAX_WEBSOCKET_STREAM_BUFFERED_BYTES = 1024 * 1024;
+
+const congestedStreamSockets = new WeakSet<WebSocket>();
+
 /**
  * Send a message on a WebSocket, swallowing (and logging) synchronous send
  * errors. Returns true if the message was sent, false if the socket was not
@@ -32,6 +40,47 @@ export function safeSend(
   }
   try {
     ws.send(message);
+    return true;
+  } catch (error) {
+    logger.error(`Failed to send ${description}`, toError(error));
+    return false;
+  }
+}
+
+/**
+ * Send high-volume stream output without allowing a slow socket to accumulate
+ * unbounded queued data. Output is dropped above the buffered amount threshold,
+ * with one warning per congestion window.
+ */
+export function sendStreamOutput(
+  ws: WebSocket,
+  message: string,
+  logger: StreamSendLogger,
+  description = 'WebSocket stream output'
+): boolean {
+  if (ws.readyState !== WS_READY_STATE.OPEN) {
+    return false;
+  }
+
+  if (ws.bufferedAmount > MAX_WEBSOCKET_STREAM_BUFFERED_BYTES) {
+    if (!congestedStreamSockets.has(ws)) {
+      congestedStreamSockets.add(ws);
+      logger.warn(`Dropping ${description} because WebSocket send buffer is congested`, {
+        bufferedAmount: ws.bufferedAmount,
+        maxBufferedAmount: MAX_WEBSOCKET_STREAM_BUFFERED_BYTES,
+      });
+    }
+    return false;
+  }
+
+  congestedStreamSockets.delete(ws);
+
+  try {
+    ws.send(message, (error) => {
+      if (error) {
+        logger.error(`Failed to send ${description}`, toError(error));
+      }
+    });
     return true;
   } catch (error) {
     logger.error(`Failed to send ${description}`, toError(error));

--- a/src/backend/lib/websocket-send.ts
+++ b/src/backend/lib/websocket-send.ts
@@ -62,7 +62,7 @@ export function sendStreamOutput(
     return false;
   }
 
-  if (ws.bufferedAmount > MAX_WEBSOCKET_STREAM_BUFFERED_BYTES) {
+  if (ws.bufferedAmount + Buffer.byteLength(message) > MAX_WEBSOCKET_STREAM_BUFFERED_BYTES) {
     if (!congestedStreamSockets.has(ws)) {
       congestedStreamSockets.add(ws);
       logger.warn(`Dropping ${description} because WebSocket send buffer is congested`, {

--- a/src/backend/routers/websocket/dev-logs.handler.test.ts
+++ b/src/backend/routers/websocket/dev-logs.handler.test.ts
@@ -212,7 +212,7 @@ describe('createDevLogsUpgradeHandler', () => {
     outputSubscriber('dropped logs\n');
     expect(ws.send).not.toHaveBeenCalled();
 
-    ws.bufferedAmount = MAX_WEBSOCKET_STREAM_BUFFERED_BYTES;
+    ws.bufferedAmount = 0;
     outputSubscriber('resumed logs\n');
     expect(ws.send).toHaveBeenCalledWith(
       JSON.stringify({ type: 'output', data: 'resumed logs\n' }),

--- a/src/backend/routers/websocket/dev-logs.handler.test.ts
+++ b/src/backend/routers/websocket/dev-logs.handler.test.ts
@@ -5,12 +5,14 @@ import { describe, expect, it, vi } from 'vitest';
 import type { WebSocket, WebSocketServer } from 'ws';
 import type { AppContext } from '@/backend/app-context';
 import { WS_READY_STATE } from '@/backend/constants/websocket';
+import { MAX_WEBSOCKET_STREAM_BUFFERED_BYTES } from '@/backend/lib/websocket-send';
 import { createDevLogsUpgradeHandler } from './dev-logs.handler';
 
 const allowedOrigin = 'http://localhost:3000';
 
 class MockWebSocket extends EventEmitter {
   readyState: number = WS_READY_STATE.OPEN;
+  bufferedAmount = 0;
   send = vi.fn();
   close = vi.fn();
   terminate = vi.fn();
@@ -205,8 +207,17 @@ describe('createDevLogsUpgradeHandler', () => {
     if (!outputSubscriber) {
       throw new Error('Expected subscribeToOutput callback to be registered');
     }
-    outputSubscriber('live logs\n');
-    expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: 'output', data: 'live logs\n' }));
+    ws.send.mockClear();
+    ws.bufferedAmount = MAX_WEBSOCKET_STREAM_BUFFERED_BYTES + 1;
+    outputSubscriber('dropped logs\n');
+    expect(ws.send).not.toHaveBeenCalled();
+
+    ws.bufferedAmount = MAX_WEBSOCKET_STREAM_BUFFERED_BYTES;
+    outputSubscriber('resumed logs\n');
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: 'output', data: 'resumed logs\n' }),
+      expect.any(Function)
+    );
 
     const callsBeforeClosed = ws.send.mock.calls.length;
     ws.readyState = WS_READY_STATE.CLOSED;

--- a/src/backend/routers/websocket/post-run-logs.handler.test.ts
+++ b/src/backend/routers/websocket/post-run-logs.handler.test.ts
@@ -11,6 +11,7 @@ const allowedOrigin = 'http://localhost:3000';
 
 class MockWebSocket extends EventEmitter {
   readyState: number = WS_READY_STATE.OPEN;
+  bufferedAmount = 0;
   send = vi.fn();
 }
 
@@ -256,7 +257,10 @@ describe('createPostRunLogsUpgradeHandler', () => {
     }
 
     outputCallback('live output');
-    expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: 'output', data: 'live output' }));
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: 'output', data: 'live output' }),
+      expect.any(Function)
+    );
 
     const sendsBeforeClosed = ws.send.mock.calls.length;
     ws.readyState = WS_READY_STATE.CLOSED;

--- a/src/backend/routers/websocket/push-channel.handler.ts
+++ b/src/backend/routers/websocket/push-channel.handler.ts
@@ -8,7 +8,7 @@
 
 import type { WebSocket } from 'ws';
 import type { AppContext } from '@/backend/app-context';
-import { safeSend } from '@/backend/lib/websocket-send';
+import { safeSend, sendStreamOutput } from '@/backend/lib/websocket-send';
 import {
   createWebSocketUpgradeHandler,
   trackConnection,
@@ -54,7 +54,7 @@ export function createPushChannelUpgradeHandler(
       }
 
       const unsubscribe = subscribeToOutput(workspaceId, (data) => {
-        safeSend(ws, JSON.stringify({ type: 'output', data }), logger, 'log output');
+        sendStreamOutput(ws, JSON.stringify({ type: 'output', data }), logger, 'log output');
       });
 
       ws.on('close', () => {

--- a/src/backend/routers/websocket/setup-terminal.handler.test.ts
+++ b/src/backend/routers/websocket/setup-terminal.handler.test.ts
@@ -326,7 +326,7 @@ describe('createSetupTerminalUpgradeHandler', () => {
     onDataCallback?.('dropped shell output');
     expect(ws.send).not.toHaveBeenCalled();
 
-    ws.bufferedAmount = MAX_WEBSOCKET_STREAM_BUFFERED_BYTES;
+    ws.bufferedAmount = 0;
     onDataCallback?.('hello from shell');
     expect(ws.send).toHaveBeenCalledWith(
       JSON.stringify({ type: 'output', data: 'hello from shell' }),

--- a/src/backend/routers/websocket/setup-terminal.handler.test.ts
+++ b/src/backend/routers/websocket/setup-terminal.handler.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { WebSocket, WebSocketServer } from 'ws';
 import type { AppContext } from '@/backend/app-context';
 import { WS_READY_STATE } from '@/backend/constants/websocket';
+import { MAX_WEBSOCKET_STREAM_BUFFERED_BYTES } from '@/backend/lib/websocket-send';
 
 const mockPtyWrite = vi.fn();
 const mockPtyResize = vi.fn();
@@ -30,6 +31,7 @@ import { createSetupTerminalUpgradeHandler } from './setup-terminal.handler';
 
 class MockWebSocket extends EventEmitter {
   readyState: number = WS_READY_STATE.OPEN;
+  bufferedAmount = 0;
   send = vi.fn();
 }
 
@@ -319,9 +321,16 @@ describe('createSetupTerminalUpgradeHandler', () => {
     );
     expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: 'created' }));
 
+    ws.send.mockClear();
+    ws.bufferedAmount = MAX_WEBSOCKET_STREAM_BUFFERED_BYTES + 1;
+    onDataCallback?.('dropped shell output');
+    expect(ws.send).not.toHaveBeenCalled();
+
+    ws.bufferedAmount = MAX_WEBSOCKET_STREAM_BUFFERED_BYTES;
     onDataCallback?.('hello from shell');
     expect(ws.send).toHaveBeenCalledWith(
-      JSON.stringify({ type: 'output', data: 'hello from shell' })
+      JSON.stringify({ type: 'output', data: 'hello from shell' }),
+      expect.any(Function)
     );
 
     ws.emit('message', JSON.stringify({ type: 'input', data: 'echo hi\n' }));

--- a/src/backend/routers/websocket/setup-terminal.handler.ts
+++ b/src/backend/routers/websocket/setup-terminal.handler.ts
@@ -13,6 +13,7 @@ import type { WebSocket } from 'ws';
 import type { AppContext } from '@/backend/app-context';
 import { WS_READY_STATE } from '@/backend/constants/websocket';
 import { toError } from '@/backend/lib/error-utils';
+import { sendStreamOutput } from '@/backend/lib/websocket-send';
 import {
   type SetupTerminalMessageInput,
   SetupTerminalMessageSchema,
@@ -66,9 +67,12 @@ function handleCreate(
   });
 
   state.pty.onData((output: string) => {
-    if (ws.readyState === WS_READY_STATE.OPEN) {
-      ws.send(JSON.stringify({ type: 'output', data: output }));
-    }
+    sendStreamOutput(
+      ws,
+      JSON.stringify({ type: 'output', data: output }),
+      logger,
+      'setup terminal output'
+    );
   });
 
   state.pty.onExit(({ exitCode }: { exitCode: number }) => {

--- a/src/backend/routers/websocket/terminal.handler.test.ts
+++ b/src/backend/routers/websocket/terminal.handler.test.ts
@@ -467,7 +467,7 @@ describe('createTerminalUpgradeHandler', () => {
     listener('dropped output');
     expect(ws.send).not.toHaveBeenCalled();
 
-    ws.bufferedAmount = MAX_WEBSOCKET_STREAM_BUFFERED_BYTES;
+    ws.bufferedAmount = 0;
     listener('resumed output');
     expect(ws.send).toHaveBeenCalledWith(
       JSON.stringify({

--- a/src/backend/routers/websocket/terminal.handler.test.ts
+++ b/src/backend/routers/websocket/terminal.handler.test.ts
@@ -403,6 +403,10 @@ describe('createTerminalUpgradeHandler', () => {
     const listeners = outputListeners.get(terminalId);
     expect(listeners?.size).toBe(2);
 
+    ws1.send.mockClear();
+    ws2.send.mockClear();
+    ws1.bufferedAmount = MAX_WEBSOCKET_STREAM_BUFFERED_BYTES + 1;
+
     for (const listener of listeners ?? []) {
       listener('live output');
     }
@@ -412,7 +416,7 @@ describe('createTerminalUpgradeHandler', () => {
       terminalId,
       data: 'live output',
     });
-    expect(ws1.send).toHaveBeenCalledWith(outputMessage, expect.any(Function));
+    expect(ws1.send).not.toHaveBeenCalled();
     expect(ws2.send).toHaveBeenCalledWith(outputMessage, expect.any(Function));
     expect(terminalConnections.get(workspaceId)?.size).toBe(2);
   });

--- a/src/backend/routers/websocket/terminal.handler.test.ts
+++ b/src/backend/routers/websocket/terminal.handler.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { WebSocket, WebSocketServer } from 'ws';
 import type { AppContext } from '@/backend/app-context';
 import { WS_READY_STATE } from '@/backend/constants/websocket';
+import { MAX_WEBSOCKET_STREAM_BUFFERED_BYTES } from '@/backend/lib/websocket-send';
 import { sessionDataService } from '@/backend/services/session';
 import { workspaceDataService } from '@/backend/services/workspace';
 import { createTerminalUpgradeHandler, terminalConnections } from './terminal.handler';
@@ -43,6 +44,7 @@ vi.mock('@/backend/services/workspace', async (importOriginal) => {
 
 class MockWebSocket extends EventEmitter {
   readyState = WS_READY_STATE.OPEN;
+  bufferedAmount = 0;
   send = vi.fn();
   close = vi.fn();
   terminate = vi.fn();
@@ -410,9 +412,67 @@ describe('createTerminalUpgradeHandler', () => {
       terminalId,
       data: 'live output',
     });
-    expect(ws1.send).toHaveBeenCalledWith(outputMessage);
-    expect(ws2.send).toHaveBeenCalledWith(outputMessage);
+    expect(ws1.send).toHaveBeenCalledWith(outputMessage, expect.any(Function));
+    expect(ws2.send).toHaveBeenCalledWith(outputMessage, expect.any(Function));
     expect(terminalConnections.get(workspaceId)?.size).toBe(2);
+  });
+
+  it('drops live terminal output while the socket is congested and resumes after drain', async () => {
+    const workspaceId = 'workspace-1';
+    const terminalId = 'terminal-1';
+    const { terminalService, outputListeners } = createTerminalService();
+    terminalService.getTerminalsForWorkspace.mockReturnValue([
+      {
+        id: terminalId,
+        createdAt: new Date('2026-07-16T00:00:00.000Z'),
+        outputBuffer: '',
+      },
+    ]);
+    const logger = createLogger();
+    const appContext = {
+      services: {
+        terminalService,
+        configService: {
+          getCorsConfig: vi.fn(() => ({ allowedOrigins: [allowedOrigin] })),
+        },
+        createLogger: vi.fn(() => logger),
+      },
+    } as unknown as AppContext;
+    const ws = new MockWebSocket();
+    const handler = createTerminalUpgradeHandler(appContext);
+
+    handler(
+      createRequest(),
+      { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex,
+      Buffer.alloc(0),
+      new URL(`http://localhost/terminal?workspaceId=${workspaceId}`),
+      createWss(ws),
+      new WeakMap<WebSocket, boolean>()
+    );
+
+    await vi.waitFor(() => {
+      expect(outputListeners.get(terminalId)?.size).toBe(1);
+    });
+    const listener = Array.from(outputListeners.get(terminalId) ?? [])[0];
+    if (!listener) {
+      throw new Error('Expected terminal output listener');
+    }
+
+    ws.send.mockClear();
+    ws.bufferedAmount = MAX_WEBSOCKET_STREAM_BUFFERED_BYTES + 1;
+    listener('dropped output');
+    expect(ws.send).not.toHaveBeenCalled();
+
+    ws.bufferedAmount = MAX_WEBSOCKET_STREAM_BUFFERED_BYTES;
+    listener('resumed output');
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({
+        type: 'output',
+        terminalId,
+        data: 'resumed output',
+      }),
+      expect.any(Function)
+    );
   });
 
   it('creates terminals, persists sessions, and routes message types', async () => {
@@ -503,7 +563,8 @@ describe('createTerminalUpgradeHandler', () => {
     }
     await Promise.resolve();
     expect(ws.send).toHaveBeenCalledWith(
-      JSON.stringify({ type: 'output', terminalId: 'terminal-1', data: 'stdout' })
+      JSON.stringify({ type: 'output', terminalId: 'terminal-1', data: 'stdout' }),
+      expect.any(Function)
     );
     expect(ws.send).toHaveBeenCalledWith(
       JSON.stringify({ type: 'exit', terminalId: 'terminal-1', exitCode: 0 })

--- a/src/backend/routers/websocket/terminal.handler.ts
+++ b/src/backend/routers/websocket/terminal.handler.ts
@@ -10,6 +10,7 @@ import type { WebSocket } from 'ws';
 import type { AppContext } from '@/backend/app-context';
 import { WS_READY_STATE } from '@/backend/constants/websocket';
 import { toError } from '@/backend/lib/error-utils';
+import { sendStreamOutput } from '@/backend/lib/websocket-send';
 import { type TerminalMessageInput, TerminalMessageSchema } from '@/backend/schemas/websocket';
 import { sessionDataService } from '@/backend/services/session';
 import { workspaceDataService } from '@/backend/services/workspace';
@@ -177,9 +178,12 @@ function attachTerminalListeners(
   cleanupMap?.set(terminalId, unsubscribers);
 
   const unsubOutput = terminalService.onOutput(terminalId, (output) => {
-    if (ws.readyState === WS_READY_STATE.OPEN) {
-      ws.send(JSON.stringify({ type: 'output', terminalId, data: output }));
-    }
+    sendStreamOutput(
+      ws,
+      JSON.stringify({ type: 'output', terminalId, data: output }),
+      logger,
+      'terminal output'
+    );
   });
   unsubscribers.push(unsubOutput);
 


### PR DESCRIPTION
## Summary

- add a shared high-volume WebSocket send helper with a 1 MiB queued-data threshold
- drop terminal and log output while an individual client is congested, then resume after its send buffer drains
- log synchronous and asynchronous `ws.send` failures
- apply the policy to live workspace-terminal, setup-terminal, dev-log, and post-run-log output
- preserve existing replay and low-volume control-message behavior

## Root cause

The high-volume WebSocket paths sent every output chunk without checking
`ws.bufferedAmount`. A slow or half-open client could therefore accumulate
unbounded queued data in Node's WebSocket send buffer. The existing send paths
also omitted the send callback, so asynchronous delivery failures were not
reported.

## Impact

Each socket now has an independent bounded backpressure policy. A congested
client drops live output without pausing shared PTYs or affecting healthy
viewers. Workspace terminal and run-script output remains recoverable through
the existing bounded reconnect buffers.

## Validation

- `pnpm check:fix`
- `pnpm typecheck`
- `pnpm check`
- `pnpm test` — 3,639 passed, 3 skipped
- focused WebSocket tests — 39 passed
- independent code review — no Critical or Important findings

Closes #1873


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes real-time delivery for slow WebSocket clients (dropped live chunks on congested sockets) across terminal and log paths, though scope is limited to live output and is covered by regression tests.
> 
> **Overview**
> Introduces **`sendStreamOutput`** in `websocket-send.ts` with a **1 MiB** limit on `bufferedAmount` plus message size. When a client would exceed that, live chunks are **dropped** (not queued), with **one warning per congestion window** via a per-socket `WeakSet`, and sends **resume** after the buffer drains. Sends use the **`ws.send` callback** so async write failures are logged; **`safeSend`** is unchanged for replay and low-volume control traffic.
> 
> **Live** dev/post-run logs (shared `push-channel.handler`), workspace **terminal** PTY output, and **setup-terminal** PTY output now go through this helper. Initial log replay on connect still uses `safeSend`. Exit/create/error paths are untouched.
> 
> Adds design/plan docs under `docs/superpowers/` and Vitest coverage for the helper and handler drop/resume behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07694e076e1cfb0d9fc77b4e4f1f5f49111df107. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->