### PR TITLE
Fix #1921: Prevent plan IDs rendering as text

### DIFF
--- a/docs/superpowers/plans/2026-07-17-plan-tool-result-text.md
+++ b/docs/superpowers/plans/2026-07-17-plan-tool-result-text.md
@@ -1,0 +1,140 @@
+# Plan Tool Result Text Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent metadata-only Codex plan results from rendering item IDs as plan text.
+
+**Architecture:** Keep permissive shared plan parsing intact for its existing consumers. Add a renderer-local content guard that follows only explicit plan-bearing fields, then use the existing extractor for normalization.
+
+**Tech Stack:** TypeScript, React renderer utilities, Vitest, Biome, pnpm
+
+## Global Constraints
+
+- Change only the plan tool-result renderer and its focused tests.
+- Preserve direct text, fenced JSON, array content, and nested `plan.content[]` support.
+- Return `null` for metadata-only, blank, or nested metadata-only plan envelopes.
+
+---
+
+### Task 1: Add plan-result regression coverage
+
+**Files:**
+- Test: `src/components/agent-activity/tool-renderers/tool-result-plan.test.ts`
+
+**Interfaces:**
+- Consumes: `extractPlanToolResult(content: ToolResultContentValue): ExtractedPlanToolResult | null`
+- Produces: Regression expectations for metadata-only and invalid explicit fields.
+
+- [ ] **Step 1: Add failing metadata-only tests**
+
+```typescript
+it('returns null for metadata-only plan payloads', () => {
+  const payload = JSON.stringify({
+    type: 'plan',
+    id: 'item_plan_approval',
+    status: 'completed',
+  });
+
+  expect(extractPlanToolResult(payload)).toBeNull();
+  expect(extractPlanToolResult([{ type: 'text', text: payload }])).toBeNull();
+});
+
+it('returns null when explicit plan fields contain no plan text', () => {
+  const blankPayload = JSON.stringify({
+    type: 'plan',
+    id: 'item_plan_approval',
+    text: '   ',
+  });
+  const nestedMetadataPayload = JSON.stringify({
+    type: 'plan',
+    plan: { id: 'item_nested_plan', status: 'completed' },
+  });
+
+  expect(extractPlanToolResult(blankPayload)).toBeNull();
+  expect(extractPlanToolResult(nestedMetadataPayload)).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `pnpm exec vitest run src/components/agent-activity/tool-renderers/tool-result-plan.test.ts`
+
+Expected: the metadata-only and invalid explicit-field tests fail because IDs are returned as plan text.
+
+### Task 2: Guard plan extraction at the renderer boundary
+
+**Files:**
+- Modify: `src/components/agent-activity/tool-renderers/tool-result-plan.ts`
+- Test: `src/components/agent-activity/tool-renderers/tool-result-plan.test.ts`
+
+**Interfaces:**
+- Consumes: parsed `Record<string, unknown>` plan envelopes and `extractPlanText(value: unknown): string | null`
+- Produces: renderer-local validation that only explicit plan content qualifies for specialized rendering.
+
+- [ ] **Step 1: Add recursive explicit-content validation**
+
+```typescript
+const PLAN_TEXT_KEYS = ['plan', 'markdown', 'text', 'content'] as const;
+
+function hasPlanTextContent(value: unknown, depth = 0): boolean {
+  if (depth > MAX_PLAN_SEARCH_DEPTH) return false;
+  if (typeof value === 'string') return value.trim().length > 0;
+  if (Array.isArray(value)) return value.some((item) => hasPlanTextContent(item, depth + 1));
+  if (typeof value !== 'object' || value === null) return false;
+
+  const record = value as Record<string, unknown>;
+  return PLAN_TEXT_KEYS.some(
+    (key) => key in record && hasPlanTextContent(record[key], depth + 1)
+  );
+}
+```
+
+- [ ] **Step 2: Guard the shared extractor call**
+
+```typescript
+if (!hasPlanTextContent(planPayload)) {
+  return null;
+}
+
+return extractPlanText(planPayload);
+```
+
+- [ ] **Step 3: Run focused tests and verify GREEN**
+
+Run: `pnpm exec vitest run src/components/agent-activity/tool-renderers/tool-result-plan.test.ts`
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit the focused fix**
+
+```bash
+git add docs/superpowers src/components/agent-activity/tool-renderers/tool-result-plan.ts src/components/agent-activity/tool-renderers/tool-result-plan.test.ts
+git commit -m "Fix plan result metadata rendering (#1921)"
+```
+
+### Task 3: Verify and publish
+
+**Files:**
+- Review: all changes relative to `origin/main`
+
+**Interfaces:**
+- Consumes: the completed renderer fix and tests.
+- Produces: a clean, pushed issue branch and a pull request closing #1921.
+
+- [ ] **Step 1: Run required verification**
+
+Run: `pnpm typecheck && pnpm check:fix && pnpm test && pnpm build`
+
+Expected: every command exits successfully.
+
+- [ ] **Step 2: Review and commit formatter-only changes if any**
+
+Run: `git diff origin/main && git status --short`
+
+Expected: only intended files differ and the working tree is clean after committing any formatter changes.
+
+- [ ] **Step 3: Push and create the pull request**
+
+Run: `git push -u origin HEAD`, then create the PR with title `Fix #1921: Prevent plan IDs rendering as text`, the required test checklist, `Closes #1921`, and the Factory Factory signature.
+
+Expected: `gh pr view` returns the created pull request URL.

