### PR TITLE
Fix #1884: Carry re-read workspace row in WORKSPACE_STATE_CHANGED

### DIFF
--- a/src/backend/orchestration/event-collector.orchestrator.test.ts
+++ b/src/backend/orchestration/event-collector.orchestrator.test.ts
@@ -537,14 +537,30 @@ describe('configureEventCollector', () => {
       workspaceId: string;
       fromStatus: string;
       toStatus: string;
+      workspace: {
+        projectId: string;
+        name: string;
+        branchName: string | null;
+        createdAt: Date;
+      };
     }) => void;
 
-    handler({ workspaceId: 'ws-1', fromStatus: 'NEW', toStatus: 'READY' });
+    handler({
+      workspaceId: 'ws-1',
+      fromStatus: 'NEW',
+      toStatus: 'READY',
+      workspace: {
+        projectId: 'proj-1',
+        name: 'ws',
+        branchName: null,
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      },
+    });
 
     expect(workspaceSnapshotStore.upsert).toHaveBeenCalledTimes(1);
     expect(workspaceSnapshotStore.upsert).toHaveBeenCalledWith(
       'ws-1',
-      { status: 'READY' },
+      expect.objectContaining({ status: 'READY' }),
       'event:workspace_state_changed'
     );
   });
@@ -971,12 +987,24 @@ describe('configureEventCollector', () => {
       workspaceId: string;
       fromStatus: string;
       toStatus: string;
+      workspace: {
+        projectId: string;
+        name: string;
+        branchName: string | null;
+        createdAt: Date;
+      };
     }) => void;
 
     handler({
       workspaceId: 'ws-1',
       fromStatus: 'NEW',
       toStatus: 'READY',
+      workspace: {
+        projectId: 'proj-1',
+        name: 'ws',
+        branchName: null,
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      },
     });
 
     expect(workspaceSnapshotStore.upsert).toHaveBeenCalledTimes(1);
@@ -987,7 +1015,7 @@ describe('configureEventCollector', () => {
     expect(workspaceSnapshotStore.upsert).toHaveBeenCalledTimes(1);
     expect(workspaceSnapshotStore.upsert).toHaveBeenCalledWith(
       'ws-1',
-      { status: 'READY' },
+      expect.objectContaining({ status: 'READY' }),
       'event:workspace_state_changed'
     );
   });

--- a/src/backend/orchestration/event-collector.orchestrator.test.ts
+++ b/src/backend/orchestration/event-collector.orchestrator.test.ts
@@ -549,6 +549,94 @@ describe('configureEventCollector', () => {
     );
   });
 
