### PR TITLE
Fix #1903: Preserve completed tool calls on ID reuse

### DIFF
--- a/src/backend/services/session/service/store/session-transcript.test.ts
+++ b/src/backend/services/session/service/store/session-transcript.test.ts
@@ -25,6 +25,49 @@ function createStore(): SessionStore {
   };
 }
 
+function createAppendOptions() {
+  return {
+    nowIso: () => '2026-02-01T00:00:00.000Z',
+    onParityTrace: vi.fn(),
+  };
+}
+
+function appendToolUse(
+  store: SessionStore,
+  input: Record<string, unknown>,
+  options: ReturnType<typeof createAppendOptions>
+): number {
+  return appendClaudeEvent(
+    store,
+    {
+      type: 'stream_event',
+      event: {
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'tool_use', id: 'tool-1', name: 'Bash', input },
+      },
+    },
+    options
+  );
+}
+
+function appendToolResult(
+  store: SessionStore,
+  options: ReturnType<typeof createAppendOptions>
+): number {
+  return appendClaudeEvent(
+    store,
+    {
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'output' }],
+      },
+    },
+    options
+  );
+}
+
 describe('session-transcript', () => {
   it('creates stable fallback IDs for history entries without uuid', () => {
     const history = [
@@ -64,44 +107,10 @@ describe('session-transcript', () => {
 
   it('upserts duplicate tool_use content_block_start events by tool id', () => {
     const store = createStore();
-    const onParityTrace = vi.fn();
+    const options = createAppendOptions();
 
-    const firstOrder = appendClaudeEvent(
-      store,
-      {
-        type: 'stream_event',
-        event: {
-          type: 'content_block_start',
-          index: 0,
-          content_block: { type: 'tool_use', id: 'tool-1', name: 'Bash', input: {} },
-        },
-      },
-      {
-        nowIso: () => '2026-02-01T00:00:00.000Z',
-        onParityTrace,
-      }
-    );
-
-    const secondOrder = appendClaudeEvent(
-      store,
-      {
-        type: 'stream_event',
-        event: {
-          type: 'content_block_start',
-          index: 0,
-          content_block: {
-            type: 'tool_use',
-            id: 'tool-1',
-            name: 'Bash',
-            input: { command: 'ls', description: 'List files' },
-          },
-        },
-      },
-      {
-        nowIso: () => '2026-02-01T00:00:01.000Z',
-        onParityTrace,
-      }
-    );
+    const firstOrder = appendToolUse(store, {}, options);
+    const secondOrder = appendToolUse(store, { command: 'ls', description: 'List files' }, options);
 
     expect(store.transcript).toHaveLength(1);
     expect(secondOrder).toBe(firstOrder);
@@ -110,9 +119,48 @@ describe('session-transcript', () => {
     const block = (entry.message as { event: { content_block: { input: unknown } } }).event
       .content_block;
     expect(block.input).toEqual({ command: 'ls', description: 'List files' });
-    expect(onParityTrace).toHaveBeenCalledWith(
+    expect(options.onParityTrace).toHaveBeenCalledWith(
       expect.objectContaining({ reason: 'duplicate_tool_use_start_enriched' })
     );
+  });
+
+  it('appends a new tool_use when a completed call reuses the same id', () => {
+    const store = createStore();
+    const options = createAppendOptions();
+
+    const firstOrder = appendToolUse(store, { command: 'echo turn1' }, options);
+    appendToolResult(store, options);
+    const secondOrder = appendToolUse(store, { command: 'echo turn2' }, options);
+
+    expect(firstOrder).toBe(0);
+    expect(secondOrder).toBe(2);
+    expect(store.transcript).toHaveLength(3);
+    expect(store.transcript[0]?.message).toMatchObject({
+      event: { content_block: { input: { command: 'echo turn1' } } },
+    });
+    expect(store.transcript[2]?.message).toMatchObject({
+      event: { content_block: { input: { command: 'echo turn2' } } },
+    });
+  });
+
+  it('enriches the newest open call after its id was reused', () => {
+    const store = createStore();
+    const options = createAppendOptions();
+
+    appendToolUse(store, { command: 'echo turn1' }, options);
+    appendToolResult(store, options);
+    const secondOrder = appendToolUse(store, {}, options);
+    const enrichedOrder = appendToolUse(store, { command: 'echo turn2' }, options);
+
+    expect(secondOrder).toBe(2);
+    expect(enrichedOrder).toBe(secondOrder);
+    expect(store.transcript).toHaveLength(3);
+    expect(store.transcript[0]?.message).toMatchObject({
+      event: { content_block: { input: { command: 'echo turn1' } } },
+    });
+    expect(store.transcript[2]?.message).toMatchObject({
+      event: { content_block: { input: { command: 'echo turn2' } } },
+    });
   });
 
   it('injects committed user message with deterministic clock hooks', () => {

--- a/src/backend/services/session/service/store/session-transcript.ts
+++ b/src/backend/services/session/service/store/session-transcript.ts
@@ -176,20 +176,51 @@ export function setNextOrderFromTranscript(store: SessionStore): void {
   store.nextOrder = maxOrder + 1;
 }
 
+function hasMatchingToolResult(message: AgentMessage, toolUseId: string): boolean {
+  const content = message.message?.content;
+  if (
+    Array.isArray(content) &&
+    content.some((item) => item.type === 'tool_result' && item.tool_use_id === toolUseId)
+  ) {
+    return true;
+  }
+
+  return (
+    message.type === 'stream_event' &&
+    message.event?.type === 'content_block_start' &&
+    message.event.content_block.type === 'tool_result' &&
+    message.event.content_block.tool_use_id === toolUseId
+  );
+}
+
 function findPersistedToolUseStart(
   store: SessionStore,
   toolUseId: string
 ): ChatMessage | undefined {
-  return store.transcript.find((entry) => {
-    if (entry.source !== 'agent' || !entry.message || entry.message.type !== 'stream_event') {
-      return false;
+  for (let index = store.transcript.length - 1; index >= 0; index -= 1) {
+    const entry = store.transcript[index];
+    if (!entry || entry.source !== 'agent' || !entry.message) {
+      continue;
     }
+
+    if (hasMatchingToolResult(entry.message, toolUseId)) {
+      return undefined;
+    }
+
+    if (entry.message.type !== 'stream_event') {
+      continue;
+    }
+
     const event = entry.message.event;
     if (!event || event.type !== 'content_block_start') {
-      return false;
+      continue;
     }
-    return event.content_block.type === 'tool_use' && event.content_block.id === toolUseId;
-  });
+    if (event.content_block.type === 'tool_use' && event.content_block.id === toolUseId) {
+      return entry;
+    }
+  }
+
+  return undefined;
 }
 
 export function appendClaudeEvent(


### PR DESCRIPTION
## Summary
- Preserve completed transcript tool calls when a later turn reuses the same tool-use ID.
- Keep progressive enrichment working for the newest open call after an ID is reused.

## Changes
- **Session transcript persistence**: Scan matching tool-call lifecycles newest-first and stop reusing an entry once a matching tool result completes it.
- **Regression coverage**: Verify completed same-ID calls append immutable history and subsequent enrichment updates only the newest open call.

## Testing
- [x] Tests pass (`env -u NODE_ENV pnpm test` — 3,764 passed, 3 skipped)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting/lint checks complete (`pnpm check:fix`)
- [x] Build succeeds (`pnpm build`)
- [x] Manual testing: Not applicable; backend transcript behavior is covered by focused regression tests.

Closes #1903

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core transcript persistence logic for tool calls; incorrect matching could still corrupt chat history or UI updates, but behavior is narrowly scoped and covered by new regression tests.
> 
> **Overview**
> Fixes session transcript handling when the same **tool-use ID** appears again after an earlier call has already received a **tool result**. Previously, duplicate `content_block_start` events were matched against the first transcript entry with that ID, which could **overwrite completed tool history** instead of recording a new call.
> 
> **`findPersistedToolUseStart`** now walks the transcript **newest-first** and only treats a `tool_use` start as upsertable if it is still **open** (no matching `tool_result` for that ID on the same or prior entries). A new helper **`hasMatchingToolResult`** recognizes tool results in both user-message content and stream `tool_result` blocks.
> 
> Progressive enrichment for the **current** open call is unchanged: repeated starts with the same ID still update in place when no result has completed that lifecycle. Tests add helpers and cover **append-after-complete** and **enrich-newest-open-after-reuse** scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ba3e8f29f102d632529a8e6f69b551ed133cbeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

