### PR TITLE
Prepare 0.4.0 minor release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,50 @@ All notable changes to Factory Factory will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-07-16
+
+### Added
+
+- Add child workspaces with cross-project spawning, live and persisted messaging, UI management, and archive safeguards (#1706, #1708, #1713, #1718, #1892)
+- Add Fable to the default Claude model options (#1845, #1846)
+- Add project default branch detection (#1824)
+- Add WebSocket output backpressure handling (#1882)
+
+### Changed
+
+- Consolidate WebSocket consumers and handlers around shared transport and topic broadcasting (#1879, #1881, #1883)
+- Strengthen ratchet dispatch and reconciliation with explicit dispatch records, resolved-thread filtering, bounded checks, and compare-and-set transitions (#1857, #1858, #1863, #1864, #1865, #1866, #1894)
+- Bound resource-intensive searches, pagination, output buffers, and shell execution (#1776, #1782, #1784, #1786, #1797, #1800, #1802, #1805, #1806, #1850)
+- Migrate the interface icon set to Phosphor (#1878)
+- Enforce test coverage minimums (#1880)
+
+### Fixed
+
+- Harden session startup, shutdown, recovery, and failed-exit persistence (#1740, #1791, #1794, #1826, #1829, #1830, #1831, #1832, #1833, #1835)
+- Preserve run-script exit state and retry terminal process cleanup (#1767, #1855, #1856)
+- Prevent lost periodic-task dispatches and overlapping terminal resource scans (#1798, #1799)
+- Keep workspace, Kanban, pull-request, review-badge, and snapshot state synchronized across concurrent transitions (#1783, #1789, #1790, #1803, #1828, #1891, #1893)
+- Make branch rename metadata atomic and clear stale automatic-rename state (#1775, #1804, #1822, #1849)
+- Fix workspace slash-command isolation, precedence, and non-file command filtering (#1719, #1834, #1848)
+- Fix workspace cleanup, deletion, and archive rollback behavior (#1787, #1793, #1825)
+- Fix chat hydration, attachment autosave warnings, rejected-message replay, and empty tool-result history (#1788, #1792, #1823, #1829)
+- Fix CORS and port binding for explicit, wildcard, and all-interface hosts (#1721, #1795, #1827, #1854)
+- Make the first user-settings read atomic (#1781)
+- Resolve nested configuration path variables (#1852)
+- Deduplicate persisted workspace notifications (#1851)
+- Shut down cleanly on unhandled rejections (#1853)
+- Prevent parent/child workspace messages from being lost during delivery (#1892)
+
+### Security
+
+- Restrict executable tRPC mutations and authorize terminal WebSocket replay (#1779, #1796)
+- Harden issue-start and branch-rename prompt context and worktree cleanup paths (#1775, #1777, #1778)
+- Apply trusted-local validation and guarded fan-out sends across WebSocket channels (#1875, #1876, #1877)
+
+### Documentation
+
+- Update child-workspace, session lifecycle, service ownership, dependency, and CI documentation (#1696, #1704, #1705, #1708, #1837, #1838, #1839, #1847)
+
 ## [0.3.21] - 2026-06-22
 
 ### Added

--- a/docs/superpowers/plans/2026-07-16-release-0.4.0.md
+++ b/docs/superpowers/plans/2026-07-16-release-0.4.0.md
@@ -1,0 +1,137 @@
+# Factory Factory 0.4.0 Release Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prepare and publish a draft pull request that bumps Factory Factory from 0.3.21 to 0.4.0 and documents the changes merged since v0.3.21.
+
+**Architecture:** This is a release-metadata-only change. Update the root package version and prepend a curated Keep a Changelog entry; do not change runtime code, dependencies, generated files, or the private core package version.
+
+**Tech Stack:** JSON package metadata, Markdown changelog, pnpm validation, Git, GitHub CLI
+
+## Global Constraints
+
+- Target version is exactly `0.4.0`.
+- Release date is exactly `2026-07-16`.
+- Changelog source range is `v0.3.21..HEAD` before release-preparation commits.
+- Preserve pull request references for traceability.
+- Open a draft pull request against `main`.
+
+---
+
+### Task 1: Prepare and publish release metadata
+
+**Files:**
+- Modify: `package.json:3`
+- Modify: `CHANGELOG.md:8`
+
+**Interfaces:**
+- Consumes: Existing root package version `0.3.21`, Keep a Changelog formatting, and commits in `v0.3.21..HEAD`.
+- Produces: Root package version `0.4.0` and a dated `0.4.0` changelog section suitable for release notes.
+
+- [x] **Step 1: Establish a clean baseline in the existing isolated worktree**
+
+Run:
+
+```bash
+pnpm test
+```
+
+Expected: Vitest exits with status 0 and reports no failed tests.
+
+- [x] **Step 2: Bump the published package version**
+
+Change the root metadata to:
+
+```json
+{
+  "name": "factory-factory",
+  "version": "0.4.0"
+}
+```
+
+Do not change `packages/core/package.json`, which remains private at version `0.1.0`.
+
+- [x] **Step 3: Add the curated changelog entry**
+
+Insert the following section immediately before `## [0.3.21] - 2026-06-22`, preserving the existing document header:
+
+```markdown
+## [0.4.0] - 2026-07-16
+
+### Added
+
+- Add child workspaces with cross-project spawning, live and persisted messaging, UI management, and archive safeguards (#1706, #1708, #1713, #1718, #1892)
+- Add Fable to the default Claude model options (#1845, #1846)
+- Add project default branch detection (#1824)
+- Add WebSocket output backpressure handling (#1882)
+
+### Changed
+
+- Consolidate WebSocket consumers and handlers around shared transport and topic broadcasting (#1879, #1881, #1883)
+- Strengthen ratchet dispatch and reconciliation with explicit dispatch records, resolved-thread filtering, bounded checks, and compare-and-set transitions (#1857, #1858, #1863, #1864, #1865, #1866, #1894)
+- Bound resource-intensive searches, pagination, output buffers, and shell execution (#1776, #1782, #1784, #1786, #1797, #1800, #1802, #1805, #1806, #1850)
+- Migrate the interface icon set to Phosphor (#1878)
+- Enforce test coverage minimums (#1880)
+
+### Fixed
+
+- Harden session startup, shutdown, recovery, and failed-exit persistence (#1740, #1791, #1794, #1826, #1829, #1830, #1831, #1832, #1833, #1835)
+- Preserve run-script exit state and retry terminal process cleanup (#1767, #1855, #1856)
+- Prevent lost periodic-task dispatches and overlapping terminal resource scans (#1798, #1799)
+- Keep workspace, Kanban, pull-request, review-badge, and snapshot state synchronized across concurrent transitions (#1783, #1789, #1790, #1803, #1828, #1891, #1893)
+- Make branch rename metadata atomic and clear stale automatic-rename state (#1775, #1804, #1822, #1849)
+- Fix workspace slash-command isolation, precedence, and non-file command filtering (#1719, #1834, #1848)
+- Fix workspace cleanup, deletion, and archive rollback behavior (#1787, #1793, #1825)
+- Fix chat hydration, attachment autosave warnings, rejected-message replay, and empty tool-result history (#1788, #1792, #1823, #1829)
+- Fix CORS and port binding for explicit, wildcard, and all-interface hosts (#1721, #1795, #1827, #1854)
+- Make the first user-settings read atomic (#1781)
+- Resolve nested configuration path variables (#1852)
+- Deduplicate persisted workspace notifications (#1851)
+- Shut down cleanly on unhandled rejections (#1853)
+- Prevent parent/child workspace messages from being lost during delivery (#1892)
+
+### Security
+
+- Restrict executable tRPC mutations and authorize terminal WebSocket replay (#1779, #1796)
+- Harden issue-start and branch-rename prompt context and worktree cleanup paths (#1775, #1777, #1778)
+- Apply trusted-local validation and guarded fan-out sends across WebSocket channels (#1875, #1876, #1877)
+
+### Documentation
+
+- Update child-workspace, session lifecycle, service ownership, dependency, and CI documentation (#1696, #1704, #1705, #1708, #1837, #1838, #1839, #1847)
+```
+
+- [x] **Step 4: Verify the release diff**
+
+Run:
+
+```bash
+git diff --check
+pnpm check
+pnpm typecheck
+git diff -- package.json CHANGELOG.md
+```
+
+Expected: All commands exit with status 0; the diff shows `0.4.0` in the root package and the new `2026-07-16` changelog section.
+
+- [x] **Step 5: Commit the release metadata**
+
+Run:
+
+```bash
+git add package.json CHANGELOG.md docs/superpowers/plans/2026-07-16-release-0.4.0.md
+git commit -m "Prepare 0.4.0 minor release"
+```
+
+Expected: Commit succeeds, including repository commit hooks.
+
+- [ ] **Step 6: Push and open the draft pull request**
+
+Run:
+
+```bash
+git push -u origin martin-purplefish/create-release-pr-let-minor-version
+gh pr create --draft --base main --head martin-purplefish/create-release-pr-let-minor-version --title "Prepare 0.4.0 minor release" --body-file /tmp/factory-factory-release-0.4.0-pr.md
+```
+
+Expected: GitHub returns the URL of a draft pull request targeting `main`.

--- a/docs/superpowers/plans/2026-07-16-release-0.4.0.md
+++ b/docs/superpowers/plans/2026-07-16-release-0.4.0.md
@@ -125,13 +125,13 @@ git commit -m "Prepare 0.4.0 minor release"
 
 Expected: Commit succeeds, including repository commit hooks.
 
-- [ ] **Step 6: Push and open the draft pull request**
+- [x] **Step 6: Push and open the draft pull request**
 
 Run:
 
 ```bash
-git push -u origin martin-purplefish/create-release-pr-let-minor-version
-gh pr create --draft --base main --head martin-purplefish/create-release-pr-let-minor-version --title "Prepare 0.4.0 minor release" --body-file /tmp/factory-factory-release-0.4.0-pr.md
+git push -u origin purplefish-ai/create-release-pr-let-minor-ve
+gh pr create --draft --base main --head purplefish-ai/create-release-pr-let-minor-ve --title "Prepare 0.4.0 minor release" --body-file /tmp/factory-factory-release-0.4.0-pr.md
 ```
 
 Expected: GitHub returns the URL of a draft pull request targeting `main`.

--- a/docs/superpowers/specs/2026-07-16-release-0.4.0-design.md
+++ b/docs/superpowers/specs/2026-07-16-release-0.4.0-design.md
@@ -1,0 +1,26 @@
+# Factory Factory 0.4.0 Release Design
+
+## Goal
+
+Prepare a draft release pull request for Factory Factory 0.4.0 that updates the published package version and summarizes the changes merged since v0.3.21.
+
+## Scope
+
+- Change the root `package.json` version from `0.3.21` to `0.4.0`.
+- Leave `packages/core/package.json` at `0.1.0` because it is private and prior release pull requests only update the root package.
+- Add a `0.4.0` entry dated `2026-07-16` at the top of `CHANGELOG.md`.
+- Cover the commits between `v0.3.21` and the release branch head.
+- Group notable changes under the existing Keep a Changelog categories and retain pull request references.
+- Do not modify runtime code, dependencies, or generated files.
+
+## Changelog Approach
+
+Use a curated, user-facing summary rather than copying all 95 commit subjects or reducing the release to a few highlights. Consolidate closely related fixes into clear entries while preserving enough pull request references to trace the underlying work. Emphasize the release's major additions and reliability improvements: child workspaces, WebSocket transport hardening, ratchet reliability, session lifecycle correctness, bounded resource usage, and UI updates.
+
+## Validation
+
+Run `pnpm check` and `pnpm typecheck`. Review the final diff to confirm that the release metadata says `0.4.0`, the changelog date is `2026-07-16`, and only intended release-preparation files are changed.
+
+## Publishing
+
+Commit the approved release changes on the existing `martin-purplefish/create-release-pr-let-minor-version` branch, push it to `origin`, and open a draft pull request targeting `main`. The pull request description will summarize the version bump, changelog coverage, impact, and validation results.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "factory-factory",
-  "version": "0.3.21",
+  "version": "0.4.0",
   "description": "Workspace-based coding environment for running multiple Claude Code and Codex sessions in parallel",
   "private": false,
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Bump the published root package version from `0.3.21` to `0.4.0`.
- Add the `0.4.0` changelog entry dated 2026-07-16.
- Summarize the 95 commits merged since `v0.3.21`, including child workspaces, WebSocket transport hardening, ratchet reliability, session lifecycle fixes, bounded resource usage, and the Phosphor icon migration.
- Record the approved release design and implementation checklist.

## Impact

This PR prepares the next minor release. It changes release metadata and documentation only; no runtime application code, dependencies, generated files, or database schemas are modified.

## Validation

- `NODE_ENV=test pnpm test` — 3,739 passed, 3 skipped
- `pnpm check` — passed with six existing `<img>` performance warnings; local Codex schema drift check skipped because the installed Codex CLI is newer than the pinned CI version
- `pnpm typecheck`
- `pnpm check:fix` — no fixes applied; same six existing warnings
- Commit hooks: typecheck, Prisma generated-drift check, dependency boundaries, and Knip

## Test environment note

The inherited shell sets `NODE_ENV=production`, which makes React's test-only `act` export unavailable. An initial baseline run therefore failed 13 setup-terminal tests before any release edits. Those tests passed under `NODE_ENV=test`, and the full suite subsequently passed with that standard test environment.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and version metadata only; no runtime, dependency, or schema changes.
> 
> **Overview**
> Prepares the **0.4.0** minor release by bumping the published root `package.json` version from `0.3.21` to **`0.4.0`** and prepending a dated **`2026-07-16`** section to `CHANGELOG.md`.
> 
> The new changelog entry is a curated Keep a Changelog summary of work merged since `v0.3.21` (child workspaces, WebSocket/ratchet hardening, session lifecycle fixes, security notes, and related areas), with PR references preserved. It also adds release **design** and **implementation plan** docs under `docs/superpowers/` that record scope (metadata only, no runtime or dependency changes) and the release checklist.
> 
> **No application code**, lockfiles, or `packages/core` version are modified in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65dc38ebdbca1f61b86462561ea3457bb50b9d02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->