--- a/docs/superpowers/plans/2026-07-17-plan-tool-result-text.md
+++ b/docs/superpowers/plans/2026-07-17-plan-tool-result-text.md
@@ -28,7 +28,7 @@
 - [ ] **Step 1: Add failing metadata-only tests**
 
 ```typescript
-it('returns null for metadata-only plan payloads', () => {
+it('returns null for metadata-only plan payload strings', () => {
   const payload = JSON.stringify({
     type: 'plan',
     id: 'item_plan_approval',
@@ -36,22 +36,35 @@ it('returns null for metadata-only plan payloads', () => {
   });
 
   expect(extractPlanToolResult(payload)).toBeNull();
+});
+
+it('returns null for metadata-only plan payloads in text item arrays', () => {
+  const payload = JSON.stringify({
+    type: 'plan',
+    id: 'item_plan_approval',
+    status: 'completed',
+  });
+
   expect(extractPlanToolResult([{ type: 'text', text: payload }])).toBeNull();
 });
 
-it('returns null when explicit plan fields contain no plan text', () => {
-  const blankPayload = JSON.stringify({
+it('returns null when an explicit plan text field is blank', () => {
+  const payload = JSON.stringify({
     type: 'plan',
     id: 'item_plan_approval',
     text: '   ',
   });
-  const nestedMetadataPayload = JSON.stringify({
+
+  expect(extractPlanToolResult(payload)).toBeNull();
+});
+
+it('returns null for nested metadata-only plan payloads', () => {
+  const payload = JSON.stringify({
     type: 'plan',
     plan: { id: 'item_nested_plan', status: 'completed' },
   });
 
-  expect(extractPlanToolResult(blankPayload)).toBeNull();
-  expect(extractPlanToolResult(nestedMetadataPayload)).toBeNull();
+  expect(extractPlanToolResult(payload)).toBeNull();
 });
 ```
 
