### PR TITLE
Fix #1897: Deliver child report-back instructions

### DIFF
--- a/docs/superpowers/plans/2026-07-17-child-workspace-report-back-prompt.md
+++ b/docs/superpowers/plans/2026-07-17-child-workspace-report-back-prompt.md
@@ -1,0 +1,167 @@
+# Child Workspace Report-Back Prompt Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver child workspace reporting guidance, including `reportBackOn`, through the queued initial message that ACP agents receive.
+
+**Architecture:** A pure helper in the session capsule owns the canonical child-context text. Workspace initialization resolves the parent context, prepends that text to the initial queued message, and preserves the existing queue, attachment, and non-child behavior.
+
+**Tech Stack:** TypeScript, Express backend service capsules, Prisma accessors, Vitest, pnpm.
+
+## Global Constraints
+
+- Import session behavior only through the `@/backend/services/session` barrel outside the session capsule.
+- Deliver instructions through `enqueueAutoMessage`; ACP `newSession` and `loadSession` do not accept a system prompt.
+- Preserve the initial message's attachments.
+- Queue child context even when `initialPrompt` is absent, empty, or whitespace-only.
+- Ignore non-string `reportBackOn` metadata.
+- Do not change UI behavior or broaden the fix to other dead `systemPrompt` content.
+
+---
+
+### Task 1: Add the regression tests
+
+**Files:**
+- Test: `src/backend/orchestration/workspace-init.orchestrator.test.ts`
+
+**Interfaces:**
+- Consumes: `initializeWorkspaceWorktree(workspaceId: string): Promise<void>` and the mocked `workspaceAccessor`, `sessionDomainService`, and `agentSessionAccessor` service APIs.
+- Produces: Regression coverage for child context composition and context-only queue delivery.
+
+- [ ] **Step 1: Write a failing child prompt test**
+
+Add a test under `default Claude session auto-start` that creates a child workspace with `parentWorkspaceId`, `initialPrompt`, and `reportBackOn`, mocks `workspaceAccessor.findParentWorkspace` with parent/project names, initializes the workspace, and asserts the queued text contains the child header and report condition before the task text.
+
+```ts
+expect(queued.text).toContain('## Child Workspace Context');
+expect(queued.text).toContain('Report back when: a PR is opened');
+expect(queued.text.indexOf('## Child Workspace Context')).toBeLessThan(
+  queued.text.indexOf('Implement the fix')
+);
+```
+
+- [ ] **Step 2: Write a failing context-only test**
+
+Add a child case with no `initialPrompt` and assert `sessionDomainService.enqueue` still receives a message containing the generic child reporting guidance.
+
+```ts
+expect(sessionDomainService.enqueue).toHaveBeenCalledWith(
+  'session-1',
+  expect.objectContaining({ text: expect.stringContaining('send_message_to_parent') })
+);
+```
+
+- [ ] **Step 3: Run the focused test and verify RED**
+
+Run: `pnpm vitest run src/backend/orchestration/workspace-init.orchestrator.test.ts`
+
+Expected: the new tests fail because `findParentWorkspace` is not called and the queued message lacks child context.
+
+### Task 2: Deliver child context through the queue
+
+**Files:**
+- Modify: `src/backend/services/session/service/lifecycle/session.prompt-builder.ts`
+- Modify: `src/backend/services/session/service/index.ts`
+- Modify: `src/backend/orchestration/workspace-init.orchestrator.ts`
+- Test: `src/backend/orchestration/workspace-init.orchestrator.test.ts`
+
+**Interfaces:**
+- Consumes: `workspaceAccessor.findParentWorkspace(childId: string)` and creation metadata fields `reportBackOn` and `initialPrompt`.
+- Produces: `buildChildWorkspaceContext(input: { parentWorkspaceName?: string | null; parentProjectName?: string | null; reportBackOn?: string | null }): string` exported by `@/backend/services/session`.
+
+- [ ] **Step 1: Extract the canonical pure helper**
+
+Move the existing child-workspace wording into `buildChildWorkspaceContext`, returning the complete Markdown block. Make `SessionPromptBuilder.buildSystemPrompt` call it when `parentWorkspaceId` is present, then export it from the session service barrel.
+
+```ts
+export function buildChildWorkspaceContext(input: {
+  parentWorkspaceName?: string | null;
+  parentProjectName?: string | null;
+  reportBackOn?: string | null;
+}): string {
+  const parentName = input.parentWorkspaceName ?? 'unknown';
+  const projectName = input.parentProjectName ?? 'unknown project';
+  let context =
+    `## Child Workspace Context\n` +
+    `You are working in a child workspace created by the parent workspace "${parentName}" (project: ${projectName}). ` +
+    `When you have completed your task or reached a significant milestone — especially if you produced a PR, a finding, or are blocked — ` +
+    `use the \`send_message_to_parent\` tool to report back. Include a brief summary of what was done and any next steps the parent workspace should be aware of.`;
+  if (input.reportBackOn) {
+    context += `\nReport back when: ${input.reportBackOn}`;
+  }
+  return `${context}\n`;
+}
+```
+
+- [ ] **Step 2: Compose the queued child message**
+
+In `startDefaultAgentSession`, resolve the parent only for child workspaces, ignore non-string `reportBackOn`, prepend the helper output to the resolved initial text, and carry through existing attachments.
+
+```ts
+const initialMessage = await resolveInitialAutoMessageContent(workspaceId, metadata);
+const childContext = workspace?.parentWorkspaceId
+  ? buildChildWorkspaceContext({
+      parentWorkspaceName: parent?.name,
+      parentProjectName: parent?.project.name,
+      reportBackOn: typeof metadata?.reportBackOn === 'string' ? metadata.reportBackOn : undefined,
+    })
+  : undefined;
+const messageToEnqueue = childContext
+  ? { text: `${childContext}\n${initialMessage?.text ?? ''}`.trimEnd(), attachments: initialMessage?.attachments }
+  : initialMessage;
+```
+
+- [ ] **Step 3: Run the focused test and verify GREEN**
+
+Run: `pnpm vitest run src/backend/orchestration/workspace-init.orchestrator.test.ts src/backend/services/session/service/lifecycle/session.prompt-builder.test.ts`
+
+Expected: both files pass with zero failed tests.
+
+- [ ] **Step 4: Commit the functional change**
+
+```bash
+git add src/backend/orchestration/workspace-init.orchestrator.ts src/backend/orchestration/workspace-init.orchestrator.test.ts src/backend/services/session/service/lifecycle/session.prompt-builder.ts src/backend/services/session/service/index.ts
+git commit -m "Fix child report-back prompt delivery (#1897)"
+```
+
+### Task 3: Verify and publish
+
+**Files:**
+- Review: all files changed from `origin/main`
+- Create temporarily: `/tmp/pr-body.md`
+
+**Interfaces:**
+- Consumes: the completed implementation and repository verification scripts.
+- Produces: a pushed branch and GitHub pull request closing issue #1897.
+
+- [ ] **Step 1: Run required verification**
+
+Run: `pnpm typecheck && pnpm check:fix && pnpm test && pnpm build`
+
+Expected: typecheck, checks, tests, and build exit successfully. If the known baseline failures remain, record them precisely and do not attribute them to this diff.
+
+- [ ] **Step 2: Review the full branch diff**
+
+Run: `git diff origin/main` and `git status --short --branch`.
+
+Expected: only the scoped design, plan, source, and test files are changed; no debug output is present.
+
+- [ ] **Step 3: Commit verification-only formatting changes if any**
+
+```bash
+git add docs/superpowers/specs/2026-07-17-child-workspace-report-back-prompt-design.md docs/superpowers/plans/2026-07-17-child-workspace-report-back-prompt.md src/backend/orchestration/workspace-init.orchestrator.ts src/backend/orchestration/workspace-init.orchestrator.test.ts src/backend/services/session/service/lifecycle/session.prompt-builder.ts src/backend/services/session/service/index.ts
+git commit -m "Document child prompt delivery fix (#1897)"
+```
+
+Skip this commit when there are no remaining uncommitted changes.
+
+- [ ] **Step 4: Push and create the PR**
+
+Push with `git push -u origin HEAD`, write the required summary, testing checklist, `Closes #1897`, and Factory Factory signature to `/tmp/pr-body.md`, then run:
+
+```bash
+gh pr create --title "Fix #1897: Deliver child report-back instructions" --body-file /tmp/pr-body.md
+gh pr view --json url,title,state
+```
+
+Expected: GitHub reports an open PR URL for the current branch.

