### PR TITLE
Fix #1910: Preserve closed-session tabs on reload

### DIFF
--- a/src/components/workspace/workspace-panel-context.test.tsx
+++ b/src/components/workspace/workspace-panel-context.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+
+import { createElement } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  type MainViewTab,
+  useWorkspacePanel,
+  WorkspacePanelProvider,
+} from './workspace-panel-context';
+
+vi.mock('@/hooks/use-mobile', () => ({
+  MOBILE_BREAKPOINT: 768,
+  useIsMobile: () => false,
+}));
+
+Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
+  configurable: true,
+  writable: true,
+  value: true,
+});
+
+const WORKSPACE_ID = 'workspace-1';
+const TABS_STORAGE_KEY = `workspace-panel-tabs-${WORKSPACE_ID}`;
+const ACTIVE_TAB_STORAGE_KEY = `workspace-panel-active-tab-${WORKSPACE_ID}`;
+
+function WorkspacePanelProbe() {
+  const { activeTabId, tabs } = useWorkspacePanel();
+  return createElement('output', null, JSON.stringify({ activeTabId, tabs }));
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.stubGlobal('matchMedia', () => ({ matches: false }));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  document.body.innerHTML = '';
+});
+
+describe('WorkspacePanelProvider persistence', () => {
+  it('restores mixed tabs when a closed-session tab is stored', async () => {
+    const storedTabs: MainViewTab[] = [
+      { id: 'chat', type: 'chat', label: 'Chat' },
+      { id: 'file-src/index.ts', type: 'file', path: 'src/index.ts', label: 'index.ts' },
+      {
+        id: 'closed-session-session-1',
+        type: 'closed-session',
+        closedSessionId: 'session-1',
+        label: 'History',
+      },
+    ];
+    localStorage.setItem(TABS_STORAGE_KEY, JSON.stringify(storedTabs));
+    localStorage.setItem(ACTIVE_TAB_STORAGE_KEY, 'closed-session-session-1');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    flushSync(() => {
+      root.render(
+        <WorkspacePanelProvider workspaceId={WORKSPACE_ID}>
+          <WorkspacePanelProbe />
+        </WorkspacePanelProvider>
+      );
+    });
+
+    await vi.waitFor(() => {
+      expect(JSON.parse(container.textContent ?? '')).toEqual({
+        activeTabId: 'closed-session-session-1',
+        tabs: storedTabs,
+      });
+    });
+
+    flushSync(() => {
+      root.unmount();
+    });
+  });
+});

--- a/src/components/workspace/workspace-panel-context.tsx
+++ b/src/components/workspace/workspace-panel-context.tsx
@@ -72,8 +72,9 @@ const CHAT_TAB: MainViewTab = {
 const MainViewTabSchema = z
   .object({
     id: z.string(),
-    type: z.enum(['chat', 'file', 'diff', 'screenshot']),
+    type: z.enum(['chat', 'file', 'diff', 'screenshot', 'closed-session']),
     path: z.string().optional(),
+    closedSessionId: z.string().optional(),
     label: z.string(),
   })
   .superRefine((tab, context) => {


### PR DESCRIPTION
## Summary
- Preserve all workspace tabs when reloading with a closed-session history tab open.
- Align persisted-tab runtime validation with the existing `MainViewTab` TypeScript type.
- Add a regression test for restoring mixed tabs and the active closed-session tab.

## Changes
- **Workspace tabs**: Accept `closed-session` tabs and preserve their optional `closedSessionId` during localStorage validation.
- **Regression coverage**: Render the real workspace panel provider from stored chat, file, and closed-session tabs and verify the full state restores.

## Testing
- [x] Tests pass (`NODE_ENV=test pnpm test --maxWorkers=1` — 3,740 passed, 3 skipped)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Repository checks pass (`pnpm check`)
- [x] Formatting checks pass (`pnpm check:fix`; six pre-existing image warnings)
- [x] Focused regression passes (`pnpm exec vitest run src/components/workspace/workspace-panel-context.test.tsx`)
- [ ] Manual testing: Reload a workspace with file and closed-session tabs open and confirm the active history tab is retained.

Closes #1910

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to localStorage tab parsing plus a test; no auth, security, or core runtime behavior beyond tab restore.
> 
> **Overview**
> Reloading a workspace with a **closed-session history** tab open no longer drops that tab or resets the active tab to chat.
> 
> **`MainViewTabSchema`** in `workspace-panel-context.tsx` now accepts `type: 'closed-session'` and optional **`closedSessionId`**, matching the existing **`MainViewTab`** TypeScript type so `loadTabsFromStorage` no longer fails validation and falls back to chat-only tabs.
> 
> A **jsdom regression test** seeds localStorage with chat, file, and closed-session tabs (with the history tab active) and asserts **`WorkspacePanelProvider`** restores the full tab list and active tab id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3d122df9cd57858291f19f7e1140942b1a03f0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

