### PR TITLE
Fix #1923: Prevent init warning banner flash

### DIFF
--- a/src/client/routes/projects/workspaces/use-workspace-detail-hooks.test.ts
+++ b/src/client/routes/projects/workspaces/use-workspace-detail-hooks.test.ts
@@ -55,6 +55,44 @@ describe('useWorkspaceInitStatus', () => {
 
     root.unmount();
   });
+
+  it('returns to an unhydrated dismissal state when the workspace changes', async () => {
+    const initStatus = {
+      status: 'READY',
+      initErrorMessage: 'Setup failed',
+      chatBanner: { showDismiss: true },
+      hasWorktreePath: true,
+    };
+    getInitStatusUseQueryMock.mockReturnValue({ data: initStatus, isPending: false });
+    const observedStates: Array<{ workspaceId: string; dismissed: boolean | null }> = [];
+
+    function Probe({ workspaceId }: { workspaceId: string }) {
+      const utils = trpc.useUtils();
+      const { setupWarningDismissed } = useWorkspaceInitStatus(workspaceId, undefined, utils);
+      observedStates.push({ workspaceId, dismissed: setupWarningDismissed });
+      return null;
+    }
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    flushSync(() => {
+      root.render(createElement(Probe, { workspaceId: 'workspace-1' }));
+    });
+    await vi.waitFor(() => {
+      expect(observedStates.at(-1)).toEqual({ workspaceId: 'workspace-1', dismissed: false });
+    });
+
+    observedStates.length = 0;
+    flushSync(() => {
+      root.render(createElement(Probe, { workspaceId: 'workspace-2' }));
+    });
+
+    expect(observedStates[0]).toEqual({ workspaceId: 'workspace-2', dismissed: null });
+
+    root.unmount();
+  });
 });
 
 describe('resolveSelectedSessionId', () => {

--- a/src/client/routes/projects/workspaces/use-workspace-detail-hooks.test.ts
+++ b/src/client/routes/projects/workspaces/use-workspace-detail-hooks.test.ts
@@ -1,5 +1,61 @@
-import { describe, expect, it } from 'vitest';
-import { resolveSelectedSessionId } from './use-workspace-detail-hooks';
+// @vitest-environment jsdom
+
+import { createElement } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { trpc } from '@/client/lib/trpc';
+import { resolveSelectedSessionId, useWorkspaceInitStatus } from './use-workspace-detail-hooks';
+
+const getInitStatusUseQueryMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/client/lib/trpc', () => ({
+  trpc: {
+    useUtils: () => ({
+      workspace: {
+        get: {
+          invalidate: vi.fn(),
+        },
+      },
+    }),
+    workspace: {
+      getInitStatus: {
+        useQuery: getInitStatusUseQueryMock,
+      },
+    },
+  },
+}));
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.clearAllMocks();
+});
+
+describe('useWorkspaceInitStatus', () => {
+  it('starts with an unhydrated setup warning dismissal state', () => {
+    getInitStatusUseQueryMock.mockReturnValue({ data: undefined, isPending: true });
+    const observedStates: Array<boolean | null> = [];
+
+    function Probe() {
+      const utils = trpc.useUtils();
+      const { setupWarningDismissed } = useWorkspaceInitStatus('workspace-1', undefined, utils);
+      observedStates.push(setupWarningDismissed);
+      return null;
+    }
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    flushSync(() => {
+      root.render(createElement(Probe));
+    });
+
+    expect(observedStates[0]).toBeNull();
+
+    root.unmount();
+  });
+});
 
 describe('resolveSelectedSessionId', () => {
   it('keeps current selection while sessions are still loading', () => {

--- a/src/client/routes/projects/workspaces/use-workspace-detail-hooks.ts
+++ b/src/client/routes/projects/workspaces/use-workspace-detail-hooks.ts
@@ -66,7 +66,18 @@ export function useWorkspaceInitStatus(
     (status === 'FAILED' && hasWorktreePath) || (status === 'READY' && !!initErrorMessage);
 
   // Persisted per workspace/error so navigating away and back does not resurface dismissed warnings.
-  const [setupWarningDismissed, setSetupWarningDismissed] = useState<boolean | null>(null);
+  // Keep the identity alongside the value so a previous workspace's hydrated `false` cannot make a
+  // newly selected workspace flash its warning before this effect reads that warning's storage key.
+  const [hydratedSetupWarning, setHydratedSetupWarning] = useState<{
+    workspaceId: string;
+    initErrorMessage: string | null;
+    dismissed: boolean;
+  } | null>(null);
+  const setupWarningDismissed =
+    hydratedSetupWarning?.workspaceId === workspaceId &&
+    hydratedSetupWarning.initErrorMessage === initErrorMessage
+      ? hydratedSetupWarning.dismissed
+      : null;
   useEffect(() => {
     if (!workspaceInitStatus) {
       return;
@@ -74,21 +85,25 @@ export function useWorkspaceInitStatus(
 
     if (!initErrorMessage) {
       forgetSetupWarningDismissed(workspaceId);
-      setSetupWarningDismissed(false);
+      setHydratedSetupWarning({ workspaceId, initErrorMessage, dismissed: false });
       return;
     }
 
     if (workspaceInitStatus.chatBanner?.showDismiss !== true) {
-      setSetupWarningDismissed(false);
+      setHydratedSetupWarning({ workspaceId, initErrorMessage, dismissed: false });
       return;
     }
 
-    setSetupWarningDismissed(isSetupWarningDismissed(workspaceId, initErrorMessage));
+    setHydratedSetupWarning({
+      workspaceId,
+      initErrorMessage,
+      dismissed: isSetupWarningDismissed(workspaceId, initErrorMessage),
+    });
   }, [workspaceId, workspaceInitStatus, initErrorMessage]);
 
   const dismissSetupWarning = useCallback(() => {
     rememberSetupWarningDismissed(workspaceId, initErrorMessage);
-    setSetupWarningDismissed(true);
+    setHydratedSetupWarning({ workspaceId, initErrorMessage, dismissed: true });
   }, [workspaceId, initErrorMessage]);
 
   return {

--- a/src/client/routes/projects/workspaces/use-workspace-detail-hooks.ts
+++ b/src/client/routes/projects/workspaces/use-workspace-detail-hooks.ts
@@ -66,7 +66,7 @@ export function useWorkspaceInitStatus(
     (status === 'FAILED' && hasWorktreePath) || (status === 'READY' && !!initErrorMessage);
 
   // Persisted per workspace/error so navigating away and back does not resurface dismissed warnings.
-  const [setupWarningDismissed, setSetupWarningDismissed] = useState(false);
+  const [setupWarningDismissed, setSetupWarningDismissed] = useState<boolean | null>(null);
   useEffect(() => {
     if (!workspaceInitStatus) {
       return;

--- a/src/client/routes/projects/workspaces/workspace-detail-container.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-container.tsx
@@ -22,6 +22,7 @@ import {
 import type { ChatContentProps } from './workspace-detail-chat-content';
 import {
   buildSessionSummariesById,
+  getVisibleInitBanner,
   hasUserMessageWithoutAgentMessage,
 } from './workspace-detail-container.utils';
 import { WorkspaceDetailView } from './workspace-detail-view';
@@ -229,10 +230,7 @@ export function WorkspaceDetailContainer() {
   );
 
   const chatTabId = selectedDbSessionId ? `chat-${selectedDbSessionId}` : null;
-  const initBanner =
-    setupWarningDismissed && workspaceInitStatus?.chatBanner?.showDismiss
-      ? null
-      : (workspaceInitStatus?.chatBanner ?? null);
+  const initBanner = getVisibleInitBanner(workspaceInitStatus?.chatBanner, setupWarningDismissed);
 
   const { persistCurrent: persistChatScroll } = usePersistentScroll({
     tabId: chatTabId,

--- a/src/client/routes/projects/workspaces/workspace-detail-container.utils.test.ts
+++ b/src/client/routes/projects/workspaces/workspace-detail-container.utils.test.ts
@@ -3,9 +3,32 @@ import type { WorkspaceSessionRuntimeSummary } from '@/components/workspace/sess
 import type { SessionRuntimeState } from '@/shared/session-runtime';
 import {
   buildSessionSummariesById,
+  getVisibleInitBanner,
   hasUserMessageWithoutAgentMessage,
   type SessionForRuntimeOverlay,
 } from './workspace-detail-container.utils';
+
+describe('getVisibleInitBanner', () => {
+  const dismissibleBanner = { message: 'Setup failed', showDismiss: true };
+
+  it('hides a dismissible warning before dismissal state hydrates', () => {
+    expect(getVisibleInitBanner(dismissibleBanner, null)).toBeNull();
+  });
+
+  it('shows a dismissible warning after dismissal state hydrates to false', () => {
+    expect(getVisibleInitBanner(dismissibleBanner, false)).toBe(dismissibleBanner);
+  });
+
+  it('hides a dismissed warning', () => {
+    expect(getVisibleInitBanner(dismissibleBanner, true)).toBeNull();
+  });
+
+  it('keeps non-dismissible init banners visible during dismissal hydration', () => {
+    const banner = { message: 'Workspace is initializing', showDismiss: false };
+
+    expect(getVisibleInitBanner(banner, null)).toBe(banner);
+  });
+});
 
 describe('workspace detail container utils', () => {
   it('returns true when the transcript has a user message and no agent message', () => {

--- a/src/client/routes/projects/workspaces/workspace-detail-container.utils.ts
+++ b/src/client/routes/projects/workspaces/workspace-detail-container.utils.ts
@@ -4,6 +4,21 @@ import type { SessionRuntimeState } from '@/shared/session-runtime';
 
 type MessageSourceOnly = Pick<ChatMessage, 'source'>;
 
+interface DismissibleInitBanner {
+  showDismiss?: boolean;
+}
+
+export function getVisibleInitBanner<T extends DismissibleInitBanner>(
+  banner: T | null | undefined,
+  setupWarningDismissed: boolean | null
+): T | null {
+  if (!banner || (banner.showDismiss === true && setupWarningDismissed !== false)) {
+    return null;
+  }
+
+  return banner;
+}
+
 export interface SessionForRuntimeOverlay {
   id: string;
   name: string | null;

--- a/src/client/routes/projects/workspaces/workspace-detail-view.test.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-view.test.tsx
@@ -71,6 +71,28 @@ function createMutationLike() {
   };
 }
 
+function createInitStatus(
+  showDismiss: boolean
+): NonNullable<WorkspaceDetailViewProps['workspaceState']['workspaceInitStatus']> {
+  return {
+    status: 'READY',
+    initErrorMessage: 'Setup failed',
+    initOutput: null,
+    initStartedAt: null,
+    initCompletedAt: null,
+    phase: 'READY_WITH_WARNING',
+    chatBanner: {
+      kind: 'warning',
+      message: 'Setup failed',
+      showRetry: true,
+      showPlay: false,
+      showDismiss,
+    },
+    hasStartupScript: true,
+    hasWorktreePath: true,
+  };
+}
+
 function createViewProps(activeChildCount: number): WorkspaceDetailViewProps {
   return {
     workspaceState: {
@@ -169,11 +191,25 @@ describe('WorkspaceDetailView', () => {
   it('does not render the script warning before dismissal state hydrates', () => {
     const props = createViewProps(0);
     props.workspaceState.isScriptFailed = true;
+    props.workspaceState.workspaceInitStatus = createInitStatus(true);
     props.workspaceState.setupWarningDismissed = null;
 
     const { container, root } = renderView(props);
 
     expect(container.textContent).not.toContain('Script failed');
+
+    root.unmount();
+  });
+
+  it('keeps non-dismissible script warnings visible during dismissal hydration', () => {
+    const props = createViewProps(0);
+    props.workspaceState.isScriptFailed = true;
+    props.workspaceState.workspaceInitStatus = createInitStatus(false);
+    props.workspaceState.setupWarningDismissed = null;
+
+    const { container, root } = renderView(props);
+
+    expect(container.textContent).toContain('Script failed');
 
     root.unmount();
   });

--- a/src/client/routes/projects/workspaces/workspace-detail-view.test.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-view.test.tsx
@@ -165,4 +165,16 @@ describe('WorkspaceDetailView', () => {
 
     root.unmount();
   });
+
+  it('does not render the script warning before dismissal state hydrates', () => {
+    const props = createViewProps(0);
+    props.workspaceState.isScriptFailed = true;
+    props.workspaceState.setupWarningDismissed = null;
+
+    const { container, root } = renderView(props);
+
+    expect(container.textContent).not.toContain('Script failed');
+
+    root.unmount();
+  });
 });

--- a/src/client/routes/projects/workspaces/workspace-detail-view.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-view.tsx
@@ -89,7 +89,8 @@ function ScriptBanner({
   setupWarningDismissed: boolean | null;
   dismissSetupWarning: () => void;
 }) {
-  if (isScriptFailed && setupWarningDismissed === false) {
+  const isDismissible = workspaceInitStatus?.chatBanner?.showDismiss === true;
+  if (isScriptFailed && (!isDismissible || setupWarningDismissed === false)) {
     return (
       <ScriptFailedBanner
         workspaceId={workspaceId}

--- a/src/client/routes/projects/workspaces/workspace-detail-view.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-view.tsx
@@ -17,6 +17,7 @@ import { AutoIterationProgressBanner } from './auto-iteration-progress-banner';
 import type { useSessionManagement, useWorkspaceData } from './use-workspace-detail';
 import type { useWorkspaceInitStatus } from './use-workspace-detail-hooks';
 import { ChatContent, type ChatContentProps } from './workspace-detail-chat-content';
+import { getVisibleInitBanner } from './workspace-detail-container.utils';
 import { ArchivingOverlay, ScriptFailedBanner } from './workspace-overlays';
 
 interface WorkspaceStateProps {
@@ -89,15 +90,18 @@ function ScriptBanner({
   setupWarningDismissed: boolean | null;
   dismissSetupWarning: () => void;
 }) {
-  const isDismissible = workspaceInitStatus?.chatBanner?.showDismiss === true;
-  if (isScriptFailed && (!isDismissible || setupWarningDismissed === false)) {
+  const visibleBanner = getVisibleInitBanner(
+    workspaceInitStatus?.chatBanner,
+    setupWarningDismissed
+  );
+  if (isScriptFailed && visibleBanner) {
     return (
       <ScriptFailedBanner
         workspaceId={workspaceId}
         initErrorMessage={workspaceInitStatus?.initErrorMessage ?? null}
         initOutput={workspaceInitStatus?.initOutput ?? null}
         hasStartupScript={workspaceInitStatus?.hasStartupScript ?? false}
-        showDismiss={workspaceInitStatus?.chatBanner?.showDismiss ?? false}
+        showDismiss={visibleBanner.showDismiss}
         onDismiss={dismissSetupWarning}
       />
     );

--- a/src/client/routes/projects/workspaces/workspace-detail-view.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-view.tsx
@@ -26,7 +26,7 @@ interface WorkspaceStateProps {
   handleBackToWorkspaces: () => void;
   isScriptFailed: boolean;
   workspaceInitStatus: ReturnType<typeof useWorkspaceInitStatus>['workspaceInitStatus'];
-  setupWarningDismissed: boolean;
+  setupWarningDismissed: boolean | null;
   dismissSetupWarning: () => void;
 }
 
@@ -86,10 +86,10 @@ function ScriptBanner({
   workspaceId: string;
   isScriptFailed: boolean;
   workspaceInitStatus: WorkspaceStateProps['workspaceInitStatus'];
-  setupWarningDismissed: boolean;
+  setupWarningDismissed: boolean | null;
   dismissSetupWarning: () => void;
 }) {
-  if (isScriptFailed && !setupWarningDismissed) {
+  if (isScriptFailed && setupWarningDismissed === false) {
     return (
       <ScriptFailedBanner
         workspaceId={workspaceId}


### PR DESCRIPTION
## Summary
- Prevent persisted, dismissed workspace setup warnings from flashing after refresh.
- Preserve immediate visibility for non-dismissible initialization warnings.
- Add regression coverage for hook hydration and both banner render paths.

## Changes
- **Workspace init hook**: Represent dismissal hydration as `boolean | null` so consumers can distinguish unresolved storage state from an undismissed warning.
- **Workspace detail banners**: Suppress dismissible outer and in-chat warnings until hydration resolves, while leaving non-dismissible banners visible.
- **Tests**: Cover the initial tri-state, dismissed/undismissed in-chat selection, and dismissible versus non-dismissible outer banners.

## Testing
- [x] Tests pass (`env -u NODE_ENV pnpm exec vitest run --maxWorkers=1`: 3,746 passed)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Formatting and lint autofix completed (`pnpm check:fix`; 6 existing `<img>` warnings)
- [ ] Manual testing: Refresh a workspace after dismissing its setup warning and confirm neither warning surface flashes.

Closes #1923

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only workspace banner and localStorage hydration behavior with targeted tests; no auth, API, or data-model changes.
> 
> **Overview**
> Fixes a brief flash of workspace setup warnings after refresh or when switching workspaces, including cases where the user had already dismissed the warning.
> 
> **`useWorkspaceInitStatus`** now exposes `setupWarningDismissed` as `boolean | null`: `null` means persisted dismissal state is not loaded yet. Hydration is keyed by `workspaceId` and `initErrorMessage` so another workspace’s cached `false` cannot leak into a newly opened workspace.
> 
> **Banner visibility** is centralized in **`getVisibleInitBanner`**, used for the in-chat init banner and the outer script-failed banner. Dismissible warnings stay hidden until hydration resolves to `false`; non-dismissible init banners still render while dismissal state is `null`.
> 
> Regression tests cover the hook tri-state, workspace switches, util rules, and view rendering for dismissible vs non-dismissible warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab6e6dbc3acae2893c4501b569b78e107702b585. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