--- a/docs/superpowers/specs/2026-07-17-child-workspace-report-back-prompt-design.md
+++ b/docs/superpowers/specs/2026-07-17-child-workspace-report-back-prompt-design.md
@@ -1,0 +1,44 @@
+# Child Workspace Report-Back Prompt Design
+
+## Problem
+
+Child workspace creation persists `initialPrompt` and `reportBackOn` in workspace creation metadata. Workspace initialization sends `initialPrompt` through the session message queue, but `reportBackOn` is only included in `AcpClientOptions.systemPrompt`. The ACP `newSession` and `loadSession` requests have no system-prompt field, so that instruction never reaches the child agent.
+
+## Selected Design
+
+Extract the existing child-workspace context wording from `SessionPromptBuilder` into a pure exported helper in the session service capsule. Keep `SessionPromptBuilder` using that helper so its current output remains consistent. During default session startup, resolve the child workspace's parent and optional string `reportBackOn`, build the same context, and prepend it to the message sent through the existing queue pipeline.
+
+The queued context is delivered even when the child has no `initialPrompt`, an empty prompt, a whitespace-only prompt, or only attachments. Non-child workspaces retain their existing initial-message behavior.
+
+## Alternatives Considered
+
+1. **Duplicate the context text in workspace initialization.** This is the smallest local edit, but two copies could diverge and produce different agent instructions.
+2. **Pass `systemPrompt` to ACP session creation.** ACP's `NewSessionRequest` and `LoadSessionRequest` do not support this field, so this cannot solve the bug within the current protocol.
+3. **Rewrite `creationMetadata.initialPrompt` during child creation.** This would alter persisted user input and couple creation to presentation wording. Queue-time composition preserves raw metadata and follows the issue's requested delivery point.
+
+## Data Flow
+
+1. `WorkspaceCreationService` persists `parentWorkspaceId`, optional `initialPrompt`, and optional `reportBackOn`.
+2. `startDefaultAgentSession` loads the child workspace and its parent/project summary.
+3. The shared helper builds generic reporting guidance and appends `Report back when: ...` only for a non-empty string instruction.
+4. Workspace initialization prepends that context to the resolved initial message, preserving attachments.
+5. `enqueueAutoMessage` sends the combined text through the normal queue and replay path.
+
+## Error Handling and Compatibility
+
+- A missing parent lookup uses the existing `unknown` and `unknown project` fallbacks.
+- A non-string `reportBackOn` value is ignored.
+- Failure to enqueue continues to use the existing warning behavior.
+- The change does not attempt to repair other dead `systemPrompt` content such as workflow, branch-rename, or dev-server instructions.
+- There is no UI behavior change, so screenshots are not applicable.
+
+## Tests
+
+- Prove a child initial prompt is queued after the child context and includes parent/project names plus `reportBackOn`.
+- Prove child context is queued when no initial prompt exists.
+- Prove regular workspace prompt behavior remains unchanged through the existing tests.
+- Run focused Vitest tests, type checking, formatting/lint fixes, the full test suite, and the production build.
+
+## Known Baseline
+
+Before implementation, `pnpm test` reports 14 unrelated failures: 13 React tests fail because `act` is not a function, and one shell timeout test observes `SIGTERM` instead of `SIGKILL`. The child-workspace orchestration suite is not among the failures.

