### PR TITLE
Fix #1885: Persist-first delivery for parent/child workspace messages

### DIFF
--- a/src/backend/orchestration/workspace-children.orchestrator.test.ts
+++ b/src/backend/orchestration/workspace-children.orchestrator.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Module mocks (before imports) ---
+
+vi.mock('@/backend/services/session', () => ({
+  sessionDataService: {
+    createAgentSession: vi.fn(),
+  },
+  sessionProviderResolverService: {
+    resolveProviderForWorkspaceCreation: vi.fn(),
+  },
+}));
+
+vi.mock('@/backend/services/workspace', () => ({
+  projectAccessor: {
+    findById: vi.fn(),
+  },
+  WorkspaceCreationService: class {
+    create = vi.fn();
+  },
+  workspaceAccessor: {
+    findByIdWithProject: vi.fn(),
+    findRawById: vi.fn(),
+  },
+  workspaceNotificationAccessor: {
+    create: vi.fn(),
+  },
+}));
+
+vi.mock('./workspace-init.orchestrator', () => ({
+  initializeWorkspaceWorktree: vi.fn(),
+}));
+
+import { workspaceAccessor, workspaceNotificationAccessor } from '@/backend/services/workspace';
+import {
+  persistChildNotification,
+  persistParentNotification,
+} from './workspace-children.orchestrator';
+
+const mockFindByIdWithProject = vi.mocked(workspaceAccessor.findByIdWithProject);
+const mockFindRawById = vi.mocked(workspaceAccessor.findRawById);
+const mockNotificationCreate = vi.mocked(workspaceNotificationAccessor.create);
+
+describe('persistChildNotification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates and returns the notification row', async () => {
+    mockFindByIdWithProject.mockResolvedValue({
+      id: 'child-1',
+      name: 'Child WS',
+      project: { name: 'Child Project' },
+    } as never);
+    mockFindRawById.mockResolvedValue({ id: 'parent-1' } as never);
+    const createdNotification = { id: 'notif-1', message: 'hello' };
+    mockNotificationCreate.mockResolvedValue(createdNotification as never);
+
+    const result = await persistChildNotification({
+      parentWorkspaceId: 'parent-1',
+      sourceWorkspaceId: 'child-1',
+      message: 'hello',
+    });
+
+    expect(mockNotificationCreate).toHaveBeenCalledWith({
+      workspaceId: 'parent-1',
+      sourceWorkspaceId: 'child-1',
+      sourceWorkspaceName: 'Child WS',
+      sourceProjectName: 'Child Project',
+      message: 'hello',
+    });
+    expect(result).toBe(createdNotification);
+  });
+
+  it('returns null without creating when a workspace is missing', async () => {
+    mockFindByIdWithProject.mockResolvedValue(null as never);
+    mockFindRawById.mockResolvedValue({ id: 'parent-1' } as never);
+
+    const result = await persistChildNotification({
+      parentWorkspaceId: 'parent-1',
+      sourceWorkspaceId: 'child-1',
+      message: 'hello',
+    });
+
+    expect(mockNotificationCreate).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+});
+
+describe('persistParentNotification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates and returns the notification row', async () => {
+    mockFindByIdWithProject.mockResolvedValue({
+      id: 'parent-1',
+      name: 'Parent WS',
+      project: { name: 'Parent Project' },
+    } as never);
+    mockFindRawById.mockResolvedValue({ id: 'child-1' } as never);
+    const createdNotification = { id: 'notif-2', message: 'do this' };
+    mockNotificationCreate.mockResolvedValue(createdNotification as never);
+
+    const result = await persistParentNotification({
+      parentWorkspaceId: 'parent-1',
+      targetChildWorkspaceId: 'child-1',
+      message: 'do this',
+    });
+
+    expect(mockNotificationCreate).toHaveBeenCalledWith({
+      workspaceId: 'child-1',
+      sourceWorkspaceId: 'parent-1',
+      sourceWorkspaceName: 'Parent WS',
+      sourceProjectName: 'Parent Project',
+      message: 'do this',
+      direction: 'PARENT_TO_CHILD',
+    });
+    expect(result).toBe(createdNotification);
+  });
+
+  it('returns null without creating when a workspace is missing', async () => {
+    mockFindByIdWithProject.mockResolvedValue({
+      id: 'parent-1',
+      name: 'Parent WS',
+      project: { name: 'Parent Project' },
+    } as never);
+    mockFindRawById.mockResolvedValue(null as never);
+
+    const result = await persistParentNotification({
+      parentWorkspaceId: 'parent-1',
+      targetChildWorkspaceId: 'child-1',
+      message: 'do this',
+    });
+
+    expect(mockNotificationCreate).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+});

--- a/src/backend/orchestration/workspace-children.orchestrator.ts
+++ b/src/backend/orchestration/workspace-children.orchestrator.ts
@@ -1,3 +1,4 @@
+import type { WorkspaceNotification } from '@prisma-gen/client';
 import { TRPCError } from '@trpc/server';
 import { DEFAULT_FOLLOWUP } from '@/backend/prompts/workflows';
 import { createLogger } from '@/backend/services/logger.service';
