### PR TITLE
Fix #1887: Add explicit transition table and CAS on fromState to ratchet state machine

### DIFF
--- a/scripts/check-single-writer.mjs
+++ b/scripts/check-single-writer.mjs
@@ -222,7 +222,11 @@ const workspaceMutationRules = {
     type: 'static',
     fields: ['ratchetActiveSessionId', 'ratchetDispatchOutcome'],
   },
-  updateRatchetCheckIfEnabled: {
+  transitionRatchetStateIfEnabled: {
+    type: 'static',
+    fields: ['ratchetState', 'ratchetLastCheckedAt'],
+  },
+  settleRatchetIdleWhileDisabled: {
     type: 'static',
     fields: ['ratchetState', 'ratchetLastCheckedAt'],
   },

--- a/src/backend/services/ratchet/service/ratchet-state-machine.test.ts
+++ b/src/backend/services/ratchet/service/ratchet-state-machine.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { RatchetState } from '@/shared/core';
+import {
+  assertValidRatchetTransition,
+  isValidRatchetTransition,
+  RATCHET_VALID_TRANSITIONS,
+  RatchetStateMachineError,
+} from './ratchet-state-machine';
+
+const ALL_STATES = Object.values(RatchetState);
+const OPEN_PR_STATES = [
+  RatchetState.CI_RUNNING,
+  RatchetState.CI_FAILED,
+  RatchetState.MERGE_CONFLICT,
+  RatchetState.REVIEW_PENDING,
+  RatchetState.READY,
+] as const;
+
+describe('ratchet state machine', () => {
+  it('declares transitions for every ratchet state', () => {
+    expect(Object.keys(RATCHET_VALID_TRANSITIONS).sort()).toEqual([...ALL_STATES].sort());
+  });
+
+  it('allows every state to settle to IDLE (PR closed / ratchet disabled)', () => {
+    for (const from of ALL_STATES) {
+      if (from === RatchetState.IDLE) {
+        continue;
+      }
+      expect(isValidRatchetTransition(from, RatchetState.IDLE)).toBe(true);
+    }
+  });
+
+  it('allows IDLE to move to any observed PR state', () => {
+    for (const to of [...OPEN_PR_STATES, RatchetState.MERGED]) {
+      expect(isValidRatchetTransition(RatchetState.IDLE, to)).toBe(true);
+    }
+  });
+
+  it('allows open-PR states to move between each other and to MERGED', () => {
+    for (const from of OPEN_PR_STATES) {
+      for (const to of [...OPEN_PR_STATES, RatchetState.MERGED]) {
+        if (from === to) {
+          continue;
+        }
+        expect(isValidRatchetTransition(from, to)).toBe(true);
+      }
+    }
+  });
+
+  it('allows MERGED to move to open-PR states (workspace PR pointer switch)', () => {
+    for (const to of OPEN_PR_STATES) {
+      expect(isValidRatchetTransition(RatchetState.MERGED, to)).toBe(true);
+    }
+  });
+
+  it('treats same-state writes as valid refreshes, not transitions', () => {
+    for (const state of ALL_STATES) {
+      expect(RATCHET_VALID_TRANSITIONS[state]).not.toContain(state);
+      expect(isValidRatchetTransition(state, state)).toBe(true);
+    }
+  });
+
+  describe('assertValidRatchetTransition', () => {
+    it('does not throw for a valid transition', () => {
+      expect(() =>
+        assertValidRatchetTransition('ws-1', RatchetState.CI_FAILED, RatchetState.IDLE)
+      ).not.toThrow();
+    });
+
+    it('throws RatchetStateMachineError naming the workspace and states when invalid', () => {
+      // No pair in the current table is invalid (the state is derived from PR
+      // observations, which can move between any two states). Exercise the
+      // guard against a hypothetical restricted table via the exported error
+      // so the throw contract is pinned for future restrictions.
+      const error = new RatchetStateMachineError(
+        'ws-1',
+        RatchetState.MERGED,
+        RatchetState.CI_RUNNING
+      );
+      expect(error.name).toBe('RatchetStateMachineError');
+      expect(error.workspaceId).toBe('ws-1');
+      expect(error.fromState).toBe(RatchetState.MERGED);
+      expect(error.toState).toBe(RatchetState.CI_RUNNING);
+      expect(error.message).toContain('MERGED');
+      expect(error.message).toContain('CI_RUNNING');
+      expect(error.message).toContain('ws-1');
+    });
+  });
+});

--- a/src/backend/services/ratchet/service/ratchet-state-machine.ts
+++ b/src/backend/services/ratchet/service/ratchet-state-machine.ts
@@ -1,0 +1,127 @@
+/**
+ * Ratchet State Machine
+ *
+ * `Workspace.ratchetState` is a state machine over PR observations, mirroring
+ * the workspace lifecycle machine's explicit transition table. Unlike the
+ * lifecycle machine, ratchet state is *derived*: each poll observes the PR on
+ * GitHub (CI status, merge conflicts, review state) and persists what it saw,
+ * so almost any state can follow any other — new commits restart CI, reviews
+ * arrive, conflicts appear and resolve, and the workspace's PR pointer can
+ * switch to a brand-new PR after the old one merged.
+ *
+ * The table below therefore encodes intent and acts as a tripwire for future
+ * refactors rather than restricting today's graph. The enforced invariant is
+ * compare-and-swap on the expected fromState at the point of persistence
+ * (see workspaceAccessor.transitionRatchetStateIfEnabled and
+ * settleRatchetIdleWhileDisabled), which guarantees that emitted
+ * RATCHET_STATE_CHANGED events carry an accurate fromState and that stale
+ * in-flight checks cannot overwrite a concurrent transition.
+ */
+
+import { RatchetState } from '@/shared/core';
+
+const OPEN_PR_STATES = [
+  RatchetState.CI_RUNNING,
+  RatchetState.CI_FAILED,
+  RatchetState.MERGE_CONFLICT,
+  RatchetState.REVIEW_PENDING,
+  RatchetState.READY,
+] as const;
+
+/**
+ * Valid state transitions for ratchet state. Self-transitions are not listed:
+ * a same-state write is a refresh (ratchetLastCheckedAt), not a transition.
+ */
+export const RATCHET_VALID_TRANSITIONS: Record<RatchetState, readonly RatchetState[]> = {
+  // IDLE: nothing being ratcheted (no open PR, PR closed, or ratchet disabled).
+  // Enabling ratchet on a workspace whose PR is already in any observable
+  // state moves directly to that state.
+  IDLE: [...OPEN_PR_STATES, RatchetState.MERGED],
+  // Open-PR states can move to any other observation (new commits restart CI,
+  // reviews arrive, conflicts appear or resolve), settle to IDLE (PR closed or
+  // ratchet disabled), or complete as MERGED.
+  CI_RUNNING: [
+    RatchetState.IDLE,
+    RatchetState.CI_FAILED,
+    RatchetState.MERGE_CONFLICT,
+    RatchetState.REVIEW_PENDING,
+    RatchetState.READY,
+    RatchetState.MERGED,
+  ],
+  CI_FAILED: [
+    RatchetState.IDLE,
+    RatchetState.CI_RUNNING,
+    RatchetState.MERGE_CONFLICT,
+    RatchetState.REVIEW_PENDING,
+    RatchetState.READY,
+    RatchetState.MERGED,
+  ],
+  MERGE_CONFLICT: [
+    RatchetState.IDLE,
+    RatchetState.CI_RUNNING,
+    RatchetState.CI_FAILED,
+    RatchetState.REVIEW_PENDING,
+    RatchetState.READY,
+    RatchetState.MERGED,
+  ],
+  REVIEW_PENDING: [
+    RatchetState.IDLE,
+    RatchetState.CI_RUNNING,
+    RatchetState.CI_FAILED,
+    RatchetState.MERGE_CONFLICT,
+    RatchetState.READY,
+    RatchetState.MERGED,
+  ],
+  READY: [
+    RatchetState.IDLE,
+    RatchetState.CI_RUNNING,
+    RatchetState.CI_FAILED,
+    RatchetState.MERGE_CONFLICT,
+    RatchetState.REVIEW_PENDING,
+    RatchetState.MERGED,
+  ],
+  // MERGED is terminal for the observed PR itself: it can settle to IDLE
+  // (ratchet disabled) or move to an open-PR state when the workspace's PR
+  // pointer switches to a new PR (event-driven check after a PR switch).
+  MERGED: [RatchetState.IDLE, ...OPEN_PR_STATES],
+};
+
+/**
+ * Error thrown when an invalid ratchet state transition is attempted.
+ */
+export class RatchetStateMachineError extends Error {
+  constructor(
+    public readonly workspaceId: string,
+    public readonly fromState: RatchetState,
+    public readonly toState: RatchetState,
+    message?: string
+  ) {
+    super(
+      message ??
+        `Invalid ratchet state transition: ${fromState} → ${toState} (workspace: ${workspaceId})`
+    );
+    this.name = 'RatchetStateMachineError';
+  }
+}
+
+export function isValidRatchetTransition(from: RatchetState, to: RatchetState): boolean {
+  if (from === to) {
+    return true;
+  }
+  return RATCHET_VALID_TRANSITIONS[from].includes(to);
+}
+
+/**
+ * Validate a ratchet state transition before persisting it.
+ *
+ * @throws RatchetStateMachineError if the transition is not in the table
+ */
+export function assertValidRatchetTransition(
+  workspaceId: string,
+  fromState: RatchetState,
+  toState: RatchetState
+): void {
+  if (!isValidRatchetTransition(fromState, toState)) {
+    throw new RatchetStateMachineError(workspaceId, fromState, toState);
+  }
+}

--- a/src/backend/services/ratchet/service/ratchet.service.test.ts
+++ b/src/backend/services/ratchet/service/ratchet.service.test.ts
@@ -10,7 +10,8 @@ vi.mock('@/backend/services/workspace', () => ({
     findWithPRsForRatchet: vi.fn(),
     findForRatchetById: vi.fn(),
     update: vi.fn(),
-    updateRatchetCheckIfEnabled: vi.fn(),
+    transitionRatchetStateIfEnabled: vi.fn(),
+    settleRatchetIdleWhileDisabled: vi.fn(),
     recordRatchetDispatchIfEnabled: vi.fn(),
     adoptRatchetActiveSessionIfEnabled: vi.fn(),
     recordRatchetSessionEnd: vi.fn(),
@@ -108,7 +109,8 @@ describe('ratchet service (state-change + idle dispatch)', () => {
       github: mockGitHubBridge,
       snapshot: mockSnapshotBridge,
     });
-    vi.mocked(workspaceAccessor.updateRatchetCheckIfEnabled).mockResolvedValue(true);
+    vi.mocked(workspaceAccessor.transitionRatchetStateIfEnabled).mockResolvedValue(true);
+    vi.mocked(workspaceAccessor.settleRatchetIdleWhileDisabled).mockResolvedValue(true);
     vi.mocked(workspaceAccessor.recordRatchetDispatchIfEnabled).mockResolvedValue(true);
     vi.mocked(workspaceAccessor.adoptRatchetActiveSessionIfEnabled).mockResolvedValue(true);
     vi.mocked(workspaceAccessor.recordRatchetSessionEnd).mockResolvedValue(true);
@@ -213,6 +215,90 @@ describe('ratchet service (state-change + idle dispatch)', () => {
       action: { type: 'DISABLED', reason: 'Workspace ratcheting disabled' },
       newState: RatchetState.IDLE,
     });
+    expect(workspaceAccessor.settleRatchetIdleWhileDisabled).toHaveBeenCalledWith(
+      'ws-disabled',
+      RatchetState.IDLE
+    );
+  });
+
+  it('settles a disabled workspace to IDLE via CAS and emits an accurate fromState', async () => {
+    const workspace = {
+      id: 'ws-disabled-settle',
+      prUrl: 'https://github.com/example/repo/pull/2',
+      prNumber: 2,
+      prState: 'OPEN',
+      prCiStatus: CIStatus.UNKNOWN,
+      ratchetEnabled: false,
+      ratchetState: RatchetState.CI_FAILED,
+      ratchetActiveSessionId: null,
+      ratchetLastCiRunId: null,
+      prReviewLastCheckedAt: null,
+      ratchetDispatchOutcome: null,
+      ratchetDispatchRetryCount: 0,
+    };
+
+    vi.mocked(workspaceAccessor.settleRatchetIdleWhileDisabled).mockResolvedValue(true);
+
+    const events: RatchetStateChangedEvent[] = [];
+    ratchetService.on(RATCHET_STATE_CHANGED, (event: RatchetStateChangedEvent) => {
+      events.push(event);
+    });
+
+    const result = await unsafeCoerce<{
+      processWorkspace: (workspaceArg: typeof workspace) => Promise<WorkspaceRatchetResult>;
+    }>(ratchetService).processWorkspace(workspace);
+
+    expect(workspaceAccessor.settleRatchetIdleWhileDisabled).toHaveBeenCalledWith(
+      'ws-disabled-settle',
+      RatchetState.CI_FAILED
+    );
+    expect(result).toMatchObject({
+      previousState: RatchetState.CI_FAILED,
+      newState: RatchetState.IDLE,
+      action: { type: 'DISABLED' },
+    });
+    expect(events).toEqual([
+      {
+        workspaceId: 'ws-disabled-settle',
+        fromState: RatchetState.CI_FAILED,
+        toState: RatchetState.IDLE,
+      },
+    ]);
+    ratchetService.removeAllListeners();
+  });
+
+  it('does not emit for a disabled workspace when the settle CAS loses', async () => {
+    const workspace = {
+      id: 'ws-disabled-settle-race',
+      prUrl: 'https://github.com/example/repo/pull/2',
+      prNumber: 2,
+      prState: 'OPEN',
+      prCiStatus: CIStatus.UNKNOWN,
+      ratchetEnabled: false,
+      ratchetState: RatchetState.CI_FAILED,
+      ratchetActiveSessionId: null,
+      ratchetLastCiRunId: null,
+      prReviewLastCheckedAt: null,
+      ratchetDispatchOutcome: null,
+      ratchetDispatchRetryCount: 0,
+    };
+
+    vi.mocked(workspaceAccessor.settleRatchetIdleWhileDisabled).mockResolvedValue(false);
+
+    const events: RatchetStateChangedEvent[] = [];
+    ratchetService.on(RATCHET_STATE_CHANGED, (event: RatchetStateChangedEvent) => {
+      events.push(event);
+    });
+
+    const result = await unsafeCoerce<{
+      processWorkspace: (workspaceArg: typeof workspace) => Promise<WorkspaceRatchetResult>;
+    }>(ratchetService).processWorkspace(workspace);
+
+    expect(result).toMatchObject({
+      action: { type: 'DISABLED' },
+    });
+    expect(events).toEqual([]);
+    ratchetService.removeAllListeners();
   });
 
   it('does not dispatch when workspace is not idle', async () => {
@@ -327,8 +413,8 @@ describe('ratchet service (state-change + idle dispatch)', () => {
       retryCount: 0,
     });
     const finalUpdatePayload = vi
-      .mocked(workspaceAccessor.updateRatchetCheckIfEnabled)
-      .mock.calls.at(-1)?.[1] as Record<string, unknown>;
+      .mocked(workspaceAccessor.transitionRatchetStateIfEnabled)
+      .mock.calls.at(-1)?.[2] as Record<string, unknown>;
     expect(finalUpdatePayload).not.toHaveProperty('ratchetLastCiRunId');
     expect(finalUpdatePayload).not.toHaveProperty('prReviewLastCheckedAt');
     expect(mockSnapshotBridge.recordReviewCheck).toHaveBeenCalledWith(
@@ -373,7 +459,11 @@ describe('ratchet service (state-change + idle dispatch)', () => {
       promptSent: true,
     } as never);
     vi.mocked(workspaceAccessor.recordRatchetDispatchIfEnabled).mockResolvedValue(false);
-    vi.mocked(workspaceAccessor.updateRatchetCheckIfEnabled).mockResolvedValue(false);
+    vi.mocked(workspaceAccessor.transitionRatchetStateIfEnabled).mockResolvedValue(false);
+    vi.mocked(workspaceAccessor.findById).mockResolvedValue({
+      id: 'ws-disable-race-dispatch',
+      ratchetEnabled: false,
+    } as never);
     vi.mocked(mockSessionBridge.isSessionRunning).mockReturnValue(true);
 
     const result = await unsafeCoerce<{
@@ -873,7 +963,11 @@ describe('ratchet service (state-change + idle dispatch)', () => {
       prState: 'OPEN',
       prNumber: 41,
     });
-    vi.mocked(workspaceAccessor.updateRatchetCheckIfEnabled).mockResolvedValue(false);
+    vi.mocked(workspaceAccessor.transitionRatchetStateIfEnabled).mockResolvedValue(false);
+    vi.mocked(workspaceAccessor.findById).mockResolvedValue({
+      id: 'ws-disable-race-state',
+      ratchetEnabled: false,
+    } as never);
     vi.mocked(agentSessionAccessor.findByWorkspaceId).mockResolvedValue([] as never);
 
     const events: RatchetStateChangedEvent[] = [];
@@ -890,6 +984,70 @@ describe('ratchet service (state-change + idle dispatch)', () => {
       action: { type: 'DISABLED', reason: 'Workspace ratcheting disabled' },
     });
     expect(events).toHaveLength(0);
+    ratchetService.removeAllListeners();
+  });
+
+  it('reports a concurrent state change without emitting when the check loses the CAS while still enabled', async () => {
+    const recentCheck = new Date();
+    const workspace = {
+      id: 'ws-superseded',
+      prUrl: 'https://github.com/example/repo/pull/42',
+      prNumber: 42,
+      prState: 'OPEN',
+      prCiStatus: CIStatus.UNKNOWN,
+      ratchetEnabled: true,
+      ratchetState: RatchetState.CI_RUNNING,
+      ratchetActiveSessionId: null,
+      ratchetLastCiRunId: 'old-snapshot',
+      prReviewLastCheckedAt: recentCheck,
+      ratchetDispatchOutcome: null,
+      ratchetDispatchRetryCount: 0,
+    };
+
+    vi.spyOn(
+      unsafeCoerce<{
+        fetchPRState: (...args: unknown[]) => Promise<unknown>;
+      }>(ratchetService),
+      'fetchPRState'
+    ).mockResolvedValue({
+      ciStatus: CIStatus.SUCCESS,
+      snapshotKey: 'new-snapshot',
+      hasChangesRequested: false,
+      latestReviewActivityAtMs: recentCheck.getTime() - 1000,
+      statusCheckRollup: null,
+      prState: 'OPEN',
+      prNumber: 42,
+    });
+    // The CAS on fromState loses (e.g. markPrClosed settled the workspace to
+    // IDLE mid-check) while ratcheting remains enabled.
+    vi.mocked(workspaceAccessor.transitionRatchetStateIfEnabled).mockResolvedValue(false);
+    vi.mocked(workspaceAccessor.findById).mockResolvedValue({
+      id: 'ws-superseded',
+      ratchetEnabled: true,
+      ratchetState: RatchetState.IDLE,
+    } as never);
+    vi.mocked(agentSessionAccessor.findByWorkspaceId).mockResolvedValue([] as never);
+
+    const events: RatchetStateChangedEvent[] = [];
+    ratchetService.on(RATCHET_STATE_CHANGED, (event: RatchetStateChangedEvent) => {
+      events.push(event);
+    });
+
+    const result = await unsafeCoerce<{
+      processWorkspace: (workspaceArg: typeof workspace) => Promise<WorkspaceRatchetResult>;
+    }>(ratchetService).processWorkspace(workspace);
+
+    expect(result).toMatchObject({
+      previousState: RatchetState.CI_RUNNING,
+      newState: RatchetState.CI_RUNNING,
+      action: {
+        type: 'WAITING',
+        reason: 'Ratchet state changed concurrently during this check; re-evaluating next cycle',
+      },
+    });
+    expect(events).toHaveLength(0);
+    expect(mockSnapshotBridge.recordCIObservation).not.toHaveBeenCalled();
+    expect(mockSnapshotBridge.recordReviewCheck).not.toHaveBeenCalled();
     ratchetService.removeAllListeners();
   });
 
@@ -2046,13 +2204,13 @@ describe('ratchet service (state-change + idle dispatch)', () => {
       ratchetService.removeAllListeners();
     });
 
-    it('resets ratchet state to IDLE and emits a state change', async () => {
+    it('resets ratchet state to IDLE via CAS on fromState and emits a state change', async () => {
       vi.mocked(workspaceAccessor.findById).mockResolvedValue({
         id: 'ws-closed',
         ratchetEnabled: true,
         ratchetState: RatchetState.CI_FAILED,
       } as never);
-      vi.mocked(workspaceAccessor.updateRatchetCheckIfEnabled).mockResolvedValue(true);
+      vi.mocked(workspaceAccessor.transitionRatchetStateIfEnabled).mockResolvedValue(true);
 
       const stateEvents: RatchetStateChangedEvent[] = [];
       ratchetService.on(RATCHET_STATE_CHANGED, (event: RatchetStateChangedEvent) => {
@@ -2061,14 +2219,62 @@ describe('ratchet service (state-change + idle dispatch)', () => {
 
       await ratchetService.markPrClosed('ws-closed');
 
-      expect(workspaceAccessor.updateRatchetCheckIfEnabled).toHaveBeenCalledWith('ws-closed', {
-        ratchetState: RatchetState.IDLE,
-        ratchetLastCheckedAt: expect.any(Date),
-      });
+      expect(workspaceAccessor.transitionRatchetStateIfEnabled).toHaveBeenCalledWith(
+        'ws-closed',
+        RatchetState.CI_FAILED,
+        {
+          ratchetState: RatchetState.IDLE,
+          ratchetLastCheckedAt: expect.any(Date),
+        }
+      );
       expect(stateEvents).toEqual([
         {
           workspaceId: 'ws-closed',
           fromState: RatchetState.CI_FAILED,
+          toState: RatchetState.IDLE,
+        },
+      ]);
+    });
+
+    it('emits the fromState that actually won the compare-and-swap after losing a race', async () => {
+      vi.mocked(workspaceAccessor.findById)
+        .mockResolvedValueOnce({
+          id: 'ws-closed',
+          ratchetEnabled: true,
+          ratchetState: RatchetState.CI_FAILED,
+        } as never)
+        .mockResolvedValueOnce({
+          id: 'ws-closed',
+          ratchetEnabled: true,
+          ratchetState: RatchetState.CI_RUNNING,
+        } as never);
+      vi.mocked(workspaceAccessor.transitionRatchetStateIfEnabled)
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true);
+
+      const stateEvents: RatchetStateChangedEvent[] = [];
+      ratchetService.on(RATCHET_STATE_CHANGED, (event: RatchetStateChangedEvent) => {
+        stateEvents.push(event);
+      });
+
+      await ratchetService.markPrClosed('ws-closed');
+
+      expect(workspaceAccessor.transitionRatchetStateIfEnabled).toHaveBeenNthCalledWith(
+        1,
+        'ws-closed',
+        RatchetState.CI_FAILED,
+        expect.objectContaining({ ratchetState: RatchetState.IDLE })
+      );
+      expect(workspaceAccessor.transitionRatchetStateIfEnabled).toHaveBeenNthCalledWith(
+        2,
+        'ws-closed',
+        RatchetState.CI_RUNNING,
+        expect.objectContaining({ ratchetState: RatchetState.IDLE })
+      );
+      expect(stateEvents).toEqual([
+        {
+          workspaceId: 'ws-closed',
+          fromState: RatchetState.CI_RUNNING,
           toState: RatchetState.IDLE,
         },
       ]);
@@ -2083,16 +2289,22 @@ describe('ratchet service (state-change + idle dispatch)', () => {
 
       await ratchetService.markPrClosed('ws-closed');
 
-      expect(workspaceAccessor.updateRatchetCheckIfEnabled).not.toHaveBeenCalled();
+      expect(workspaceAccessor.transitionRatchetStateIfEnabled).not.toHaveBeenCalled();
     });
 
     it('does not emit when ratcheting was disabled concurrently', async () => {
-      vi.mocked(workspaceAccessor.findById).mockResolvedValue({
-        id: 'ws-closed',
-        ratchetEnabled: true,
-        ratchetState: RatchetState.CI_FAILED,
-      } as never);
-      vi.mocked(workspaceAccessor.updateRatchetCheckIfEnabled).mockResolvedValue(false);
+      vi.mocked(workspaceAccessor.findById)
+        .mockResolvedValueOnce({
+          id: 'ws-closed',
+          ratchetEnabled: true,
+          ratchetState: RatchetState.CI_FAILED,
+        } as never)
+        .mockResolvedValueOnce({
+          id: 'ws-closed',
+          ratchetEnabled: false,
+          ratchetState: RatchetState.IDLE,
+        } as never);
+      vi.mocked(workspaceAccessor.transitionRatchetStateIfEnabled).mockResolvedValue(false);
 
       const stateEvents: RatchetStateChangedEvent[] = [];
       ratchetService.on(RATCHET_STATE_CHANGED, (event: RatchetStateChangedEvent) => {
@@ -2109,7 +2321,7 @@ describe('ratchet service (state-change + idle dispatch)', () => {
 
       await ratchetService.markPrClosed('ws-missing');
 
-      expect(workspaceAccessor.updateRatchetCheckIfEnabled).not.toHaveBeenCalled();
+      expect(workspaceAccessor.transitionRatchetStateIfEnabled).not.toHaveBeenCalled();
     });
 
     it('does not continue to side effects after a timed-out await completes', async () => {
@@ -2165,7 +2377,7 @@ describe('ratchet service (state-change + idle dispatch)', () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       expect(finishSpy).not.toHaveBeenCalled();
-      expect(workspaceAccessor.updateRatchetCheckIfEnabled).not.toHaveBeenCalled();
+      expect(workspaceAccessor.transitionRatchetStateIfEnabled).not.toHaveBeenCalled();
     });
   });
 

--- a/src/backend/services/ratchet/service/ratchet.service.test.ts
+++ b/src/backend/services/ratchet/service/ratchet.service.test.ts
@@ -143,6 +143,12 @@ describe('ratchet service (state-change + idle dispatch)', () => {
     vi.mocked(userSettingsAccessor.getDefaultSessionProvider).mockResolvedValue('CLAUDE');
   });
 
+  afterEach(() => {
+    // Listener-registering tests must not leak into later tests even when an
+    // assertion fails before their inline cleanup.
+    ratchetService.removeAllListeners();
+  });
+
   it('checks workspaces and processes each', async () => {
     vi.mocked(workspaceAccessor.findWithPRsForRatchet).mockResolvedValue([
       {
@@ -264,7 +270,6 @@ describe('ratchet service (state-change + idle dispatch)', () => {
         toState: RatchetState.IDLE,
       },
     ]);
-    ratchetService.removeAllListeners();
   });
 
   it('does not emit for a disabled workspace when the settle CAS loses', async () => {
@@ -294,11 +299,14 @@ describe('ratchet service (state-change + idle dispatch)', () => {
       processWorkspace: (workspaceArg: typeof workspace) => Promise<WorkspaceRatchetResult>;
     }>(ratchetService).processWorkspace(workspace);
 
+    // The settle did not persist, so the result must not report a state
+    // change this check never committed.
     expect(result).toMatchObject({
+      previousState: RatchetState.CI_FAILED,
+      newState: RatchetState.CI_FAILED,
       action: { type: 'DISABLED' },
     });
     expect(events).toEqual([]);
-    ratchetService.removeAllListeners();
   });
 
   it('does not dispatch when workspace is not idle', async () => {
@@ -1037,6 +1045,11 @@ describe('ratchet service (state-change + idle dispatch)', () => {
       processWorkspace: (workspaceArg: typeof workspace) => Promise<WorkspaceRatchetResult>;
     }>(ratchetService).processWorkspace(workspace);
 
+    expect(workspaceAccessor.transitionRatchetStateIfEnabled).toHaveBeenCalledWith(
+      'ws-superseded',
+      RatchetState.CI_RUNNING,
+      expect.objectContaining({ ratchetState: RatchetState.READY })
+    );
     expect(result).toMatchObject({
       previousState: RatchetState.CI_RUNNING,
       newState: RatchetState.CI_RUNNING,
@@ -1048,7 +1061,6 @@ describe('ratchet service (state-change + idle dispatch)', () => {
     expect(events).toHaveLength(0);
     expect(mockSnapshotBridge.recordCIObservation).not.toHaveBeenCalled();
     expect(mockSnapshotBridge.recordReviewCheck).not.toHaveBeenCalled();
-    ratchetService.removeAllListeners();
   });
 
   it('redispatches with an incremented retry count when the previous fixer died', async () => {

--- a/src/backend/services/ratchet/service/ratchet.service.ts
+++ b/src/backend/services/ratchet/service/ratchet.service.ts
@@ -302,8 +302,12 @@ class RatchetService extends EventEmitter {
    *
    * The transition is CAS'd on the fromState just read, so the emitted event
    * carries the state that was actually replaced. Losing the CAS means an
-   * in-flight check wrote a fresh state concurrently; retry so a closed PR
-   * cannot end up stuck in a non-IDLE state (it will never be polled again).
+   * in-flight check wrote a fresh state concurrently; retry so that racing
+   * check does not leave the closed PR parked in a non-IDLE state (it will
+   * never be polled again). Closed PRs leave the poll set, so at most one
+   * such check can be in flight and the bounded retries are expected to
+   * always suffice; if they are ever exhausted anyway, this logs a warning
+   * and leaves the stale state for a manual ratchet toggle to clear.
    */
   async markPrClosed(workspaceId: string): Promise<void> {
     const maxCasAttempts = 3;
@@ -454,11 +458,14 @@ class RatchetService extends EventEmitter {
           toState: newState,
         } satisfies RatchetStateChangedEvent);
       }
-      this.logWorkspaceRatchetingDecision(workspace, fromState, newState, action, null);
+      // A lost settle persisted nothing, so report the state unchanged rather
+      // than a transition this check never committed.
+      const reportedState = settled ? newState : fromState;
+      this.logWorkspaceRatchetingDecision(workspace, fromState, reportedState, action, null);
       return {
         workspaceId: workspace.id,
         previousState: fromState,
-        newState,
+        newState: reportedState,
         action,
       };
     }

--- a/src/backend/services/ratchet/service/ratchet.service.ts
+++ b/src/backend/services/ratchet/service/ratchet.service.ts
@@ -39,6 +39,7 @@ import {
   isPRStateFetchSkipped,
   shouldSkipCleanPR as shouldSkipCleanPRHelper,
 } from './ratchet-pr-state.helpers';
+import { assertValidRatchetTransition } from './ratchet-state-machine';
 import {
   RatchetWorkspaceCheckCoordinator,
   type WorkspaceCheckScheduler,
@@ -298,26 +299,44 @@ class RatchetService extends EventEmitter {
    * Settle ratchet state for a workspace whose PR is closed (not merged).
    * Closed PRs are excluded from the poll set, so the poll loop can no longer
    * transition them to IDLE itself. Idempotent; no GitHub fetch.
+   *
+   * The transition is CAS'd on the fromState just read, so the emitted event
+   * carries the state that was actually replaced. Losing the CAS means an
+   * in-flight check wrote a fresh state concurrently; retry so a closed PR
+   * cannot end up stuck in a non-IDLE state (it will never be polled again).
    */
   async markPrClosed(workspaceId: string): Promise<void> {
-    const workspace = await workspaceAccessor.findById(workspaceId);
-    if (!workspace || workspace.ratchetState === RatchetState.IDLE) {
-      return;
+    const maxCasAttempts = 3;
+    for (let attempt = 0; attempt < maxCasAttempts; attempt++) {
+      const workspace = await workspaceAccessor.findById(workspaceId);
+      if (!workspace?.ratchetEnabled || workspace.ratchetState === RatchetState.IDLE) {
+        return;
+      }
+
+      const fromState = workspace.ratchetState;
+      assertValidRatchetTransition(workspaceId, fromState, RatchetState.IDLE);
+      const updated = await workspaceAccessor.transitionRatchetStateIfEnabled(
+        workspaceId,
+        fromState,
+        {
+          ratchetState: RatchetState.IDLE,
+          ratchetLastCheckedAt: new Date(),
+        }
+      );
+      if (updated) {
+        this.emit(RATCHET_STATE_CHANGED, {
+          workspaceId,
+          fromState,
+          toState: RatchetState.IDLE,
+        } satisfies RatchetStateChangedEvent);
+        return;
+      }
     }
 
-    const updated = await workspaceAccessor.updateRatchetCheckIfEnabled(workspaceId, {
-      ratchetState: RatchetState.IDLE,
-      ratchetLastCheckedAt: new Date(),
-    });
-    if (!updated) {
-      return;
-    }
-
-    this.emit(RATCHET_STATE_CHANGED, {
+    logger.warn('markPrClosed gave up after losing repeated state CAS races', {
       workspaceId,
-      fromState: workspace.ratchetState,
-      toState: RatchetState.IDLE,
-    } satisfies RatchetStateChangedEvent);
+      attempts: maxCasAttempts,
+    });
   }
 
   private async runWorkspaceCheckSafely(
@@ -416,30 +435,29 @@ class RatchetService extends EventEmitter {
 
     if (!workspace.ratchetEnabled) {
       const action: RatchetAction = { type: 'DISABLED', reason: 'Workspace ratcheting disabled' };
+      const fromState = workspace.ratchetState;
       const newState = RatchetState.IDLE;
       signal.throwIfAborted();
-      await workspaceAccessor.update(workspace.id, {
-        ratchetState: newState,
-        ratchetLastCheckedAt: new Date(),
-      });
+      assertValidRatchetTransition(workspace.id, fromState, newState);
+      // CAS on the pre-read fromState: a lost swap means another path already
+      // settled (or re-enabled) the workspace, and that path emitted its own
+      // event, so emitting here with this fromState would be stale.
+      const settled = await workspaceAccessor.settleRatchetIdleWhileDisabled(
+        workspace.id,
+        fromState
+      );
       signal.throwIfAborted();
-      if (workspace.ratchetState !== newState) {
+      if (settled && fromState !== newState) {
         this.emit(RATCHET_STATE_CHANGED, {
           workspaceId: workspace.id,
-          fromState: workspace.ratchetState,
+          fromState,
           toState: newState,
         } satisfies RatchetStateChangedEvent);
       }
-      this.logWorkspaceRatchetingDecision(
-        workspace,
-        workspace.ratchetState,
-        newState,
-        action,
-        null
-      );
+      this.logWorkspaceRatchetingDecision(workspace, fromState, newState, action, null);
       return {
         workspaceId: workspace.id,
-        previousState: workspace.ratchetState,
+        previousState: fromState,
         newState,
         action,
       };
@@ -750,7 +768,7 @@ class RatchetService extends EventEmitter {
     signal: AbortSignal = new AbortController().signal
   ): Promise<WorkspaceRatchetResult> {
     signal.throwIfAborted();
-    const updateApplied = await this.updateWorkspaceAfterCheck(
+    const updateResult = await this.updateWorkspaceAfterCheck(
       workspace,
       prStateInfo,
       action,
@@ -762,7 +780,7 @@ class RatchetService extends EventEmitter {
     // The conditional update refused to persist: ratcheting was disabled while
     // this check was in flight. Report DISABLED and emit nothing — the disable
     // path already settled the workspace to IDLE.
-    if (!updateApplied) {
+    if (updateResult === 'disabled') {
       const disabledAction: RatchetAction = {
         type: 'DISABLED',
         reason: 'Workspace ratcheting disabled',
@@ -780,6 +798,31 @@ class RatchetService extends EventEmitter {
         previousState: decisionContext.previousState,
         newState: RatchetState.IDLE,
         action: disabledAction,
+      };
+    }
+
+    // The CAS on fromState lost while ratcheting stayed enabled: another path
+    // (e.g. markPrClosed) transitioned the state mid-check and emitted its own
+    // event. This check's result is stale, so persist and emit nothing; the
+    // next cycle re-evaluates from the fresh state.
+    if (updateResult === 'superseded') {
+      const supersededAction: RatchetAction = {
+        type: 'WAITING',
+        reason: 'Ratchet state changed concurrently during this check; re-evaluating next cycle',
+      };
+      this.logWorkspaceRatchetingDecision(
+        workspace,
+        decisionContext.previousState,
+        decisionContext.previousState,
+        supersededAction,
+        prStateInfo,
+        decisionContext
+      );
+      return {
+        workspaceId: workspace.id,
+        previousState: decisionContext.previousState,
+        newState: decisionContext.previousState,
+        action: supersededAction,
       };
     }
 
@@ -822,21 +865,31 @@ class RatchetService extends EventEmitter {
     action: RatchetAction,
     nextState: RatchetState,
     signal: AbortSignal = new AbortController().signal
-  ): Promise<boolean> {
+  ): Promise<'applied' | 'disabled' | 'superseded'> {
     const now = new Date();
     // The dispatch record itself (session pointer, snapshot key, outcome,
     // retry count) is written atomically inside triggerFixer.
     const dispatched = action.type === 'TRIGGERED_FIXER' && action.promptSent;
 
     signal.throwIfAborted();
-    const updated = await workspaceAccessor.updateRatchetCheckIfEnabled(workspace.id, {
-      ratchetState: nextState,
-      ratchetLastCheckedAt: now,
-    });
+    assertValidRatchetTransition(workspace.id, workspace.ratchetState, nextState);
+    const updated = await workspaceAccessor.transitionRatchetStateIfEnabled(
+      workspace.id,
+      workspace.ratchetState,
+      {
+        ratchetState: nextState,
+        ratchetLastCheckedAt: now,
+      }
+    );
     signal.throwIfAborted();
 
     if (!updated) {
-      return false;
+      // The CAS refused the write: either ratcheting was disabled mid-check,
+      // or another path (markPrClosed, disable+re-enable) transitioned the
+      // state away from the one this check ran against.
+      const fresh = await workspaceAccessor.findById(workspace.id);
+      signal.throwIfAborted();
+      return fresh?.ratchetEnabled ? 'superseded' : 'disabled';
     }
 
     if (dispatched) {
@@ -855,7 +908,7 @@ class RatchetService extends EventEmitter {
       signal.throwIfAborted();
     }
 
-    return true;
+    return 'applied';
   }
 
   private async checkActiveFixerSession(

--- a/src/backend/services/workspace/resources/workspace.accessor.test.ts
+++ b/src/backend/services/workspace/resources/workspace.accessor.test.ts
@@ -177,19 +177,19 @@ describe('workspaceAccessor', () => {
     ).resolves.toBe(false);
   });
 
-  it('updates ratchet check state only when ratchet is enabled', async () => {
+  it('transitions ratchet state only when enabled and fromState still matches', async () => {
     const checkedAt = new Date('2026-01-01T00:00:00.000Z');
     mockUpdateMany.mockResolvedValue({ count: 1 });
 
     await expect(
-      workspaceAccessor.updateRatchetCheckIfEnabled('ws-1', {
+      workspaceAccessor.transitionRatchetStateIfEnabled('ws-1', 'CI_RUNNING', {
         ratchetState: 'CI_FAILED',
         ratchetLastCheckedAt: checkedAt,
       })
     ).resolves.toBe(true);
 
     expect(mockUpdateMany).toHaveBeenCalledWith({
-      where: { id: 'ws-1', ratchetEnabled: true },
+      where: { id: 'ws-1', ratchetEnabled: true, ratchetState: 'CI_RUNNING' },
       data: {
         ratchetState: 'CI_FAILED',
         ratchetLastCheckedAt: checkedAt,
@@ -197,14 +197,38 @@ describe('workspaceAccessor', () => {
     });
   });
 
-  it('returns false when ratchet check conditional update affects no rows', async () => {
+  it('returns false when ratchet state transition loses the compare-and-swap', async () => {
     mockUpdateMany.mockResolvedValue({ count: 0 });
 
     await expect(
-      workspaceAccessor.updateRatchetCheckIfEnabled('ws-1', {
+      workspaceAccessor.transitionRatchetStateIfEnabled('ws-1', 'CI_RUNNING', {
         ratchetState: 'READY',
         ratchetLastCheckedAt: new Date('2026-01-01T00:00:00.000Z'),
       })
+    ).resolves.toBe(false);
+  });
+
+  it('settles ratchet state to IDLE only while disabled and fromState still matches', async () => {
+    mockUpdateMany.mockResolvedValue({ count: 1 });
+
+    await expect(
+      workspaceAccessor.settleRatchetIdleWhileDisabled('ws-1', 'CI_FAILED')
+    ).resolves.toBe(true);
+
+    expect(mockUpdateMany).toHaveBeenCalledWith({
+      where: { id: 'ws-1', ratchetEnabled: false, ratchetState: 'CI_FAILED' },
+      data: {
+        ratchetState: 'IDLE',
+        ratchetLastCheckedAt: expect.any(Date),
+      },
+    });
+  });
+
+  it('returns false when the disabled-settle compare-and-swap affects no rows', async () => {
+    mockUpdateMany.mockResolvedValue({ count: 0 });
+
+    await expect(
+      workspaceAccessor.settleRatchetIdleWhileDisabled('ws-1', 'CI_FAILED')
     ).resolves.toBe(false);
   });
 

--- a/src/backend/services/workspace/resources/workspace.accessor.ts
+++ b/src/backend/services/workspace/resources/workspace.accessor.ts
@@ -631,16 +631,39 @@ class WorkspaceAccessor {
   }
 
   /**
-   * Persist ratchet check output only while ratcheting remains enabled.
-   * This prevents stale in-flight checks from overwriting the disabled state.
+   * Compare-and-swap ratchet state transition, mirroring transitionWithCas.
+   * Persists only while ratcheting remains enabled AND the state still matches
+   * the fromState the caller observed, so stale in-flight checks can neither
+   * overwrite the disabled state nor a concurrent transition, and emitted
+   * fromState values are accurate by construction. Transition validity is
+   * checked by the caller against RATCHET_VALID_TRANSITIONS (see
+   * ratchet-state-machine.ts).
    */
-  async updateRatchetCheckIfEnabled(
+  async transitionRatchetStateIfEnabled(
     workspaceId: string,
+    fromState: RatchetState,
     data: Pick<UpdateWorkspaceInput, 'ratchetState' | 'ratchetLastCheckedAt'>
   ): Promise<boolean> {
     const result = await prisma.workspace.updateMany({
-      where: { id: workspaceId, ratchetEnabled: true },
+      where: { id: workspaceId, ratchetEnabled: true, ratchetState: fromState },
       data,
+    });
+    return result.count > 0;
+  }
+
+  /**
+   * Settle ratchet state to IDLE for a workspace whose ratcheting is disabled,
+   * CAS on the fromState the caller observed. The disabled condition keeps
+   * this write from clobbering a concurrent re-enable, and the fromState
+   * condition keeps the emitted transition accurate.
+   */
+  async settleRatchetIdleWhileDisabled(
+    workspaceId: string,
+    fromState: RatchetState
+  ): Promise<boolean> {
+    const result = await prisma.workspace.updateMany({
+      where: { id: workspaceId, ratchetEnabled: false, ratchetState: fromState },
+      data: { ratchetState: 'IDLE', ratchetLastCheckedAt: new Date() },
     });
     return result.count > 0;
   }


### PR DESCRIPTION
Fixes #1887.

## What changed

Ratchet's state machine over `Workspace.ratchetState` now has an explicit transition table and every `ratchetState` write is compare-and-swapped on the expected `fromState`, mirroring the lifecycle machine's `VALID_TRANSITIONS` + `transitionWithCas` pattern.

### New: `ratchet-state-machine.ts`

- `RATCHET_VALID_TRANSITIONS` — explicit per-state transition table. Because ratchet state is *derived* from PR observations (new commits restart CI, reviews arrive, conflicts appear/resolve, and the workspace PR pointer can switch to a new PR after a merge), today's graph is intentionally permissive; the table encodes intent and acts as a tripwire for future refactors. Same-state writes are treated as refreshes (`ratchetLastCheckedAt`), not transitions.
- `assertValidRatchetTransition` / `RatchetStateMachineError` — validated at every persistence call site.

### Accessor: CAS at the point of persistence

`updateRatchetCheckIfEnabled` (gated only on `ratchetEnabled`) is replaced by:

- `transitionRatchetStateIfEnabled(id, fromState, data)` — `WHERE id AND ratchetEnabled AND ratchetState = fromState`
- `settleRatchetIdleWhileDisabled(id, fromState)` — `WHERE id AND NOT ratchetEnabled AND ratchetState = fromState`

Both are registered in `scripts/check-single-writer.mjs`.

### Service behavior

- **Check path (`updateWorkspaceAfterCheck`)** now distinguishes three outcomes: `applied`, `disabled` (unchanged behavior: report DISABLED, no emit), and a new `superseded` outcome for when the CAS loses while ratcheting stays enabled (e.g. `markPrClosed` settled the workspace mid-check). Superseded checks persist nothing, emit nothing, and report a WAITING action — previously a stale check could silently overwrite a concurrent transition.
- **`markPrClosed`** CASes on the state it just read and retries (bounded) on a lost swap, so the emitted `fromState` is the state that was actually replaced, and neither ordering of the markPrClosed-vs-in-flight-check race can leave a closed PR stuck in a non-IDLE state.
- **DISABLED early path** settles to IDLE via CAS and only emits when its own swap won, fixing the second stale-`fromState` emit called out in the issue.

`RATCHET_STATE_CHANGED` events are now accurate by construction: an event is only emitted by the writer whose CAS committed the transition it describes.

## Not included

The `ratchetLastCiRunId` → dispatch-snapshot-key rename suggested in the issue is skipped: this change needs no migration, so the rename is left for a follow-up that already has one on the table.

## Testing

- New `ratchet-state-machine.test.ts` pinning the transition table and error contract
- New/updated service tests: superseded-check reporting, `markPrClosed` CAS race emitting the winning `fromState`, disabled-settle emit/no-emit
- Updated accessor tests for the CAS WHERE clauses
- `pnpm test` (3697 passed), `pnpm typecheck`, `pnpm check` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core ratchet concurrency and event semantics for workspace PR automation; behavior is heavily tested but mistakes could affect fixer dispatch timing or UI state updates.
> 
> **Overview**
> Ratchet **`Workspace.ratchetState`** persistence now follows the workspace lifecycle pattern: an explicit **`RATCHET_VALID_TRANSITIONS`** table (documented as intent/tripwire for derived PR observations) plus **compare-and-swap on the observed `fromState`** at write time.
> 
> **Accessor:** `updateRatchetCheckIfEnabled` is replaced by **`transitionRatchetStateIfEnabled(id, fromState, data)`** (`ratchetEnabled` + matching `ratchetState`) and **`settleRatchetIdleWhileDisabled(id, fromState)`** for disabled workspaces. Both are wired into **`check-single-writer.mjs`**.
> 
> **Service:** Every persist path calls **`assertValidRatchetTransition`**. In-flight checks that lose the CAS while ratcheting stays enabled are **`superseded`** (no DB write, no **`RATCHET_STATE_CHANGED`**, WAITING to re-evaluate). The disabled early path settles via CAS and only emits when its swap wins. **`markPrClosed`** CAS-retries (bounded) so closed PRs cannot stay non-IDLE after races with an in-flight check, and events use the state that actually committed.
> 
> **`RATCHET_STATE_CHANGED`** is intended to be accurate: only the writer whose CAS succeeded emits the transition it described.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94357866b8cd38f1a5d37afd37697deb88b747ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->