### PR TITLE
Fix #1904: Surface child workspace tRPC errors

### DIFF
--- a/src/backend/services/session/service/acp/child-workspace-mcp-server.test.ts
+++ b/src/backend/services/session/service/acp/child-workspace-mcp-server.test.ts
@@ -1,0 +1,139 @@
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { createServer } from 'node:http';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+const toolResponseSchema = z.object({
+  result: z.object({
+    content: z.array(z.object({ type: z.string(), text: z.string() })),
+    isError: z.boolean().optional(),
+  }),
+});
+
+type ToolResponse = z.infer<typeof toolResponseSchema>;
+
+async function callToolWithHttpResponse(options: {
+  body: unknown;
+  status: number;
+  toolName: 'spawn_child_workspace' | 'list_projects';
+}): Promise<{ requestMethod: string | undefined; response: ToolResponse }> {
+  let requestMethod: string | undefined;
+  const server = createServer((req, res) => {
+    requestMethod = req.method;
+    res.writeHead(options.status, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(options.body));
+  });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+
+  try {
+    const address = server.address();
+    if (address === null || typeof address === 'string') {
+      throw new Error('Expected the test HTTP server to listen on a TCP port');
+    }
+    const child = spawn(
+      process.execPath,
+      [fileURLToPath(new URL('./child-workspace-mcp-server.ts', import.meta.url))],
+      {
+        env: {
+          ...process.env,
+          FF_CHILD_WORKSPACE_MCP: '1',
+          FF_WORKSPACE_ID: 'parent-workspace',
+          FF_WORKSPACE_PARENT_ID: '',
+          FF_API_BASE_URL: `http://127.0.0.1:${address.port}`,
+        },
+      }
+    );
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk: string) => {
+      stderr += chunk;
+    });
+    child.stdin.end(
+      `${JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: options.toolName,
+          arguments:
+            options.toolName === 'spawn_child_workspace'
+              ? { projectId: 'missing-project', name: 'Child workspace' }
+              : {},
+        },
+      })}\n`
+    );
+
+    const [exitCode] = await once(child, 'exit');
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe('');
+    return { requestMethod, response: toolResponseSchema.parse(JSON.parse(stdout.trim())) };
+  } finally {
+    server.close();
+    await once(server, 'close');
+  }
+}
+
+describe('child workspace MCP tRPC errors', () => {
+  it('surfaces nested superjson mutation errors before legacy messages', async () => {
+    const { requestMethod, response } = await callToolWithHttpResponse({
+      status: 404,
+      toolName: 'spawn_child_workspace',
+      body: {
+        error: {
+          message: 'Legacy project error',
+          json: {
+            message: 'Project not found: missing-project',
+            code: -32_004,
+            data: { code: 'NOT_FOUND', httpStatus: 404 },
+          },
+        },
+      },
+    });
+
+    expect(requestMethod).toBe('POST');
+    expect(response.result).toEqual({
+      content: [{ type: 'text', text: 'Error: Project not found: missing-project' }],
+      isError: true,
+    });
+  });
+
+  it('surfaces nested superjson query errors', async () => {
+    const { requestMethod, response } = await callToolWithHttpResponse({
+      status: 500,
+      toolName: 'list_projects',
+      body: { error: { json: { message: 'Unable to list projects' } } },
+    });
+
+    expect(requestMethod).toBe('GET');
+    expect(response.result.content[0]?.text).toBe('Error: Unable to list projects');
+    expect(response.result.isError).toBe(true);
+  });
+
+  it('falls back to a legacy top-level tRPC error message', async () => {
+    const { response } = await callToolWithHttpResponse({
+      status: 400,
+      toolName: 'spawn_child_workspace',
+      body: { error: { message: 'Legacy validation error' } },
+    });
+
+    expect(response.result.content[0]?.text).toBe('Error: Legacy validation error');
+  });
+
+  it('falls back to the HTTP status when tRPC omits an error message', async () => {
+    const { response } = await callToolWithHttpResponse({
+      status: 503,
+      toolName: 'list_projects',
+      body: { error: { json: {} } },
+    });
+
+    expect(response.result.content[0]?.text).toBe('Error: HTTP 503');
+  });
+});