+  it('workspace event with re-read row includes co-updated snapshot fields in the upsert', () => {
+    vi.mocked(workspaceSnapshotStore.getByWorkspaceId).mockReturnValue({
+      projectId: 'proj-1',
+    } as ReturnType<typeof workspaceSnapshotStore.getByWorkspaceId>);
+
+    configureEventCollector();
+
+    const onCall = vi
+      .mocked(workspaceStateMachine.on)
+      .mock.calls.find((call) => call[0] === 'workspace_state_changed');
+    const handler = onCall![1] as (event: {
+      workspaceId: string;
+      fromStatus: string;
+      toStatus: string;
+      workspace: {
+        projectId: string;
+        name: string;
+        branchName: string | null;
+        createdAt: Date;
+      } | null;
+    }) => void;
+
+    handler({
+      workspaceId: 'ws-1',
+      fromStatus: 'PROVISIONING',
+      toStatus: 'READY',
+      workspace: {
+        projectId: 'proj-1',
+        name: 'My workspace',
+        branchName: 'feature/test',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      },
+    });
+
+    expect(workspaceSnapshotStore.upsert).toHaveBeenCalledWith(
+      'ws-1',
+      {
+        status: 'READY',
+        projectId: 'proj-1',
+        name: 'My workspace',
+        branchName: 'feature/test',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+      'event:workspace_state_changed'
+    );
+  });
+
+  it('workspace event with re-read row seeds a workspace unknown to the store', () => {
+    vi.mocked(workspaceSnapshotStore.getByWorkspaceId).mockReturnValue(undefined);
+
+    configureEventCollector();
+
+    const onCall = vi
+      .mocked(workspaceStateMachine.on)
+      .mock.calls.find((call) => call[0] === 'workspace_state_changed');
+    const handler = onCall![1] as (event: {
+      workspaceId: string;
+      fromStatus: string;
+      toStatus: string;
+      workspace: {
+        projectId: string;
+        name: string;
+        branchName: string | null;
+        createdAt: Date;
+      } | null;
+    }) => void;
+
+    handler({
+      workspaceId: 'ws-new',
+      fromStatus: 'NEW',
+      toStatus: 'PROVISIONING',
+      workspace: {
+        projectId: 'proj-1',
+        name: 'Fresh workspace',
+        branchName: null,
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      },
+    });
+
+    // projectId from the row lets the coalescer seed the entry instead of
+    // skipping the upsert while waiting for reconciliation.
+    expect(workspaceSnapshotStore.upsert).toHaveBeenCalledWith(
+      'ws-new',
+      expect.objectContaining({ status: 'PROVISIONING', projectId: 'proj-1' }),
+      'event:workspace_state_changed'
+    );
+  });
+
   it('ratchet_state_changed is applied immediately', () => {
     vi.mocked(workspaceSnapshotStore.getByWorkspaceId).mockReturnValue({
       projectId: 'proj-1',

--- a/src/backend/orchestration/event-collector.orchestrator.ts
+++ b/src/backend/orchestration/event-collector.orchestrator.ts
@@ -370,19 +370,20 @@ async function refreshWorkspaceSessionSummariesForSession(
  * forward the snapshot-relevant fields co-updated in the transition (e.g.
  * branchName on READY) from the re-read row, so they don't wait for the next
  * reconciliation pass. Carrying projectId also lets the coalescer seed
- * workspaces the store doesn't know yet. hasHadSessions is deliberately
- * excluded: the session-activity path sets it optimistically in the store and
- * a lagging DB row must not downgrade it.
+ * workspaces the store doesn't know yet; the state machine suppresses
+ * superseded events, so this cannot re-seed an entry a newer ARCHIVED event
+ * removed. hasHadSessions is deliberately excluded: the session-activity path
+ * sets it optimistically in the store and a lagging DB row must not
+ * downgrade it.
  */
 function buildWorkspaceStateChangeFields(event: WorkspaceStateChangedEvent): SnapshotUpdateInput {
-  const fields: SnapshotUpdateInput = { status: event.toStatus };
-  if (event.workspace) {
-    fields.projectId = event.workspace.projectId;
-    fields.name = event.workspace.name;
-    fields.branchName = event.workspace.branchName;
-    fields.createdAt = event.workspace.createdAt.toISOString();
-  }
-  return fields;
+  return {
+    status: event.toStatus,
+    projectId: event.workspace.projectId,
+    name: event.workspace.name,
+    branchName: event.workspace.branchName,
+    createdAt: event.workspace.createdAt.toISOString(),
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/backend/orchestration/event-collector.orchestrator.ts
+++ b/src/backend/orchestration/event-collector.orchestrator.ts
@@ -365,6 +365,26 @@ async function refreshWorkspaceSessionSummariesForSession(
   }
 }
 
+/**
+ * Build the snapshot update for a workspace state change. Beyond the status,
+ * forward the snapshot-relevant fields co-updated in the transition (e.g.
+ * branchName on READY) from the re-read row, so they don't wait for the next
+ * reconciliation pass. Carrying projectId also lets the coalescer seed
+ * workspaces the store doesn't know yet. hasHadSessions is deliberately
+ * excluded: the session-activity path sets it optimistically in the store and
+ * a lagging DB row must not downgrade it.
+ */
+function buildWorkspaceStateChangeFields(event: WorkspaceStateChangedEvent): SnapshotUpdateInput {
+  const fields: SnapshotUpdateInput = { status: event.toStatus };
+  if (event.workspace) {
+    fields.projectId = event.workspace.projectId;
+    fields.name = event.workspace.name;
+    fields.branchName = event.workspace.branchName;
+    fields.createdAt = event.workspace.createdAt.toISOString();
+  }
+  return fields;
+}
+
 // ---------------------------------------------------------------------------
 // Linear state sync on PR merge
 // ---------------------------------------------------------------------------
@@ -482,7 +502,7 @@ function configureEventCollectorWithState(
     }
     coalescer.enqueue(
       event.workspaceId,
-      { status: event.toStatus },
+      buildWorkspaceStateChangeFields(event),
       'event:workspace_state_changed',
       { immediate: true }
     );

--- a/src/backend/services/workspace/service/lifecycle/state-machine.service.test.ts
+++ b/src/backend/services/workspace/service/lifecycle/state-machine.service.test.ts
@@ -827,6 +827,67 @@ describe('WorkspaceStateMachineService', () => {
       expect(events[0]?.workspace).toEqual(updatedWorkspace);
     });
 
+    it('includes the re-read workspace row on startProvisioningFromReady', async () => {
+      const workspace = { id: 'ws-1', status: 'READY', initRetryCount: 0 };
+      const updatedWorkspace = { ...workspace, status: 'PROVISIONING', initRetryCount: 1 };
+
+      mockFindUnique.mockResolvedValueOnce(workspace).mockResolvedValueOnce(updatedWorkspace);
+      mockUpdateMany.mockResolvedValue({ count: 1 });
+
+      const events: WorkspaceStateChangedEvent[] = [];
+      workspaceStateMachine.on(WORKSPACE_STATE_CHANGED, (event: WorkspaceStateChangedEvent) => {
+        events.push(event);
+      });
+
+      await workspaceStateMachine.startProvisioningFromReady('ws-1');
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({
+        workspaceId: 'ws-1',
+        fromStatus: 'READY',
+        toStatus: 'PROVISIONING',
+        workspace: updatedWorkspace,
+      });
+    });
+
+    it('does NOT emit when the transition was superseded before the re-read', async () => {
+      const workspace = { id: 'ws-1', status: 'PROVISIONING' };
+      // Another transition (READY -> ARCHIVING) committed between our CAS and
+      // the re-read: the row no longer reflects this transition's target.
+      const supersededWorkspace = { ...workspace, status: 'ARCHIVING' };
+
+      mockFindUnique.mockResolvedValue(workspace);
+      mockUpdateMany.mockResolvedValue({ count: 1 });
+      mockFindUniqueOrThrow.mockResolvedValue(supersededWorkspace);
+
+      const events: WorkspaceStateChangedEvent[] = [];
+      workspaceStateMachine.on(WORKSPACE_STATE_CHANGED, (event: WorkspaceStateChangedEvent) => {
+        events.push(event);
+      });
+
+      await workspaceStateMachine.transition('ws-1', 'READY');
+
+      expect(events).toHaveLength(0);
+    });
+
+    it('does NOT emit on startProvisioning retry when the re-read finds no row', async () => {
+      const workspace = { id: 'ws-1', status: 'FAILED', initRetryCount: 0 };
+
+      mockFindUnique
+        .mockResolvedValueOnce(workspace) // Status check
+        .mockResolvedValueOnce(null); // Workspace deleted after the update
+      mockUpdateMany.mockResolvedValue({ count: 1 });
+
+      const events: WorkspaceStateChangedEvent[] = [];
+      workspaceStateMachine.on(WORKSPACE_STATE_CHANGED, (event: WorkspaceStateChangedEvent) => {
+        events.push(event);
+      });
+
+      await workspaceStateMachine.startProvisioning('ws-1');
+
+      expect(events).toHaveLength(0);
+    });
+
     it('does NOT emit on CAS failure', async () => {
       const workspace = { id: 'ws-1', status: 'PROVISIONING' };
 

--- a/src/backend/services/workspace/service/lifecycle/state-machine.service.test.ts
+++ b/src/backend/services/workspace/service/lifecycle/state-machine.service.test.ts
@@ -767,7 +767,64 @@ describe('WorkspaceStateMachineService', () => {
         workspaceId: 'ws-1',
         fromStatus: 'PROVISIONING',
         toStatus: 'READY',
+        workspace: updatedWorkspace,
       });
+    });
+
+    it('includes the re-read workspace row in the emitted event', async () => {
+      const workspace = { id: 'ws-1', status: 'PROVISIONING' };
+      const updatedWorkspace = { ...workspace, status: 'READY', branchName: 'feature/test' };
+
+      mockFindUnique.mockResolvedValue(workspace);
+      mockUpdateMany.mockResolvedValue({ count: 1 });
+      mockFindUniqueOrThrow.mockResolvedValue(updatedWorkspace);
+
+      const events: WorkspaceStateChangedEvent[] = [];
+      workspaceStateMachine.on(WORKSPACE_STATE_CHANGED, (event: WorkspaceStateChangedEvent) => {
+        events.push(event);
+      });
+
+      await workspaceStateMachine.transition('ws-1', 'READY', { branchName: 'feature/test' });
+
+      expect(events).toHaveLength(1);
+      expect(events[0]?.workspace).toEqual(updatedWorkspace);
+    });
+
+    it('includes the re-read workspace row on startProvisioning retry', async () => {
+      const workspace = { id: 'ws-1', status: 'FAILED', initRetryCount: 0 };
+      const updatedWorkspace = { ...workspace, status: 'PROVISIONING', initRetryCount: 1 };
+
+      mockFindUnique.mockResolvedValueOnce(workspace).mockResolvedValueOnce(updatedWorkspace);
+      mockUpdateMany.mockResolvedValue({ count: 1 });
+
+      const events: WorkspaceStateChangedEvent[] = [];
+      workspaceStateMachine.on(WORKSPACE_STATE_CHANGED, (event: WorkspaceStateChangedEvent) => {
+        events.push(event);
+      });
+
+      await workspaceStateMachine.startProvisioning('ws-1');
+
+      expect(events).toHaveLength(1);
+      expect(events[0]?.workspace).toEqual(updatedWorkspace);
+    });
+
+    it('includes the re-read workspace row on startArchivingWithSourceStatus', async () => {
+      const workspace = { id: 'ws-1', status: 'READY' };
+      const updatedWorkspace = { ...workspace, status: 'ARCHIVING' };
+
+      mockFindUnique.mockResolvedValue(workspace);
+      mockUpdateMany.mockResolvedValue({ count: 1 });
+      mockFindUniqueOrThrow.mockResolvedValue(updatedWorkspace);
+
+      const events: WorkspaceStateChangedEvent[] = [];
+      workspaceStateMachine.on(WORKSPACE_STATE_CHANGED, (event: WorkspaceStateChangedEvent) => {
+        events.push(event);
+      });
+
+      await workspaceStateMachine.startArchivingWithSourceStatus('ws-1');
+
+      expect(events).toHaveLength(1);
+      expect(events[0]?.workspace).toEqual(updatedWorkspace);
     });
 
     it('does NOT emit on CAS failure', async () => {
@@ -825,6 +882,7 @@ describe('WorkspaceStateMachineService', () => {
         workspaceId: 'ws-1',
         fromStatus: 'FAILED',
         toStatus: 'PROVISIONING',
+        workspace: updatedWorkspace,
       });
     });
 
@@ -864,6 +922,7 @@ describe('WorkspaceStateMachineService', () => {
         workspaceId: 'ws-1',
         fromStatus: 'FAILED',
         toStatus: 'NEW',
+        workspace: updatedWorkspace,
       });
     });
 

--- a/src/backend/services/workspace/service/lifecycle/state-machine.service.ts
+++ b/src/backend/services/workspace/service/lifecycle/state-machine.service.ts
@@ -74,12 +74,13 @@ export interface WorkspaceStateChangedEvent {
   fromStatus: WorkspaceStatus;
   toStatus: WorkspaceStatus;
   /**
-   * The workspace row re-read after the transition committed. Carries fields
-   * co-updated with the status (e.g. branchName) so consumers don't have to
-   * wait for the next reconciliation pass. Null only if the re-read found no
-   * row (workspace deleted concurrently).
+   * The workspace row re-read after the transition committed, guaranteed to
+   * still reflect toStatus. Carries fields co-updated with the status (e.g.
+   * branchName) so consumers don't have to wait for the next reconciliation
+   * pass. Emission is suppressed entirely when the re-read shows the row was
+   * deleted or superseded by a later transition (which announces itself).
    */
-  workspace: Workspace | null;
+  workspace: Workspace;
 }
 
 export interface StartProvisioningOptions {
@@ -176,6 +177,38 @@ class WorkspaceStateMachineService extends EventEmitter {
   }
 
   /**
+   * Emit WORKSPACE_STATE_CHANGED only when the re-read row still reflects the
+   * committed transition. If the row is gone (deleted concurrently) or already
+   * shows a later transition's status, this event is stale: the superseding
+   * transition emits its own event with the newer state, and emitting here
+   * could resurrect snapshot state that the newer event already cleared
+   * (e.g. re-seeding a snapshot entry removed by an ARCHIVED event).
+   */
+  private emitStateChanged(
+    workspaceId: string,
+    fromStatus: WorkspaceStatus,
+    toStatus: WorkspaceStatus,
+    workspace: Workspace | null
+  ): void {
+    if (!workspace || workspace.status !== toStatus) {
+      logger.debug('Suppressing superseded workspace_state_changed emit', {
+        workspaceId,
+        fromStatus,
+        toStatus,
+        rereadStatus: workspace?.status ?? null,
+      });
+      return;
+    }
+
+    this.emit(WORKSPACE_STATE_CHANGED, {
+      workspaceId,
+      fromStatus,
+      toStatus,
+      workspace,
+    } satisfies WorkspaceStateChangedEvent);
+  }
+
+  /**
    * Transition a workspace to a new status with validation.
    * Uses compare-and-swap to prevent race conditions.
    *
@@ -226,12 +259,7 @@ class WorkspaceStateMachineService extends EventEmitter {
     // Re-read workspace after successful CAS update
     const updated = await workspaceAccessor.findRawByIdOrThrow(workspaceId);
 
-    this.emit(WORKSPACE_STATE_CHANGED, {
-      workspaceId,
-      fromStatus: currentStatus,
-      toStatus: targetStatus,
-      workspace: updated,
-    } satisfies WorkspaceStateChangedEvent);
+    this.emitStateChanged(workspaceId, currentStatus, targetStatus, updated);
 
     logger.debug('Workspace status transitioned', {
       workspaceId,
@@ -287,12 +315,7 @@ class WorkspaceStateMachineService extends EventEmitter {
 
       const updated = await workspaceAccessor.findRawById(workspaceId);
 
-      this.emit(WORKSPACE_STATE_CHANGED, {
-        workspaceId,
-        fromStatus: 'FAILED' as WorkspaceStatus,
-        toStatus: 'PROVISIONING' as WorkspaceStatus,
-        workspace: updated,
-      } satisfies WorkspaceStateChangedEvent);
+      this.emitStateChanged(workspaceId, 'FAILED', 'PROVISIONING', updated);
 
       logger.debug('Workspace retry started', {
         workspaceId,
@@ -365,12 +388,7 @@ class WorkspaceStateMachineService extends EventEmitter {
 
     const updated = await workspaceAccessor.findRawByIdOrThrow(workspaceId);
 
-    this.emit(WORKSPACE_STATE_CHANGED, {
-      workspaceId,
-      fromStatus: currentStatus,
-      toStatus: 'ARCHIVING',
-      workspace: updated,
-    } satisfies WorkspaceStateChangedEvent);
+    this.emitStateChanged(workspaceId, currentStatus, 'ARCHIVING', updated);
 
     logger.debug('Workspace status transitioned', {
       workspaceId,
@@ -449,12 +467,7 @@ class WorkspaceStateMachineService extends EventEmitter {
 
     const updated = await workspaceAccessor.findRawById(workspaceId);
 
-    this.emit(WORKSPACE_STATE_CHANGED, {
-      workspaceId,
-      fromStatus: 'READY' as WorkspaceStatus,
-      toStatus: 'PROVISIONING' as WorkspaceStatus,
-      workspace: updated,
-    } satisfies WorkspaceStateChangedEvent);
+    this.emitStateChanged(workspaceId, 'READY', 'PROVISIONING', updated);
 
     logger.debug('Workspace setup script retry started from READY+warning', {
       workspaceId,
@@ -499,12 +512,7 @@ class WorkspaceStateMachineService extends EventEmitter {
 
     const updated = await workspaceAccessor.findRawById(workspaceId);
 
-    this.emit(WORKSPACE_STATE_CHANGED, {
-      workspaceId,
-      fromStatus: 'FAILED' as WorkspaceStatus,
-      toStatus: 'NEW' as WorkspaceStatus,
-      workspace: updated,
-    } satisfies WorkspaceStateChangedEvent);
+    this.emitStateChanged(workspaceId, 'FAILED', 'NEW', updated);
 
     logger.debug('Workspace reset to NEW for retry', {
       workspaceId,

--- a/src/backend/services/workspace/service/lifecycle/state-machine.service.ts
+++ b/src/backend/services/workspace/service/lifecycle/state-machine.service.ts
@@ -73,6 +73,13 @@ export interface WorkspaceStateChangedEvent {
   workspaceId: string;
   fromStatus: WorkspaceStatus;
   toStatus: WorkspaceStatus;
+  /**
+   * The workspace row re-read after the transition committed. Carries fields
+   * co-updated with the status (e.g. branchName) so consumers don't have to
+   * wait for the next reconciliation pass. Null only if the re-read found no
+   * row (workspace deleted concurrently).
+   */
+  workspace: Workspace | null;
 }
 
 export interface StartProvisioningOptions {
@@ -223,6 +230,7 @@ class WorkspaceStateMachineService extends EventEmitter {
       workspaceId,
       fromStatus: currentStatus,
       toStatus: targetStatus,
+      workspace: updated,
     } satisfies WorkspaceStateChangedEvent);
 
     logger.debug('Workspace status transitioned', {
@@ -283,6 +291,7 @@ class WorkspaceStateMachineService extends EventEmitter {
         workspaceId,
         fromStatus: 'FAILED' as WorkspaceStatus,
         toStatus: 'PROVISIONING' as WorkspaceStatus,
+        workspace: updated,
       } satisfies WorkspaceStateChangedEvent);
 
       logger.debug('Workspace retry started', {
@@ -360,6 +369,7 @@ class WorkspaceStateMachineService extends EventEmitter {
       workspaceId,
       fromStatus: currentStatus,
       toStatus: 'ARCHIVING',
+      workspace: updated,
     } satisfies WorkspaceStateChangedEvent);
 
     logger.debug('Workspace status transitioned', {
@@ -443,6 +453,7 @@ class WorkspaceStateMachineService extends EventEmitter {
       workspaceId,
       fromStatus: 'READY' as WorkspaceStatus,
       toStatus: 'PROVISIONING' as WorkspaceStatus,
+      workspace: updated,
     } satisfies WorkspaceStateChangedEvent);
 
     logger.debug('Workspace setup script retry started from READY+warning', {
@@ -492,6 +503,7 @@ class WorkspaceStateMachineService extends EventEmitter {
       workspaceId,
       fromStatus: 'FAILED' as WorkspaceStatus,
       toStatus: 'NEW' as WorkspaceStatus,
+      workspace: updated,
     } satisfies WorkspaceStateChangedEvent);
 
     logger.debug('Workspace reset to NEW for retry', {


### PR DESCRIPTION
Fixes #1884.

## Problem

Workspace state transitions emitted only `toStatus` in `WORKSPACE_STATE_CHANGED`, and the event collector upserted only `{status}` into the snapshot store. Fields co-updated in the same transition — most importantly `branchName` on PROVISIONING→READY — reached connected clients only via the 60s snapshot reconciliation loop, a built-in up-to-one-minute UI staleness window.

## Change

- `WorkspaceStateChangedEvent` now carries the workspace row re-read after the CAS update (`workspace: Workspace | null`; null only if the re-read found no row). All five emit sites populate it — the state machine already performed the re-read, so no extra queries.
- The event collector's non-ARCHIVED handler forwards the snapshot-relevant fields from the row (`branchName`, `name`, `createdAt`, `projectId`) alongside `status`.
- Side benefit: carrying `projectId` lets a transition seed a store entry for a workspace the store doesn't know yet, instead of the coalescer skipping the upsert until the next reconciliation pass.
- `hasHadSessions` is deliberately **not** forwarded from the row: the session-activity path sets it optimistically in the store, and both live in the same field-timestamp group, so a lagging DB row would downgrade it.

## Tests

- New: emitted event includes the re-read row (`transition`, `startProvisioning` retry, `startArchivingWithSourceStatus`); collector upsert includes the co-updated fields; collector seeds unknown workspaces when the row is present.
- Updated: existing exact-shape event assertions extended with the new field.
- Ran `pnpm test` (one unrelated pre-existing flake in `src/backend/lib/shell.test.ts` under full-suite load; passes in isolation and also flakes on `main`), `pnpm typecheck`, `pnpm check`, `pnpm check:fix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core workspace lifecycle events and snapshot coalescing; supersede logic reduces race risk, but incorrect field forwarding could still skew live UI state until reconciliation.
> 
> **Overview**
> **`WORKSPACE_STATE_CHANGED` now includes the post-CAS workspace row**, and emission is skipped when the re-read is missing or already superseded by a later status—avoiding stale events that could resurrect snapshot state after archive.
> 
> The event collector upserts **status plus snapshot fields from that row** (`branchName`, `name`, `createdAt`, `projectId`) on non-ARCHIVED transitions, so co-updated fields (e.g. branch on PROVISIONING→READY) reach clients immediately instead of waiting on reconciliation. **`hasHadSessions` is not copied** from the DB row to avoid downgrading optimistic session-activity updates.
> 
> Tests cover the new event shape, suppressed emits, collector field forwarding, and seeding unknown workspaces via `projectId`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0afe1215ee09d3d8fd34b2305bee3d0b5d7cba7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

