### PR TITLE
Fix #1889: Unify snapshot cache merge strategy and session-status derivation

### DIFF
--- a/src/client/components/kanban/kanban-context.tsx
+++ b/src/client/components/kanban/kanban-context.tsx
@@ -8,6 +8,7 @@ import {
   useState,
 } from 'react';
 import { toast } from 'sonner';
+import { useToggleRatcheting } from '@/client/hooks/use-toggle-ratcheting';
 import {
   shouldSyncGitHubCLIHealthFromIssuesResponse,
   syncGitHubCLIHealth,
@@ -170,7 +171,7 @@ export function KanbanProvider({
   const syncMutation = trpc.workspace.syncAllPRStatuses.useMutation({
     onError: (error) => toast.error(`Failed to sync PR statuses: ${error.message}`),
   });
-  const toggleRatchetingMutation = trpc.workspace.toggleRatcheting.useMutation();
+  const toggleRatchetingMutation = useToggleRatcheting(projectId);
   const renameMutation = trpc.workspace.rename.useMutation({
     onError: (error) => toast.error(`Failed to rename workspace: ${error.message}`),
   });
@@ -200,12 +201,9 @@ export function KanbanProvider({
   const toggleWorkspaceRatcheting = async (workspaceId: string, enabled: boolean) => {
     setTogglingWorkspaceId(workspaceId);
     try {
+      // Optimistic cache updates and settle-time invalidation live in the
+      // shared useToggleRatcheting hook.
       await toggleRatchetingMutation.mutateAsync({ workspaceId, enabled });
-      await Promise.all([
-        refetchWorkspaces(),
-        utils.workspace.getProjectSummaryState.invalidate({ projectId }),
-        utils.workspace.get.invalidate({ id: workspaceId }),
-      ]);
     } finally {
       setTogglingWorkspaceId(null);
     }

--- a/src/client/components/kanban/kanban-context.tsx
+++ b/src/client/components/kanban/kanban-context.tsx
@@ -204,6 +204,9 @@ export function KanbanProvider({
       // Optimistic cache updates and settle-time invalidation live in the
       // shared useToggleRatcheting hook.
       await toggleRatchetingMutation.mutateAsync({ workspaceId, enabled });
+    } catch {
+      // Error feedback is surfaced by useToggleRatcheting's onError toast;
+      // callers fire-and-forget, so don't propagate an unhandled rejection.
     } finally {
       setTogglingWorkspaceId(null);
     }

--- a/src/client/hooks/use-project-snapshot-sync.test.ts
+++ b/src/client/hooks/use-project-snapshot-sync.test.ts
@@ -748,6 +748,11 @@ describe('useProjectSnapshotSync', () => {
       const onMessage = capturedOptions!.onMessage!;
       const onDisconnected = capturedOptions!.onDisconnected!;
 
+      onMessage({
+        type: 'snapshot_full',
+        projectId: 'proj-1',
+        entries: [],
+      });
       onDisconnected();
       onMessage({
         type: 'snapshot_full',
@@ -764,6 +769,23 @@ describe('useProjectSnapshotSync', () => {
       expect(mockListInvalidate).toHaveBeenCalledTimes(1);
       expect(mockSummaryInvalidate).toHaveBeenCalledTimes(1);
       expect(mockKanbanInvalidate).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not heal when connection attempts fail before the first baseline', () => {
+      useProjectSnapshotSync('proj-1');
+      const onMessage = capturedOptions!.onMessage!;
+      const onDisconnected = capturedOptions!.onDisconnected!;
+
+      // Failed connection attempts fire onDisconnected without any baseline.
+      onDisconnected();
+      onDisconnected();
+      onMessage({
+        type: 'snapshot_full',
+        projectId: 'proj-1',
+        entries: [makeEntry()],
+      });
+
+      expectNoInvalidations();
     });
   });
 

--- a/src/client/hooks/use-project-snapshot-sync.test.ts
+++ b/src/client/hooks/use-project-snapshot-sync.test.ts
@@ -771,6 +771,37 @@ describe('useProjectSnapshotSync', () => {
       expect(mockKanbanInvalidate).toHaveBeenCalledTimes(1);
     });
 
+    it('keeps the heal scoped to the project that disconnected', () => {
+      useProjectSnapshotSync('proj-1');
+      const onMessage = capturedOptions!.onMessage!;
+      const onDisconnected = capturedOptions!.onDisconnected!;
+
+      onMessage({
+        type: 'snapshot_full',
+        projectId: 'proj-1',
+        entries: [],
+      });
+      onDisconnected();
+
+      // A baseline for a different project must neither heal nor consume
+      // proj-1's pending heal.
+      onMessage({
+        type: 'snapshot_full',
+        projectId: 'proj-2',
+        entries: [],
+      });
+      expectNoInvalidations();
+
+      onMessage({
+        type: 'snapshot_full',
+        projectId: 'proj-1',
+        entries: [],
+      });
+      expect(mockListInvalidate).toHaveBeenCalledTimes(1);
+      expect(mockListInvalidate).toHaveBeenCalledWith({ projectId: 'proj-1' });
+      expect(mockKanbanInvalidate).toHaveBeenCalledWith({ projectId: 'proj-1' });
+    });
+
     it('does not heal when connection attempts fail before the first baseline', () => {
       useProjectSnapshotSync('proj-1');
       const onMessage = capturedOptions!.onMessage!;

--- a/src/client/hooks/use-project-snapshot-sync.test.ts
+++ b/src/client/hooks/use-project-snapshot-sync.test.ts
@@ -1,4 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  resetPendingRatchetTogglesForTests,
+  setPendingRatchetToggle,
+} from '@/client/lib/ratchet-toggle-cache';
 import type { WorkspaceSnapshotEntry } from '@/client/lib/snapshot-to-sidebar';
 import type { UseWebSocketTransportOptions } from '@/hooks/use-websocket-transport';
 import { useProjectSnapshotSync } from './use-project-snapshot-sync';
@@ -31,7 +35,9 @@ const mockSetData = vi.fn();
 const mockKanbanSetData = vi.fn();
 const mockWorkspaceGetSetData = vi.fn();
 const mockListInvalidate = vi.fn();
-const mockListWithRuntimeStateInvalidate = vi.fn();
+const mockWorkspaceGetInvalidate = vi.fn();
+const mockSummaryInvalidate = vi.fn();
+const mockKanbanInvalidate = vi.fn();
 const mockGlobalDispatchEvent = vi.fn();
 
 vi.mock('@/client/lib/trpc', () => ({
@@ -40,18 +46,18 @@ vi.mock('@/client/lib/trpc', () => ({
       workspace: {
         getProjectSummaryState: {
           setData: mockSetData,
+          invalidate: mockSummaryInvalidate,
         },
         listWithKanbanState: {
           setData: mockKanbanSetData,
+          invalidate: mockKanbanInvalidate,
         },
         get: {
           setData: mockWorkspaceGetSetData,
+          invalidate: mockWorkspaceGetInvalidate,
         },
         list: {
           invalidate: mockListInvalidate,
-        },
-        listWithRuntimeState: {
-          invalidate: mockListWithRuntimeStateInvalidate,
         },
       },
     }),
@@ -121,8 +127,11 @@ describe('useProjectSnapshotSync', () => {
     mockKanbanSetData.mockReset();
     mockWorkspaceGetSetData.mockReset();
     mockListInvalidate.mockClear();
-    mockListWithRuntimeStateInvalidate.mockClear();
+    mockWorkspaceGetInvalidate.mockClear();
+    mockSummaryInvalidate.mockClear();
+    mockKanbanInvalidate.mockClear();
     mockGlobalDispatchEvent.mockClear();
+    resetPendingRatchetTogglesForTests();
     vi.stubGlobal('dispatchEvent', mockGlobalDispatchEvent);
   });
 
@@ -664,11 +673,35 @@ describe('useProjectSnapshotSync', () => {
   });
 
   // ===========================================================================
-  // workspace.list cache invalidation tests
+  // Merge strategy: deltas are pure patches, reconnect baseline heals
   // ===========================================================================
 
-  describe('workspace.list cache invalidation', () => {
-    it('snapshot_full invalidates workspace.list cache', () => {
+  function expectNoInvalidations(): void {
+    expect(mockListInvalidate).not.toHaveBeenCalled();
+    expect(mockWorkspaceGetInvalidate).not.toHaveBeenCalled();
+    expect(mockSummaryInvalidate).not.toHaveBeenCalled();
+    expect(mockKanbanInvalidate).not.toHaveBeenCalled();
+  }
+
+  describe('cache invalidation strategy', () => {
+    it('snapshot_changed and snapshot_removed never invalidate caches', () => {
+      useProjectSnapshotSync('proj-1');
+      const onMessage = capturedOptions!.onMessage!;
+
+      onMessage({
+        type: 'snapshot_changed',
+        workspaceId: 'ws-1',
+        entry: makeEntry(),
+      });
+      onMessage({
+        type: 'snapshot_removed',
+        workspaceId: 'ws-1',
+      });
+
+      expectNoInvalidations();
+    });
+
+    it('the initial snapshot_full baseline does not invalidate caches', () => {
       useProjectSnapshotSync('proj-1');
       const onMessage = capturedOptions!.onMessage!;
 
@@ -678,41 +711,118 @@ describe('useProjectSnapshotSync', () => {
         entries: [makeEntry()],
       });
 
-      expect(mockListInvalidate).toHaveBeenCalledTimes(1);
-      expect(mockListInvalidate).toHaveBeenCalledWith({ projectId: 'proj-1' });
-      expect(mockListWithRuntimeStateInvalidate).toHaveBeenCalledTimes(1);
-      expect(mockListWithRuntimeStateInvalidate).toHaveBeenCalledWith({ projectId: 'proj-1' });
+      expectNoInvalidations();
     });
 
-    it('snapshot_changed invalidates workspace.list cache', () => {
+    it('the first snapshot_full after a disconnect heals the workspace caches', () => {
+      useProjectSnapshotSync('proj-1');
+      const onMessage = capturedOptions!.onMessage!;
+      const onDisconnected = capturedOptions!.onDisconnected!;
+
+      onMessage({
+        type: 'snapshot_full',
+        projectId: 'proj-1',
+        entries: [makeEntry()],
+      });
+      expectNoInvalidations();
+
+      onDisconnected();
+      onMessage({
+        type: 'snapshot_full',
+        projectId: 'proj-1',
+        entries: [makeEntry()],
+      });
+
+      expect(mockWorkspaceGetInvalidate).toHaveBeenCalledTimes(1);
+      expect(mockWorkspaceGetInvalidate).toHaveBeenCalledWith();
+      expect(mockListInvalidate).toHaveBeenCalledTimes(1);
+      expect(mockListInvalidate).toHaveBeenCalledWith({ projectId: 'proj-1' });
+      expect(mockSummaryInvalidate).toHaveBeenCalledTimes(1);
+      expect(mockSummaryInvalidate).toHaveBeenCalledWith({ projectId: 'proj-1' });
+      expect(mockKanbanInvalidate).toHaveBeenCalledTimes(1);
+      expect(mockKanbanInvalidate).toHaveBeenCalledWith({ projectId: 'proj-1' });
+    });
+
+    it('heals only once per disconnect', () => {
+      useProjectSnapshotSync('proj-1');
+      const onMessage = capturedOptions!.onMessage!;
+      const onDisconnected = capturedOptions!.onDisconnected!;
+
+      onDisconnected();
+      onMessage({
+        type: 'snapshot_full',
+        projectId: 'proj-1',
+        entries: [],
+      });
+      onMessage({
+        type: 'snapshot_full',
+        projectId: 'proj-1',
+        entries: [],
+      });
+
+      expect(mockWorkspaceGetInvalidate).toHaveBeenCalledTimes(1);
+      expect(mockListInvalidate).toHaveBeenCalledTimes(1);
+      expect(mockSummaryInvalidate).toHaveBeenCalledTimes(1);
+      expect(mockKanbanInvalidate).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ===========================================================================
+  // In-flight ratchet toggle overrides
+  // ===========================================================================
+
+  describe('pending ratchet toggle override', () => {
+    it('snapshot_changed entries are overridden while a toggle is in flight', () => {
+      useProjectSnapshotSync('proj-1');
+      const onMessage = capturedOptions!.onMessage!;
+
+      setPendingRatchetToggle('ws-1', false);
+      onMessage({
+        type: 'snapshot_changed',
+        workspaceId: 'ws-1',
+        entry: makeEntry({ workspaceId: 'ws-1', ratchetEnabled: true, ratchetState: 'READY' }),
+      });
+
+      const [, updater] = mockSetData.mock.calls[0]!;
+      const result = updater(undefined);
+      expect(result.workspaces[0].ratchetEnabled).toBe(false);
+      expect(result.workspaces[0].ratchetState).toBe('IDLE');
+
+      const [, detailUpdater] = mockWorkspaceGetSetData.mock.calls[0]!;
+      const detail = detailUpdater({ id: 'ws-1' });
+      expect(detail.ratchetEnabled).toBe(false);
+    });
+
+    it('snapshot_full entries are overridden while a toggle is in flight', () => {
+      useProjectSnapshotSync('proj-1');
+      const onMessage = capturedOptions!.onMessage!;
+
+      setPendingRatchetToggle('ws-1', true);
+      onMessage({
+        type: 'snapshot_full',
+        projectId: 'proj-1',
+        entries: [makeEntry({ workspaceId: 'ws-1', ratchetEnabled: false })],
+      });
+
+      const [, updater] = mockSetData.mock.calls[0]!;
+      const result = updater(undefined);
+      expect(result.workspaces[0].ratchetEnabled).toBe(true);
+    });
+
+    it('entries pass through untouched when no toggle is pending', () => {
       useProjectSnapshotSync('proj-1');
       const onMessage = capturedOptions!.onMessage!;
 
       onMessage({
         type: 'snapshot_changed',
         workspaceId: 'ws-1',
-        entry: makeEntry(),
+        entry: makeEntry({ workspaceId: 'ws-1', ratchetEnabled: true, ratchetState: 'READY' }),
       });
 
-      expect(mockListInvalidate).toHaveBeenCalledTimes(1);
-      expect(mockListInvalidate).toHaveBeenCalledWith({ projectId: 'proj-1' });
-      expect(mockListWithRuntimeStateInvalidate).toHaveBeenCalledTimes(1);
-      expect(mockListWithRuntimeStateInvalidate).toHaveBeenCalledWith({ projectId: 'proj-1' });
-    });
-
-    it('snapshot_removed invalidates workspace.list cache', () => {
-      useProjectSnapshotSync('proj-1');
-      const onMessage = capturedOptions!.onMessage!;
-
-      onMessage({
-        type: 'snapshot_removed',
-        workspaceId: 'ws-1',
-      });
-
-      expect(mockListInvalidate).toHaveBeenCalledTimes(1);
-      expect(mockListInvalidate).toHaveBeenCalledWith({ projectId: 'proj-1' });
-      expect(mockListWithRuntimeStateInvalidate).toHaveBeenCalledTimes(1);
-      expect(mockListWithRuntimeStateInvalidate).toHaveBeenCalledWith({ projectId: 'proj-1' });
+      const [, updater] = mockSetData.mock.calls[0]!;
+      const result = updater(undefined);
+      expect(result.workspaces[0].ratchetEnabled).toBe(true);
+      expect(result.workspaces[0].ratchetState).toBe('READY');
     });
   });
 

--- a/src/client/hooks/use-project-snapshot-sync.test.ts
+++ b/src/client/hooks/use-project-snapshot-sync.test.ts
@@ -714,10 +714,9 @@ describe('useProjectSnapshotSync', () => {
       expectNoInvalidations();
     });
 
-    it('the first snapshot_full after a disconnect heals the workspace caches', () => {
+    it('heals the workspace caches on every baseline after a project&apos;s first', () => {
       useProjectSnapshotSync('proj-1');
       const onMessage = capturedOptions!.onMessage!;
-      const onDisconnected = capturedOptions!.onDisconnected!;
 
       onMessage({
         type: 'snapshot_full',
@@ -726,7 +725,8 @@ describe('useProjectSnapshotSync', () => {
       });
       expectNoInvalidations();
 
-      onDisconnected();
+      // A later baseline follows a gap (reconnect or project switch) during
+      // which deltas were dropped, so it must heal.
       onMessage({
         type: 'snapshot_full',
         projectId: 'proj-1',
@@ -741,50 +741,27 @@ describe('useProjectSnapshotSync', () => {
       expect(mockSummaryInvalidate).toHaveBeenCalledWith({ projectId: 'proj-1' });
       expect(mockKanbanInvalidate).toHaveBeenCalledTimes(1);
       expect(mockKanbanInvalidate).toHaveBeenCalledWith({ projectId: 'proj-1' });
+
+      onMessage({
+        type: 'snapshot_full',
+        projectId: 'proj-1',
+        entries: [makeEntry()],
+      });
+      expect(mockWorkspaceGetInvalidate).toHaveBeenCalledTimes(2);
+      expect(mockListInvalidate).toHaveBeenCalledTimes(2);
     });
 
-    it('heals only once per disconnect', () => {
+    it('tracks the first baseline per project', () => {
       useProjectSnapshotSync('proj-1');
       const onMessage = capturedOptions!.onMessage!;
-      const onDisconnected = capturedOptions!.onDisconnected!;
 
       onMessage({
         type: 'snapshot_full',
         projectId: 'proj-1',
         entries: [],
       });
-      onDisconnected();
-      onMessage({
-        type: 'snapshot_full',
-        projectId: 'proj-1',
-        entries: [],
-      });
-      onMessage({
-        type: 'snapshot_full',
-        projectId: 'proj-1',
-        entries: [],
-      });
 
-      expect(mockWorkspaceGetInvalidate).toHaveBeenCalledTimes(1);
-      expect(mockListInvalidate).toHaveBeenCalledTimes(1);
-      expect(mockSummaryInvalidate).toHaveBeenCalledTimes(1);
-      expect(mockKanbanInvalidate).toHaveBeenCalledTimes(1);
-    });
-
-    it('keeps the heal scoped to the project that disconnected', () => {
-      useProjectSnapshotSync('proj-1');
-      const onMessage = capturedOptions!.onMessage!;
-      const onDisconnected = capturedOptions!.onDisconnected!;
-
-      onMessage({
-        type: 'snapshot_full',
-        projectId: 'proj-1',
-        entries: [],
-      });
-      onDisconnected();
-
-      // A baseline for a different project must neither heal nor consume
-      // proj-1's pending heal.
+      // Another project's first baseline neither heals nor counts as proj-1's.
       onMessage({
         type: 'snapshot_full',
         projectId: 'proj-2',
@@ -792,6 +769,7 @@ describe('useProjectSnapshotSync', () => {
       });
       expectNoInvalidations();
 
+      // Returning to proj-1 (its second baseline) heals proj-1 only.
       onMessage({
         type: 'snapshot_full',
         projectId: 'proj-1',
@@ -800,23 +778,6 @@ describe('useProjectSnapshotSync', () => {
       expect(mockListInvalidate).toHaveBeenCalledTimes(1);
       expect(mockListInvalidate).toHaveBeenCalledWith({ projectId: 'proj-1' });
       expect(mockKanbanInvalidate).toHaveBeenCalledWith({ projectId: 'proj-1' });
-    });
-
-    it('does not heal when connection attempts fail before the first baseline', () => {
-      useProjectSnapshotSync('proj-1');
-      const onMessage = capturedOptions!.onMessage!;
-      const onDisconnected = capturedOptions!.onDisconnected!;
-
-      // Failed connection attempts fire onDisconnected without any baseline.
-      onDisconnected();
-      onDisconnected();
-      onMessage({
-        type: 'snapshot_full',
-        projectId: 'proj-1',
-        entries: [makeEntry()],
-      });
-
-      expectNoInvalidations();
     });
   });
 

--- a/src/client/hooks/use-project-snapshot-sync.ts
+++ b/src/client/hooks/use-project-snapshot-sync.ts
@@ -6,11 +6,11 @@
  * Merge strategy — one strategy per cache per message:
  * - snapshot_changed / snapshot_removed deltas are pure setData patches;
  *   they never trigger invalidation refetches.
- * - snapshot_full is the (re)connect baseline. After a disconnect the
- *   staleTime: Infinity workspace caches may hold state whose deltas were
- *   dropped (queuePolicy: 'drop'), and snapshot entries don't carry every
- *   DB-backed field, so the first baseline after a disconnect additionally
- *   invalidates the workspace caches to let them self-heal.
+ * - snapshot_full is the (re)connect baseline. Any baseline after a
+ *   project's first follows a gap (network reconnect, or a switch away and
+ *   back) during which deltas were dropped, and snapshot entries don't carry
+ *   every DB-backed field, so those baselines additionally invalidate the
+ *   workspace caches to let them self-heal.
  *
  * Follows the use-log-stream.ts pattern: receive-only WebSocket hook with
  * drop queue policy (no outbound messages, reconnect discards stale data).
@@ -157,11 +157,11 @@ function triggerWorkspaceAttention(workspaceId: string): void {
 }
 
 /**
- * Invalidates the workspace caches after the first snapshot_full baseline
- * that follows a disconnect. The snapshot patches keep the UI instant; the
- * refetches restore DB-backed fields the snapshot doesn't carry (issue
- * links, etc.) and drop workspace.get entries for workspaces that were
- * archived while disconnected.
+ * Invalidates the workspace caches after any snapshot_full baseline past a
+ * project's first. The snapshot patches keep the UI instant; the refetches
+ * restore DB-backed fields the snapshot doesn't carry (issue links, etc.)
+ * and drop workspace.get entries for workspaces that were archived while
+ * no socket for the project was connected.
  */
 function healWorkspaceCachesAfterReconnect(utils: TrpcUtils, projectId: string): void {
   utils.workspace.get.invalidate();
@@ -317,31 +317,25 @@ function applySnapshotRemovedMessage(
 export function useProjectSnapshotSync(projectId: string | undefined): void {
   const utils = trpc.useUtils();
   const previousPendingRequestsRef = useRef<Map<string, PendingRequestType>>(new Map());
-  // Deltas may have been dropped while disconnected, so the next snapshot_full
-  // baseline must also refetch-heal the staleTime: Infinity workspace caches.
-  // Failed attempts before the first baseline don't count: nothing has been
-  // patched yet, so the initial hydration stays refetch-free. Both sets are
-  // keyed by projectId — the hook survives project switches, so a disconnect
-  // on one project must not consume (or grant) another project's heal.
-  const staleProjectsRef = useRef<Set<string>>(new Set());
+  // A project's first snapshot_full arrives alongside its initial query
+  // fetches, so it needs no refetch. Every later baseline for that project
+  // follows a gap — a network reconnect or a switch away and back — during
+  // which deltas were dropped, so it must also refetch-heal the
+  // staleTime: Infinity workspace caches. Keyed per project because the hook
+  // survives project switches.
   const baselineProjectsRef = useRef<Set<string>>(new Set());
 
   const url = projectId ? buildWebSocketUrl('/snapshots', { projectId }) : null;
-
-  const handleDisconnected = useCallback(() => {
-    if (projectId && baselineProjectsRef.current.has(projectId)) {
-      staleProjectsRef.current.add(projectId);
-    }
-  }, [projectId]);
 
   const handleMessage = useCallback(
     (message: z.infer<typeof SnapshotServerMessageSchema>) => {
       switch (message.type) {
         case 'snapshot_full': {
           applySnapshotFullMessage(utils, message, previousPendingRequestsRef.current);
-          baselineProjectsRef.current.add(message.projectId);
-          if (staleProjectsRef.current.delete(message.projectId)) {
+          if (baselineProjectsRef.current.has(message.projectId)) {
             healWorkspaceCachesAfterReconnect(utils, message.projectId);
+          } else {
+            baselineProjectsRef.current.add(message.projectId);
           }
           break;
         }
@@ -380,7 +374,6 @@ export function useProjectSnapshotSync(projectId: string | undefined): void {
     url,
     schema: SnapshotServerMessageSchema,
     onMessage: handleMessage,
-    onDisconnected: handleDisconnected,
     queuePolicy: 'drop',
   });
 }

--- a/src/client/hooks/use-project-snapshot-sync.ts
+++ b/src/client/hooks/use-project-snapshot-sync.ts
@@ -320,26 +320,27 @@ export function useProjectSnapshotSync(projectId: string | undefined): void {
   // Deltas may have been dropped while disconnected, so the next snapshot_full
   // baseline must also refetch-heal the staleTime: Infinity workspace caches.
   // Failed attempts before the first baseline don't count: nothing has been
-  // patched yet, so the initial hydration stays refetch-free.
-  const staleSinceDisconnectRef = useRef(false);
-  const hasReceivedBaselineRef = useRef(false);
+  // patched yet, so the initial hydration stays refetch-free. Both sets are
+  // keyed by projectId — the hook survives project switches, so a disconnect
+  // on one project must not consume (or grant) another project's heal.
+  const staleProjectsRef = useRef<Set<string>>(new Set());
+  const baselineProjectsRef = useRef<Set<string>>(new Set());
 
   const url = projectId ? buildWebSocketUrl('/snapshots', { projectId }) : null;
 
   const handleDisconnected = useCallback(() => {
-    if (hasReceivedBaselineRef.current) {
-      staleSinceDisconnectRef.current = true;
+    if (projectId && baselineProjectsRef.current.has(projectId)) {
+      staleProjectsRef.current.add(projectId);
     }
-  }, []);
+  }, [projectId]);
 
   const handleMessage = useCallback(
     (message: z.infer<typeof SnapshotServerMessageSchema>) => {
       switch (message.type) {
         case 'snapshot_full': {
           applySnapshotFullMessage(utils, message, previousPendingRequestsRef.current);
-          hasReceivedBaselineRef.current = true;
-          if (staleSinceDisconnectRef.current) {
-            staleSinceDisconnectRef.current = false;
+          baselineProjectsRef.current.add(message.projectId);
+          if (staleProjectsRef.current.delete(message.projectId)) {
             healWorkspaceCachesAfterReconnect(utils, message.projectId);
           }
           break;

--- a/src/client/hooks/use-project-snapshot-sync.ts
+++ b/src/client/hooks/use-project-snapshot-sync.ts
@@ -319,12 +319,17 @@ export function useProjectSnapshotSync(projectId: string | undefined): void {
   const previousPendingRequestsRef = useRef<Map<string, PendingRequestType>>(new Map());
   // Deltas may have been dropped while disconnected, so the next snapshot_full
   // baseline must also refetch-heal the staleTime: Infinity workspace caches.
+  // Failed attempts before the first baseline don't count: nothing has been
+  // patched yet, so the initial hydration stays refetch-free.
   const staleSinceDisconnectRef = useRef(false);
+  const hasReceivedBaselineRef = useRef(false);
 
   const url = projectId ? buildWebSocketUrl('/snapshots', { projectId }) : null;
 
   const handleDisconnected = useCallback(() => {
-    staleSinceDisconnectRef.current = true;
+    if (hasReceivedBaselineRef.current) {
+      staleSinceDisconnectRef.current = true;
+    }
   }, []);
 
   const handleMessage = useCallback(
@@ -332,6 +337,7 @@ export function useProjectSnapshotSync(projectId: string | undefined): void {
       switch (message.type) {
         case 'snapshot_full': {
           applySnapshotFullMessage(utils, message, previousPendingRequestsRef.current);
+          hasReceivedBaselineRef.current = true;
           if (staleSinceDisconnectRef.current) {
             staleSinceDisconnectRef.current = false;
             healWorkspaceCachesAfterReconnect(utils, message.projectId);

--- a/src/client/hooks/use-project-snapshot-sync.ts
+++ b/src/client/hooks/use-project-snapshot-sync.ts
@@ -1,9 +1,16 @@
 /**
- * React hook that syncs /snapshots WebSocket messages into both the
+ * React hook that syncs /snapshots WebSocket messages into the
  * getProjectSummaryState (sidebar), listWithKanbanState (kanban), and
  * workspace.get (detail header/session runtime) React Query cache entries.
- * Also invalidates the workspace.list and workspace.listWithRuntimeState caches
- * so table/list views refetch with fresh data on every snapshot event.
+ *
+ * Merge strategy — one strategy per cache per message:
+ * - snapshot_changed / snapshot_removed deltas are pure setData patches;
+ *   they never trigger invalidation refetches.
+ * - snapshot_full is the (re)connect baseline. After a disconnect the
+ *   staleTime: Infinity workspace caches may hold state whose deltas were
+ *   dropped (queuePolicy: 'drop'), and snapshot entries don't carry every
+ *   DB-backed field, so the first baseline after a disconnect additionally
+ *   invalidates the workspace caches to let them self-heal.
  *
  * Follows the use-log-stream.ts pattern: receive-only WebSocket hook with
  * drop queue policy (no outbound messages, reconnect discards stale data).
@@ -11,6 +18,7 @@
 
 import { useCallback, useRef } from 'react';
 import type { z } from 'zod';
+import { overridePendingRatchetToggle } from '@/client/lib/ratchet-toggle-cache';
 import { mapSnapshotEntryToKanbanWorkspace } from '@/client/lib/snapshot-to-kanban';
 import {
   mapSnapshotEntryToServerWorkspace,
@@ -148,9 +156,18 @@ function triggerWorkspaceAttention(workspaceId: string): void {
   }
 }
 
-function invalidateWorkspaceListCaches(utils: TrpcUtils, projectId: string): void {
+/**
+ * Invalidates the workspace caches after the first snapshot_full baseline
+ * that follows a disconnect. The snapshot patches keep the UI instant; the
+ * refetches restore DB-backed fields the snapshot doesn't carry (issue
+ * links, etc.) and drop workspace.get entries for workspaces that were
+ * archived while disconnected.
+ */
+function healWorkspaceCachesAfterReconnect(utils: TrpcUtils, projectId: string): void {
+  utils.workspace.get.invalidate();
   utils.workspace.list.invalidate({ projectId });
-  utils.workspace.listWithRuntimeState.invalidate({ projectId });
+  utils.workspace.getProjectSummaryState.invalidate({ projectId });
+  utils.workspace.listWithKanbanState.invalidate({ projectId });
 }
 
 function seedPendingRequests(
@@ -181,7 +198,9 @@ function applySnapshotFullMessage(
   message: SnapshotFullMessage,
   pendingRequests: Map<string, PendingRequestType>
 ): void {
-  seedPendingRequests(pendingRequests, message.entries);
+  const entries = message.entries.map(overridePendingRatchetToggle);
+
+  seedPendingRequests(pendingRequests, entries);
 
   const { setData } = utils.workspace.getProjectSummaryState;
   const { setData: setKanbanData } = utils.workspace.listWithKanbanState;
@@ -195,7 +214,7 @@ function applySnapshotFullMessage(
       }
     }
     return {
-      workspaces: message.entries.map((e) =>
+      workspaces: entries.map((e) =>
         mapSnapshotEntryToServerWorkspace(e, existingById.get(e.workspaceId))
       ),
       reviewCount: message.reviewCount ?? prev?.reviewCount ?? 0,
@@ -203,14 +222,12 @@ function applySnapshotFullMessage(
   }) as never);
 
   setKanbanData({ projectId: message.projectId }, ((prev: KanbanCacheData) =>
-    buildKanbanCacheFromFull(message.entries, prev)) as never);
+    buildKanbanCacheFromFull(entries, prev)) as never);
 
-  for (const entry of message.entries) {
+  for (const entry of entries) {
     setWorkspaceDetailData({ id: entry.workspaceId }, ((prev: WorkspaceDetailCache) =>
       mergeWorkspaceDetailFromSnapshot(prev, entry)) as never);
   }
-
-  invalidateWorkspaceListCaches(utils, message.projectId);
 }
 
 function applySnapshotChangedMessage(
@@ -219,7 +236,9 @@ function applySnapshotChangedMessage(
   message: SnapshotChangedMessage,
   pendingRequests: Map<string, PendingRequestType>
 ): void {
-  maybeTriggerPendingRequestAttention(pendingRequests, message.entry);
+  const entry = overridePendingRatchetToggle(message.entry);
+
+  maybeTriggerPendingRequestAttention(pendingRequests, entry);
 
   const { setData } = utils.workspace.getProjectSummaryState;
   const { setData: setKanbanData } = utils.workspace.listWithKanbanState;
@@ -228,13 +247,13 @@ function applySnapshotChangedMessage(
   setData({ projectId }, ((prev: CacheData | undefined) => {
     if (!prev) {
       return {
-        workspaces: [mapSnapshotEntryToServerWorkspace(message.entry)],
+        workspaces: [mapSnapshotEntryToServerWorkspace(entry)],
         reviewCount: message.reviewCount ?? 0,
       };
     }
 
-    const existingEntry = prev.workspaces.find((w) => w.id === message.entry.workspaceId);
-    const mapped = mapSnapshotEntryToServerWorkspace(message.entry, existingEntry);
+    const existingEntry = prev.workspaces.find((w) => w.id === entry.workspaceId);
+    const mapped = mapSnapshotEntryToServerWorkspace(entry, existingEntry);
     const existingIndex = prev.workspaces.findIndex((w) => w.id === mapped.id);
     const workspaces = [...prev.workspaces];
 
@@ -248,12 +267,10 @@ function applySnapshotChangedMessage(
   }) as never);
 
   setKanbanData({ projectId }, ((prev: KanbanCacheData) =>
-    upsertKanbanCacheEntry(message.entry, prev)) as never);
+    upsertKanbanCacheEntry(entry, prev)) as never);
 
-  setWorkspaceDetailData({ id: message.entry.workspaceId }, ((prev: WorkspaceDetailCache) =>
-    mergeWorkspaceDetailFromSnapshot(prev, message.entry)) as never);
-
-  invalidateWorkspaceListCaches(utils, projectId);
+  setWorkspaceDetailData({ id: entry.workspaceId }, ((prev: WorkspaceDetailCache) =>
+    mergeWorkspaceDetailFromSnapshot(prev, entry)) as never);
 }
 
 function applySnapshotRemovedMessage(
@@ -282,8 +299,6 @@ function applySnapshotRemovedMessage(
     removeFromKanbanCache(message.workspaceId, prev)) as never);
 
   setWorkspaceDetailData({ id: message.workspaceId }, undefined as never);
-
-  invalidateWorkspaceListCaches(utils, projectId);
 }
 
 // =============================================================================
@@ -302,14 +317,25 @@ function applySnapshotRemovedMessage(
 export function useProjectSnapshotSync(projectId: string | undefined): void {
   const utils = trpc.useUtils();
   const previousPendingRequestsRef = useRef<Map<string, PendingRequestType>>(new Map());
+  // Deltas may have been dropped while disconnected, so the next snapshot_full
+  // baseline must also refetch-heal the staleTime: Infinity workspace caches.
+  const staleSinceDisconnectRef = useRef(false);
 
   const url = projectId ? buildWebSocketUrl('/snapshots', { projectId }) : null;
+
+  const handleDisconnected = useCallback(() => {
+    staleSinceDisconnectRef.current = true;
+  }, []);
 
   const handleMessage = useCallback(
     (message: z.infer<typeof SnapshotServerMessageSchema>) => {
       switch (message.type) {
         case 'snapshot_full': {
           applySnapshotFullMessage(utils, message, previousPendingRequestsRef.current);
+          if (staleSinceDisconnectRef.current) {
+            staleSinceDisconnectRef.current = false;
+            healWorkspaceCachesAfterReconnect(utils, message.projectId);
+          }
           break;
         }
 
@@ -347,6 +373,7 @@ export function useProjectSnapshotSync(projectId: string | undefined): void {
     url,
     schema: SnapshotServerMessageSchema,
     onMessage: handleMessage,
+    onDisconnected: handleDisconnected,
     queuePolicy: 'drop',
   });
 }

--- a/src/client/hooks/use-toggle-ratcheting.ts
+++ b/src/client/hooks/use-toggle-ratcheting.ts
@@ -1,0 +1,66 @@
+/**
+ * Shared optimistic mutation for workspace.toggleRatcheting.
+ *
+ * Single toggle path for both the workspace header and the kanban board:
+ * optimistically patches the three workspace caches, registers the in-flight
+ * value so snapshot merges can't flip it back (see
+ * overridePendingRatchetToggle), and reconciles with the server on settle.
+ */
+
+import {
+  applyRatchetToggleState,
+  clearPendingRatchetToggle,
+  setPendingRatchetToggle,
+  updateWorkspaceRatchetState,
+} from '@/client/lib/ratchet-toggle-cache';
+import { trpc } from '@/client/lib/trpc';
+
+export interface ToggleRatchetingInput {
+  workspaceId: string;
+  enabled: boolean;
+}
+
+/** Explicit return type to avoid TypeScript portability issues with internal tRPC types */
+export interface UseToggleRatchetingReturn {
+  mutate: (input: ToggleRatchetingInput) => void;
+  mutateAsync: (input: ToggleRatchetingInput) => Promise<unknown>;
+  isPending: boolean;
+}
+
+export function useToggleRatcheting(projectId: string): UseToggleRatchetingReturn {
+  const utils = trpc.useUtils();
+
+  return trpc.workspace.toggleRatcheting.useMutation({
+    onMutate: ({ workspaceId, enabled }) => {
+      setPendingRatchetToggle(workspaceId, enabled);
+
+      utils.workspace.get.setData({ id: workspaceId }, (old) => {
+        if (!old) {
+          return old;
+        }
+        return applyRatchetToggleState(old, enabled);
+      });
+      utils.workspace.listWithKanbanState.setData({ projectId }, (old) => {
+        if (!old) {
+          return old;
+        }
+        return updateWorkspaceRatchetState(old, workspaceId, enabled);
+      });
+      utils.workspace.getProjectSummaryState.setData({ projectId }, (old) => {
+        if (!old) {
+          return old;
+        }
+        return {
+          ...old,
+          workspaces: updateWorkspaceRatchetState(old.workspaces, workspaceId, enabled),
+        };
+      });
+    },
+    onSettled: (_data, _error, { workspaceId }) => {
+      clearPendingRatchetToggle(workspaceId);
+      utils.workspace.get.invalidate({ id: workspaceId });
+      utils.workspace.listWithKanbanState.invalidate({ projectId });
+      utils.workspace.getProjectSummaryState.invalidate({ projectId });
+    },
+  });
+}

--- a/src/client/hooks/use-toggle-ratcheting.ts
+++ b/src/client/hooks/use-toggle-ratcheting.ts
@@ -7,6 +7,7 @@
  * overridePendingRatchetToggle), and reconciles with the server on settle.
  */
 
+import { toast } from 'sonner';
 import {
   applyRatchetToggleState,
   clearPendingRatchetToggle,
@@ -32,7 +33,7 @@ export function useToggleRatcheting(projectId: string): UseToggleRatchetingRetur
 
   return trpc.workspace.toggleRatcheting.useMutation({
     onMutate: ({ workspaceId, enabled }) => {
-      setPendingRatchetToggle(workspaceId, enabled);
+      const pendingToggleToken = setPendingRatchetToggle(workspaceId, enabled);
 
       utils.workspace.get.setData({ id: workspaceId }, (old) => {
         if (!old) {
@@ -55,9 +56,16 @@ export function useToggleRatcheting(projectId: string): UseToggleRatchetingRetur
           workspaces: updateWorkspaceRatchetState(old.workspaces, workspaceId, enabled),
         };
       });
+
+      return { pendingToggleToken };
     },
-    onSettled: (_data, _error, { workspaceId }) => {
-      clearPendingRatchetToggle(workspaceId);
+    onError: (error) => {
+      toast.error(`Failed to toggle ratchet: ${error.message}`);
+    },
+    onSettled: (_data, _error, { workspaceId }, context) => {
+      if (context) {
+        clearPendingRatchetToggle(workspaceId, context.pendingToggleToken);
+      }
       utils.workspace.get.invalidate({ id: workspaceId });
       utils.workspace.listWithKanbanState.invalidate({ projectId });
       utils.workspace.getProjectSummaryState.invalidate({ projectId });

--- a/src/client/lib/ratchet-toggle-cache.test.ts
+++ b/src/client/lib/ratchet-toggle-cache.test.ts
@@ -94,9 +94,21 @@ describe('pending ratchet toggle override', () => {
   });
 
   it('stops overriding after the toggle is cleared', () => {
-    setPendingRatchetToggle('ws-1', false);
-    clearPendingRatchetToggle('ws-1');
+    const token = setPendingRatchetToggle('ws-1', false);
+    clearPendingRatchetToggle('ws-1', token);
     const entry = makeEntry(true);
     expect(overridePendingRatchetToggle(entry)).toBe(entry);
+  });
+
+  it('keeps the newer toggle when an older mutation settles late', () => {
+    const firstToken = setPendingRatchetToggle('ws-1', true);
+    setPendingRatchetToggle('ws-1', false);
+
+    // The first mutation settles after the second was registered; its clear
+    // must not remove the second mutation's pending value.
+    clearPendingRatchetToggle('ws-1', firstToken);
+
+    const overridden = overridePendingRatchetToggle(makeEntry(true));
+    expect(overridden.ratchetEnabled).toBe(false);
   });
 });

--- a/src/client/lib/ratchet-toggle-cache.test.ts
+++ b/src/client/lib/ratchet-toggle-cache.test.ts
@@ -1,5 +1,12 @@
-import { describe, expect, it } from 'vitest';
-import { applyRatchetToggleState, updateWorkspaceRatchetState } from './ratchet-toggle-cache';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  applyRatchetToggleState,
+  clearPendingRatchetToggle,
+  overridePendingRatchetToggle,
+  resetPendingRatchetTogglesForTests,
+  setPendingRatchetToggle,
+  updateWorkspaceRatchetState,
+} from './ratchet-toggle-cache';
 
 describe('ratchet-toggle-cache', () => {
   it('recomputes sidebarStatus when sidebar fields are present', () => {
@@ -37,5 +44,59 @@ describe('ratchet-toggle-cache', () => {
       { id: 'ws-1', ratchetEnabled: false, ratchetState: 'IDLE', ratchetButtonAnimated: false },
       { id: 'ws-2', ratchetEnabled: true, ratchetState: 'READY' },
     ]);
+  });
+});
+
+describe('pending ratchet toggle override', () => {
+  beforeEach(() => {
+    resetPendingRatchetTogglesForTests();
+  });
+
+  function makeEntry(ratchetEnabled: boolean) {
+    return {
+      workspaceId: 'ws-1',
+      ratchetEnabled,
+      ratchetState: 'CI_RUNNING' as const,
+      ratchetButtonAnimated: true,
+      isWorking: false,
+      prUrl: 'https://github.com/purplefish-ai/factory-factory/pull/1080',
+      prState: 'OPEN' as const,
+      prCiStatus: 'UNKNOWN' as const,
+      sidebarStatus: { activityState: 'IDLE' as const, ciState: 'RUNNING' as const },
+    };
+  }
+
+  it('returns the entry unchanged when no toggle is pending', () => {
+    const entry = makeEntry(true);
+    expect(overridePendingRatchetToggle(entry)).toBe(entry);
+  });
+
+  it('returns the entry unchanged when the pending value matches', () => {
+    setPendingRatchetToggle('ws-1', true);
+    const entry = makeEntry(true);
+    expect(overridePendingRatchetToggle(entry)).toBe(entry);
+  });
+
+  it('overrides a snapshot entry that would revert an in-flight toggle', () => {
+    setPendingRatchetToggle('ws-1', false);
+    const overridden = overridePendingRatchetToggle(makeEntry(true));
+
+    expect(overridden.ratchetEnabled).toBe(false);
+    expect(overridden.ratchetState).toBe('IDLE');
+    expect(overridden.ratchetButtonAnimated).toBe(false);
+    expect(overridden.sidebarStatus).toEqual({ activityState: 'IDLE', ciState: 'UNKNOWN' });
+  });
+
+  it('only overrides the workspace with the pending toggle', () => {
+    setPendingRatchetToggle('ws-other', false);
+    const entry = makeEntry(true);
+    expect(overridePendingRatchetToggle(entry)).toBe(entry);
+  });
+
+  it('stops overriding after the toggle is cleared', () => {
+    setPendingRatchetToggle('ws-1', false);
+    clearPendingRatchetToggle('ws-1');
+    const entry = makeEntry(true);
+    expect(overridePendingRatchetToggle(entry)).toBe(entry);
   });
 });

--- a/src/client/lib/ratchet-toggle-cache.ts
+++ b/src/client/lib/ratchet-toggle-cache.ts
@@ -59,6 +59,45 @@ export function applyRatchetToggleState<T extends Omit<RatchetToggleCacheShape, 
   };
 }
 
+// =============================================================================
+// Pending toggle registry
+// =============================================================================
+//
+// While a toggleRatcheting mutation is in flight, snapshot messages computed
+// before the mutation committed can still arrive and would overwrite the
+// optimistic cache updates (visible flip-flop). The registry records the
+// in-flight value per workspace so the snapshot sync hook can keep entries
+// consistent with the pending toggle until the mutation settles.
+
+const pendingRatchetToggles = new Map<string, boolean>();
+
+export function setPendingRatchetToggle(workspaceId: string, enabled: boolean): void {
+  pendingRatchetToggles.set(workspaceId, enabled);
+}
+
+export function clearPendingRatchetToggle(workspaceId: string): void {
+  pendingRatchetToggles.delete(workspaceId);
+}
+
+export function resetPendingRatchetTogglesForTests(): void {
+  pendingRatchetToggles.clear();
+}
+
+/**
+ * Applies an in-flight ratchet toggle to a snapshot entry. Returns the entry
+ * unchanged when no toggle is pending for its workspace or when the entry
+ * already reflects the pending value.
+ */
+export function overridePendingRatchetToggle<
+  T extends Omit<RatchetToggleCacheShape, 'id'> & { workspaceId: string },
+>(entry: T): T {
+  const pending = pendingRatchetToggles.get(entry.workspaceId);
+  if (pending === undefined || pending === entry.ratchetEnabled) {
+    return entry;
+  }
+  return applyRatchetToggleState(entry, pending);
+}
+
 export function updateWorkspaceRatchetState<T extends RatchetToggleCacheShape>(
   items: T[],
   workspaceId: string,

--- a/src/client/lib/ratchet-toggle-cache.ts
+++ b/src/client/lib/ratchet-toggle-cache.ts
@@ -69,14 +69,24 @@ export function applyRatchetToggleState<T extends Omit<RatchetToggleCacheShape, 
 // in-flight value per workspace so the snapshot sync hook can keep entries
 // consistent with the pending toggle until the mutation settles.
 
-const pendingRatchetToggles = new Map<string, boolean>();
+const pendingRatchetToggles = new Map<string, { enabled: boolean; token: number }>();
+let nextPendingRatchetToggleToken = 0;
 
-export function setPendingRatchetToggle(workspaceId: string, enabled: boolean): void {
-  pendingRatchetToggles.set(workspaceId, enabled);
+/**
+ * Registers an in-flight toggle and returns a token identifying it. A newer
+ * toggle for the same workspace replaces the previous registration, and the
+ * older mutation's clear (with its stale token) becomes a no-op.
+ */
+export function setPendingRatchetToggle(workspaceId: string, enabled: boolean): number {
+  nextPendingRatchetToggleToken += 1;
+  pendingRatchetToggles.set(workspaceId, { enabled, token: nextPendingRatchetToggleToken });
+  return nextPendingRatchetToggleToken;
 }
 
-export function clearPendingRatchetToggle(workspaceId: string): void {
-  pendingRatchetToggles.delete(workspaceId);
+export function clearPendingRatchetToggle(workspaceId: string, token: number): void {
+  if (pendingRatchetToggles.get(workspaceId)?.token === token) {
+    pendingRatchetToggles.delete(workspaceId);
+  }
 }
 
 export function resetPendingRatchetTogglesForTests(): void {
@@ -92,10 +102,10 @@ export function overridePendingRatchetToggle<
   T extends Omit<RatchetToggleCacheShape, 'id'> & { workspaceId: string },
 >(entry: T): T {
   const pending = pendingRatchetToggles.get(entry.workspaceId);
-  if (pending === undefined || pending === entry.ratchetEnabled) {
+  if (pending === undefined || pending.enabled === entry.ratchetEnabled) {
     return entry;
   }
-  return applyRatchetToggleState(entry, pending);
+  return applyRatchetToggleState(entry, pending.enabled);
 }
 
 export function updateWorkspaceRatchetState<T extends RatchetToggleCacheShape>(

--- a/src/client/routes/projects/workspaces/workspace-detail-container.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-container.tsx
@@ -6,13 +6,12 @@ import { resolveWorkspaceFileLink } from '@/client/lib/workspace-file-links';
 import { WorkspaceDetailHeaderSlot } from '@/client/routes/projects/workspaces/workspace-detail-header';
 import { useChatWebSocket } from '@/components/chat';
 import { usePersistentScroll, useWorkspacePanel } from '@/components/workspace';
-import type { WorkspaceSessionRuntimeSummary } from '@/components/workspace/session-tab-runtime';
 import { useAutoScroll } from '@/hooks/use-auto-scroll';
 import {
   resolveEffectiveSessionProvider,
   type SessionProviderValue,
 } from '@/lib/session-provider-selection';
-import { isSessionSummaryWorking, type SessionRuntimeState } from '@/shared/session-runtime';
+import { isSessionSummaryWorking } from '@/shared/session-runtime';
 import { forgetResumeWorkspace } from './resume-workspace-storage';
 import { useSessionManagement, useWorkspaceData } from './use-workspace-detail';
 import {
@@ -21,97 +20,11 @@ import {
   useWorkspaceInitStatus,
 } from './use-workspace-detail-hooks';
 import type { ChatContentProps } from './workspace-detail-chat-content';
-import { hasUserMessageWithoutAgentMessage } from './workspace-detail-container.utils';
+import {
+  buildSessionSummariesById,
+  hasUserMessageWithoutAgentMessage,
+} from './workspace-detail-container.utils';
 import { WorkspaceDetailView } from './workspace-detail-view';
-
-function areRuntimeStatesEqual(
-  left: SessionRuntimeState | undefined,
-  right: SessionRuntimeState
-): boolean {
-  if (!left) {
-    return false;
-  }
-
-  const leftExit = left.lastExit;
-  const rightExit = right.lastExit;
-  const sameLastExit =
-    leftExit === rightExit ||
-    (leftExit?.code === rightExit?.code &&
-      leftExit?.timestamp === rightExit?.timestamp &&
-      leftExit?.unexpected === rightExit?.unexpected);
-
-  return (
-    left.phase === right.phase &&
-    left.processState === right.processState &&
-    left.activity === right.activity &&
-    left.errorMessage === right.errorMessage &&
-    left.updatedAt === right.updatedAt &&
-    sameLastExit
-  );
-}
-
-function isLiveRuntimeNewerOrEqual(
-  liveRuntime: SessionRuntimeState,
-  summaryUpdatedAt: string | undefined
-): boolean {
-  if (!summaryUpdatedAt) {
-    return true;
-  }
-  const liveTs = Date.parse(liveRuntime.updatedAt);
-  const summaryTs = Date.parse(summaryUpdatedAt);
-  if (Number.isNaN(liveTs) || Number.isNaN(summaryTs)) {
-    return true;
-  }
-  return liveTs >= summaryTs;
-}
-
-interface SessionForRuntimeOverlay {
-  id: string;
-  name: string | null;
-  workflow: string | null;
-  model: string | null;
-  provider?: WorkspaceSessionRuntimeSummary['provider'];
-  status: WorkspaceSessionRuntimeSummary['persistedStatus'];
-}
-
-function mergeSessionSummariesWithLiveRuntime(
-  workspaceSummaries: WorkspaceSessionRuntimeSummary[] | undefined,
-  sessions: SessionForRuntimeOverlay[] | undefined,
-  liveSessionRuntimeById: Map<string, SessionRuntimeState>
-): Map<string, WorkspaceSessionRuntimeSummary> {
-  const summaries = new Map(
-    (workspaceSummaries ?? []).map((summary) => [summary.sessionId, summary])
-  );
-
-  for (const session of sessions ?? []) {
-    const liveRuntime = liveSessionRuntimeById.get(session.id);
-    if (!liveRuntime) {
-      continue;
-    }
-
-    const existingSummary = summaries.get(session.id);
-    if (!isLiveRuntimeNewerOrEqual(liveRuntime, existingSummary?.updatedAt)) {
-      continue;
-    }
-
-    summaries.set(session.id, {
-      sessionId: session.id,
-      name: existingSummary?.name ?? session.name ?? null,
-      workflow: existingSummary?.workflow ?? session.workflow ?? null,
-      model: existingSummary?.model ?? session.model ?? null,
-      provider: existingSummary?.provider ?? session.provider,
-      persistedStatus: existingSummary?.persistedStatus ?? session.status,
-      runtimePhase: liveRuntime.phase,
-      processState: liveRuntime.processState,
-      activity: liveRuntime.activity,
-      updatedAt: liveRuntime.updatedAt,
-      lastExit: liveRuntime.lastExit ?? existingSummary?.lastExit ?? null,
-      errorMessage: liveRuntime.errorMessage ?? existingSummary?.errorMessage ?? null,
-    });
-  }
-
-  return summaries;
-}
 
 export function WorkspaceDetailContainer() {
   const { slug = '', id: workspaceId = '' } = useParams<{ slug: string; id: string }>();
@@ -231,51 +144,16 @@ export function WorkspaceDetailContainer() {
     processStatus.state === 'unknown' &&
     hasUserMessageWithoutAgentMessage(messages);
 
-  const [liveSessionRuntimeById, setLiveSessionRuntimeById] = useState<
-    Map<string, SessionRuntimeState>
-  >(new Map());
-
-  useEffect(() => {
-    if (!selectedDbSessionId) {
-      return;
-    }
-
-    setLiveSessionRuntimeById((previous) => {
-      const previousRuntime = previous.get(selectedDbSessionId);
-      if (areRuntimeStatesEqual(previousRuntime, sessionRuntime)) {
-        return previous;
-      }
-
-      const next = new Map(previous);
-      next.set(selectedDbSessionId, sessionRuntime);
-      return next;
-    });
-  }, [selectedDbSessionId, sessionRuntime]);
-
-  useEffect(() => {
-    const knownSessionIds = new Set(sessionIds);
-    setLiveSessionRuntimeById((previous) => {
-      let changed = false;
-      const next = new Map<string, SessionRuntimeState>();
-      for (const [sessionId, runtime] of previous) {
-        if (knownSessionIds.has(sessionId)) {
-          next.set(sessionId, runtime);
-        } else {
-          changed = true;
-        }
-      }
-      return changed ? next : previous;
-    });
-  }, [sessionIds]);
-
   const sessionSummariesById = useMemo(
     () =>
-      mergeSessionSummariesWithLiveRuntime(
-        workspace?.sessionSummaries,
+      buildSessionSummariesById({
+        workspaceSummaries: workspace?.sessionSummaries,
         sessions,
-        liveSessionRuntimeById
-      ),
-    [workspace?.sessionSummaries, sessions, liveSessionRuntimeById]
+        selectedSessionId: selectedDbSessionId,
+        liveRuntime: sessionRuntime,
+        chatConnected: connected,
+      }),
+    [workspace?.sessionSummaries, sessions, selectedDbSessionId, sessionRuntime, connected]
   );
   const workspaceRunning = useMemo(
     () =>

--- a/src/client/routes/projects/workspaces/workspace-detail-container.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-container.tsx
@@ -101,6 +101,7 @@ export function WorkspaceDetailContainer() {
     sessionStatus,
     processStatus,
     sessionRuntime,
+    runtimeSessionId,
     pendingRequest,
     chatSettings,
     chatCapabilities,
@@ -151,9 +152,17 @@ export function WorkspaceDetailContainer() {
         sessions,
         selectedSessionId: selectedDbSessionId,
         liveRuntime: sessionRuntime,
+        runtimeSessionId,
         chatConnected: connected,
       }),
-    [workspace?.sessionSummaries, sessions, selectedDbSessionId, sessionRuntime, connected]
+    [
+      workspace?.sessionSummaries,
+      sessions,
+      selectedDbSessionId,
+      sessionRuntime,
+      runtimeSessionId,
+      connected,
+    ]
   );
   const workspaceRunning = useMemo(
     () =>

--- a/src/client/routes/projects/workspaces/workspace-detail-container.utils.test.ts
+++ b/src/client/routes/projects/workspaces/workspace-detail-container.utils.test.ts
@@ -84,6 +84,7 @@ describe('buildSessionSummariesById', () => {
       sessions: [makeSession()],
       selectedSessionId: null,
       liveRuntime: makeLiveRuntime(),
+      runtimeSessionId: null,
       chatConnected: true,
     });
 
@@ -97,6 +98,7 @@ describe('buildSessionSummariesById', () => {
       sessions: [makeSession()],
       selectedSessionId: 'session-1',
       liveRuntime: makeLiveRuntime({ phase: 'stopping', activity: 'IDLE' }),
+      runtimeSessionId: 'session-1',
       chatConnected: true,
     });
 
@@ -109,12 +111,42 @@ describe('buildSessionSummariesById', () => {
     expect(merged?.persistedStatus).toBe('RUNNING');
   });
 
+  it('does not overlay while the runtime still describes a previous session', () => {
+    // During a session switch the reducer holds the old session's runtime for
+    // a render or two; overlaying it would paint the wrong session's status
+    // onto the newly selected tab.
+    const result = buildSessionSummariesById({
+      workspaceSummaries: [makeSummary(), makeSummary({ sessionId: 'session-2' })],
+      sessions: [makeSession(), makeSession({ id: 'session-2' })],
+      selectedSessionId: 'session-2',
+      liveRuntime: makeLiveRuntime({ phase: 'running', activity: 'WORKING' }),
+      runtimeSessionId: 'session-1',
+      chatConnected: true,
+    });
+
+    expect(result.get('session-2')).toEqual(makeSummary({ sessionId: 'session-2' }));
+  });
+
+  it('does not overlay before the first hydration', () => {
+    const result = buildSessionSummariesById({
+      workspaceSummaries: [makeSummary()],
+      sessions: [makeSession()],
+      selectedSessionId: 'session-1',
+      liveRuntime: makeLiveRuntime({ phase: 'running' }),
+      runtimeSessionId: null,
+      chatConnected: true,
+    });
+
+    expect(result.get('session-1')).toEqual(makeSummary());
+  });
+
   it('does not overlay when the chat socket is disconnected', () => {
     const result = buildSessionSummariesById({
       workspaceSummaries: [makeSummary()],
       sessions: [makeSession()],
       selectedSessionId: 'session-1',
       liveRuntime: makeLiveRuntime({ phase: 'stopping' }),
+      runtimeSessionId: 'session-1',
       chatConnected: false,
     });
 
@@ -127,6 +159,7 @@ describe('buildSessionSummariesById', () => {
       sessions: [makeSession(), makeSession({ id: 'session-2' })],
       selectedSessionId: 'session-1',
       liveRuntime: makeLiveRuntime({ phase: 'error' }),
+      runtimeSessionId: 'session-1',
       chatConnected: true,
     });
 
@@ -139,6 +172,7 @@ describe('buildSessionSummariesById', () => {
       sessions: [makeSession()],
       selectedSessionId: 'session-gone',
       liveRuntime: makeLiveRuntime(),
+      runtimeSessionId: 'session-gone',
       chatConnected: true,
     });
 
@@ -151,6 +185,7 @@ describe('buildSessionSummariesById', () => {
       sessions: [makeSession({ id: 'session-new', name: 'Fresh chat', status: 'IDLE' })],
       selectedSessionId: 'session-new',
       liveRuntime: makeLiveRuntime({ phase: 'starting' }),
+      runtimeSessionId: 'session-new',
       chatConnected: true,
     });
 

--- a/src/client/routes/projects/workspaces/workspace-detail-container.utils.test.ts
+++ b/src/client/routes/projects/workspaces/workspace-detail-container.utils.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { hasUserMessageWithoutAgentMessage } from './workspace-detail-container.utils';
+import type { WorkspaceSessionRuntimeSummary } from '@/components/workspace/session-tab-runtime';
+import type { SessionRuntimeState } from '@/shared/session-runtime';
+import {
+  buildSessionSummariesById,
+  hasUserMessageWithoutAgentMessage,
+  type SessionForRuntimeOverlay,
+} from './workspace-detail-container.utils';
 
 describe('workspace detail container utils', () => {
   it('returns true when the transcript has a user message and no agent message', () => {
@@ -24,5 +30,134 @@ describe('workspace detail container utils', () => {
     };
 
     expect(hasUserMessageWithoutAgentMessage([{ source: 'agent' }, laterMessage])).toBe(false);
+  });
+});
+
+describe('buildSessionSummariesById', () => {
+  function makeSummary(
+    overrides: Partial<WorkspaceSessionRuntimeSummary> = {}
+  ): WorkspaceSessionRuntimeSummary {
+    return {
+      sessionId: 'session-1',
+      name: 'Snapshot name',
+      workflow: 'followup',
+      model: 'claude-sonnet-5',
+      provider: 'CLAUDE',
+      persistedStatus: 'RUNNING',
+      runtimePhase: 'running',
+      processState: 'alive',
+      activity: 'WORKING',
+      updatedAt: '2026-07-16T10:00:00.000Z',
+      lastExit: null,
+      errorMessage: null,
+      ...overrides,
+    };
+  }
+
+  function makeSession(
+    overrides: Partial<SessionForRuntimeOverlay> = {}
+  ): SessionForRuntimeOverlay {
+    return {
+      id: 'session-1',
+      name: 'DB name',
+      workflow: 'followup',
+      model: 'claude-sonnet-5',
+      provider: 'CLAUDE',
+      status: 'RUNNING',
+      ...overrides,
+    };
+  }
+
+  function makeLiveRuntime(overrides: Partial<SessionRuntimeState> = {}): SessionRuntimeState {
+    return {
+      phase: 'idle',
+      processState: 'alive',
+      activity: 'IDLE',
+      updatedAt: '2026-07-16T11:00:00.000Z',
+      ...overrides,
+    };
+  }
+
+  it('returns snapshot summaries as the base map', () => {
+    const result = buildSessionSummariesById({
+      workspaceSummaries: [makeSummary(), makeSummary({ sessionId: 'session-2' })],
+      sessions: [makeSession()],
+      selectedSessionId: null,
+      liveRuntime: makeLiveRuntime(),
+      chatConnected: true,
+    });
+
+    expect(result.size).toBe(2);
+    expect(result.get('session-1')).toEqual(makeSummary());
+  });
+
+  it('overlays live runtime on the selected session while connected', () => {
+    const result = buildSessionSummariesById({
+      workspaceSummaries: [makeSummary()],
+      sessions: [makeSession()],
+      selectedSessionId: 'session-1',
+      liveRuntime: makeLiveRuntime({ phase: 'stopping', activity: 'IDLE' }),
+      chatConnected: true,
+    });
+
+    const merged = result.get('session-1');
+    expect(merged?.runtimePhase).toBe('stopping');
+    expect(merged?.activity).toBe('IDLE');
+    expect(merged?.updatedAt).toBe('2026-07-16T11:00:00.000Z');
+    // Metadata still comes from the snapshot summary.
+    expect(merged?.name).toBe('Snapshot name');
+    expect(merged?.persistedStatus).toBe('RUNNING');
+  });
+
+  it('does not overlay when the chat socket is disconnected', () => {
+    const result = buildSessionSummariesById({
+      workspaceSummaries: [makeSummary()],
+      sessions: [makeSession()],
+      selectedSessionId: 'session-1',
+      liveRuntime: makeLiveRuntime({ phase: 'stopping' }),
+      chatConnected: false,
+    });
+
+    expect(result.get('session-1')).toEqual(makeSummary());
+  });
+
+  it('does not overlay sessions other than the selected one', () => {
+    const result = buildSessionSummariesById({
+      workspaceSummaries: [makeSummary(), makeSummary({ sessionId: 'session-2' })],
+      sessions: [makeSession(), makeSession({ id: 'session-2' })],
+      selectedSessionId: 'session-1',
+      liveRuntime: makeLiveRuntime({ phase: 'error' }),
+      chatConnected: true,
+    });
+
+    expect(result.get('session-2')).toEqual(makeSummary({ sessionId: 'session-2' }));
+  });
+
+  it('ignores a selected session that no longer exists in the session list', () => {
+    const result = buildSessionSummariesById({
+      workspaceSummaries: [],
+      sessions: [makeSession()],
+      selectedSessionId: 'session-gone',
+      liveRuntime: makeLiveRuntime(),
+      chatConnected: true,
+    });
+
+    expect(result.size).toBe(0);
+  });
+
+  it('creates an entry from the session row when no snapshot summary exists yet', () => {
+    const result = buildSessionSummariesById({
+      workspaceSummaries: [],
+      sessions: [makeSession({ id: 'session-new', name: 'Fresh chat', status: 'IDLE' })],
+      selectedSessionId: 'session-new',
+      liveRuntime: makeLiveRuntime({ phase: 'starting' }),
+      chatConnected: true,
+    });
+
+    const created = result.get('session-new');
+    expect(created?.name).toBe('Fresh chat');
+    expect(created?.persistedStatus).toBe('IDLE');
+    expect(created?.runtimePhase).toBe('starting');
+    expect(created?.lastExit).toBeNull();
   });
 });

--- a/src/client/routes/projects/workspaces/workspace-detail-container.utils.ts
+++ b/src/client/routes/projects/workspaces/workspace-detail-container.utils.ts
@@ -18,6 +18,8 @@ export interface BuildSessionSummariesOptions {
   sessions: SessionForRuntimeOverlay[] | undefined;
   selectedSessionId: string | null;
   liveRuntime: SessionRuntimeState;
+  /** The session the live runtime was hydrated for (null before hydration). */
+  runtimeSessionId: string | null;
   chatConnected: boolean;
 }
 
@@ -26,8 +28,12 @@ export interface BuildSessionSummariesOptions {
  * snapshot `sessionSummaries` are the base for every session, and the chat
  * WebSocket runtime overlays only the currently selected session while the
  * chat socket is connected (it is the direct authority for that session).
- * All other sessions stay on snapshot data, which the /snapshots channel
- * keeps live — no timestamp reconciliation needed.
+ * The overlay additionally requires the runtime to have been hydrated for
+ * the selected session — during a session switch the reducer still holds the
+ * previous session's runtime for a render or two, and overlaying it would
+ * paint the wrong session's status onto the new tab. All other sessions stay
+ * on snapshot data, which the /snapshots channel keeps live — no timestamp
+ * reconciliation needed.
  */
 export function buildSessionSummariesById(
   options: BuildSessionSummariesOptions
@@ -38,7 +44,7 @@ export function buildSessionSummariesById(
     (workspaceSummaries ?? []).map((summary) => [summary.sessionId, summary])
   );
 
-  if (!(selectedSessionId && chatConnected)) {
+  if (!(selectedSessionId && chatConnected && options.runtimeSessionId === selectedSessionId)) {
     return summaries;
   }
 

--- a/src/client/routes/projects/workspaces/workspace-detail-container.utils.ts
+++ b/src/client/routes/projects/workspaces/workspace-detail-container.utils.ts
@@ -1,6 +1,70 @@
+import type { WorkspaceSessionRuntimeSummary } from '@/components/workspace/session-tab-runtime';
 import type { ChatMessage } from '@/lib/chat-protocol';
+import type { SessionRuntimeState } from '@/shared/session-runtime';
 
 type MessageSourceOnly = Pick<ChatMessage, 'source'>;
+
+export interface SessionForRuntimeOverlay {
+  id: string;
+  name: string | null;
+  workflow: string | null;
+  model: string | null;
+  provider?: WorkspaceSessionRuntimeSummary['provider'];
+  status: WorkspaceSessionRuntimeSummary['persistedStatus'];
+}
+
+export interface BuildSessionSummariesOptions {
+  workspaceSummaries: WorkspaceSessionRuntimeSummary[] | undefined;
+  sessions: SessionForRuntimeOverlay[] | undefined;
+  selectedSessionId: string | null;
+  liveRuntime: SessionRuntimeState;
+  chatConnected: boolean;
+}
+
+/**
+ * Builds the per-session runtime summary map from a single reconciled source:
+ * snapshot `sessionSummaries` are the base for every session, and the chat
+ * WebSocket runtime overlays only the currently selected session while the
+ * chat socket is connected (it is the direct authority for that session).
+ * All other sessions stay on snapshot data, which the /snapshots channel
+ * keeps live — no timestamp reconciliation needed.
+ */
+export function buildSessionSummariesById(
+  options: BuildSessionSummariesOptions
+): Map<string, WorkspaceSessionRuntimeSummary> {
+  const { workspaceSummaries, sessions, selectedSessionId, liveRuntime, chatConnected } = options;
+
+  const summaries = new Map(
+    (workspaceSummaries ?? []).map((summary) => [summary.sessionId, summary])
+  );
+
+  if (!(selectedSessionId && chatConnected)) {
+    return summaries;
+  }
+
+  const session = sessions?.find((s) => s.id === selectedSessionId);
+  if (!session) {
+    return summaries;
+  }
+
+  const existing = summaries.get(selectedSessionId);
+  summaries.set(selectedSessionId, {
+    sessionId: selectedSessionId,
+    name: existing?.name ?? session.name ?? null,
+    workflow: existing?.workflow ?? session.workflow ?? null,
+    model: existing?.model ?? session.model ?? null,
+    provider: existing?.provider ?? session.provider,
+    persistedStatus: existing?.persistedStatus ?? session.status,
+    runtimePhase: liveRuntime.phase,
+    processState: liveRuntime.processState,
+    activity: liveRuntime.activity,
+    updatedAt: liveRuntime.updatedAt,
+    lastExit: liveRuntime.lastExit ?? existing?.lastExit ?? null,
+    errorMessage: liveRuntime.errorMessage ?? existing?.errorMessage ?? null,
+  });
+
+  return summaries;
+}
 
 export function hasUserMessageWithoutAgentMessage(messages: readonly MessageSourceOnly[]): boolean {
   let hasUserMessage = false;

--- a/src/client/routes/projects/workspaces/workspace-detail-header/ratcheting-toggle.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-header/ratcheting-toggle.tsx
@@ -1,9 +1,5 @@
 import { LightningIcon, SpinnerGapIcon } from '@phosphor-icons/react';
-import {
-  applyRatchetToggleState,
-  updateWorkspaceRatchetState,
-} from '@/client/lib/ratchet-toggle-cache';
-import { trpc } from '@/client/lib/trpc';
+import { useToggleRatcheting } from '@/client/hooks/use-toggle-ratcheting';
 import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
 import { RatchetToggleButton } from '@/components/workspace';
 import type { WorkspaceHeaderWorkspace } from './types';
@@ -17,43 +13,7 @@ export function RatchetingToggle({
   workspaceId: string;
   renderAsMenuItem?: boolean;
 }) {
-  const utils = trpc.useUtils();
-
-  const toggleRatcheting = trpc.workspace.toggleRatcheting.useMutation({
-    onMutate: ({ enabled }) => {
-      utils.workspace.get.setData({ id: workspaceId }, (old) => {
-        if (!old) {
-          return old;
-        }
-        return applyRatchetToggleState(old, enabled);
-      });
-      utils.workspace.listWithKanbanState.setData({ projectId: workspace.projectId }, (old) => {
-        if (!old) {
-          return old;
-        }
-        return updateWorkspaceRatchetState(old, workspaceId, enabled);
-      });
-      utils.workspace.getProjectSummaryState.setData({ projectId: workspace.projectId }, (old) => {
-        if (!old) {
-          return old;
-        }
-        return {
-          ...old,
-          workspaces: updateWorkspaceRatchetState(old.workspaces, workspaceId, enabled),
-        };
-      });
-    },
-    onError: () => {
-      utils.workspace.get.invalidate({ id: workspaceId });
-      utils.workspace.listWithKanbanState.invalidate({ projectId: workspace.projectId });
-      utils.workspace.getProjectSummaryState.invalidate({ projectId: workspace.projectId });
-    },
-    onSuccess: () => {
-      utils.workspace.get.invalidate({ id: workspaceId });
-      utils.workspace.listWithKanbanState.invalidate({ projectId: workspace.projectId });
-      utils.workspace.getProjectSummaryState.invalidate({ projectId: workspace.projectId });
-    },
-  });
+  const toggleRatcheting = useToggleRatcheting(workspace.projectId);
 
   const workspaceRatchetEnabled = workspace.ratchetEnabled ?? true;
 

--- a/src/components/chat/reducer/slices/session.ts
+++ b/src/components/chat/reducer/slices/session.ts
@@ -1,23 +1,17 @@
 import { createSessionSwitchResetState } from '@/components/chat/reducer/state';
 import type { ChatAction, ChatState } from '@/components/chat/reducer/types';
+import { deriveSessionUiStatusKind } from '@/shared/session-runtime';
 
 function deriveSessionStatus(runtime: ChatState['sessionRuntime']): ChatState['sessionStatus'] {
-  switch (runtime.phase) {
+  switch (deriveSessionUiStatusKind(runtime)) {
     case 'loading':
       return { phase: 'loading' };
     case 'starting':
       return { phase: 'starting' };
     case 'stopping':
       return { phase: 'stopping' };
-    case 'running':
-      // If process is stopped, show ready instead of running
-      if (runtime.processState === 'stopped') {
-        return { phase: 'ready' };
-      }
+    case 'working':
       return { phase: 'running' };
-    case 'idle':
-    case 'error':
-      return { phase: 'ready' };
     default:
       return { phase: 'ready' };
   }

--- a/src/components/chat/use-chat-websocket.ts
+++ b/src/components/chat/use-chat-websocket.ts
@@ -56,6 +56,13 @@ export interface UseChatWebSocketReturn {
   processStatus: ReturnType<typeof useChatState>['processStatus'];
   // Authoritative runtime snapshot for the selected session
   sessionRuntime: SessionRuntimeState;
+  /**
+   * The dbSessionId the current reducer state was hydrated for, or null
+   * before the first hydration. Stays on the previous session during a
+   * session switch until the new session's hydration batch arrives, so
+   * consumers can tell whether sessionRuntime describes dbSessionId yet.
+   */
+  runtimeSessionId: string | null;
   gitBranch: string | null;
   availableSessions: SessionInfo[];
   // Pending interactive request (permission or user question)
@@ -311,6 +318,7 @@ export function useChatWebSocket(options: UseChatWebSocketOptions): UseChatWebSo
     // State from chat
     messages: chat.messages,
     connected: transport.connected,
+    runtimeSessionId: hydratedSessionIdRef.current,
     sessionStatus: chat.sessionStatus,
     processStatus: chat.processStatus,
     sessionRuntime: chat.sessionRuntime,

--- a/src/components/chat/use-chat-websocket.ts
+++ b/src/components/chat/use-chat-websocket.ts
@@ -172,6 +172,18 @@ export function useChatWebSocket(options: UseChatWebSocketOptions): UseChatWebSo
   const cancelConnectLoadingRef = useRef<(() => void) | null>(null);
   const hydratedSessionIdRef = useRef<string | null>(null);
 
+  // Drop the hydration marker when the selected session moves away from the
+  // hydrated one. Without this, switching A -> B -> back to A before B
+  // hydrates would leave the marker claiming A is hydrated while the reducer
+  // state was reset by the switches, and consumers of runtimeSessionId would
+  // treat the reset runtime as authoritative for A. Same-session reconnects
+  // keep the marker so hydrated state isn't spuriously reported as loading.
+  useEffect(() => {
+    if (hydratedSessionIdRef.current !== null && hydratedSessionIdRef.current !== dbSessionId) {
+      hydratedSessionIdRef.current = null;
+    }
+  }, [dbSessionId]);
+
   const clearLoadTimeout = useCallback(() => {
     if (loadTimeoutRef.current) {
       clearTimeout(loadTimeoutRef.current);

--- a/src/components/workspace/session-tab-runtime.ts
+++ b/src/components/workspace/session-tab-runtime.ts
@@ -176,7 +176,9 @@ export function deriveSessionTabRuntime(
         isRunning: true,
       };
 
-    default:
+    // No default: the declared return type makes this switch exhaustive, so
+    // adding a SessionUiStatusKind fails to compile until it is handled here.
+    case 'idle':
       return IDLE_STATUS;
   }
 }

--- a/src/components/workspace/session-tab-runtime.ts
+++ b/src/components/workspace/session-tab-runtime.ts
@@ -10,8 +10,8 @@ import {
 import type { SessionStatus as DbSessionStatus } from '@/shared/core';
 import {
   getSessionSummaryErrorMessage,
-  isSessionSummaryWorking,
   type SessionSummary,
+  sessionUiStatusKindFromSummary,
 } from '@/shared/session-runtime';
 
 export type WorkspaceSessionRuntimeSummary = SessionSummary;
@@ -96,93 +96,87 @@ export function deriveSessionTabRuntime(
     return getFallbackStatusInfo(persistedStatus);
   }
 
-  if (summary.runtimePhase === 'loading') {
-    return {
-      color: 'text-muted-foreground',
-      pulse: false,
-      spin: true,
-      label: 'Loading',
-      description: 'Loading session...',
-      icon: SpinnerGapIcon,
-      isRunning: false,
-    };
-  }
+  switch (sessionUiStatusKindFromSummary(summary)) {
+    case 'loading':
+      return {
+        color: 'text-muted-foreground',
+        pulse: false,
+        spin: true,
+        label: 'Loading',
+        description: 'Loading session...',
+        icon: SpinnerGapIcon,
+        isRunning: false,
+      };
 
-  if (summary.runtimePhase === 'starting') {
-    return {
-      color: 'text-muted-foreground',
-      pulse: false,
-      spin: true,
-      label: 'Starting',
-      description: 'Launching agent...',
-      icon: SpinnerGapIcon,
-      isRunning: false,
-    };
-  }
+    case 'starting':
+      return {
+        color: 'text-muted-foreground',
+        pulse: false,
+        spin: true,
+        label: 'Starting',
+        description: 'Launching agent...',
+        icon: SpinnerGapIcon,
+        isRunning: false,
+      };
 
-  if (summary.runtimePhase === 'stopping') {
-    return {
-      color: 'text-brand',
-      pulse: false,
-      spin: true,
-      label: 'Stopping',
-      description: 'Finishing current request...',
-      icon: SpinnerGapIcon,
-      isRunning: false,
-    };
-  }
+    case 'stopping':
+      return {
+        color: 'text-brand',
+        pulse: false,
+        spin: true,
+        label: 'Stopping',
+        description: 'Finishing current request...',
+        icon: SpinnerGapIcon,
+        isRunning: false,
+      };
 
-  if (summary.runtimePhase === 'error') {
-    const runtimeError = getSessionSummaryErrorMessage(summary);
-    return {
-      color: 'text-destructive',
-      pulse: false,
-      spin: false,
-      label: 'Error',
-      description: runtimeError ?? 'Session entered an error state',
-      icon: XCircleIcon,
-      isRunning: false,
-    };
-  }
+    case 'error':
+      return {
+        color: 'text-destructive',
+        pulse: false,
+        spin: false,
+        label: 'Error',
+        description: getSessionSummaryErrorMessage(summary) ?? 'Session entered an error state',
+        icon: XCircleIcon,
+        isRunning: false,
+      };
 
-  if (summary.processState === 'stopped') {
-    if (summary.lastExit?.unexpected) {
-      const runtimeError = getSessionSummaryErrorMessage(summary);
+    case 'unexpected-exit':
       return {
         color: 'text-destructive',
         pulse: false,
         spin: false,
         label: 'Error',
         description:
-          runtimeError ??
-          `Exited unexpectedly${summary.lastExit.code !== null ? ` (code ${summary.lastExit.code})` : ''}`,
+          getSessionSummaryErrorMessage(summary) ??
+          `Exited unexpectedly${summary.lastExit?.code != null ? ` (code ${summary.lastExit.code})` : ''}`,
         icon: XCircleIcon,
         isRunning: false,
       };
-    }
 
-    return {
-      color: 'text-muted-foreground',
-      pulse: false,
-      spin: false,
-      label: 'Stopped',
-      description: 'Send a message to start',
-      icon: ProhibitIcon,
-      isRunning: false,
-    };
+    case 'stopped':
+      return {
+        color: 'text-muted-foreground',
+        pulse: false,
+        spin: false,
+        label: 'Stopped',
+        description: 'Send a message to start',
+        icon: ProhibitIcon,
+        isRunning: false,
+      };
+
+    case 'working':
+      return {
+        color: 'text-brand',
+        pulse: true,
+        spin: false,
+        label: 'Running',
+        description: 'Processing your request',
+        icon: PulseIcon,
+        isRunning: true,
+      };
+
+    default:
+      return IDLE_STATUS;
   }
-
-  if (isSessionSummaryWorking(summary)) {
-    return {
-      color: 'text-brand',
-      pulse: true,
-      spin: false,
-      label: 'Running',
-      description: 'Processing your request',
-      icon: PulseIcon,
-      isRunning: true,
-    };
-  }
-
-  return IDLE_STATUS;
 }

--- a/src/hooks/use-websocket-transport.replay.test.tsx
+++ b/src/hooks/use-websocket-transport.replay.test.tsx
@@ -330,6 +330,35 @@ describe('useWebSocketTransport replay queue', () => {
     harness.cleanup();
   });
 
+  it('reports disconnected while a URL-change replacement socket is still connecting', async () => {
+    const harness = createHarness({ initialUrl: 'ws://localhost:3000/chat?sessionId=one' });
+    await flushEffects();
+
+    const firstSocket = getLastSocket();
+    flushSync(() => {
+      firstSocket.simulateOpen();
+    });
+    expect(harness.transportRef.current?.connected).toBe(true);
+
+    harness.rerenderUrl('ws://localhost:3000/chat?sessionId=two');
+    await flushEffects();
+
+    // The old socket is closed and the new one has not opened yet. The state
+    // update from the effect cleanup lands on the next scheduler tick.
+    await vi.waitFor(() => {
+      expect(harness.transportRef.current?.connected).toBe(false);
+    });
+
+    const secondSocket = getLastSocket();
+    expect(secondSocket).not.toBe(firstSocket);
+    flushSync(() => {
+      secondSocket.simulateOpen();
+    });
+    expect(harness.transportRef.current?.connected).toBe(true);
+
+    harness.cleanup();
+  });
+
   it('exposes gaveUp after exhausting reconnect attempts and resets on manual reconnect', async () => {
     vi.useFakeTimers();
     vi.spyOn(Math, 'random').mockReturnValue(0);

--- a/src/hooks/use-websocket-transport.ts
+++ b/src/hooks/use-websocket-transport.ts
@@ -345,6 +345,11 @@ export function useWebSocketTransport(
       if (wsRef.current) {
         wsRef.current.close();
         wsRef.current = null;
+        // The closing socket's onclose is ignored once wsRef is cleared, so
+        // reflect the closed state here. Otherwise a URL change leaves
+        // consumers reading connected=true while the replacement socket is
+        // still connecting.
+        setConnected(false);
       }
     };
   }, [url, connect]);

--- a/src/shared/session-runtime.test.ts
+++ b/src/shared/session-runtime.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import {
+  deriveSessionUiStatusKind,
   getSessionRuntimeErrorMessage,
   getSessionSummaryErrorMessage,
   hasWorkingSessionSummary,
   isSessionSummaryWorking,
   type SessionRuntimeLastExit,
   type SessionRuntimePhase,
+  type SessionUiStatusInput,
+  sessionUiStatusKindFromSummary,
 } from './session-runtime';
 
 interface RuntimeErrorCase {
@@ -71,6 +74,74 @@ describe('session runtime error message helpers', () => {
       ).toBe(testCase.expected);
     });
   }
+});
+
+describe('deriveSessionUiStatusKind', () => {
+  function makeInput(overrides: Partial<SessionUiStatusInput> = {}): SessionUiStatusInput {
+    return {
+      phase: 'idle',
+      processState: 'alive',
+      activity: 'IDLE',
+      lastExit: null,
+      ...overrides,
+    };
+  }
+
+  it('maps lifecycle transition phases directly', () => {
+    expect(deriveSessionUiStatusKind(makeInput({ phase: 'loading' }))).toBe('loading');
+    expect(deriveSessionUiStatusKind(makeInput({ phase: 'starting' }))).toBe('starting');
+    expect(deriveSessionUiStatusKind(makeInput({ phase: 'stopping' }))).toBe('stopping');
+  });
+
+  it('reports error phase before process state', () => {
+    expect(deriveSessionUiStatusKind(makeInput({ phase: 'error', processState: 'stopped' }))).toBe(
+      'error'
+    );
+  });
+
+  it('reports stopped process before working, distinguishing unexpected exits', () => {
+    expect(
+      deriveSessionUiStatusKind(
+        makeInput({ phase: 'running', processState: 'stopped', activity: 'WORKING' })
+      )
+    ).toBe('stopped');
+    expect(
+      deriveSessionUiStatusKind(
+        makeInput({ phase: 'running', processState: 'stopped', lastExit: unexpectedExit })
+      )
+    ).toBe('unexpected-exit');
+  });
+
+  it('treats activity WORKING or phase running as working', () => {
+    expect(deriveSessionUiStatusKind(makeInput({ activity: 'WORKING' }))).toBe('working');
+    expect(deriveSessionUiStatusKind(makeInput({ phase: 'running' }))).toBe('working');
+  });
+
+  it('falls back to idle', () => {
+    expect(deriveSessionUiStatusKind(makeInput())).toBe('idle');
+    expect(deriveSessionUiStatusKind(makeInput({ processState: 'unknown' }))).toBe('idle');
+  });
+});
+
+describe('sessionUiStatusKindFromSummary', () => {
+  it('adapts summary field names to the runtime input shape', () => {
+    expect(
+      sessionUiStatusKindFromSummary({
+        runtimePhase: 'idle',
+        processState: 'stopped',
+        activity: 'IDLE',
+        lastExit: unexpectedExit,
+      })
+    ).toBe('unexpected-exit');
+    expect(
+      sessionUiStatusKindFromSummary({
+        runtimePhase: 'idle',
+        processState: 'alive',
+        activity: 'WORKING',
+        lastExit: null,
+      })
+    ).toBe('working');
+  });
 });
 
 describe('session runtime working helpers', () => {

--- a/src/shared/session-runtime.ts
+++ b/src/shared/session-runtime.ts
@@ -42,6 +42,56 @@ export interface SessionRuntimeState {
   updatedAt: string;
 }
 
+/**
+ * Canonical UI-facing session status, derived from the runtime signals in a
+ * fixed precedence order. Both the chat reducer (composer status) and the
+ * session tab presenter derive from this single function so their semantics
+ * cannot drift apart.
+ */
+export type SessionUiStatusKind =
+  | 'loading'
+  | 'starting'
+  | 'stopping'
+  | 'error'
+  | 'unexpected-exit'
+  | 'stopped'
+  | 'working'
+  | 'idle';
+
+export interface SessionUiStatusInput {
+  phase: SessionRuntimePhase;
+  processState: SessionRuntimeProcessState;
+  activity: SessionRuntimeActivity;
+  lastExit?: SessionRuntimeLastExit | null;
+}
+
+export function deriveSessionUiStatusKind(input: SessionUiStatusInput): SessionUiStatusKind {
+  if (input.phase === 'loading' || input.phase === 'starting' || input.phase === 'stopping') {
+    return input.phase;
+  }
+  if (input.phase === 'error') {
+    return 'error';
+  }
+  if (input.processState === 'stopped') {
+    return input.lastExit?.unexpected ? 'unexpected-exit' : 'stopped';
+  }
+  if (input.activity === 'WORKING' || input.phase === 'running') {
+    return 'working';
+  }
+  return 'idle';
+}
+
+export function sessionUiStatusKindFromSummary(
+  summary: Pick<SessionSummary, 'runtimePhase' | 'processState' | 'activity' | 'lastExit'>
+): SessionUiStatusKind {
+  return deriveSessionUiStatusKind({
+    phase: summary.runtimePhase,
+    processState: summary.processState,
+    activity: summary.activity,
+    lastExit: summary.lastExit,
+  });
+}
+
 export function createInitialSessionRuntimeState(): SessionRuntimeState {
   return {
     phase: 'idle',


### PR DESCRIPTION
Fixes #1889.

## What changed

**1. One merge strategy per cache (issue point 1).** `/snapshots` deltas (`snapshot_changed` / `snapshot_removed`) are now pure `setData` patches — they no longer invalidate `workspace.list` on every message (no more per-delta refetch storms), and the `workspace.listWithRuntimeState` invalidation was removed entirely (it has no client consumers). `workspace.list`'s only consumer (inline workspace form) uses default `staleTime: 0` and refetches on mount, so it needs no snapshot-driven invalidation.

**2. Single session-status derivation (issue point 2).** Added a canonical `SessionUiStatusKind` + `deriveSessionUiStatusKind()` in `src/shared/session-runtime.ts` with a fixed precedence (loading → starting → stopping → error → stopped/unexpected-exit → working → idle). Both the chat reducer's `deriveSessionStatus` and the tab presenter's `deriveSessionTabRuntime` now derive from it, so they can no longer drift apart. One intentional unification: `phase: 'idle', activity: 'WORKING'` now reports `running` in the chat composer (previously `ready`), matching the tab presenter.

The three-representation timestamp dance is gone: `liveSessionRuntimeById` + `mergeSessionSummariesWithLiveRuntime`'s `updatedAt` comparison were replaced by `buildSessionSummariesById`, which uses snapshot `sessionSummaries` as the base and overlays the chat WS runtime only for the currently selected session while the chat socket is connected — the socket is the direct authority for that session, and every other session stays on live-pushed snapshot data. No clock comparison, no equal-timestamp/clock-skew flip.

**3. Self-healing on WS reconnect (issue point 3).** The server re-sends `snapshot_full` on every connect, but the `staleTime: Infinity` caches hold DB-backed fields the snapshot doesn't carry (issue links) and `workspace.get` entries for workspaces archived while disconnected. The sync hook now tracks disconnects and, on the first `snapshot_full` after a disconnect, additionally invalidates `workspace.get`, `workspace.list`, `workspace.getProjectSummaryState`, and `workspace.listWithKanbanState`. The initial baseline on page load does not refetch.

**4. One ratchet-toggle path with overwrite guard (issue point 4).** Both the header toggle and the kanban toggle now use a shared `useToggleRatcheting` hook (optimistic `setData` on all three caches, invalidate on settle). While the mutation is in flight, the workspace's pending value is registered in a module-level registry and `overridePendingRatchetToggle` is applied to every incoming snapshot entry, so a stale snapshot computed before the mutation committed can no longer flip the toggle back (visible flip-flop).

## Tests

- New: `deriveSessionUiStatusKind` precedence, `buildSessionSummariesById` overlay rules, pending-toggle override, delta-vs-baseline invalidation strategy.
- Updated: snapshot-sync invalidation assertions.
- `pnpm test` (3684 passed), `pnpm typecheck`, `pnpm check`, `pnpm check:fix` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core real-time cache merge paths (snapshots, ratchet, session tabs/chat) where subtle race bugs could show wrong workspace or session state; changes are well-tested but behavior shifts (e.g. fewer delta refetches, composer "running" when idle+WORKING).
> 
> **Overview**
> Unifies how live workspace and session state is merged into React Query and the UI, fixing flip-flops, refetch storms, and divergent status semantics.
> 
> **Snapshot sync** now treats `snapshot_changed` / `snapshot_removed` as **setData-only** patches (no per-delta invalidation). **Reconnect healing** runs only on a project's **second and later** `snapshot_full` baselines, invalidating `workspace.get`, `workspace.list`, summary, and kanban caches to restore DB-only fields. Incoming snapshot entries pass through **`overridePendingRatchetToggle`** while a ratchet mutation is in flight.
> 
> **Ratchet toggles** share **`useToggleRatcheting`** (header + kanban): optimistic cache patches, a tokenized pending registry, and settle-time invalidation replace duplicated mutation logic.
> 
> **Session runtime** uses **`deriveSessionUiStatusKind`** for both the chat reducer and session tabs. Workspace detail builds summaries via **`buildSessionSummariesById`** (snapshot base + chat WS overlay for the selected session only), with **`runtimeSessionId`** so stale runtime is not applied during tab switches. **`useWebSocketTransport`** sets `connected` false when the URL changes and the replacement socket is still connecting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f453a9c67264f05e67fad2bc65d6c6a98b4f9375. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->