--- a/src/backend/services/session/service/acp/child-workspace-mcp-server.test.ts
+++ b/src/backend/services/session/service/acp/child-workspace-mcp-server.test.ts
@@ -1,9 +1,18 @@
 import { spawn } from 'node:child_process';
 import { once } from 'node:events';
 import { createServer } from 'node:http';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../../../../../');
+const TSX_BIN = join(
+  REPO_ROOT,
+  'node_modules',
+  '.bin',
+  process.platform === 'win32' ? 'tsx.cmd' : 'tsx'
+);
 
 const toolResponseSchema = z.object({
   result: z.object({
@@ -34,7 +43,7 @@ async function callToolWithHttpResponse(options: {
       throw new Error('Expected the test HTTP server to listen on a TCP port');
     }
     const child = spawn(
-      process.execPath,
+      TSX_BIN,
       [fileURLToPath(new URL('./child-workspace-mcp-server.ts', import.meta.url))],
       {
         env: {

--- a/src/backend/services/session/service/acp/child-workspace-mcp-server.ts
+++ b/src/backend/services/session/service/acp/child-workspace-mcp-server.ts
@@ -131,10 +131,10 @@ async function callTrpcMutation(
     });
     const body = (await res.json()) as {
       result?: { data?: { json?: unknown } };
-      error?: { message?: string };
+      error?: { json?: { message?: string }; message?: string };
     };
     if (!res.ok || body.error) {
-      return { error: body.error?.message ?? `HTTP ${res.status}` };
+      return { error: body.error?.json?.message ?? body.error?.message ?? `HTTP ${res.status}` };
     }
     return { result: body.result?.data?.json };
   } catch (err) {
@@ -154,10 +154,10 @@ async function callTrpcQuery(
     const res = await fetch(url, { method: 'GET' });
     const body = (await res.json()) as {
       result?: { data?: { json?: unknown } };
-      error?: { message?: string };
+      error?: { json?: { message?: string }; message?: string };
     };
     if (!res.ok || body.error) {
-      return { error: body.error?.message ?? `HTTP ${res.status}` };
+      return { error: body.error?.json?.message ?? body.error?.message ?? `HTTP ${res.status}` };
     }
     return { result: body.result?.data?.json };
   } catch (err) {


### PR DESCRIPTION
## Summary
- Surface actionable tRPC error messages from child workspace MCP tools.
- Preserve compatibility with legacy error payloads and HTTP-status fallbacks.

## Changes
- **Child workspace MCP**: Read superjson-wrapped errors from `error.json.message` before falling back to `error.message` or the HTTP status.
- **Regression coverage**: Exercise real MCP subprocess calls for mutation and query errors, nested-message precedence, legacy payloads, and status-only errors.

## Testing
- [x] Tests pass (`NODE_ENV=test pnpm test` — 3,799 passed, 3 skipped)
- [x] Types pass (`NODE_ENV=test pnpm typecheck`)
- [x] Formatting passes (`NODE_ENV=test pnpm check:fix`; 6 pre-existing warnings)
- [x] Build succeeds (`pnpm build`)
- [x] Manual testing: Verified MCP JSON-RPC responses through spawned server processes backed by a local HTTP server.

Closes #1904

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to MCP HTTP error parsing and test coverage only; no auth, persistence, or API contract changes.
> 
> **Overview**
> Child workspace MCP tools now return **actionable tRPC error text** instead of generic or legacy messages when the internal API fails.
> 
> `callTrpcMutation` and `callTrpcQuery` prefer **`error.json.message`** (superjson-shaped responses), then **`error.message`**, then **`HTTP {status}`**. That fixes cases where nested messages like `Project not found` were hidden behind a top-level legacy string.
> 
> New **integration tests** spawn the real MCP server against a local mock HTTP API and assert mutation/query error formatting, precedence, and fallbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 790f86e9613801b8b6a50b60eb7859eb7e3341f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->