@@ -77,17 +78,19 @@ export async function createChildWorkspace(input: CreateChildWorkspaceInput): Pr
 }
 
 /**
- * Deliver a notification from a child workspace to the parent.
+ * Persist a notification from a child workspace to the parent.
  *
- * If the parent workspace has an active/idle agent session the notification will be
- * injected live by the caller (tRPC sendMessageToParent). If it does not, this
- * persists the notification so it is delivered when the parent's next session starts.
+ * Always writes a WorkspaceNotification row so the message survives even if a
+ * live delivery attempt races a dying session. Callers that deliver live mark
+ * the row delivered after a successful dispatch; otherwise it is delivered when
+ * the parent's next session starts. Returns the created row, or null if either
+ * workspace no longer exists.
  */
 export async function persistChildNotification(input: {
   parentWorkspaceId: string;
   sourceWorkspaceId: string;
   message: string;
-}): Promise<void> {
+}): Promise<WorkspaceNotification | null> {
   const [sourceWorkspace, parentWorkspace] = await Promise.all([
     workspaceAccessor.findByIdWithProject(input.sourceWorkspaceId),
     workspaceAccessor.findRawById(input.parentWorkspaceId),
@@ -95,10 +98,10 @@ export async function persistChildNotification(input: {
 
   if (!(sourceWorkspace && parentWorkspace)) {
     logger.warn('persistChildNotification: workspace not found', input);
-    return;
+    return null;
   }
 
-  await workspaceNotificationAccessor.create({
+  return workspaceNotificationAccessor.create({
     workspaceId: input.parentWorkspaceId,
     sourceWorkspaceId: input.sourceWorkspaceId,
     sourceWorkspaceName: sourceWorkspace.name,
@@ -108,17 +111,19 @@ export async function persistChildNotification(input: {
 }
 
 /**
- * Deliver a notification from a parent workspace to a specific child.
+ * Persist a notification from a parent workspace to a specific child.
  *
- * If the child workspace has an active/idle agent session the notification will be
- * injected live by the caller (tRPC sendMessageToChild). If it does not, this
- * persists the notification so it is delivered when the child's next session starts.
+ * Always writes a WorkspaceNotification row so the message survives even if a
+ * live delivery attempt races a dying session. Callers that deliver live mark
+ * the row delivered after a successful dispatch; otherwise it is delivered when
+ * the child's next session starts. Returns the created row, or null if either
+ * workspace no longer exists.
  */
 export async function persistParentNotification(input: {
   parentWorkspaceId: string;
   targetChildWorkspaceId: string;
   message: string;
-}): Promise<void> {
+}): Promise<WorkspaceNotification | null> {
   const [parentWorkspace, childWorkspace] = await Promise.all([
     workspaceAccessor.findByIdWithProject(input.parentWorkspaceId),
     workspaceAccessor.findRawById(input.targetChildWorkspaceId),
@@ -126,10 +131,10 @@ export async function persistParentNotification(input: {
 
   if (!(parentWorkspace && childWorkspace)) {
     logger.warn('persistParentNotification: workspace not found', input);
-    return;
+    return null;
   }
 
-  await workspaceNotificationAccessor.create({
+  return workspaceNotificationAccessor.create({
     workspaceId: input.targetChildWorkspaceId,
     sourceWorkspaceId: input.parentWorkspaceId,
     sourceWorkspaceName: parentWorkspace.name,

--- a/src/backend/services/session/service/chat/chat-message-handlers.service.test.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers.service.test.ts
@@ -413,6 +413,134 @@ describe('chatMessageHandlerService.tryDispatchNextMessage', () => {
     expect(mockWorkspaceNotificationAccessor.markDelivered).toHaveBeenCalledWith(['notif-parent']);
   });
 
+  it('retries a pending notification on another session after the claiming session is reset', async () => {
+    const client = {
+      isCompactingActive: vi.fn().mockReturnValue(false),
+      startCompaction: vi.fn(),
+      endCompaction: vi.fn(),
+      setMaxThinkingTokens: vi.fn().mockResolvedValue(undefined),
+    };
+    const notificationMessage = {
+      ...queuedMessage,
+      id: 'workspace-notification-notif-parent',
+    };
+    chatMessageHandlerService.resetDispatchState('s2');
+    mockSessionService.getSessionClient.mockReturnValue(client);
+    mockWorkspaceNotificationAccessor.findById.mockResolvedValue({
+      id: 'notif-parent',
+      deliveredAt: null,
+    });
+    const sendResolvers: Array<() => void> = [];
+    mockSessionService.sendSessionMessage.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          sendResolvers.push(() => resolve());
+        })
+    );
+    const queues: Record<string, QueuedMessage[]> = {
+      s1: [notificationMessage],
+      s2: [notificationMessage],
+    };
+    mockSessionDomainService.peekNextMessage.mockImplementation(
+      (sessionId: string) => queues[sessionId]?.[0]
+    );
+    mockSessionDomainService.dequeueNext.mockImplementation((sessionId: string) =>
+      queues[sessionId]?.shift()
+    );
+    mockSessionDomainService.removeQueuedMessage.mockImplementation((sessionId: string) => {
+      queues[sessionId]?.shift();
+      return true;
+    });
+
+    // Session 1 starts delivering and hangs in send.
+    const hungDispatch = chatMessageHandlerService.tryDispatchNextMessage('s1');
+    await vi.waitFor(() => {
+      expect(mockSessionService.sendSessionMessage).toHaveBeenCalledTimes(1);
+    });
+
+    // The session is stopped/reset while the send is still hung.
+    chatMessageHandlerService.resetDispatchState('s1');
+
+    // A later session must be able to deliver the still-pending notification.
+    const retryDispatch = chatMessageHandlerService.tryDispatchNextMessage('s2');
+    await vi.waitFor(() => {
+      expect(mockSessionService.sendSessionMessage).toHaveBeenCalledTimes(2);
+    });
+
+    for (const resolveSend of sendResolvers) {
+      resolveSend();
+    }
+    await Promise.all([hungDispatch, retryDispatch]);
+  });
+
+  it('does not release another session claim when a stale dispatch settles', async () => {
+    const client = {
+      isCompactingActive: vi.fn().mockReturnValue(false),
+      startCompaction: vi.fn(),
+      endCompaction: vi.fn(),
+      setMaxThinkingTokens: vi.fn().mockResolvedValue(undefined),
+    };
+    const notificationMessage = {
+      ...queuedMessage,
+      id: 'workspace-notification-notif-parent',
+    };
+    chatMessageHandlerService.resetDispatchState('s2');
+    chatMessageHandlerService.resetDispatchState('s3');
+    mockSessionService.getSessionClient.mockReturnValue(client);
+    mockWorkspaceNotificationAccessor.findById.mockResolvedValue({
+      id: 'notif-parent',
+      deliveredAt: null,
+    });
+    const sendSettlers: Array<{ reject: (error: Error) => void; resolve: () => void }> = [];
+    mockSessionService.sendSessionMessage.mockImplementation(
+      () =>
+        new Promise<void>((resolve, reject) => {
+          sendSettlers.push({ resolve: () => resolve(), reject });
+        })
+    );
+    const queues: Record<string, QueuedMessage[]> = {
+      s1: [notificationMessage],
+      s2: [notificationMessage],
+      s3: [notificationMessage],
+    };
+    mockSessionDomainService.peekNextMessage.mockImplementation(
+      (sessionId: string) => queues[sessionId]?.[0]
+    );
+    mockSessionDomainService.dequeueNext.mockImplementation((sessionId: string) =>
+      queues[sessionId]?.shift()
+    );
+    mockSessionDomainService.removeQueuedMessage.mockImplementation((sessionId: string) => {
+      queues[sessionId]?.shift();
+      return true;
+    });
+
+    // Session 1 hangs in send, then gets reset; session 2 claims the retry.
+    const staleDispatch = chatMessageHandlerService.tryDispatchNextMessage('s1');
+    await vi.waitFor(() => {
+      expect(mockSessionService.sendSessionMessage).toHaveBeenCalledTimes(1);
+    });
+    chatMessageHandlerService.resetDispatchState('s1');
+    const retryDispatch = chatMessageHandlerService.tryDispatchNextMessage('s2');
+    await vi.waitFor(() => {
+      expect(mockSessionService.sendSessionMessage).toHaveBeenCalledTimes(2);
+    });
+
+    // The stale session-1 send settles; it must not evict session 2's claim.
+    sendSettlers[0]?.reject(new Error('session stopped'));
+    await staleDispatch;
+
+    // Session 3 holds a duplicate copy; session 2 is still delivering, so it drops.
+    await chatMessageHandlerService.tryDispatchNextMessage('s3');
+    expect(mockSessionService.sendSessionMessage).toHaveBeenCalledTimes(2);
+    expect(mockSessionDomainService.removeQueuedMessage).toHaveBeenCalledWith(
+      's3',
+      'workspace-notification-notif-parent'
+    );
+
+    sendSettlers[1]?.resolve();
+    await retryDispatch;
+  });
+
   it('dispatches a workspace notification whose row is still pending', async () => {
     const client = {
       isCompactingActive: vi.fn().mockReturnValue(false),

--- a/src/backend/services/session/service/chat/chat-message-handlers.service.test.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers.service.test.ts
@@ -19,6 +19,7 @@ const {
     commitSentUserMessageAtOrder: vi.fn(),
     removeTranscriptMessageById: vi.fn(),
     getQueueLength: vi.fn(),
+    getTranscriptSnapshot: vi.fn(),
   },
   mockSessionService: {
     getClient: vi.fn(),
@@ -37,6 +38,7 @@ const {
   },
   mockWorkspaceNotificationAccessor: {
     markDelivered: vi.fn(),
+    findById: vi.fn(),
   },
 }));
 
@@ -92,6 +94,8 @@ describe('chatMessageHandlerService.tryDispatchNextMessage', () => {
     mockSessionService.setSessionReasoningEffort.mockResolvedValue(undefined);
     mockSessionService.sendSessionMessage.mockResolvedValue(undefined);
     mockWorkspaceNotificationAccessor.markDelivered.mockResolvedValue(undefined);
+    mockWorkspaceNotificationAccessor.findById.mockResolvedValue(null);
+    mockSessionDomainService.getTranscriptSnapshot.mockReturnValue([]);
     mockSessionService.isSessionWorking.mockReturnValue(false);
     mockSessionService.isSessionRunning.mockReturnValue(true);
     mockSessionService.isSessionStopping.mockReturnValue(false);
@@ -280,6 +284,82 @@ describe('chatMessageHandlerService.tryDispatchNextMessage', () => {
     mockSessionService.getSessionClient.mockReturnValue(client);
     mockSessionDomainService.peekNextMessage.mockReturnValue(notificationMessage);
     mockSessionDomainService.dequeueNext.mockReturnValue(notificationMessage);
+
+    await chatMessageHandlerService.tryDispatchNextMessage('s1');
+
+    expect(mockSessionService.sendSessionMessage).toHaveBeenCalledWith('s1', 'hello');
+    expect(mockWorkspaceNotificationAccessor.markDelivered).toHaveBeenCalledWith(['notif-parent']);
+  });
+
+  it('drops a workspace notification already committed to the transcript', async () => {
+    const client = {
+      isCompactingActive: vi.fn().mockReturnValue(false),
+      startCompaction: vi.fn(),
+      endCompaction: vi.fn(),
+      setMaxThinkingTokens: vi.fn().mockResolvedValue(undefined),
+    };
+    const notificationMessage = {
+      ...queuedMessage,
+      id: 'workspace-notification-notif-parent',
+    };
+    mockSessionService.getSessionClient.mockReturnValue(client);
+    mockSessionDomainService.peekNextMessage.mockReturnValue(notificationMessage);
+    mockSessionDomainService.dequeueNext.mockReturnValue(notificationMessage);
+    mockSessionDomainService.getTranscriptSnapshot.mockReturnValue([
+      { source: 'user', id: 'workspace-notification-notif-parent', text: 'hello' },
+    ]);
+
+    await chatMessageHandlerService.tryDispatchNextMessage('s1');
+
+    expect(mockSessionService.sendSessionMessage).not.toHaveBeenCalled();
+    expect(mockSessionDomainService.markRunning).not.toHaveBeenCalled();
+    expect(mockSessionDomainService.commitSentUserMessageAtOrder).not.toHaveBeenCalled();
+  });
+
+  it('drops a workspace notification whose row is already marked delivered', async () => {
+    const client = {
+      isCompactingActive: vi.fn().mockReturnValue(false),
+      startCompaction: vi.fn(),
+      endCompaction: vi.fn(),
+      setMaxThinkingTokens: vi.fn().mockResolvedValue(undefined),
+    };
+    const notificationMessage = {
+      ...queuedMessage,
+      id: 'workspace-notification-notif-parent',
+    };
+    mockSessionService.getSessionClient.mockReturnValue(client);
+    mockSessionDomainService.peekNextMessage.mockReturnValue(notificationMessage);
+    mockSessionDomainService.dequeueNext.mockReturnValue(notificationMessage);
+    mockWorkspaceNotificationAccessor.findById.mockResolvedValue({
+      id: 'notif-parent',
+      deliveredAt: new Date('2026-02-01T00:00:00.000Z'),
+    });
+
+    await chatMessageHandlerService.tryDispatchNextMessage('s1');
+
+    expect(mockWorkspaceNotificationAccessor.findById).toHaveBeenCalledWith('notif-parent');
+    expect(mockSessionService.sendSessionMessage).not.toHaveBeenCalled();
+    expect(mockSessionDomainService.markRunning).not.toHaveBeenCalled();
+  });
+
+  it('dispatches a workspace notification whose row is still pending', async () => {
+    const client = {
+      isCompactingActive: vi.fn().mockReturnValue(false),
+      startCompaction: vi.fn(),
+      endCompaction: vi.fn(),
+      setMaxThinkingTokens: vi.fn().mockResolvedValue(undefined),
+    };
+    const notificationMessage = {
+      ...queuedMessage,
+      id: 'workspace-notification-notif-parent',
+    };
+    mockSessionService.getSessionClient.mockReturnValue(client);
+    mockSessionDomainService.peekNextMessage.mockReturnValue(notificationMessage);
+    mockSessionDomainService.dequeueNext.mockReturnValue(notificationMessage);
+    mockWorkspaceNotificationAccessor.findById.mockResolvedValue({
+      id: 'notif-parent',
+      deliveredAt: null,
+    });
 
     await chatMessageHandlerService.tryDispatchNextMessage('s1');
 

--- a/src/backend/services/session/service/chat/chat-message-handlers.service.test.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers.service.test.ts
@@ -18,6 +18,7 @@ const {
     emitDelta: vi.fn(),
     commitSentUserMessageAtOrder: vi.fn(),
     removeTranscriptMessageById: vi.fn(),
+    removeQueuedMessage: vi.fn(),
     getQueueLength: vi.fn(),
     getTranscriptSnapshot: vi.fn(),
   },
@@ -96,6 +97,7 @@ describe('chatMessageHandlerService.tryDispatchNextMessage', () => {
     mockWorkspaceNotificationAccessor.markDelivered.mockResolvedValue(undefined);
     mockWorkspaceNotificationAccessor.findById.mockResolvedValue(null);
     mockSessionDomainService.getTranscriptSnapshot.mockReturnValue([]);
+    mockSessionDomainService.removeQueuedMessage.mockReturnValue(true);
     mockSessionService.isSessionWorking.mockReturnValue(false);
     mockSessionService.isSessionRunning.mockReturnValue(true);
     mockSessionService.isSessionStopping.mockReturnValue(false);
@@ -291,7 +293,7 @@ describe('chatMessageHandlerService.tryDispatchNextMessage', () => {
     expect(mockWorkspaceNotificationAccessor.markDelivered).toHaveBeenCalledWith(['notif-parent']);
   });
 
-  it('drops a workspace notification already committed to the transcript', async () => {
+  it('drops a duplicate notification and dispatches the next queued message', async () => {
     const client = {
       isCompactingActive: vi.fn().mockReturnValue(false),
       startCompaction: vi.fn(),
@@ -303,17 +305,25 @@ describe('chatMessageHandlerService.tryDispatchNextMessage', () => {
       id: 'workspace-notification-notif-parent',
     };
     mockSessionService.getSessionClient.mockReturnValue(client);
-    mockSessionDomainService.peekNextMessage.mockReturnValue(notificationMessage);
-    mockSessionDomainService.dequeueNext.mockReturnValue(notificationMessage);
+    // Duplicate at the head of the queue, a regular message behind it.
+    mockSessionDomainService.peekNextMessage
+      .mockReturnValueOnce(notificationMessage)
+      .mockReturnValue(queuedMessage);
     mockSessionDomainService.getTranscriptSnapshot.mockReturnValue([
       { source: 'user', id: 'workspace-notification-notif-parent', text: 'hello' },
     ]);
 
     await chatMessageHandlerService.tryDispatchNextMessage('s1');
 
-    expect(mockSessionService.sendSessionMessage).not.toHaveBeenCalled();
-    expect(mockSessionDomainService.markRunning).not.toHaveBeenCalled();
-    expect(mockSessionDomainService.commitSentUserMessageAtOrder).not.toHaveBeenCalled();
+    // The duplicate is removed with a queue-state update, not silently dequeued.
+    expect(mockSessionDomainService.removeQueuedMessage).toHaveBeenCalledWith(
+      's1',
+      'workspace-notification-notif-parent'
+    );
+    // The message behind the duplicate still dispatches in the same pass.
+    expect(mockSessionService.sendSessionMessage).toHaveBeenCalledTimes(1);
+    expect(mockSessionService.sendSessionMessage).toHaveBeenCalledWith('s1', 'hello');
+    expect(mockWorkspaceNotificationAccessor.markDelivered).not.toHaveBeenCalled();
   });
 
   it('drops a workspace notification whose row is already marked delivered', async () => {
@@ -328,8 +338,9 @@ describe('chatMessageHandlerService.tryDispatchNextMessage', () => {
       id: 'workspace-notification-notif-parent',
     };
     mockSessionService.getSessionClient.mockReturnValue(client);
-    mockSessionDomainService.peekNextMessage.mockReturnValue(notificationMessage);
-    mockSessionDomainService.dequeueNext.mockReturnValue(notificationMessage);
+    mockSessionDomainService.peekNextMessage
+      .mockReturnValueOnce(notificationMessage)
+      .mockReturnValue(undefined);
     mockWorkspaceNotificationAccessor.findById.mockResolvedValue({
       id: 'notif-parent',
       deliveredAt: new Date('2026-02-01T00:00:00.000Z'),
@@ -338,8 +349,68 @@ describe('chatMessageHandlerService.tryDispatchNextMessage', () => {
     await chatMessageHandlerService.tryDispatchNextMessage('s1');
 
     expect(mockWorkspaceNotificationAccessor.findById).toHaveBeenCalledWith('notif-parent');
+    expect(mockSessionDomainService.removeQueuedMessage).toHaveBeenCalledWith(
+      's1',
+      'workspace-notification-notif-parent'
+    );
     expect(mockSessionService.sendSessionMessage).not.toHaveBeenCalled();
     expect(mockSessionDomainService.markRunning).not.toHaveBeenCalled();
+  });
+
+  it('drops a duplicate while another session is delivering the same notification', async () => {
+    const client = {
+      isCompactingActive: vi.fn().mockReturnValue(false),
+      startCompaction: vi.fn(),
+      endCompaction: vi.fn(),
+      setMaxThinkingTokens: vi.fn().mockResolvedValue(undefined),
+    };
+    const notificationMessage = {
+      ...queuedMessage,
+      id: 'workspace-notification-notif-parent',
+    };
+    chatMessageHandlerService.resetDispatchState('s2');
+    mockSessionService.getSessionClient.mockReturnValue(client);
+    mockWorkspaceNotificationAccessor.findById.mockResolvedValue({
+      id: 'notif-parent',
+      deliveredAt: null,
+    });
+    let resolveSend!: () => void;
+    mockSessionService.sendSessionMessage.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSend = () => resolve();
+        })
+    );
+    const s2Queue: QueuedMessage[] = [notificationMessage];
+    mockSessionDomainService.peekNextMessage.mockImplementation((sessionId: string) =>
+      sessionId === 's2' ? s2Queue[0] : notificationMessage
+    );
+    mockSessionDomainService.dequeueNext.mockReturnValue(notificationMessage);
+    mockSessionDomainService.removeQueuedMessage.mockImplementation((sessionId: string) => {
+      if (sessionId === 's2') {
+        s2Queue.shift();
+      }
+      return true;
+    });
+
+    // Session 1 starts delivering the notification and blocks in send.
+    const firstDispatch = chatMessageHandlerService.tryDispatchNextMessage('s1');
+    await vi.waitFor(() => {
+      expect(mockSessionService.sendSessionMessage).toHaveBeenCalledTimes(1);
+    });
+
+    // Session 2 holds a copy of the same notification; it must not send it again.
+    await chatMessageHandlerService.tryDispatchNextMessage('s2');
+
+    expect(mockSessionService.sendSessionMessage).toHaveBeenCalledTimes(1);
+    expect(mockSessionDomainService.removeQueuedMessage).toHaveBeenCalledWith(
+      's2',
+      'workspace-notification-notif-parent'
+    );
+
+    resolveSend();
+    await firstDispatch;
+    expect(mockWorkspaceNotificationAccessor.markDelivered).toHaveBeenCalledWith(['notif-parent']);
   });
 
   it('dispatches a workspace notification whose row is still pending', async () => {

--- a/src/backend/services/session/service/chat/chat-message-handlers.service.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers.service.ts
@@ -478,6 +478,14 @@ class ChatMessageHandlerService {
     client: unknown,
     stopGeneration: number
   ): Promise<void> {
+    if (await this.isWorkspaceNotificationAlreadyDelivered(dbSessionId, msg.id)) {
+      logger.info('[Chat WS] Dropping already-delivered workspace notification', {
+        dbSessionId,
+        messageId: msg.id,
+      });
+      return;
+    }
+
     const isCompactCommand = this.isCompactCommand(msg.text);
     const compactionClient = isClaudeCompactionClient(client) ? client : null;
 
@@ -553,6 +561,46 @@ class ChatMessageHandlerService {
         messageId: msg.id,
         remainingInQueue: sessionDomainService.getQueueLength(dbSessionId),
       });
+    }
+  }
+
+  /**
+   * Persist-first delivery can enqueue the same workspace notification twice
+   * (a live send racing session-startup delivery). Dispatch is serialized per
+   * session, so dropping duplicates here — already committed to this session's
+   * transcript, or already marked delivered by another session — guarantees the
+   * agent sees each notification at most once.
+   */
+  private async isWorkspaceNotificationAlreadyDelivered(
+    dbSessionId: string,
+    messageId: string
+  ): Promise<boolean> {
+    if (!messageId.startsWith(WORKSPACE_NOTIFICATION_MESSAGE_ID_PREFIX)) {
+      return false;
+    }
+    const notificationId = messageId.slice(WORKSPACE_NOTIFICATION_MESSAGE_ID_PREFIX.length);
+    if (!notificationId) {
+      return false;
+    }
+
+    const alreadyCommitted = sessionDomainService
+      .getTranscriptSnapshot(dbSessionId)
+      .some((entry) => entry.source === 'user' && entry.id === messageId);
+    if (alreadyCommitted) {
+      return true;
+    }
+
+    try {
+      const notification = await workspaceNotificationAccessor.findById(notificationId);
+      return notification?.deliveredAt != null;
+    } catch (error) {
+      logger.warn('[Chat WS] Failed to check workspace notification delivery state', {
+        dbSessionId,
+        messageId,
+        error: this.formatDispatchError(error),
+      });
+      // Fail open: a duplicate delivery is better than a lost message.
+      return false;
     }
   }
 

--- a/src/backend/services/session/service/chat/chat-message-handlers.service.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers.service.ts
@@ -95,12 +95,14 @@ class ChatMessageHandlerService {
   private turnInProgressRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private turnInProgressRetryAttempts = new Map<string, number>();
   /**
-   * Workspace notifications currently being delivered by some session. Claimed
-   * synchronously before dispatch so a concurrent dispatch of a duplicate copy
-   * (persist-first delivery can enqueue the same notification on two sessions)
-   * drops instead of double-sending. Released once the send settles.
+   * Workspace notifications currently being delivered, keyed by notification id
+   * with the owning session as value. Claimed synchronously before dispatch so a
+   * concurrent dispatch of a duplicate copy (persist-first delivery can enqueue
+   * the same notification on two sessions) drops instead of double-sending.
+   * Released once the send settles, or when the owning session is reset — a hung
+   * send must not block redelivery of a still-pending notification forever.
    */
-  private inFlightNotificationDeliveries = new Set<string>();
+  private inFlightNotificationDeliveries = new Map<string, string>();
 
   /** Client creator function - injected to avoid circular dependencies */
   private clientCreator: ClientCreator | null = null;
@@ -152,6 +154,11 @@ class ChatMessageHandlerService {
   resetDispatchState(sessionId: string): void {
     this.dispatchInProgress.delete(sessionId);
     this.clearTurnInProgressRetry(sessionId);
+    for (const [notificationId, ownerSessionId] of this.inFlightNotificationDeliveries) {
+      if (ownerSessionId === sessionId) {
+        this.inFlightNotificationDeliveries.delete(notificationId);
+      }
+    }
   }
 
   private isDispatchInProgress(dbSessionId: string): boolean {
@@ -250,8 +257,19 @@ class ChatMessageHandlerService {
       return 'done';
     } finally {
       if (claim.status === 'claimed') {
-        this.inFlightNotificationDeliveries.delete(claim.notificationId);
+        this.releaseNotificationClaim(dbSessionId, claim.notificationId);
       }
+    }
+  }
+
+  /**
+   * Release a notification claim, but only if this session still owns it — a
+   * reset may have transferred the claim to another session's retry while a
+   * stale dispatch was hung in send.
+   */
+  private releaseNotificationClaim(dbSessionId: string, notificationId: string): void {
+    if (this.inFlightNotificationDeliveries.get(notificationId) === dbSessionId) {
+      this.inFlightNotificationDeliveries.delete(notificationId);
     }
   }
 
@@ -275,7 +293,7 @@ class ChatMessageHandlerService {
     ) {
       return { status: 'duplicate' };
     }
-    this.inFlightNotificationDeliveries.add(notificationId);
+    this.inFlightNotificationDeliveries.set(notificationId, dbSessionId);
     return { status: 'claimed', notificationId };
   }
 

--- a/src/backend/services/session/service/chat/chat-message-handlers.service.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers.service.ts
@@ -94,6 +94,13 @@ class ChatMessageHandlerService {
   /** Retry timers for provider-side busy responses that are not reflected locally yet. */
   private turnInProgressRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private turnInProgressRetryAttempts = new Map<string, number>();
+  /**
+   * Workspace notifications currently being delivered by some session. Claimed
+   * synchronously before dispatch so a concurrent dispatch of a duplicate copy
+   * (persist-first delivery can enqueue the same notification on two sessions)
+   * drops instead of double-sending. Released once the send settles.
+   */
+  private inFlightNotificationDeliveries = new Set<string>();
 
   /** Client creator function - injected to avoid circular dependencies */
   private clientCreator: ClientCreator | null = null;
@@ -201,45 +208,111 @@ class ChatMessageHandlerService {
     const dispatchToken = this.reserveDispatchToken(dbSessionId);
 
     try {
-      // Peek first — message stays in queue (visible in snapshots during auto-start).
-      const peeked = sessionDomainService.peekNextMessage(dbSessionId);
-      if (!peeked) {
-        this.turnInProgressRetryAttempts.delete(dbSessionId);
-        return;
-      }
-
-      const dispatchGate = await this.evaluateDispatchGateSafely(dbSessionId);
-      if (!this.isDispatchGenerationCurrent(dbSessionId, stopGeneration)) {
-        return;
-      }
-      if (dispatchGate.policy !== 'allowed') {
-        this.handleBlockedDispatchGate(dbSessionId, dispatchGate);
-        return;
-      }
-
-      const clientResult = await this.resolveClientForDispatch(dbSessionId, peeked);
-      if (!clientResult) {
-        return;
-      }
-
-      if (!this.isDispatchGenerationCurrent(dbSessionId, stopGeneration)) {
-        return;
-      }
-
-      // NOW dequeue — client is ready, we're about to dispatch.
-      const msg = sessionDomainService.dequeueNext(dbSessionId, { emitSnapshot: false });
-      if (!msg) {
-        return;
-      }
-
-      try {
-        await this.dispatchMessage(dbSessionId, msg, clientResult.client, stopGeneration);
-        this.turnInProgressRetryAttempts.delete(dbSessionId);
-      } catch (error) {
-        this.handleDispatchError(dbSessionId, msg, error, stopGeneration);
+      // Loop: a dropped duplicate notification advances to the next queued message.
+      let outcome: 'continue' | 'done' = 'continue';
+      while (outcome === 'continue') {
+        outcome = await this.dispatchHeadOfQueue(dbSessionId, stopGeneration);
       }
     } finally {
       this.releaseDispatchToken(dbSessionId, dispatchToken);
+    }
+  }
+
+  /**
+   * Examine the head of the queue: drop it if it is a duplicate workspace
+   * notification ('continue' — caller should examine the new head), otherwise
+   * dispatch it ('done').
+   */
+  private async dispatchHeadOfQueue(
+    dbSessionId: string,
+    stopGeneration: number
+  ): Promise<'continue' | 'done'> {
+    // Peek first — message stays in queue (visible in snapshots during auto-start).
+    const peeked = sessionDomainService.peekNextMessage(dbSessionId);
+    if (!peeked) {
+      this.turnInProgressRetryAttempts.delete(dbSessionId);
+      return 'done';
+    }
+
+    const claim = this.claimNotificationForDispatch(dbSessionId, peeked.id);
+    if (claim.status === 'duplicate') {
+      return this.dropDuplicateNotification(dbSessionId, peeked.id) ? 'continue' : 'done';
+    }
+
+    try {
+      if (
+        claim.status === 'claimed' &&
+        (await this.isNotificationRowDelivered(claim.notificationId))
+      ) {
+        return this.dropDuplicateNotification(dbSessionId, peeked.id) ? 'continue' : 'done';
+      }
+      await this.dispatchPeekedMessage(dbSessionId, peeked, stopGeneration);
+      return 'done';
+    } finally {
+      if (claim.status === 'claimed') {
+        this.inFlightNotificationDeliveries.delete(claim.notificationId);
+      }
+    }
+  }
+
+  /**
+   * Persist-first delivery can enqueue the same workspace notification twice
+   * (a live send racing session-startup delivery). Claim the notification
+   * synchronously — no awaits between the duplicate checks and the claim —
+   * so concurrent dispatches on other sessions see it as in flight.
+   */
+  private claimNotificationForDispatch(
+    dbSessionId: string,
+    messageId: string
+  ): { status: 'none' } | { status: 'duplicate' } | { status: 'claimed'; notificationId: string } {
+    const notificationId = this.getWorkspaceNotificationId(messageId);
+    if (!notificationId) {
+      return { status: 'none' };
+    }
+    if (
+      this.inFlightNotificationDeliveries.has(notificationId) ||
+      this.isNotificationCommittedToTranscript(dbSessionId, messageId)
+    ) {
+      return { status: 'duplicate' };
+    }
+    this.inFlightNotificationDeliveries.add(notificationId);
+    return { status: 'claimed', notificationId };
+  }
+
+  private async dispatchPeekedMessage(
+    dbSessionId: string,
+    peeked: QueuedMessage,
+    stopGeneration: number
+  ): Promise<void> {
+    const dispatchGate = await this.evaluateDispatchGateSafely(dbSessionId);
+    if (!this.isDispatchGenerationCurrent(dbSessionId, stopGeneration)) {
+      return;
+    }
+    if (dispatchGate.policy !== 'allowed') {
+      this.handleBlockedDispatchGate(dbSessionId, dispatchGate);
+      return;
+    }
+
+    const clientResult = await this.resolveClientForDispatch(dbSessionId, peeked);
+    if (!clientResult) {
+      return;
+    }
+
+    if (!this.isDispatchGenerationCurrent(dbSessionId, stopGeneration)) {
+      return;
+    }
+
+    // NOW dequeue — client is ready, we're about to dispatch.
+    const msg = sessionDomainService.dequeueNext(dbSessionId, { emitSnapshot: false });
+    if (!msg) {
+      return;
+    }
+
+    try {
+      await this.dispatchMessage(dbSessionId, msg, clientResult.client, stopGeneration);
+      this.turnInProgressRetryAttempts.delete(dbSessionId);
+    } catch (error) {
+      this.handleDispatchError(dbSessionId, msg, error, stopGeneration);
     }
   }
 
@@ -478,14 +551,6 @@ class ChatMessageHandlerService {
     client: unknown,
     stopGeneration: number
   ): Promise<void> {
-    if (await this.isWorkspaceNotificationAlreadyDelivered(dbSessionId, msg.id)) {
-      logger.info('[Chat WS] Dropping already-delivered workspace notification', {
-        dbSessionId,
-        messageId: msg.id,
-      });
-      return;
-    }
-
     const isCompactCommand = this.isCompactCommand(msg.text);
     const compactionClient = isClaudeCompactionClient(client) ? client : null;
 
@@ -564,39 +629,27 @@ class ChatMessageHandlerService {
     }
   }
 
-  /**
-   * Persist-first delivery can enqueue the same workspace notification twice
-   * (a live send racing session-startup delivery). Dispatch is serialized per
-   * session, so dropping duplicates here — already committed to this session's
-   * transcript, or already marked delivered by another session — guarantees the
-   * agent sees each notification at most once.
-   */
-  private async isWorkspaceNotificationAlreadyDelivered(
-    dbSessionId: string,
-    messageId: string
-  ): Promise<boolean> {
+  private getWorkspaceNotificationId(messageId: string): string | null {
     if (!messageId.startsWith(WORKSPACE_NOTIFICATION_MESSAGE_ID_PREFIX)) {
-      return false;
+      return null;
     }
     const notificationId = messageId.slice(WORKSPACE_NOTIFICATION_MESSAGE_ID_PREFIX.length);
-    if (!notificationId) {
-      return false;
-    }
+    return notificationId || null;
+  }
 
-    const alreadyCommitted = sessionDomainService
+  private isNotificationCommittedToTranscript(dbSessionId: string, messageId: string): boolean {
+    return sessionDomainService
       .getTranscriptSnapshot(dbSessionId)
       .some((entry) => entry.source === 'user' && entry.id === messageId);
-    if (alreadyCommitted) {
-      return true;
-    }
+  }
 
+  private async isNotificationRowDelivered(notificationId: string): Promise<boolean> {
     try {
       const notification = await workspaceNotificationAccessor.findById(notificationId);
       return notification?.deliveredAt != null;
     } catch (error) {
       logger.warn('[Chat WS] Failed to check workspace notification delivery state', {
-        dbSessionId,
-        messageId,
+        notificationId,
         error: this.formatDispatchError(error),
       });
       // Fail open: a duplicate delivery is better than a lost message.
@@ -604,12 +657,21 @@ class ChatMessageHandlerService {
     }
   }
 
-  private async markWorkspaceNotificationDeliveredIfNeeded(messageId: string): Promise<void> {
-    if (!messageId.startsWith(WORKSPACE_NOTIFICATION_MESSAGE_ID_PREFIX)) {
-      return;
-    }
+  /**
+   * Remove a duplicate workspace notification from the queue, emitting a queue
+   * snapshot so the UI does not keep a phantom queued card. Returns false if the
+   * message was unexpectedly absent (caller should stop looping).
+   */
+  private dropDuplicateNotification(dbSessionId: string, messageId: string): boolean {
+    logger.info('[Chat WS] Dropping already-delivered workspace notification', {
+      dbSessionId,
+      messageId,
+    });
+    return sessionDomainService.removeQueuedMessage(dbSessionId, messageId);
+  }
 
-    const notificationId = messageId.slice(WORKSPACE_NOTIFICATION_MESSAGE_ID_PREFIX.length);
+  private async markWorkspaceNotificationDeliveredIfNeeded(messageId: string): Promise<void> {
+    const notificationId = this.getWorkspaceNotificationId(messageId);
     if (!notificationId) {
       return;
     }

--- a/src/backend/services/session/service/chat/chat-message-handlers.service.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers.service.ts
@@ -24,6 +24,7 @@ import {
   resolveSelectedModel,
 } from '@/shared/acp-protocol';
 import type { ChatMessageInput } from '@/shared/websocket';
+import { WORKSPACE_NOTIFICATION_MESSAGE_ID_PREFIX } from '@/shared/workspace-notifications';
 import {
   PermanentAttachmentError,
   processAttachmentsAndBuildContent,
@@ -35,7 +36,6 @@ import type { ClientCreator } from './chat-message-handlers/types';
 const logger = createLogger('chat-message-handlers');
 const TURN_IN_PROGRESS_RETRY_BASE_MS = 1000;
 const TURN_IN_PROGRESS_RETRY_MAX_MS = 30_000;
-const WORKSPACE_NOTIFICATION_MESSAGE_ID_PREFIX = 'workspace-notification-';
 
 // ============================================================================
 // Types

--- a/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
+++ b/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
@@ -27,6 +27,11 @@ import {
   createInitialSessionRuntimeState,
   type SessionRuntimeState,
 } from '@/shared/session-runtime';
+import {
+  buildWorkspaceNotificationMessageText,
+  WORKSPACE_NOTIFICATION_MESSAGE_ID_PREFIX,
+  workspaceNotificationMessageId,
+} from '@/shared/workspace-notifications';
 import type { AcpEventProcessor } from './acp-event-processor';
 import { closedSessionPersistenceService } from './closed-session-persistence.service';
 import type {
@@ -1116,12 +1121,11 @@ export class SessionLifecycleService {
       for (const notification of pending) {
         this.assertStartupAllowed(sessionId, stopGeneration);
         const timestamp = notification.createdAt.toISOString();
-        const messageId = `workspace-notification-${notification.id}`;
+        const messageId = workspaceNotificationMessageId(notification.id);
         if (this.sessionDomainService.hasQueuedMessage(sessionId, messageId)) {
           dispatchableCount += 1;
           continue;
         }
-        let enqueueText: string;
         let claudeMessage: AgentMessage;
         if (notification.direction === 'PARENT_TO_CHILD') {
           claudeMessage = {
@@ -1132,7 +1136,6 @@ export class SessionLifecycleService {
             text: notification.message,
             timestamp,
           };
-          enqueueText = `[Message from parent workspace "${notification.sourceWorkspaceName}"]: ${notification.message}`;
         } else {
           claudeMessage = {
             type: 'child_workspace_update' as const,
@@ -1142,9 +1145,8 @@ export class SessionLifecycleService {
             text: notification.message,
             timestamp,
           };
-          enqueueText = `[Message from child workspace "${notification.sourceWorkspaceName}"]: ${notification.message}`;
         }
-        enqueueText = `${enqueueText}\n\n<!-- factory-factory-workspace-notification:${notification.id} -->`;
+        const enqueueText = buildWorkspaceNotificationMessageText(notification);
         const alreadyDelivered = await this.markDeliveredIfTranscriptMatch(
           sessionId,
           workspaceId,
@@ -1222,7 +1224,7 @@ export class SessionLifecycleService {
     }
     const contentMatch = userEntries.find(
       (entry) =>
-        !entry.id.startsWith('workspace-notification-') &&
+        !entry.id.startsWith(WORKSPACE_NOTIFICATION_MESSAGE_ID_PREFIX) &&
         entry.text === messageText &&
         !consumedContentMatchIds.has(entry.id)
     );

--- a/src/backend/services/workspace/resources/workspace-notification.accessor.ts
+++ b/src/backend/services/workspace/resources/workspace-notification.accessor.ts
@@ -18,6 +18,10 @@ class WorkspaceNotificationAccessor {
     });
   }
 
+  findById(id: string): Promise<WorkspaceNotification | null> {
+    return prisma.workspaceNotification.findUnique({ where: { id } });
+  }
+
   /**
    * Find all undelivered notifications for a workspace, ordered oldest-first
    * so they are delivered in the order they were sent.

--- a/src/backend/trpc/workspace.router.test.ts
+++ b/src/backend/trpc/workspace.router.test.ts
@@ -43,6 +43,7 @@ const mockFindSessionsByWorkspaceId = vi.hoisted(() => vi.fn());
 const mockAppendClaudeEvent = vi.hoisted(() => vi.fn());
 const mockEmitDelta = vi.hoisted(() => vi.fn());
 const mockEnqueue = vi.hoisted(() => vi.fn());
+const mockHasQueuedMessage = vi.hoisted(() => vi.fn());
 const mockTryDispatchNextMessage = vi.hoisted(() => vi.fn());
 const mockPersistChildNotification = vi.hoisted(() => vi.fn());
 const mockPersistParentNotification = vi.hoisted(() => vi.fn());
@@ -73,6 +74,7 @@ vi.mock('@/backend/services/session', () => ({
     appendClaudeEvent: (...args: unknown[]) => mockAppendClaudeEvent(...args),
     emitDelta: (...args: unknown[]) => mockEmitDelta(...args),
     enqueue: (...args: unknown[]) => mockEnqueue(...args),
+    hasQueuedMessage: (...args: unknown[]) => mockHasQueuedMessage(...args),
   },
   sessionDataService: {
     createAgentSession: (...args: unknown[]) => mockCreateAgentSession(...args),
@@ -680,6 +682,7 @@ describe('workspaceRouter', () => {
       });
       mockAppendClaudeEvent.mockReturnValue(1);
       mockEnqueue.mockReturnValue({ position: 0 });
+      mockHasQueuedMessage.mockReturnValue(false);
       mockTryDispatchNextMessage.mockResolvedValue(undefined);
     });
 
@@ -741,6 +744,21 @@ describe('workspaceRouter', () => {
       expect(mockPersistChildNotification).toHaveBeenCalled();
       expect(mockTryDispatchNextMessage).not.toHaveBeenCalled();
     });
+
+    it('skips enqueue when session startup already queued the notification', async () => {
+      mockFindSessionsByWorkspaceId.mockResolvedValue([{ id: 'sess-1', status: 'RUNNING' }]);
+      mockHasQueuedMessage.mockReturnValue(true);
+
+      const { caller } = createCaller();
+      await expect(
+        caller.sendMessageToParent({ childWorkspaceId: 'child-1', message: 'hello' })
+      ).resolves.toEqual({ delivered: true });
+
+      expect(mockHasQueuedMessage).toHaveBeenCalledWith('sess-1', 'workspace-notification-notif-1');
+      expect(mockEnqueue).not.toHaveBeenCalled();
+      expect(mockAppendClaudeEvent).not.toHaveBeenCalled();
+      expect(mockEmitDelta).not.toHaveBeenCalled();
+    });
   });
 
   describe('sendMessageToChild', () => {
@@ -769,6 +787,7 @@ describe('workspaceRouter', () => {
       });
       mockAppendClaudeEvent.mockReturnValue(1);
       mockEnqueue.mockReturnValue({ position: 0 });
+      mockHasQueuedMessage.mockReturnValue(false);
       mockTryDispatchNextMessage.mockResolvedValue(undefined);
     });
 
@@ -824,6 +843,25 @@ describe('workspaceRouter', () => {
       });
       expect(mockEnqueue).not.toHaveBeenCalled();
       expect(mockTryDispatchNextMessage).not.toHaveBeenCalled();
+    });
+
+    it('skips enqueue when session startup already queued the notification', async () => {
+      mockFindSessionsByWorkspaceId.mockResolvedValue([{ id: 'sess-2', status: 'IDLE' }]);
+      mockHasQueuedMessage.mockReturnValue(true);
+
+      const { caller } = createCaller();
+      await expect(
+        caller.sendMessageToChild({
+          parentWorkspaceId: 'parent-1',
+          childWorkspaceId: 'child-1',
+          message: 'do this',
+        })
+      ).resolves.toEqual({ delivered: true });
+
+      expect(mockHasQueuedMessage).toHaveBeenCalledWith('sess-2', 'workspace-notification-notif-2');
+      expect(mockEnqueue).not.toHaveBeenCalled();
+      expect(mockAppendClaudeEvent).not.toHaveBeenCalled();
+      expect(mockEmitDelta).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/backend/trpc/workspace.router.test.ts
+++ b/src/backend/trpc/workspace.router.test.ts
@@ -38,10 +38,21 @@ const mockCreateAgentSession = vi.hoisted(() => vi.fn());
 const mockResolveProviderForWorkspaceCreation = vi.hoisted(() =>
   vi.fn(async (_explicitProvider?: unknown) => 'CLAUDE')
 );
+const mockFindByIdWithProject = vi.hoisted(() => vi.fn());
+const mockFindSessionsByWorkspaceId = vi.hoisted(() => vi.fn());
+const mockAppendClaudeEvent = vi.hoisted(() => vi.fn());
+const mockEmitDelta = vi.hoisted(() => vi.fn());
+const mockEnqueue = vi.hoisted(() => vi.fn());
+const mockTryDispatchNextMessage = vi.hoisted(() => vi.fn());
+const mockPersistChildNotification = vi.hoisted(() => vi.fn());
+const mockPersistParentNotification = vi.hoisted(() => vi.fn());
 
 vi.mock('@/backend/services/workspace', () => ({
   workspaceDataService: mockWorkspaceDataService,
   workspaceQueryService: mockWorkspaceQueryService,
+  workspaceAccessor: {
+    findByIdWithProject: (...args: unknown[]) => mockFindByIdWithProject(...args),
+  },
   workspaceActivityService: {
     clearWorkspace: (...args: unknown[]) => mockClearWorkspaceActivity(...args),
   },
@@ -59,6 +70,9 @@ vi.mock('@/backend/services/session', () => ({
   },
   sessionDomainService: {
     getAllPendingRequests: () => new Map(),
+    appendClaudeEvent: (...args: unknown[]) => mockAppendClaudeEvent(...args),
+    emitDelta: (...args: unknown[]) => mockEmitDelta(...args),
+    enqueue: (...args: unknown[]) => mockEnqueue(...args),
   },
   sessionDataService: {
     createAgentSession: (...args: unknown[]) => mockCreateAgentSession(...args),
@@ -66,6 +80,12 @@ vi.mock('@/backend/services/session', () => ({
   sessionProviderResolverService: {
     resolveProviderForWorkspaceCreation: (explicitProvider?: unknown) =>
       mockResolveProviderForWorkspaceCreation(explicitProvider),
+  },
+  agentSessionAccessor: {
+    findByWorkspaceId: (...args: unknown[]) => mockFindSessionsByWorkspaceId(...args),
+  },
+  chatMessageHandlerService: {
+    tryDispatchNextMessage: (...args: unknown[]) => mockTryDispatchNextMessage(...args),
   },
 }));
 
@@ -93,6 +113,13 @@ vi.mock('@/backend/orchestration/workspace-archive.orchestrator', () => ({
 
 vi.mock('@/backend/orchestration/workspace-init.orchestrator', () => ({
   initializeWorkspaceWorktree: (...args: unknown[]) => mockInitializeWorkspaceWorktree(...args),
+}));
+
+vi.mock('@/backend/orchestration/workspace-children.orchestrator', () => ({
+  createChildWorkspace: vi.fn(),
+  fireLifecycleNotification: vi.fn(),
+  persistChildNotification: (...args: unknown[]) => mockPersistChildNotification(...args),
+  persistParentNotification: (...args: unknown[]) => mockPersistParentNotification(...args),
 }));
 
 vi.mock('./workspace/workspace-helpers', () => ({
@@ -633,5 +660,170 @@ describe('workspaceRouter', () => {
     expect(runScriptService.evictWorkspaceBuffers).not.toHaveBeenCalled();
     expect(terminalService.destroyWorkspaceTerminals).toHaveBeenCalledWith('w1');
     expect(mockWorkspaceDataService.delete).not.toHaveBeenCalled();
+  });
+
+  describe('sendMessageToParent', () => {
+    const child = {
+      id: 'child-1',
+      name: 'Child WS',
+      parentWorkspaceId: 'parent-1',
+      project: { name: 'Child Project' },
+    };
+
+    beforeEach(() => {
+      mockFindByIdWithProject.mockResolvedValue(child);
+      mockPersistChildNotification.mockResolvedValue({
+        id: 'notif-1',
+        direction: 'CHILD_TO_PARENT',
+        sourceWorkspaceName: 'Child WS',
+        message: 'hello',
+      });
+      mockAppendClaudeEvent.mockReturnValue(1);
+      mockEnqueue.mockReturnValue({ position: 0 });
+      mockTryDispatchNextMessage.mockResolvedValue(undefined);
+    });
+
+    it('persists the notification before live delivery to an active session', async () => {
+      mockFindSessionsByWorkspaceId.mockResolvedValue([{ id: 'sess-1', status: 'RUNNING' }]);
+
+      const { caller } = createCaller();
+      await expect(
+        caller.sendMessageToParent({ childWorkspaceId: 'child-1', message: 'hello' })
+      ).resolves.toEqual({ delivered: true });
+
+      expect(mockPersistChildNotification).toHaveBeenCalledWith({
+        parentWorkspaceId: 'parent-1',
+        sourceWorkspaceId: 'child-1',
+        message: 'hello',
+      });
+      expect(mockEnqueue).toHaveBeenCalledWith(
+        'sess-1',
+        expect.objectContaining({
+          id: 'workspace-notification-notif-1',
+          text: `[Message from child workspace "Child WS"]: hello\n\n<!-- factory-factory-workspace-notification:notif-1 -->`,
+        })
+      );
+      expect(mockTryDispatchNextMessage).toHaveBeenCalledWith('sess-1');
+      const persistOrder = mockPersistChildNotification.mock.invocationCallOrder[0];
+      const enqueueOrder = mockEnqueue.mock.invocationCallOrder[0];
+      if (persistOrder === undefined || enqueueOrder === undefined) {
+        throw new Error('Expected both persist and enqueue to be called');
+      }
+      expect(persistOrder).toBeLessThan(enqueueOrder);
+    });
+
+    it('persists the notification and skips live delivery when no active session', async () => {
+      mockFindSessionsByWorkspaceId.mockResolvedValue([{ id: 'sess-1', status: 'STOPPED' }]);
+
+      const { caller } = createCaller();
+      await expect(
+        caller.sendMessageToParent({ childWorkspaceId: 'child-1', message: 'hello' })
+      ).resolves.toEqual({ delivered: false });
+
+      expect(mockPersistChildNotification).toHaveBeenCalledWith({
+        parentWorkspaceId: 'parent-1',
+        sourceWorkspaceId: 'child-1',
+        message: 'hello',
+      });
+      expect(mockEnqueue).not.toHaveBeenCalled();
+      expect(mockTryDispatchNextMessage).not.toHaveBeenCalled();
+    });
+
+    it('leaves the notification pending when live enqueue fails', async () => {
+      mockFindSessionsByWorkspaceId.mockResolvedValue([{ id: 'sess-1', status: 'RUNNING' }]);
+      mockEnqueue.mockReturnValue({ error: 'queue full' });
+
+      const { caller } = createCaller();
+      await expect(
+        caller.sendMessageToParent({ childWorkspaceId: 'child-1', message: 'hello' })
+      ).resolves.toEqual({ delivered: false });
+
+      expect(mockPersistChildNotification).toHaveBeenCalled();
+      expect(mockTryDispatchNextMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('sendMessageToChild', () => {
+    const child = {
+      id: 'child-1',
+      name: 'Child WS',
+      parentWorkspaceId: 'parent-1',
+      project: { name: 'Child Project' },
+    };
+    const parent = {
+      id: 'parent-1',
+      name: 'Parent WS',
+      parentWorkspaceId: null,
+      project: { name: 'Parent Project' },
+    };
+
+    beforeEach(() => {
+      mockFindByIdWithProject.mockImplementation(async (id: unknown) =>
+        id === 'child-1' ? child : parent
+      );
+      mockPersistParentNotification.mockResolvedValue({
+        id: 'notif-2',
+        direction: 'PARENT_TO_CHILD',
+        sourceWorkspaceName: 'Parent WS',
+        message: 'do this',
+      });
+      mockAppendClaudeEvent.mockReturnValue(1);
+      mockEnqueue.mockReturnValue({ position: 0 });
+      mockTryDispatchNextMessage.mockResolvedValue(undefined);
+    });
+
+    it('persists the notification before live delivery to an active session', async () => {
+      mockFindSessionsByWorkspaceId.mockResolvedValue([{ id: 'sess-2', status: 'IDLE' }]);
+
+      const { caller } = createCaller();
+      await expect(
+        caller.sendMessageToChild({
+          parentWorkspaceId: 'parent-1',
+          childWorkspaceId: 'child-1',
+          message: 'do this',
+        })
+      ).resolves.toEqual({ delivered: true });
+
+      expect(mockPersistParentNotification).toHaveBeenCalledWith({
+        parentWorkspaceId: 'parent-1',
+        targetChildWorkspaceId: 'child-1',
+        message: 'do this',
+      });
+      expect(mockEnqueue).toHaveBeenCalledWith(
+        'sess-2',
+        expect.objectContaining({
+          id: 'workspace-notification-notif-2',
+          text: `[Message from parent workspace "Parent WS"]: do this\n\n<!-- factory-factory-workspace-notification:notif-2 -->`,
+        })
+      );
+      expect(mockTryDispatchNextMessage).toHaveBeenCalledWith('sess-2');
+      const persistOrder = mockPersistParentNotification.mock.invocationCallOrder[0];
+      const enqueueOrder = mockEnqueue.mock.invocationCallOrder[0];
+      if (persistOrder === undefined || enqueueOrder === undefined) {
+        throw new Error('Expected both persist and enqueue to be called');
+      }
+      expect(persistOrder).toBeLessThan(enqueueOrder);
+    });
+
+    it('persists the notification and skips live delivery when no active session', async () => {
+      mockFindSessionsByWorkspaceId.mockResolvedValue([]);
+
+      const { caller } = createCaller();
+      await expect(
+        caller.sendMessageToChild({
+          parentWorkspaceId: 'parent-1',
+          childWorkspaceId: 'child-1',
+          message: 'do this',
+        })
+      ).resolves.toEqual({ delivered: false });
+
+      expect(mockPersistParentNotification).toHaveBeenCalledWith({
+        parentWorkspaceId: 'parent-1',
+        targetChildWorkspaceId: 'child-1',
+        message: 'do this',
+      });
+      expect(mockEnqueue).not.toHaveBeenCalled();
+      expect(mockTryDispatchNextMessage).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/backend/trpc/workspace.trpc.ts
+++ b/src/backend/trpc/workspace.trpc.ts
@@ -616,9 +616,16 @@ export const workspaceRouter = router({
         return { delivered: false };
       }
 
+      // Session startup delivery may have already queued this notification
+      // (persist above races deliverPendingChildNotifications on a starting session).
+      const messageId = workspaceNotificationMessageId(notification.id);
+      if (sessionDomainService.hasQueuedMessage(activeSession.id, messageId)) {
+        return { delivered: true };
+      }
+
       // Enqueue as a user message so the parent agent acts on it
       const enqueueResult = sessionDomainService.enqueue(activeSession.id, {
-        id: workspaceNotificationMessageId(notification.id),
+        id: messageId,
         text: buildWorkspaceNotificationMessageText(notification),
         timestamp: new Date().toISOString(),
         settings: {
@@ -704,9 +711,16 @@ export const workspaceRouter = router({
         return { delivered: false };
       }
 
+      // Session startup delivery may have already queued this notification
+      // (persist above races deliverPendingChildNotifications on a starting session).
+      const messageId = workspaceNotificationMessageId(notification.id);
+      if (sessionDomainService.hasQueuedMessage(activeSession.id, messageId)) {
+        return { delivered: true };
+      }
+
       // Enqueue as a user message so the child agent acts on it
       const enqueueResult = sessionDomainService.enqueue(activeSession.id, {
-        id: workspaceNotificationMessageId(notification.id),
+        id: messageId,
         text: buildWorkspaceNotificationMessageText(notification),
         timestamp: new Date().toISOString(),
         settings: {

--- a/src/backend/trpc/workspace.trpc.ts
+++ b/src/backend/trpc/workspace.trpc.ts
@@ -45,6 +45,10 @@ import { KanbanColumn, WorkspaceStatus } from '@/shared/core';
 import { autoIterationConfigSchema } from '@/shared/schemas/auto-iteration.schema';
 import { findWorkspaceSessionRuntimeError } from '@/shared/session-runtime';
 import { AttachmentSchema } from '@/shared/websocket';
+import {
+  buildWorkspaceNotificationMessageText,
+  workspaceNotificationMessageId,
+} from '@/shared/workspace-notifications';
 import { deriveWorkspaceSidebarStatus } from '@/shared/workspace-sidebar-status';
 import { type Context, publicProcedure, router, trustedLocalProcedure } from './trpc';
 import { workspaceFilesRouter } from './workspace/files.trpc';
@@ -573,7 +577,7 @@ export const workspaceRouter = router({
         message: z.string().min(1),
       })
     )
-    .mutation(async ({ input }) => {
+    .mutation(async ({ ctx, input }) => {
       const child = await workspaceAccessor.findByIdWithProject(input.childWorkspaceId);
       if (!child) {
         throw new TRPCError({
@@ -590,6 +594,17 @@ export const workspaceRouter = router({
 
       const parentWorkspaceId = child.parentWorkspaceId;
 
+      // Persist first so the message survives if live delivery races a dying
+      // session; successful dispatch marks the row delivered.
+      const notification = await persistChildNotification({
+        parentWorkspaceId,
+        sourceWorkspaceId: input.childWorkspaceId,
+        message: input.message,
+      });
+      if (!notification) {
+        return { delivered: false };
+      }
+
       // Try to find an active/idle session on the parent workspace to inject into.
       // Use the most recently created active session so we target the current one.
       const parentSessions = await agentSessionAccessor.findByWorkspaceId(parentWorkspaceId);
@@ -597,49 +612,50 @@ export const workspaceRouter = router({
         .reverse()
         .find((s) => s.status === 'RUNNING' || s.status === 'IDLE');
 
-      if (activeSession) {
-        // Show notification card in parent's UI
-        const claudeMessage = {
-          type: 'child_workspace_update' as const,
-          childWorkspaceId: input.childWorkspaceId,
-          childWorkspaceName: child.name,
-          childProjectName: child.project.name,
-          text: input.message,
-          timestamp: new Date().toISOString(),
-        };
-        const order = sessionDomainService.appendClaudeEvent(activeSession.id, claudeMessage);
-        sessionDomainService.emitDelta(activeSession.id, {
-          type: 'agent_message',
-          data: claudeMessage,
-          order,
-        } as SessionDeltaEvent & { order: number });
-        // Enqueue as a user message so the parent agent acts on it
-        const msgId = `child-msg-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
-        const enqueueText = `[Message from child workspace "${child.name}"]: ${input.message}`;
-        sessionDomainService.enqueue(activeSession.id, {
-          id: msgId,
-          text: enqueueText,
-          timestamp: new Date().toISOString(),
-          settings: {
-            selectedModel: null,
-            reasoningEffort: null,
-            thinkingEnabled: false,
-            planModeEnabled: false,
-          },
-        });
-        await chatMessageHandlerService.tryDispatchNextMessage(activeSession.id);
-      }
-
-      // Only persist if there is no active session to receive it live
       if (!activeSession) {
-        await persistChildNotification({
-          parentWorkspaceId,
-          sourceWorkspaceId: input.childWorkspaceId,
-          message: input.message,
-        });
+        return { delivered: false };
       }
 
-      return { delivered: Boolean(activeSession) };
+      // Enqueue as a user message so the parent agent acts on it
+      const enqueueResult = sessionDomainService.enqueue(activeSession.id, {
+        id: workspaceNotificationMessageId(notification.id),
+        text: buildWorkspaceNotificationMessageText(notification),
+        timestamp: new Date().toISOString(),
+        settings: {
+          selectedModel: null,
+          reasoningEffort: null,
+          thinkingEnabled: false,
+          planModeEnabled: false,
+        },
+      });
+      if ('error' in enqueueResult) {
+        // Leave the notification pending; it is delivered at next session start.
+        getLogger(ctx).warn('sendMessageToParent: live enqueue failed, left pending', {
+          notificationId: notification.id,
+          sessionId: activeSession.id,
+          error: enqueueResult.error,
+        });
+        return { delivered: false };
+      }
+
+      // Show notification card in parent's UI
+      const claudeMessage = {
+        type: 'child_workspace_update' as const,
+        childWorkspaceId: input.childWorkspaceId,
+        childWorkspaceName: child.name,
+        childProjectName: child.project.name,
+        text: input.message,
+        timestamp: new Date().toISOString(),
+      };
+      const order = sessionDomainService.appendClaudeEvent(activeSession.id, claudeMessage);
+      sessionDomainService.emitDelta(activeSession.id, {
+        type: 'agent_message',
+        data: claudeMessage,
+        order,
+      } as SessionDeltaEvent & { order: number });
+      await chatMessageHandlerService.tryDispatchNextMessage(activeSession.id);
+
+      return { delivered: true };
     }),
 
   // Send a message from a parent workspace to a child's active session (or queue it)
@@ -651,7 +667,7 @@ export const workspaceRouter = router({
         message: z.string().min(1),
       })
     )
-    .mutation(async ({ input }) => {
+    .mutation(async ({ ctx, input }) => {
       const child = await workspaceAccessor.findByIdWithProject(input.childWorkspaceId);
       if (!child) {
         throw new TRPCError({
@@ -668,52 +684,66 @@ export const workspaceRouter = router({
 
       const parent = await workspaceAccessor.findByIdWithProject(input.parentWorkspaceId);
 
+      // Persist first so the message survives if live delivery races a dying
+      // session; successful dispatch marks the row delivered.
+      const notification = await persistParentNotification({
+        parentWorkspaceId: input.parentWorkspaceId,
+        targetChildWorkspaceId: input.childWorkspaceId,
+        message: input.message,
+      });
+      if (!notification) {
+        return { delivered: false };
+      }
+
       const childSessions = await agentSessionAccessor.findByWorkspaceId(input.childWorkspaceId);
       const activeSession = [...childSessions]
         .reverse()
         .find((s) => s.status === 'RUNNING' || s.status === 'IDLE');
 
-      if (activeSession) {
-        // Show notification card in child's UI
-        const claudeMessage = {
-          type: 'parent_workspace_update' as const,
-          parentWorkspaceId: input.parentWorkspaceId,
-          parentWorkspaceName: parent?.name,
-          parentProjectName: parent?.project.name,
-          text: input.message,
-          timestamp: new Date().toISOString(),
-        };
-        const order = sessionDomainService.appendClaudeEvent(activeSession.id, claudeMessage);
-        sessionDomainService.emitDelta(activeSession.id, {
-          type: 'agent_message',
-          data: claudeMessage,
-          order,
-        } as SessionDeltaEvent & { order: number });
-        // Enqueue as a user message so the child agent acts on it
-        const msgId = `parent-msg-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
-        const parentLabel = parent?.name ?? 'parent workspace';
-        const enqueueText = `[Message from parent workspace "${parentLabel}"]: ${input.message}`;
-        sessionDomainService.enqueue(activeSession.id, {
-          id: msgId,
-          text: enqueueText,
-          timestamp: new Date().toISOString(),
-          settings: {
-            selectedModel: null,
-            reasoningEffort: null,
-            thinkingEnabled: false,
-            planModeEnabled: false,
-          },
-        });
-        await chatMessageHandlerService.tryDispatchNextMessage(activeSession.id);
-      } else {
-        await persistParentNotification({
-          parentWorkspaceId: input.parentWorkspaceId,
-          targetChildWorkspaceId: input.childWorkspaceId,
-          message: input.message,
-        });
+      if (!activeSession) {
+        return { delivered: false };
       }
 
-      return { delivered: Boolean(activeSession) };
+      // Enqueue as a user message so the child agent acts on it
+      const enqueueResult = sessionDomainService.enqueue(activeSession.id, {
+        id: workspaceNotificationMessageId(notification.id),
+        text: buildWorkspaceNotificationMessageText(notification),
+        timestamp: new Date().toISOString(),
+        settings: {
+          selectedModel: null,
+          reasoningEffort: null,
+          thinkingEnabled: false,
+          planModeEnabled: false,
+        },
+      });
+      if ('error' in enqueueResult) {
+        // Leave the notification pending; it is delivered at next session start.
+        getLogger(ctx).warn('sendMessageToChild: live enqueue failed, left pending', {
+          notificationId: notification.id,
+          sessionId: activeSession.id,
+          error: enqueueResult.error,
+        });
+        return { delivered: false };
+      }
+
+      // Show notification card in child's UI
+      const claudeMessage = {
+        type: 'parent_workspace_update' as const,
+        parentWorkspaceId: input.parentWorkspaceId,
+        parentWorkspaceName: parent?.name,
+        parentProjectName: parent?.project.name,
+        text: input.message,
+        timestamp: new Date().toISOString(),
+      };
+      const order = sessionDomainService.appendClaudeEvent(activeSession.id, claudeMessage);
+      sessionDomainService.emitDelta(activeSession.id, {
+        type: 'agent_message',
+        data: claudeMessage,
+        order,
+      } as SessionDeltaEvent & { order: number });
+      await chatMessageHandlerService.tryDispatchNextMessage(activeSession.id);
+
+      return { delivered: true };
     }),
 
   // Archive a child workspace on behalf of the parent

--- a/src/shared/workspace-notifications.ts
+++ b/src/shared/workspace-notifications.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared helpers for parent/child workspace notification delivery.
+ *
+ * Notifications are persisted first (WorkspaceNotification row), then delivered
+ * live when an active session exists. The queued-message id prefix lets the chat
+ * dispatcher mark the row delivered after a successful send, and the transcript
+ * marker lets session startup dedup a message that was already delivered live.
+ */
+
+export const WORKSPACE_NOTIFICATION_MESSAGE_ID_PREFIX = 'workspace-notification-';
+
+export function workspaceNotificationMessageId(notificationId: string): string {
+  return `${WORKSPACE_NOTIFICATION_MESSAGE_ID_PREFIX}${notificationId}`;
+}
+
+/**
+ * Build the exact user-message text enqueued for a workspace notification.
+ * Live delivery and startup redelivery must produce identical text so the
+ * transcript content match can detect an already-delivered notification.
+ */
+export function buildWorkspaceNotificationMessageText(notification: {
+  id: string;
+  direction: string;
+  sourceWorkspaceName: string;
+  message: string;
+}): string {
+  const label =
+    notification.direction === 'PARENT_TO_CHILD'
+      ? `[Message from parent workspace "${notification.sourceWorkspaceName}"]`
+      : `[Message from child workspace "${notification.sourceWorkspaceName}"]`;
+  return `${label}: ${notification.message}\n\n<!-- factory-factory-workspace-notification:${notification.id} -->`;
+}

--- a/src/shared/workspace-notifications.ts
+++ b/src/shared/workspace-notifications.ts
@@ -9,6 +9,9 @@
 
 export const WORKSPACE_NOTIFICATION_MESSAGE_ID_PREFIX = 'workspace-notification-';
 
+/** Mirrors the Prisma NotificationDirection enum. */
+export type WorkspaceNotificationDirection = 'CHILD_TO_PARENT' | 'PARENT_TO_CHILD';
+
 export function workspaceNotificationMessageId(notificationId: string): string {
   return `${WORKSPACE_NOTIFICATION_MESSAGE_ID_PREFIX}${notificationId}`;
 }
@@ -20,7 +23,7 @@ export function workspaceNotificationMessageId(notificationId: string): string {
  */
 export function buildWorkspaceNotificationMessageText(notification: {
   id: string;
-  direction: string;
+  direction: WorkspaceNotificationDirection;
   sourceWorkspaceName: string;
   message: string;
 }): string {


### PR DESCRIPTION
Fixes #1885.

## Problem

`sendMessageToParent` / `sendMessageToChild` used a read-then-act pattern: if an active parent/child session was found, the message was enqueued live and **never persisted**. If the chosen session died between the lookup and dispatch, the message was silently lost.

## Change

Parent↔child message delivery is now persist-first, unifying it with the lifecycle-notification path:

1. **Always persist** the `WorkspaceNotification` row first (`persistChildNotification` / `persistParentNotification` now return the created row).
2. **Attempt live delivery** to the most recent RUNNING/IDLE session, enqueuing with the `workspace-notification-{id}` message ID so the existing dispatch path (`markWorkspaceNotificationDeliveredIfNeeded`) marks the row delivered on successful send.
3. If the session dies before dispatch, the row stays pending and is delivered at the next session start; the existing transcript-marker dedup (`<!-- factory-factory-workspace-notification:{id} -->`) prevents double delivery.

Supporting refactor: the message-ID prefix, transcript marker, and enqueue-text format were previously hardcoded in three places; they now live in a shared module (`src/shared/workspace-notifications.ts`) used by the tRPC mutations, the chat dispatcher, and the session-startup redelivery path. Live delivery builds the enqueue text from the persisted row, guaranteeing it matches redelivery text exactly for content-based dedup.

Also fixed along the way: a failed live `enqueue` now leaves the notification pending and returns `delivered: false` (previously the enqueue result was ignored and the mutation reported `delivered: true`).

## Tests

- New: `workspace-children.orchestrator.test.ts` — persist functions return the created row / null on missing workspaces.
- Extended `workspace.router.test.ts` — both mutations persist before live delivery (call-order asserted), use notification-backed message IDs with the transcript marker, skip live delivery with no active session, and leave the row pending when enqueue fails.

Ran: `pnpm test` (3642 passed), `pnpm typecheck`, `pnpm check`, `pnpm check:fix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core message-delivery ordering and adds concurrent dispatch logic for workspace notifications; behavior is heavily tested but affects agent queue/session startup paths.
> 
> **Overview**
> Parent↔child workspace messaging no longer depends on finding a live session first: **`sendMessageToParent`** and **`sendMessageToChild`** always create a **`WorkspaceNotification`** row, then optionally enqueue to the latest RUNNING/IDLE session using stable `workspace-notification-{id}` message IDs and shared enqueue text from `src/shared/workspace-notifications.ts`.
> 
> Live delivery now respects **persist-before-enqueue** ordering, returns **`delivered: false`** when enqueue fails (instead of reporting success), and skips duplicate enqueue when startup redelivery already queued the same notification. **`persistChildNotification`** / **`persistParentNotification`** return the created row or **`null`** if a workspace is missing.
> 
> The chat dispatcher gains **duplicate workspace-notification handling**: in-flight claims across sessions, drops when the row is already delivered or the message is already in the transcript, and **`removeQueuedMessage`** so phantom queue cards do not linger. Session startup redelivery uses the same shared helpers for consistent transcript-marker dedup.
> 
> Tests cover persist helpers, tRPC mutation flows, and concurrent/multi-session dispatch edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13c63d6afd43b315774f46d1a7480490b3e8b9ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->