@@ -74,6 +87,8 @@ Expected: the metadata-only and invalid explicit-field tests fail because IDs ar
 - [ ] **Step 1: Add recursive explicit-content validation**
 
 ```typescript
+const MAX_PLAN_SEARCH_DEPTH = 6;
+const PLAN_TYPE = 'plan';
 const PLAN_TEXT_KEYS = ['plan', 'markdown', 'text', 'content'] as const;
 
 function hasPlanTextContent(value: unknown, depth = 0): boolean {

--- a/docs/superpowers/specs/2026-07-17-plan-tool-result-text-design.md
+++ b/docs/superpowers/specs/2026-07-17-plan-tool-result-text-design.md
@@ -1,0 +1,27 @@
+# Plan Tool Result Text Design
+
+## Problem
+
+Completed Codex plan items can contain only metadata, such as `type`, `id`, and `status`. The agent-activity plan renderer currently passes the entire item to the permissive shared plan-text extractor. Its fallback selects the longest string, so an item ID can be displayed as plan text.
+
+## Scope
+
+Keep the shared plan extractor and backend plan-approval flow unchanged. Restrict only agent-activity plan tool-result rendering so a typed plan envelope is specialized when it contains nonblank text under an explicit `plan`, `markdown`, `text`, or `content` field. Otherwise, return `null` and let the generic tool-result renderer display the raw result.
+
+## Design
+
+After locating a `type: "plan"` payload, inspect only the four plan-bearing fields. Validation follows those fields through arrays and nested plan-bearing or typed text/markdown objects, preserving the existing `plan.content[]` format without allowing unrelated metadata such as `id` or `status` to qualify. Once content is validated, the existing shared extractor performs the final normalization.
+
+Alternatives rejected:
+
+- Changing the shared extractor would alter ExitPlanMode and permission consumers outside this bug.
+- Requiring a top-level string would reject the already-supported nested `plan.content[]` payload.
+- Checking only field presence would allow blank or metadata-only nested fields to fall through to an ID.
+
+## Tests
+
+Add focused parser regressions for metadata-only payloads, blank explicit text, and nested metadata beneath a plan field. Preserve the existing positive coverage for direct text, fenced JSON, and nested structured content. Focused tests must fail before the production change and pass afterward; the repository typecheck, formatter/checks, full tests, and build must pass before completion.
+
+## UI Verification
+
+This changes which existing renderer branch is selected and adds no visual layout or styling. Automated parser/renderer coverage is the deterministic verification; no new screenshot fixture is required.

--- a/src/components/agent-activity/tool-renderers/tool-result-plan.test.ts
+++ b/src/components/agent-activity/tool-renderers/tool-result-plan.test.ts
@@ -43,4 +43,30 @@ describe('extractPlanToolResult', () => {
     const payload = JSON.stringify({ type: 'tool_result', text: '# Not a plan' });
     expect(extractPlanToolResult(payload)).toBeNull();
   });
+
+  it('returns null for metadata-only plan payloads', () => {
+    const payload = JSON.stringify({
+      type: 'plan',
+      id: 'item_plan_approval',
+      status: 'completed',
+    });
+
+    expect(extractPlanToolResult(payload)).toBeNull();
+    expect(extractPlanToolResult([{ type: 'text', text: payload }])).toBeNull();
+  });
+
+  it('returns null when explicit plan fields contain no plan text', () => {
+    const blankPayload = JSON.stringify({
+      type: 'plan',
+      id: 'item_plan_approval',
+      text: '   ',
+    });
+    const nestedMetadataPayload = JSON.stringify({
+      type: 'plan',
+      plan: { id: 'item_nested_plan', status: 'completed' },
+    });
+
+    expect(extractPlanToolResult(blankPayload)).toBeNull();
+    expect(extractPlanToolResult(nestedMetadataPayload)).toBeNull();
+  });
 });

--- a/src/components/agent-activity/tool-renderers/tool-result-plan.test.ts
+++ b/src/components/agent-activity/tool-renderers/tool-result-plan.test.ts
@@ -44,7 +44,7 @@ describe('extractPlanToolResult', () => {
     expect(extractPlanToolResult(payload)).toBeNull();
   });
 
-  it('returns null for metadata-only plan payloads', () => {
+  it('returns null for metadata-only plan payload strings', () => {
     const payload = JSON.stringify({
       type: 'plan',
       id: 'item_plan_approval',
@@ -52,21 +52,34 @@ describe('extractPlanToolResult', () => {
     });
 
     expect(extractPlanToolResult(payload)).toBeNull();
+  });
+
+  it('returns null for metadata-only plan payloads in text item arrays', () => {
+    const payload = JSON.stringify({
+      type: 'plan',
+      id: 'item_plan_approval',
+      status: 'completed',
+    });
+
     expect(extractPlanToolResult([{ type: 'text', text: payload }])).toBeNull();
   });
 
-  it('returns null when explicit plan fields contain no plan text', () => {
-    const blankPayload = JSON.stringify({
+  it('returns null when an explicit plan text field is blank', () => {
+    const payload = JSON.stringify({
       type: 'plan',
       id: 'item_plan_approval',
       text: '   ',
     });
-    const nestedMetadataPayload = JSON.stringify({
+
+    expect(extractPlanToolResult(payload)).toBeNull();
+  });
+
+  it('returns null for nested metadata-only plan payloads', () => {
+    const payload = JSON.stringify({
       type: 'plan',
       plan: { id: 'item_nested_plan', status: 'completed' },
     });
 
-    expect(extractPlanToolResult(blankPayload)).toBeNull();
-    expect(extractPlanToolResult(nestedMetadataPayload)).toBeNull();
+    expect(extractPlanToolResult(payload)).toBeNull();
   });
 });

--- a/src/components/agent-activity/tool-renderers/tool-result-plan.ts
+++ b/src/components/agent-activity/tool-renderers/tool-result-plan.ts
@@ -1,9 +1,30 @@
 import type { ToolResultContentValue } from '@/lib/chat-protocol';
 import { extractPlanText } from '@/shared/acp-protocol/plan-content';
-import { findTypedPayload, unwrapJsonCodeFence } from './tool-result-parse-utils';
+import { findTypedPayload, isObjectRecord, unwrapJsonCodeFence } from './tool-result-parse-utils';
 
 const MAX_PLAN_SEARCH_DEPTH = 6;
 const PLAN_TYPE = 'plan';
+const PLAN_TEXT_KEYS = ['plan', 'markdown', 'text', 'content'] as const;
+
+function hasPlanTextContent(value: unknown, depth = 0): boolean {
+  if (depth > MAX_PLAN_SEARCH_DEPTH) {
+    return false;
+  }
+
+  if (typeof value === 'string') {
+    return value.trim().length > 0;
+  }
+
+  if (Array.isArray(value)) {
+    return value.some((item) => hasPlanTextContent(item, depth + 1));
+  }
+
+  if (!isObjectRecord(value)) {
+    return false;
+  }
+
+  return PLAN_TEXT_KEYS.some((key) => key in value && hasPlanTextContent(value[key], depth + 1));
+}
 
 function extractPlanResultFromRawText(rawText: string): string | null {
   const trimmed = rawText.trim();
@@ -24,6 +45,10 @@ function extractPlanResultFromRawText(rawText: string): string | null {
     maxDepth: MAX_PLAN_SEARCH_DEPTH,
   });
   if (!planPayload) {
+    return null;
+  }
+
+  if (!hasPlanTextContent(planPayload)) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
- Prevent metadata-only Codex plan completion payloads from rendering item IDs as plan text
- Preserve direct, fenced, array, and nested structured plan content rendering
- Add regression coverage for metadata-only, blank, and nested metadata payloads

## Changes
- **Agent Activity plan renderer**: Require nonblank content under an explicit `plan`, `markdown`, `text`, or `content` path before using specialized plan rendering
- **Tests**: Cover string and tool-result-array metadata payloads, whitespace-only text, and nested metadata without changing the shared ACP extractor

## Testing
- [x] Tests pass (`pnpm test`) — 3,741 passed, 3 skipped
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting passes (`pnpm check:fix`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not run; this renderer-branch change is covered by focused parser and renderer tests

Closes #1921

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI parsing change in the agent-activity plan renderer with regression tests; shared plan extraction and backend flows are untouched.
> 
> **Overview**
> Fixes agent-activity plan tool results where **metadata-only** Codex `type: "plan"` payloads (e.g. `id`, `status`) were shown as plan markdown because the shared extractor could pick the longest string field.
> 
> **`tool-result-plan.ts`** now runs **`hasPlanTextContent`** on the located plan envelope before **`extractPlanText`**. Only nonblank content under explicit **`plan`**, **`markdown`**, **`text`**, or **`content`** paths (including nested/array shapes) qualifies for specialized plan rendering; otherwise extraction returns **`null`** and the generic tool-result path is used. The shared ACP plan extractor is unchanged.
> 
> Adds focused Vitest regressions and superpowers design/plan docs for the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65b55f4dfdb266e7e010cc1ba90f0d191eba8371. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->