--- a/src/backend/orchestration/workspace-init.orchestrator.test.ts
+++ b/src/backend/orchestration/workspace-init.orchestrator.test.ts
@@ -977,6 +977,50 @@ describe('initializeWorkspaceWorktree', () => {
       );
     });
 
+    it('queues child workspace context with attachments when no initial prompt is provided', async () => {
+      setupHappyPath({
+        parentWorkspaceId: 'parent-1',
+        creationMetadata: {
+          initialAttachments: [
+            {
+              id: 'att-child-only-1',
+              name: 'child-only-evidence.png',
+              type: 'image/png',
+              size: 120,
+              data: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB',
+              contentType: 'image',
+            },
+          ],
+        },
+      });
+      vi.mocked(workspaceAccessor.findParentWorkspace).mockResolvedValue(
+        unsafeCoerce({
+          id: 'parent-1',
+          name: 'parent-workspace',
+          project: { id: 'parent-project-1', name: 'parent-project' },
+        })
+      );
+      vi.mocked(agentSessionAccessor.findByWorkspaceId).mockResolvedValue([
+        unsafeCoerce({ id: 'session-1', status: SessionStatus.IDLE, model: 'claude-sonnet' }),
+      ]);
+      vi.mocked(sessionDomainService.enqueue).mockReturnValue({ position: 0 });
+
+      await initializeWorkspaceWorktree(WORKSPACE_ID);
+
+      expect(sessionDomainService.enqueue).toHaveBeenCalledWith(
+        'session-1',
+        expect.objectContaining({
+          text: '## Child Workspace Context\nUse send_message_to_parent.',
+          attachments: [
+            expect.objectContaining({
+              id: 'att-child-only-1',
+              name: 'child-only-evidence.png',
+            }),
+          ],
+        })
+      );
+    });
+
     it('queues child workspace context for a whitespace-only initial prompt', async () => {
       setupHappyPath({
         parentWorkspaceId: 'parent-1',

--- a/src/backend/orchestration/workspace-init.orchestrator.test.ts
+++ b/src/backend/orchestration/workspace-init.orchestrator.test.ts
@@ -19,6 +19,10 @@ vi.mock('@/backend/services/run-script', () => ({
 }));
 
 vi.mock('@/backend/services/session', () => ({
+  buildChildWorkspaceContext: vi.fn(
+    (input: { reportBackOn?: string | null }) =>
+      `## Child Workspace Context\nUse send_message_to_parent.${input.reportBackOn ? `\nReport back when: ${input.reportBackOn}` : ''}\n`
+  ),
   chatMessageHandlerService: {
     tryDispatchNextMessage: vi.fn(),
   },

--- a/src/backend/orchestration/workspace-init.orchestrator.test.ts
+++ b/src/backend/orchestration/workspace-init.orchestrator.test.ts
@@ -116,6 +116,7 @@ import { startupScriptService } from '@/backend/services/run-script';
 import { runScriptConfigPersistenceService } from '@/backend/services/run-script-config-persistence.service';
 import {
   agentSessionAccessor,
+  buildChildWorkspaceContext,
   chatMessageHandlerService,
   sessionDataService,
   sessionDomainService,
@@ -899,6 +900,11 @@ describe('initializeWorkspaceWorktree', () => {
         queued.text.indexOf('Implement the fix')
       );
       expect(workspaceAccessor.findParentWorkspace).toHaveBeenCalledWith(WORKSPACE_ID);
+      expect(buildChildWorkspaceContext).toHaveBeenCalledWith({
+        parentWorkspaceName: 'parent-workspace',
+        parentProjectName: 'parent-project',
+        reportBackOn: 'a PR is opened',
+      });
     });
 
     it('enqueues child workspace context when no initial prompt is provided', async () => {
@@ -924,6 +930,122 @@ describe('initializeWorkspaceWorktree', () => {
         'session-1',
         expect.objectContaining({ text: expect.stringContaining('send_message_to_parent') })
       );
+    });
+
+    it('preserves initial attachments when composing child workspace context', async () => {
+      setupHappyPath({
+        parentWorkspaceId: 'parent-1',
+        creationMetadata: {
+          initialPrompt: 'Review the evidence',
+          initialAttachments: [
+            {
+              id: 'att-child-1',
+              name: 'child-evidence.png',
+              type: 'image/png',
+              size: 120,
+              data: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB',
+              contentType: 'image',
+            },
+          ],
+        },
+      });
+      vi.mocked(workspaceAccessor.findParentWorkspace).mockResolvedValue(
+        unsafeCoerce({
+          id: 'parent-1',
+          name: 'parent-workspace',
+          project: { id: 'parent-project-1', name: 'parent-project' },
+        })
+      );
+      vi.mocked(agentSessionAccessor.findByWorkspaceId).mockResolvedValue([
+        unsafeCoerce({ id: 'session-1', status: SessionStatus.IDLE, model: 'claude-sonnet' }),
+      ]);
+      vi.mocked(sessionDomainService.enqueue).mockReturnValue({ position: 0 });
+
+      await initializeWorkspaceWorktree(WORKSPACE_ID);
+
+      expect(sessionDomainService.enqueue).toHaveBeenCalledWith(
+        'session-1',
+        expect.objectContaining({
+          text: expect.stringContaining('Review the evidence'),
+          attachments: [
+            expect.objectContaining({
+              id: 'att-child-1',
+              name: 'child-evidence.png',
+            }),
+          ],
+        })
+      );
+    });
+
+    it('queues child workspace context for a whitespace-only initial prompt', async () => {
+      setupHappyPath({
+        parentWorkspaceId: 'parent-1',
+        creationMetadata: { initialPrompt: '  \n\t' },
+      });
+      vi.mocked(workspaceAccessor.findParentWorkspace).mockResolvedValue(
+        unsafeCoerce({
+          id: 'parent-1',
+          name: 'parent-workspace',
+          project: { id: 'parent-project-1', name: 'parent-project' },
+        })
+      );
+      vi.mocked(agentSessionAccessor.findByWorkspaceId).mockResolvedValue([
+        unsafeCoerce({ id: 'session-1', status: SessionStatus.IDLE, model: 'claude-sonnet' }),
+      ]);
+      vi.mocked(sessionDomainService.enqueue).mockReturnValue({ position: 0 });
+
+      await initializeWorkspaceWorktree(WORKSPACE_ID);
+
+      expect(sessionDomainService.enqueue).toHaveBeenCalledWith(
+        'session-1',
+        expect.objectContaining({
+          text: '## Child Workspace Context\nUse send_message_to_parent.',
+        })
+      );
+    });
+
+    it('ignores non-string child report-back metadata', async () => {
+      setupHappyPath({
+        parentWorkspaceId: 'parent-1',
+        creationMetadata: {
+          initialPrompt: 'Implement the fix',
+          reportBackOn: { event: 'pull-request' },
+        },
+      });
+      vi.mocked(workspaceAccessor.findParentWorkspace).mockResolvedValue(
+        unsafeCoerce({
+          id: 'parent-1',
+          name: 'parent-workspace',
+          project: { id: 'parent-project-1', name: 'parent-project' },
+        })
+      );
+      vi.mocked(agentSessionAccessor.findByWorkspaceId).mockResolvedValue([
+        unsafeCoerce({ id: 'session-1', status: SessionStatus.IDLE, model: 'claude-sonnet' }),
+      ]);
+      vi.mocked(sessionDomainService.enqueue).mockReturnValue({ position: 0 });
+
+      await initializeWorkspaceWorktree(WORKSPACE_ID);
+
+      expect(buildChildWorkspaceContext).toHaveBeenCalledWith({
+        parentWorkspaceName: 'parent-workspace',
+        parentProjectName: 'parent-project',
+        reportBackOn: undefined,
+      });
+    });
+
+    it('does not resolve a parent workspace for non-child initialization', async () => {
+      setupHappyPath({
+        creationMetadata: { initialPrompt: 'Implement the fix' },
+      });
+      vi.mocked(agentSessionAccessor.findByWorkspaceId).mockResolvedValue([
+        unsafeCoerce({ id: 'session-1', status: SessionStatus.IDLE, model: 'claude-sonnet' }),
+      ]);
+      vi.mocked(sessionDomainService.enqueue).mockReturnValue({ position: 0 });
+
+      await initializeWorkspaceWorktree(WORKSPACE_ID);
+
+      expect(workspaceAccessor.findParentWorkspace).not.toHaveBeenCalled();
+      expect(buildChildWorkspaceContext).not.toHaveBeenCalled();
     });
 
     it('enqueues initial attachments from workspace creation metadata', async () => {

--- a/src/backend/orchestration/workspace-init.orchestrator.test.ts
+++ b/src/backend/orchestration/workspace-init.orchestrator.test.ts
@@ -63,6 +63,7 @@ vi.mock('@/backend/services/workspace', () => ({
   workspaceAccessor: {
     findById: vi.fn(),
     findByIdWithProject: vi.fn(),
+    findParentWorkspace: vi.fn(),
     update: vi.fn(),
   },
 }));
@@ -860,6 +861,65 @@ describe('initializeWorkspaceWorktree', () => {
       await initializeWorkspaceWorktree(WORKSPACE_ID);
 
       expect(workspaceStateMachine.markReady).toHaveBeenCalled();
+    });
+
+    it('prepends child workspace context to the initial prompt', async () => {
+      setupHappyPath({
+        parentWorkspaceId: 'parent-1',
+        creationMetadata: {
+          initialPrompt: 'Implement the fix',
+          reportBackOn: 'a PR is opened',
+        },
+      });
+      vi.mocked(workspaceAccessor.findParentWorkspace).mockResolvedValue(
+        unsafeCoerce({
+          id: 'parent-1',
+          name: 'parent-workspace',
+          project: { id: 'parent-project-1', name: 'parent-project' },
+        })
+      );
+      vi.mocked(agentSessionAccessor.findByWorkspaceId).mockResolvedValue([
+        unsafeCoerce({ id: 'session-1', status: SessionStatus.IDLE, model: 'claude-sonnet' }),
+      ]);
+      vi.mocked(sessionDomainService.enqueue).mockReturnValue({ position: 0 });
+
+      await initializeWorkspaceWorktree(WORKSPACE_ID);
+
+      const queued = vi.mocked(sessionDomainService.enqueue).mock.calls[0]?.[1];
+      if (!queued) {
+        throw new Error('Expected an initial message to be queued');
+      }
+      expect(queued.text).toContain('## Child Workspace Context');
+      expect(queued.text).toContain('Report back when: a PR is opened');
+      expect(queued.text.indexOf('## Child Workspace Context')).toBeLessThan(
+        queued.text.indexOf('Implement the fix')
+      );
+      expect(workspaceAccessor.findParentWorkspace).toHaveBeenCalledWith(WORKSPACE_ID);
+    });
+
+    it('enqueues child workspace context when no initial prompt is provided', async () => {
+      setupHappyPath({
+        parentWorkspaceId: 'parent-1',
+        creationMetadata: {},
+      });
+      vi.mocked(workspaceAccessor.findParentWorkspace).mockResolvedValue(
+        unsafeCoerce({
+          id: 'parent-1',
+          name: 'parent-workspace',
+          project: { id: 'parent-project-1', name: 'parent-project' },
+        })
+      );
+      vi.mocked(agentSessionAccessor.findByWorkspaceId).mockResolvedValue([
+        unsafeCoerce({ id: 'session-1', status: SessionStatus.IDLE, model: 'claude-sonnet' }),
+      ]);
+      vi.mocked(sessionDomainService.enqueue).mockReturnValue({ position: 0 });
+
+      await initializeWorkspaceWorktree(WORKSPACE_ID);
+
+      expect(sessionDomainService.enqueue).toHaveBeenCalledWith(
+        'session-1',
+        expect.objectContaining({ text: expect.stringContaining('send_message_to_parent') })
+      );
     });
 
     it('enqueues initial attachments from workspace creation metadata', async () => {

--- a/src/backend/orchestration/workspace-init.orchestrator.ts
+++ b/src/backend/orchestration/workspace-init.orchestrator.ts
@@ -8,6 +8,7 @@ import { createLogger } from '@/backend/services/logger.service';
 import { runScriptConfigPersistenceService } from '@/backend/services/run-script-config-persistence.service';
 import {
   agentSessionAccessor,
+  buildChildWorkspaceContext,
   chatMessageHandlerService,
   sessionDataService,
   sessionDomainService,
@@ -364,6 +365,23 @@ async function startDefaultAgentSession(workspaceId: string): Promise<string | n
 
     // Build the initial prompt from linked issue data, or fallback to creation metadata.
     const initialMessage = await resolveInitialAutoMessageContent(workspaceId, metadata);
+    const parent = workspace?.parentWorkspaceId
+      ? await workspaceAccessor.findParentWorkspace(workspaceId)
+      : null;
+    const childContext = workspace?.parentWorkspaceId
+      ? buildChildWorkspaceContext({
+          parentWorkspaceName: parent?.name,
+          parentProjectName: parent?.project.name,
+          reportBackOn:
+            typeof metadata?.reportBackOn === 'string' ? metadata.reportBackOn : undefined,
+        })
+      : undefined;
+    const messageToEnqueue = childContext
+      ? {
+          text: `${childContext}\n${initialMessage?.text ?? ''}`.trimEnd(),
+          attachments: initialMessage?.attachments,
+        }
+      : initialMessage;
 
     // Start the session - pass empty string to start without any initial prompt
     // (undefined would default to 'Continue with the task.')
@@ -373,13 +391,13 @@ async function startDefaultAgentSession(workspaceId: string): Promise<string | n
     });
 
     // Route the initial prompt through the queue pipeline so runtime and replay remain consistent.
-    if (initialMessage) {
+    if (messageToEnqueue) {
       enqueueAutoMessage(
         session.id,
         workspaceId,
-        initialMessage.text,
+        messageToEnqueue.text,
         session.model,
-        initialMessage.attachments
+        messageToEnqueue.attachments
       );
     }
 

--- a/src/backend/services/session/service/index.ts
+++ b/src/backend/services/session/service/index.ts
@@ -24,7 +24,10 @@ export { sessionProviderResolverService } from './data/session-provider-resolver
 export type { SessionInterceptorBridge } from './interceptor.bridge';
 export { sessionInterceptorBridge } from './interceptor.bridge';
 export type { ClosedSessionTranscript } from './lifecycle/closed-session-persistence.service';
-export { sessionPromptBuilder } from './lifecycle/session.prompt-builder';
+export {
+  buildChildWorkspaceContext,
+  sessionPromptBuilder,
+} from './lifecycle/session.prompt-builder';
 export { sessionRepository } from './lifecycle/session.repository';
 // Session lifecycle (start/stop/create)
 export { createSessionService, sessionService } from './lifecycle/session.service';

--- a/src/backend/services/session/service/lifecycle/session.prompt-builder.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.prompt-builder.test.ts
@@ -19,7 +19,39 @@ vi.mock('@/backend/services/logger.service', () => ({
 
 import { buildBranchRenameInstruction } from '@/backend/prompts/branch-rename';
 import { getWorkflowContent } from '@/backend/prompts/workflows';
-import { SessionPromptBuilder } from './session.prompt-builder';
+import { buildChildWorkspaceContext, SessionPromptBuilder } from './session.prompt-builder';
+
+describe('buildChildWorkspaceContext', () => {
+  it('builds the exact child context with parent details and report-back criteria', () => {
+    expect(
+      buildChildWorkspaceContext({
+        parentWorkspaceName: 'parent-workspace',
+        parentProjectName: 'parent-project',
+        reportBackOn: 'a PR is opened',
+      })
+    ).toBe(
+      `## Child Workspace Context\n` +
+        `You are working in a child workspace created by the parent workspace "parent-workspace" (project: parent-project). ` +
+        `When you have completed your task or reached a significant milestone — especially if you produced a PR, a finding, or are blocked — ` +
+        `use the \`send_message_to_parent\` tool to report back. Include a brief summary of what was done and any next steps the parent workspace should be aware of.\n` +
+        `Report back when: a PR is opened\n`
+    );
+  });
+
+  it('uses parent-name fallbacks and omits absent report-back criteria', () => {
+    expect(
+      buildChildWorkspaceContext({
+        parentWorkspaceName: null,
+        parentProjectName: null,
+      })
+    ).toBe(
+      `## Child Workspace Context\n` +
+        `You are working in a child workspace created by the parent workspace "unknown" (project: unknown project). ` +
+        `When you have completed your task or reached a significant milestone — especially if you produced a PR, a finding, or are blocked — ` +
+        `use the \`send_message_to_parent\` tool to report back. Include a brief summary of what was done and any next steps the parent workspace should be aware of.\n`
+    );
+  });
+});
 
 describe('SessionPromptBuilder', () => {
   describe('shouldInjectBranchRename', () => {

--- a/src/backend/services/session/service/lifecycle/session.prompt-builder.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.prompt-builder.test.ts
@@ -51,6 +51,19 @@ describe('buildChildWorkspaceContext', () => {
         `use the \`send_message_to_parent\` tool to report back. Include a brief summary of what was done and any next steps the parent workspace should be aware of.\n`
     );
   });
+
+  it('omits whitespace-only report-back criteria', () => {
+    const context = buildChildWorkspaceContext({ reportBackOn: '  \n\t' });
+
+    expect(context).not.toContain('Report back when:');
+  });
+
+  it('trims surrounding whitespace from report-back criteria', () => {
+    const context = buildChildWorkspaceContext({ reportBackOn: '  a PR is opened  ' });
+
+    expect(context).toContain('\nReport back when: a PR is opened\n');
+    expect(context).not.toContain('  a PR is opened  ');
+  });
 });
 
 describe('SessionPromptBuilder', () => {

--- a/src/backend/services/session/service/lifecycle/session.prompt-builder.ts
+++ b/src/backend/services/session/service/lifecycle/session.prompt-builder.ts
@@ -24,6 +24,24 @@ export type BuildPromptResult = {
   injectedBranchRename: boolean;
 };
 
+export function buildChildWorkspaceContext(input: {
+  parentWorkspaceName?: string | null;
+  parentProjectName?: string | null;
+  reportBackOn?: string | null;
+}): string {
+  const parentName = input.parentWorkspaceName ?? 'unknown';
+  const projectName = input.parentProjectName ?? 'unknown project';
+  let context =
+    `## Child Workspace Context\n` +
+    `You are working in a child workspace created by the parent workspace "${parentName}" (project: ${projectName}). ` +
+    `When you have completed your task or reached a significant milestone — especially if you produced a PR, a finding, or are blocked — ` +
+    `use the \`send_message_to_parent\` tool to report back. Include a brief summary of what was done and any next steps the parent workspace should be aware of.`;
+  if (input.reportBackOn) {
+    context += `\nReport back when: ${input.reportBackOn}`;
+  }
+  return `${context}\n`;
+}
+
 export class SessionPromptBuilder {
   /**
    * Workflow prompts reserved for automated helper sessions.
@@ -77,18 +95,12 @@ export class SessionPromptBuilder {
     }
 
     if (workspace.parentWorkspaceId) {
-      const parentName = workspace.parentWorkspaceName ?? 'unknown';
-      const projectName = workspace.parentProjectName ?? 'unknown project';
-      let childContext =
-        `\n\n## Child Workspace Context\n` +
-        `You are working in a child workspace created by the parent workspace "${parentName}" (project: ${projectName}). ` +
-        `When you have completed your task or reached a significant milestone — especially if you produced a PR, a finding, or are blocked — ` +
-        `use the \`send_message_to_parent\` tool to report back. Include a brief summary of what was done and any next steps the parent workspace should be aware of.`;
-      if (workspace.reportBackOn) {
-        childContext += `\nReport back when: ${workspace.reportBackOn}`;
-      }
-      childContext += '\n';
-      systemPrompt = (systemPrompt ?? '') + childContext;
+      const childContext = buildChildWorkspaceContext({
+        parentWorkspaceName: workspace.parentWorkspaceName,
+        parentProjectName: workspace.parentProjectName,
+        reportBackOn: workspace.reportBackOn,
+      });
+      systemPrompt = `${systemPrompt ?? ''}\n\n${childContext}`;
     }
 
     return { workflowPrompt, systemPrompt, injectedBranchRename };

--- a/src/backend/services/session/service/lifecycle/session.prompt-builder.ts
+++ b/src/backend/services/session/service/lifecycle/session.prompt-builder.ts
@@ -31,13 +31,14 @@ export function buildChildWorkspaceContext(input: {
 }): string {
   const parentName = input.parentWorkspaceName ?? 'unknown';
   const projectName = input.parentProjectName ?? 'unknown project';
+  const reportBackOn = input.reportBackOn?.trim();
   let context =
     `## Child Workspace Context\n` +
     `You are working in a child workspace created by the parent workspace "${parentName}" (project: ${projectName}). ` +
     `When you have completed your task or reached a significant milestone — especially if you produced a PR, a finding, or are blocked — ` +
     `use the \`send_message_to_parent\` tool to report back. Include a brief summary of what was done and any next steps the parent workspace should be aware of.`;
-  if (input.reportBackOn) {
-    context += `\nReport back when: ${input.reportBackOn}`;
+  if (reportBackOn) {
+    context += `\nReport back when: ${reportBackOn}`;
   }
   return `${context}\n`;
 }


### PR DESCRIPTION
## Summary

- Deliver child workspace context and `reportBackOn` instructions through the queued initial message that ACP agents receive.
- Reuse one canonical child-context builder for session prompts and workspace initialization.
- Cover prompt ordering, context-only delivery, attachments, metadata validation, fallbacks, and whitespace normalization.

## Changes

- **Workspace initialization**: Resolve the child workspace's parent, prepend reporting guidance to the queued initial message, and preserve attachments even when no task text is provided.
- **Session prompt builder**: Extract and export the canonical child workspace context helper while preserving existing system-prompt output.
- **Regression coverage**: Add focused tests for report conditions, missing and whitespace-only prompts, attachments-only children, invalid metadata, parent fallbacks, and non-child behavior.

## Testing

- [x] Tests pass (`NODE_ENV=test pnpm test` — 3,761 passed, 3 skipped)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting/lint fixes pass (`pnpm check:fix`; six pre-existing `<img>` warnings)
- [x] Guardrails pass (`pnpm check`; local Codex schema check skipped its documented CLI-version mismatch)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Automated orchestration coverage verifies the exact queued agent message and attachment payload.

Closes #1897

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what child ACP agents see on first message during workspace init, but the path is narrow, metadata-validated, and heavily regression-tested.
>
> **Overview**
> Fixes child agents not receiving **`reportBackOn`** and parent-reporting guidance because that text lived only in **`systemPrompt`**, which ACP session creation does not deliver.
>
> **`buildChildWorkspaceContext`** is extracted from **`SessionPromptBuilder`**, exported from the session barrel, and reused when building system prompts. **`startDefaultAgentSession`** in workspace init loads the parent workspace for children, builds the same context (string **`reportBackOn`** only, with trim/whitespace handling), and **prepends** it to the queued initial message while keeping attachments and leaving non-child enqueue behavior unchanged. Child context is still enqueued when there is no task text, only attachments, or a whitespace-only prompt.
>
> Adds design/plan docs and Vitest coverage for ordering, metadata validation, attachments, and non-child paths.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bde1040e873b980eb74f795c3e5510c2d032fa19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
