### PR TITLE
Fix #1905: prevent workspace switch on link click

### DIFF
--- a/src/client/components/workspace-item-content.test.tsx
+++ b/src/client/components/workspace-item-content.test.tsx
@@ -50,13 +50,30 @@ const baseWorkspace = {
   linearIssueUrl: null,
 } as unknown as ServerWorkspace;
 
-function renderContent(workspace: ServerWorkspace): { container: HTMLDivElement; root: Root } {
+function renderContent(
+  workspace: ServerWorkspace,
+  {
+    onOpenPr,
+    onOpenIssue,
+    onParentPointerUp,
+  }: {
+    onOpenPr?: () => void;
+    onOpenIssue?: () => void;
+    onParentPointerUp?: () => void;
+  } = {}
+): { container: HTMLDivElement; root: Root } {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const root = createRoot(container);
 
   flushSync(() => {
-    root.render(createElement(WorkspaceItemContent, { workspace }));
+    root.render(
+      createElement(
+        'div',
+        { onPointerUp: onParentPointerUp },
+        createElement(WorkspaceItemContent, { workspace, onOpenPr, onOpenIssue })
+      )
+    );
   });
 
   return { container, root };
@@ -76,6 +93,55 @@ afterEach(() => {
 });
 
 describe('WorkspaceItemContent', () => {
+  it('opens a pull request without propagating pointerup to its parent', () => {
+    const onOpenPr = vi.fn();
+    const onParentPointerUp = vi.fn();
+    const { container, root } = renderContent(
+      {
+        ...baseWorkspace,
+        prUrl: 'https://github.com/example/repo/pull/42',
+        prNumber: 42,
+        prState: 'OPEN',
+      },
+      { onOpenPr, onParentPointerUp }
+    );
+    const button = container.querySelector('button');
+
+    expect(button).not.toBeNull();
+    button?.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));
+    button?.click();
+
+    expect(onParentPointerUp).not.toHaveBeenCalled();
+    expect(onOpenPr).toHaveBeenCalledOnce();
+
+    root.unmount();
+    container.remove();
+  });
+
+  it('opens an issue without propagating pointerup to its parent', () => {
+    const onOpenIssue = vi.fn();
+    const onParentPointerUp = vi.fn();
+    const { container, root } = renderContent(
+      {
+        ...baseWorkspace,
+        githubIssueNumber: 1905,
+        githubIssueUrl: 'https://github.com/example/repo/issues/1905',
+      },
+      { onOpenIssue, onParentPointerUp }
+    );
+    const button = container.querySelector('button');
+
+    expect(button).not.toBeNull();
+    button?.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));
+    button?.click();
+
+    expect(onParentPointerUp).not.toHaveBeenCalled();
+    expect(onOpenIssue).toHaveBeenCalledOnce();
+
+    root.unmount();
+    container.remove();
+  });
+
   it('hides default idle status reasons', () => {
     const { container, root } = renderContent({
       ...baseWorkspace,

--- a/src/client/components/workspace-item-content.tsx
+++ b/src/client/components/workspace-item-content.tsx
@@ -31,6 +31,9 @@ function PrLink({ prNumber, onOpenPr }: { prNumber: number; onOpenPr?: () => voi
       <button
         type="button"
         className="flex items-center gap-0.5 hover:text-foreground"
+        onPointerUp={(event) => {
+          event.stopPropagation();
+        }}
         onClick={(event) => {
           event.preventDefault();
           event.stopPropagation();
@@ -117,6 +120,9 @@ export function WorkspaceItemContent({
             <button
               type="button"
               className="inline-flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+              onPointerUp={(event) => {
+                event.stopPropagation();
+              }}
               onClick={(event) => {
                 event.preventDefault();
                 event.stopPropagation();


### PR DESCRIPTION
## Summary
- Prevent PR and issue link clicks in the workspace switcher from selecting another workspace
- Add focused regression coverage for both nested link controls

## Changes
- **Workspace item links**: Stop `pointerup` propagation before Radix Select can select the surrounding workspace item, while preserving the existing URL-opening click behavior
- **Tests**: Verify PR and issue controls do not propagate `pointerup` to a parent and still invoke their open callbacks

## Testing
- [x] Tests pass (`NODE_ENV=test pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting checks complete (`pnpm check:fix`; six pre-existing warnings)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Open the workspace switcher and click PR/Issue links; browser control was unavailable in this session

Closes #1905

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
