### PR TITLE
Prevent workspace header overlap on smaller displays

### DIFF
--- a/src/client/routes/projects/workspaces/workspace-detail-header.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-header.tsx
@@ -134,7 +134,7 @@ export function WorkspaceDetailHeaderSlot({
               className="min-w-0 max-w-[18rem] text-sm font-semibold bg-transparent border-b border-primary outline-none"
             />
           ) : (
-            <div className="group flex items-center gap-0.5">
+            <div className="group flex min-w-0 items-center gap-0.5">
               <WorkspaceSwitcherDropdown
                 projectSlug={slug}
                 projectId={workspace.projectId}

--- a/src/client/routes/projects/workspaces/workspace-detail-header/workspace-switcher-dropdown.stories.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-header/workspace-switcher-dropdown.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from '@/components/ui/button';
+import { WorkspaceSwitcherDropdown } from './workspace-switcher-dropdown';
+
+const meta = {
+  title: 'Workspaces/WorkspaceSwitcherDropdown',
+  component: WorkspaceSwitcherDropdown,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    (Story) => (
+      <div className="flex w-[32rem] items-center gap-1 border p-2">
+        <Story />
+        <div className="flex shrink-0 items-center gap-1">
+          <Button size="sm" variant="ghost">
+            Settings
+          </Button>
+          <Button size="sm" variant="ghost">
+            Archive
+          </Button>
+          <Button size="sm" variant="ghost">
+            Panel
+          </Button>
+        </div>
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof WorkspaceSwitcherDropdown>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const LongBranchOnSmallerDisplay: Story = {
+  args: {
+    projectSlug: 'factory-factory',
+    projectId: 'project-1',
+    currentWorkspaceId: 'workspace-1',
+    currentWorkspaceLabel:
+      'martin-purplefish/smaller-displays-top-bar-starts-overlapping-fixed-controls',
+    currentWorkspaceName: 'Prevent top-bar overlap',
+  },
+};

--- a/src/client/routes/projects/workspaces/workspace-detail-header/workspace-switcher-dropdown.test.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-header/workspace-switcher-dropdown.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+
+import type { ReactNode } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { WorkspaceSwitcherDropdown } from './workspace-switcher-dropdown';
+
+vi.mock('@phosphor-icons/react', () => ({
+  CaretUpDownIcon: () => null,
+}));
+
+vi.mock('react-router', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('@/client/lib/trpc', () => ({
+  trpc: {
+    workspace: {
+      getProjectSummaryState: {
+        useQuery: () => ({ data: { workspaces: [] } }),
+      },
+    },
+  },
+}));
+
+vi.mock('@/client/components/workspace-item-content', () => ({
+  WorkspaceItemContent: () => null,
+}));
+
+vi.mock('@/components/ui/select', () => ({
+  Select: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SelectContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SelectGroup: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SelectItem: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SelectLabel: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SelectTrigger: ({ children, ...props }: { children: ReactNode; [key: string]: unknown }) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+let root: Root | null = null;
+
+afterEach(() => {
+  root?.unmount();
+  root = null;
+  document.body.innerHTML = '';
+});
+
+describe('WorkspaceSwitcherDropdown', () => {
+  it('keeps a long branch label shrinkable and clipped at desktop widths', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    flushSync(() => {
+      root?.render(
+        <WorkspaceSwitcherDropdown
+          projectSlug="factory-factory"
+          projectId="project-1"
+          currentWorkspaceId="workspace-1"
+          currentWorkspaceLabel="feature/a-very-long-branch-name-that-must-not-overlap-actions"
+          currentWorkspaceName="Workspace"
+        />
+      );
+    });
+
+    const trigger = container.querySelector('#workspace-detail-workspace-select');
+    const label = container.querySelector('.workspace-switcher-label');
+
+    expect(trigger?.className).toContain('min-w-0');
+    expect(label?.className).toContain('truncate');
+    expect(label?.className).not.toContain('md:overflow-visible');
+    expect(label?.className).not.toContain('md:text-clip');
+  });
+});

--- a/src/client/routes/projects/workspaces/workspace-detail-header/workspace-switcher-dropdown.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-header/workspace-switcher-dropdown.tsx
@@ -74,9 +74,9 @@ export function WorkspaceSwitcherDropdown({
       <SelectTrigger
         id="workspace-detail-workspace-select"
         aria-label={`Open workspace menu (${queueSummaryLabel})`}
-        className="h-7 w-auto max-w-[10rem] border-0 bg-transparent px-0.5 text-[11px] font-normal text-muted-foreground shadow-none focus:ring-0 hover:[&>.workspace-switcher-label]:underline focus-visible:[&>.workspace-switcher-label]:underline md:max-w-[18rem] md:px-1 md:text-sm lg:max-w-none [&>svg:last-of-type]:hidden"
+        className="h-7 min-w-0 w-auto max-w-[10rem] border-0 bg-transparent px-0.5 text-[11px] font-normal text-muted-foreground shadow-none focus:ring-0 hover:[&>.workspace-switcher-label]:underline focus-visible:[&>.workspace-switcher-label]:underline md:max-w-[18rem] md:px-1 md:text-sm lg:max-w-none [&>svg:last-of-type]:hidden"
       >
-        <span className="workspace-switcher-label flex-1 min-w-0 truncate text-foreground font-semibold md:overflow-visible md:text-clip">
+        <span className="workspace-switcher-label flex-1 min-w-0 truncate text-foreground font-semibold">
           {currentWorkspaceLabel}
         </span>
         <span className="shrink-0" aria-hidden>


### PR DESCRIPTION
## Summary

- make the workspace branch selector shrinkable inside the top bar
- keep long branch names truncated at every breakpoint so they cannot paint over fixed controls
- preserve the header's existing wrapping behavior as the last-resort layout fallback
- add a focused regression test and a narrow-display Storybook case

## Root cause

At medium and larger breakpoints, the workspace label explicitly restored visible overflow and clipped text while its trigger lacked `min-width: 0`. Flexbox could allocate the label less space, but the text still painted outside that allocation and overlapped the action controls.

## User impact

Long branch names now collapse to an ellipsis first on smaller displays. Header actions remain visible and the top bar wraps only when its fixed controls physically cannot fit.

## Validation

- `pnpm exec vitest run src/client/routes/projects/workspaces/workspace-detail-header/workspace-switcher-dropdown.test.tsx`
- `pnpm typecheck`
- `pnpm check`
- `pnpm build:storybook`
- `pnpm test` — 3,735 tests pass; 13 unrelated setup-terminal tests fail because `act` is unavailable in the current test environment


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout changes in the workspace header with regression test and Storybook coverage; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes the workspace detail top bar so **long branch/workspace labels no longer paint over header actions** on medium+ widths.
> 
> The workspace switcher trigger gets **`min-w-0`** so it can shrink inside the flex row, and the label no longer uses **`md:overflow-visible` / `md:text-clip`**, so **`truncate` applies at every breakpoint**. The surrounding header group also gets **`min-w-0`** so the left cluster can shrink before overlapping fixed right-side controls.
> 
> Adds a **Vitest** regression on the trigger/label classes and a **Storybook** story that shows a long branch name beside mock action buttons in a narrow layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93a031cf0c4fcc0d87e57b04fe06518b67a77483. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->