### PR TITLE
Fix #1942: Avoid no-op snapshot reconciliation fan-out

### DIFF
--- a/docs/superpowers/plans/2026-07-17-value-aware-snapshot-reconciliation.md
+++ b/docs/superpowers/plans/2026-07-17-value-aware-snapshot-reconciliation.md
@@ -82,7 +82,7 @@ Expected: FAIL because the result and log do not yet expose the metrics.
 
 - [ ] **Step 3: Aggregate outcomes in reconciliation**
 
-Extend `ReconciliationResult` and fallback results, collect each `upsert()` result, increment `workspacesChanged`, count both changed-upsert and successful stale-removal events in `deltasEmitted`, and include the requested fields in the completion log and returned result. Preserve existing result fields for compatibility.
+Extend `ReconciliationResult` and fallback results, collect each `upsert()` result, increment `workspacesChanged` when `upsertResult.changed` is true, increment `deltasEmitted` when `upsertResult.emitted` is true, count successful stale-removal events separately in `deltasEmitted`, and include the requested fields in the completion log and returned result. Preserve existing result fields for compatibility.
 
 - [ ] **Step 4: Run the focused test and verify GREEN**
 

--- a/docs/superpowers/plans/2026-07-17-value-aware-snapshot-reconciliation.md
+++ b/docs/superpowers/plans/2026-07-17-value-aware-snapshot-reconciliation.md
@@ -1,0 +1,132 @@
+# Value-Aware Snapshot Reconciliation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent unchanged snapshot reconciliation upserts from incrementing versions or emitting deltas while preserving ordering metadata.
+
+**Architecture:** Separate timestamp acceptance from value change inside `WorkspaceSnapshotStore`, where field-group ordering is authoritative. Return an explicit upsert outcome so the reconciliation orchestrator can aggregate changed-workspace and emitted-delta metrics without duplicating equality logic.
+
+**Tech Stack:** TypeScript, Node.js `EventEmitter` and `isDeepStrictEqual`, Vitest, Express backend services.
+
+## Global Constraints
+
+- Equal newer updates must advance field-group timestamps.
+- Equal newer updates must not increment `version` or emit `SNAPSHOT_CHANGED` unless their time-sensitive derived candidate changed.
+- Structured equality must not use JSON serialization.
+- Stale updates and removal tombstones must retain their current ordering guarantees.
+- A real change must emit exactly one consistent snapshot delta.
+- Reconciliation logs must include `workspacesScanned`, `workspacesChanged`, and `deltasEmitted`.
+
+---
+
+### Task 1: Value-aware snapshot store merging
+
+**Files:**
+- Modify: `src/backend/services/workspace-snapshot-store.service.ts`
+- Test: `src/backend/services/workspace-snapshot-store.service.test.ts`
+
+**Interfaces:**
+- Produces: `SnapshotUpsertResult` with boolean `accepted`, `changed`, and `emitted` properties.
+- Produces: `WorkspaceSnapshotStore.upsert(...): SnapshotUpsertResult`.
+
+- [ ] **Step 1: Write failing scalar and ordering tests**
+
+Add tests that seed at timestamp 100, apply an equal scalar update at 200, and assert the workspace group timestamp is 200 while version, metadata, and event count remain unchanged. Then apply a conflicting update at 150 and assert it is rejected.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `pnpm test src/backend/services/workspace-snapshot-store.service.test.ts`
+
+Expected: FAIL because equal newer upserts currently increment versions and emit events.
+
+- [ ] **Step 3: Write failing structured and race tests**
+
+Add equal and changed cases for `gitStats` and `sessionSummaries`, retain removal/recreation coverage, and add a derived-state-only assertion using a mutable or time-sensitive derivation result with otherwise equal raw fields.
+
+- [ ] **Step 4: Implement accepted-versus-changed merging**
+
+Add `SnapshotUpsertResult`, targeted equality helpers, a merge result carrying timestamp acceptance and raw value change, and derived-candidate assignment that compares structured derived fields without serialization. Return ignored/no-op/changed outcomes from every `upsert` path.
+
+- [ ] **Step 5: Run the focused test and verify GREEN**
+
+Run: `pnpm test src/backend/services/workspace-snapshot-store.service.test.ts`
+
+Expected: PASS with equal updates producing no event or version change.
+
+- [ ] **Step 6: Commit the store change**
+
+```bash
+git add src/backend/services/workspace-snapshot-store.service.ts src/backend/services/workspace-snapshot-store.service.test.ts
+git commit -m "Avoid no-op snapshot store updates (#1942)"
+```
+
+### Task 2: Reconciliation outcome metrics
+
+**Files:**
+- Modify: `src/backend/orchestration/snapshot-reconciliation.orchestrator.ts`
+- Test: `src/backend/orchestration/snapshot-reconciliation.orchestrator.test.ts`
+
+**Interfaces:**
+- Consumes: `WorkspaceSnapshotStore.upsert(...): SnapshotUpsertResult`.
+- Produces: `ReconciliationResult.workspacesScanned`, `.workspacesChanged`, and `.deltasEmitted`.
+
+- [ ] **Step 1: Write failing reconciliation metric tests**
+
+Make the store mock return explicit outcomes. Assert a pass with unchanged existing fixtures reports scanned workspaces but zero changed workspaces and zero deltas, while a real change reports one of each. Assert the summary logger receives all three fields.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `pnpm test src/backend/orchestration/snapshot-reconciliation.orchestrator.test.ts`
+
+Expected: FAIL because the result and log do not yet expose the metrics.
+
+- [ ] **Step 3: Aggregate outcomes in reconciliation**
+
+Extend `ReconciliationResult` and fallback results, collect each `upsert()` result, increment `workspacesChanged`, count both changed-upsert and successful stale-removal events in `deltasEmitted`, and include the requested fields in the completion log and returned result. Preserve existing result fields for compatibility.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run: `pnpm test src/backend/orchestration/snapshot-reconciliation.orchestrator.test.ts`
+
+Expected: PASS with idle fixtures reporting zero changes and deltas.
+
+- [ ] **Step 5: Commit reconciliation metrics**
+
+```bash
+git add src/backend/orchestration/snapshot-reconciliation.orchestrator.ts src/backend/orchestration/snapshot-reconciliation.orchestrator.test.ts
+git commit -m "Report snapshot reconciliation deltas (#1942)"
+```
+
+### Task 3: Full verification and pull request
+
+**Files:**
+- Review: all files changed from `origin/main`.
+
+**Interfaces:**
+- Consumes: completed store and reconciliation behavior.
+- Produces: a clean, pushed branch and a draft-ready GitHub pull request closing #1942.
+
+- [ ] **Step 1: Run repository verification**
+
+Run: `pnpm typecheck && pnpm check:fix && pnpm test && pnpm build`
+
+Expected: all commands exit 0.
+
+- [ ] **Step 2: Review the complete diff**
+
+Run: `git diff origin/main` and inspect for unnecessary complexity, debug code, test gaps, and accidental formatting changes.
+
+- [ ] **Step 3: Commit verification-only formatting if needed**
+
+```bash
+git add src/backend/services/workspace-snapshot-store.service.ts src/backend/services/workspace-snapshot-store.service.test.ts src/backend/orchestration/snapshot-reconciliation.orchestrator.ts src/backend/orchestration/snapshot-reconciliation.orchestrator.test.ts
+git commit -m "Format snapshot reconciliation changes (#1942)"
+```
+
+- [ ] **Step 4: Push and create the PR**
+
+Push with `git push -u origin HEAD`, create a body containing summary, changes, verification results, `Closes #1942`, and the required Factory Factory signature, then run `gh pr create --title "Fix #1942: Avoid no-op snapshot reconciliation fan-out" --body-file /tmp/pr-body.md`.
+
+- [ ] **Step 5: Verify the PR**
+
+Run: `gh pr view --json url,title,state` and report the created URL.

--- a/docs/superpowers/specs/2026-07-17-value-aware-snapshot-reconciliation-design.md
+++ b/docs/superpowers/specs/2026-07-17-value-aware-snapshot-reconciliation-design.md
@@ -1,0 +1,50 @@
+# Value-Aware Snapshot Reconciliation Design
+
+## Goal
+
+Stop unchanged authoritative reconciliation passes from incrementing workspace snapshot versions or emitting `SNAPSHOT_CHANGED`, while preserving field-group timestamp ordering and existing removal tombstone safety.
+
+## Root Cause
+
+`WorkspaceSnapshotStore.mergeFieldGroups()` currently returns one boolean for two distinct outcomes: a newer timestamp was accepted and the corresponding values changed. `upsert()` therefore treats every accepted reconciliation timestamp as a public snapshot change, recomputes derived state, increments `version`, and emits an event even when all values are equal.
+
+The reconciler cannot safely filter these calls before the store. Equal authoritative updates must still advance field-group timestamps so an older delayed event cannot overwrite the confirmed state.
+
+## Design
+
+The store will return an explicit `SnapshotUpsertResult` with `accepted`, `changed`, and `emitted` flags. Field-group merging will always advance timestamps for accepted groups, but it will assign only values that differ and report value changes separately from timestamp acceptance.
+
+Equality will avoid JSON serialization. Scalar fields use `Object.is`; `gitStats` uses a targeted property comparison; `sessionSummaries` uses stable deep equality because it is an array of structured runtime summaries. Derived structured fields (`sidebarStatus` and `statusReason`) use targeted property comparisons, while derived scalar fields use `Object.is`.
+
+The raw session `isWorking` signal remains tracked in `rawSessionIsWorkingByWorkspaceId`, because the public entry's `isWorking` field is derived. Equality for an incoming session activity value compares against that raw signal, not against the public derived field.
+
+Every accepted update computes a derived-state candidate because flow derivation contains time-sensitive behavior, including the unknown-CI grace window. The candidate is compared to the stored derived fields before assignment. If neither raw values nor the derived candidate changed, `upsert()` returns after advancing timestamps without changing public metadata, incrementing the public version, updating indexes, or emitting. A raw or derived change emits one consistent entry.
+
+New entries always count as changed and emit their initial seed. Stale updates and updates blocked by removal tombstones return an ignored result. A newer upsert after removal recreates the entry normally and clears the tombstone.
+
+## Reconciliation Metrics
+
+`SnapshotReconciliationService.reconcile()` will aggregate store outcomes and report:
+
+- `workspacesScanned`: authoritative workspaces processed;
+- `workspacesChanged`: upserts whose public/raw state changed;
+- `deltasEmitted`: `SNAPSHOT_CHANGED` events emitted by those upserts plus successful stale-entry removal deltas.
+
+The existing reconciliation diagnostics remain available for compatibility. The completion log includes all three new metrics so idle passes are observable as scanned workspaces with zero changes and zero deltas.
+
+## Testing
+
+Store tests will prove:
+
+- newer equal scalar values advance timestamps without version or event changes;
+- equal `gitStats` and `sessionSummaries` are stable no-ops;
+- genuine scalar and structured changes emit exactly once;
+- a stale update cannot overwrite a value confirmed by a newer equal reconciliation;
+- removal tombstones still block stale recreation and allow genuinely newer recreation;
+- an accepted update whose raw values are equal but whose time-sensitive derived state changed emits the correct derived snapshot.
+
+Reconciliation tests will use upsert outcomes to prove repeated unchanged fixtures produce zero changed workspaces and zero deltas after the seed, and will verify the new summary log fields.
+
+## Non-Goals
+
+Client-side animation-frame batching is not included because eliminating the guaranteed backend no-op events removes the identified fan-out at its source. No UI behavior or wire format changes are required.

--- a/src/backend/orchestration/event-collector.orchestrator.test.ts
+++ b/src/backend/orchestration/event-collector.orchestrator.test.ts
@@ -881,6 +881,7 @@ describe('configureEventCollector', () => {
       if (update.prUrl !== undefined) {
         existingSnapshot.prUrl = update.prUrl;
       }
+      return { accepted: true, changed: true, emitted: true };
     });
 
     configureEventCollector();

--- a/src/backend/orchestration/snapshot-reconciliation.orchestrator.test.ts
+++ b/src/backend/orchestration/snapshot-reconciliation.orchestrator.test.ts
@@ -300,6 +300,8 @@ describe('SnapshotReconciliationService', () => {
     mockFindAllNonArchived.mockResolvedValue([]);
     mockGetAllWorkspaceIds.mockReturnValue([]);
     mockGetByWorkspaceId.mockReturnValue(undefined);
+    mockUpsert.mockReturnValue({ accepted: true, changed: true, emitted: true });
+    mockRemove.mockReturnValue(true);
   });
 
   afterEach(async () => {
@@ -737,11 +739,54 @@ describe('SnapshotReconciliationService', () => {
 
       const result = await service.reconcile();
 
+      expect(result.workspacesScanned).toBe(2);
+      expect(result.workspacesChanged).toBe(2);
+      expect(result.deltasEmitted).toBe(3);
       expect(result.workspacesReconciled).toBe(2);
       expect(result.driftsDetected).toBeGreaterThan(0);
       expect(result.staleEntriesRemoved).toBe(1);
       expect(result.gitStatsComputed).toBe(1);
       expect(result.durationMs).toBeGreaterThanOrEqual(0);
+      expect(mockLoggerInfo).toHaveBeenCalledWith(
+        'Reconciliation complete',
+        expect.objectContaining({
+          workspacesScanned: 2,
+          workspacesChanged: 2,
+          deltasEmitted: 3,
+        })
+      );
+    });
+
+    it('reports zero changes and deltas for repeated unchanged reconciliation', async () => {
+      mockFindAllNonArchived.mockResolvedValue([
+        createMockWorkspace({ id: 'ws-1', worktreePath: null }),
+      ]);
+      mockGetByWorkspaceId.mockReturnValue(createSnapshotEntry());
+      mockUpsert
+        .mockReturnValueOnce({ accepted: true, changed: true, emitted: true })
+        .mockReturnValue({ accepted: true, changed: false, emitted: false });
+
+      const initial = await service.reconcile();
+      const unchanged = await service.reconcile();
+
+      expect(initial).toMatchObject({
+        workspacesScanned: 1,
+        workspacesChanged: 1,
+        deltasEmitted: 1,
+      });
+      expect(unchanged).toMatchObject({
+        workspacesScanned: 1,
+        workspacesChanged: 0,
+        deltasEmitted: 0,
+      });
+      expect(mockLoggerInfo).toHaveBeenLastCalledWith(
+        'Reconciliation complete',
+        expect.objectContaining({
+          workspacesScanned: 1,
+          workspacesChanged: 0,
+          deltasEmitted: 0,
+        })
+      );
     });
   });
 

--- a/src/backend/orchestration/snapshot-reconciliation.orchestrator.ts
+++ b/src/backend/orchestration/snapshot-reconciliation.orchestrator.ts
@@ -63,6 +63,9 @@ export interface ReconciliationBridges {
 }
 
 export interface ReconciliationResult {
+  workspacesScanned: number;
+  workspacesChanged: number;
+  deltasEmitted: number;
   workspacesReconciled: number;
   driftsDetected: number;
   staleEntriesRemoved: number;
@@ -165,6 +168,9 @@ export class SnapshotReconciliationService {
       .catch((err) => {
         logger.error('Initial reconciliation failed', { error: String(err) });
         return {
+          workspacesScanned: 0,
+          workspacesChanged: 0,
+          deltasEmitted: 0,
           workspacesReconciled: 0,
           driftsDetected: 0,
           staleEntriesRemoved: 0,
@@ -185,6 +191,9 @@ export class SnapshotReconciliationService {
         .catch((err) => {
           logger.error('Reconciliation tick failed', { error: String(err) });
           return {
+            workspacesScanned: 0,
+            workspacesChanged: 0,
+            deltasEmitted: 0,
             workspacesReconciled: 0,
             driftsDetected: 0,
             staleEntriesRemoved: 0,
@@ -278,19 +287,21 @@ export class SnapshotReconciliationService {
   /**
    * Remove snapshot entries for workspaces no longer in the DB.
    */
-  private removeStaleEntries(dbWorkspaceIds: Set<string>): number {
+  private removeStaleEntries(dbWorkspaceIds: Set<string>): {
+    staleEntriesRemoved: number;
+    deltasEmitted: number;
+  } {
     const storeWorkspaceIds = workspaceSnapshotStore.getAllWorkspaceIds();
     let removed = 0;
 
     for (const storeId of storeWorkspaceIds) {
-      if (!dbWorkspaceIds.has(storeId)) {
-        workspaceSnapshotStore.remove(storeId);
+      if (!dbWorkspaceIds.has(storeId) && workspaceSnapshotStore.remove(storeId)) {
         removed++;
         logger.info('Removed stale snapshot entry', { workspaceId: storeId });
       }
     }
 
-    return removed;
+    return { staleEntriesRemoved: removed, deltasEmitted: removed };
   }
 
   async reconcile(): Promise<ReconciliationResult> {
@@ -330,6 +341,8 @@ export class SnapshotReconciliationService {
     // 4. Reconcile each workspace
     let driftsDetected = 0;
     let gitStatsComputed = 0;
+    let workspacesChanged = 0;
+    let deltasEmitted = 0;
 
     for (const ws of workspaces) {
       const authoritativeFields = this.buildAuthoritativeFields(
@@ -362,26 +375,44 @@ export class SnapshotReconciliationService {
       }
 
       // Upsert with pollStartTs (RCNL-03)
-      workspaceSnapshotStore.upsert(ws.id, authoritativeFields, 'reconciliation', pollStartTs);
+      const upsertResult = workspaceSnapshotStore.upsert(
+        ws.id,
+        authoritativeFields,
+        'reconciliation',
+        pollStartTs
+      );
+      if (upsertResult.changed) {
+        workspacesChanged++;
+      }
+      if (upsertResult.emitted) {
+        deltasEmitted++;
+      }
     }
 
     // 5. Stale entry cleanup
-    const staleEntriesRemoved = this.removeStaleEntries(new Set(workspaces.map((w) => w.id)));
+    const staleCleanup = this.removeStaleEntries(new Set(workspaces.map((w) => w.id)));
+    deltasEmitted += staleCleanup.deltasEmitted;
 
     // 6. Log summary
     const durationMs = Date.now() - pollStartTs;
     logger.info('Reconciliation complete', {
+      workspacesScanned: workspaces.length,
+      workspacesChanged,
+      deltasEmitted,
       workspacesReconciled: workspaces.length,
       driftsDetected,
-      staleEntriesRemoved,
+      staleEntriesRemoved: staleCleanup.staleEntriesRemoved,
       gitStatsComputed,
       durationMs,
     });
 
     return {
+      workspacesScanned: workspaces.length,
+      workspacesChanged,
+      deltasEmitted,
       workspacesReconciled: workspaces.length,
       driftsDetected,
-      staleEntriesRemoved,
+      staleEntriesRemoved: staleCleanup.staleEntriesRemoved,
       gitStatsComputed,
       durationMs,
     };

--- a/src/backend/services/workspace-snapshot-store.service.test.ts
+++ b/src/backend/services/workspace-snapshot-store.service.test.ts
@@ -20,6 +20,7 @@ import {
   type SnapshotChangedEvent,
   type SnapshotRemovedEvent,
   type SnapshotUpdateInput,
+  type WorkspaceSessionSummary,
   WorkspaceSnapshotStore,
 } from './workspace-snapshot-store.service';
 
@@ -47,6 +48,30 @@ function makeUpdate(overrides: Partial<SnapshotUpdateInput> = {}): SnapshotUpdat
     pendingRequestType: null,
     gitStats: null,
     lastActivityAt: null,
+    ...overrides,
+  };
+}
+
+function makeSessionSummary(
+  overrides: Partial<WorkspaceSessionSummary> = {}
+): WorkspaceSessionSummary {
+  return {
+    sessionId: 'session-1',
+    name: 'Chat 1',
+    workflow: 'followup',
+    model: 'claude-sonnet',
+    provider: 'CLAUDE',
+    persistedStatus: 'IDLE',
+    runtimePhase: 'idle',
+    processState: 'alive',
+    activity: 'IDLE',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    lastExit: {
+      code: 0,
+      timestamp: '2026-01-01T00:00:00.000Z',
+      unexpected: false,
+    },
+    errorMessage: null,
     ...overrides,
   };
 }
@@ -141,18 +166,18 @@ describe('WorkspaceSnapshotStore', () => {
       expect(entry!.version).toBe(1);
     });
 
-    it('version increments on each upsert', () => {
-      for (let i = 0; i < 5; i++) {
-        store.upsert('ws-1', makeUpdate(), 'test', 100 + i);
-      }
+    it('version increments only when snapshot values change', () => {
+      store.upsert('ws-1', makeUpdate({ name: 'one' }), 'test', 100);
+      store.upsert('ws-1', makeUpdate({ name: 'one' }), 'test', 200);
+      store.upsert('ws-1', makeUpdate({ name: 'two' }), 'test', 300);
 
       const entry = store.getByWorkspaceId('ws-1');
-      expect(entry!.version).toBe(5);
+      expect(entry!.version).toBe(2);
     });
 
     it('each workspace has independent version counter', () => {
       store.upsert('ws-A', makeUpdate(), 'test', 100);
-      store.upsert('ws-A', makeUpdate(), 'test', 200);
+      store.upsert('ws-A', makeUpdate({ name: 'Updated' }), 'test', 200);
       store.upsert('ws-B', makeUpdate(), 'test', 100);
 
       expect(store.getByWorkspaceId('ws-A')!.version).toBe(2);
@@ -190,11 +215,11 @@ describe('WorkspaceSnapshotStore', () => {
       expect(entry!.source).toBe('event:pr_state_change');
     });
 
-    it('updates computedAt and source on each upsert', () => {
+    it('updates computedAt and source on each changed upsert', () => {
       store.upsert('ws-1', makeUpdate(), 'source-1', 100);
       const firstComputedAt = store.getByWorkspaceId('ws-1')!.computedAt;
 
-      store.upsert('ws-1', makeUpdate(), 'source-2', 200);
+      store.upsert('ws-1', makeUpdate({ name: 'Updated' }), 'source-2', 200);
       const entry2 = store.getByWorkspaceId('ws-1');
 
       expect(entry2!.source).toBe('source-2');
@@ -316,6 +341,84 @@ describe('WorkspaceSnapshotStore', () => {
   // STORE-06: Field-level timestamps for concurrent update safety
   // -------------------------------------------------------------------------
   describe('STORE-06: Field-level timestamps for concurrent update safety', () => {
+    it('advances ordering metadata without changing the public snapshot for equal scalars', () => {
+      const handler = vi.fn();
+      store.on(SNAPSHOT_CHANGED, handler);
+      store.upsert('ws-1', makeUpdate({ name: 'authoritative' }), 'seed', 100);
+      const before = store.getByWorkspaceId('ws-1')!;
+      const beforeVersion = before.version;
+      const beforeComputedAt = before.computedAt;
+
+      const result = store.upsert('ws-1', { name: 'authoritative' }, 'reconciliation', 200);
+
+      const after = store.getByWorkspaceId('ws-1')!;
+      expect(result).toEqual({ accepted: true, changed: false, emitted: false });
+      expect(after.fieldTimestamps.workspace).toBe(200);
+      expect(after.version).toBe(beforeVersion);
+      expect(after.computedAt).toBe(beforeComputedAt);
+      expect(after.source).toBe('seed');
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      const staleResult = store.upsert('ws-1', { name: 'delayed' }, 'event', 150);
+      expect(staleResult).toEqual({ accepted: false, changed: false, emitted: false });
+      expect(store.getByWorkspaceId('ws-1')!.name).toBe('authoritative');
+    });
+
+    it('treats equal structured reconciliation and session fields as no-ops', () => {
+      const handler = vi.fn();
+      store.on(SNAPSHOT_CHANGED, handler);
+      const gitStats = { total: 3, additions: 2, deletions: 1, hasUncommitted: true };
+      const sessionSummaries = [makeSessionSummary()];
+      store.upsert('ws-1', makeUpdate({ gitStats, sessionSummaries }), 'seed', 100);
+
+      const result = store.upsert(
+        'ws-1',
+        {
+          gitStats: { ...gitStats },
+          sessionSummaries: [
+            makeSessionSummary({ lastExit: { ...sessionSummaries[0]!.lastExit! } }),
+          ],
+        },
+        'reconciliation',
+        200
+      );
+
+      const entry = store.getByWorkspaceId('ws-1')!;
+      expect(result).toEqual({ accepted: true, changed: false, emitted: false });
+      expect(entry.version).toBe(1);
+      expect(entry.fieldTimestamps.reconciliation).toBe(200);
+      expect(entry.fieldTimestamps.session).toBe(200);
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it('emits exactly once when a structured field changes', () => {
+      const handler = vi.fn();
+      store.on(SNAPSHOT_CHANGED, handler);
+      store.upsert('ws-1', makeUpdate({ sessionSummaries: [makeSessionSummary()] }), 'seed', 100);
+      handler.mockClear();
+
+      const result = store.upsert(
+        'ws-1',
+        {
+          sessionSummaries: [
+            makeSessionSummary({
+              lastExit: {
+                code: 1,
+                timestamp: '2026-01-01T00:00:00.000Z',
+                unexpected: true,
+              },
+            }),
+          ],
+        },
+        'event:session_state_change',
+        200
+      );
+
+      expect(result).toEqual({ accepted: true, changed: true, emitted: true });
+      expect(store.getByWorkspaceId('ws-1')!.version).toBe(2);
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
     it('newer timestamp overwrites fields', () => {
       store.upsert('ws-1', makeUpdate({ name: 'old' }), 'test', 100);
       store.upsert('ws-1', { name: 'new' }, 'test', 200);
@@ -565,6 +668,32 @@ describe('WorkspaceSnapshotStore', () => {
       expect(entry!.sidebarStatus.activityState).toBe('IDLE');
       expect(entry!.kanbanColumn).toBe('WAITING');
     });
+
+    it('emits when only the time-sensitive derived candidate changes', () => {
+      let flowPhase: 'NO_PR' | 'CI_WAIT' = 'NO_PR';
+      store.configure({
+        deriveFlowState: () => ({
+          phase: flowPhase,
+          ciObservation: 'CHECKS_UNKNOWN',
+          hasActivePr: flowPhase !== 'NO_PR',
+          isWorking: false,
+          shouldAnimateRatchetButton: false,
+        }),
+        computeKanbanColumn: () => KanbanColumn.WAITING,
+        deriveSidebarStatus: () => ({ activityState: 'IDLE', ciState: 'NONE' }),
+      });
+      store.upsert('ws-1', makeUpdate(), 'seed', 100);
+      const handler = vi.fn();
+      store.on(SNAPSHOT_CHANGED, handler);
+      flowPhase = 'CI_WAIT';
+
+      const result = store.upsert('ws-1', makeUpdate(), 'reconciliation', 200);
+
+      expect(result).toEqual({ accepted: true, changed: true, emitted: true });
+      expect(store.getByWorkspaceId('ws-1')!.flowPhase).toBe('CI_WAIT');
+      expect(store.getByWorkspaceId('ws-1')!.version).toBe(2);
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -639,15 +768,15 @@ describe('WorkspaceSnapshotStore', () => {
       expect(event.entry.flowPhase).toBe('CI_WAIT');
     });
 
-    it('emits one event per upsert call', () => {
+    it('emits only for upserts that change snapshot values', () => {
       const handler = vi.fn();
       store.on(SNAPSHOT_CHANGED, handler);
 
       store.upsert('ws-1', makeUpdate(), 'test', 100);
       store.upsert('ws-1', makeUpdate(), 'test', 200);
-      store.upsert('ws-1', makeUpdate(), 'test', 300);
+      store.upsert('ws-1', makeUpdate({ name: 'Updated' }), 'test', 300);
 
-      expect(handler).toHaveBeenCalledTimes(3);
+      expect(handler).toHaveBeenCalledTimes(2);
     });
 
     it('does not emit or bump version when stale update is fully ignored', () => {

--- a/src/backend/services/workspace-snapshot-store.service.test.ts
+++ b/src/backend/services/workspace-snapshot-store.service.test.ts
@@ -391,6 +391,29 @@ describe('WorkspaceSnapshotStore', () => {
       expect(handler).toHaveBeenCalledTimes(1);
     });
 
+    it('treats reordered session summaries as equal without changing stored order', () => {
+      const handler = vi.fn();
+      store.on(SNAPSHOT_CHANGED, handler);
+      const first = makeSessionSummary({ sessionId: 'session-1', name: 'First' });
+      const second = makeSessionSummary({ sessionId: 'session-2', name: 'Second' });
+      store.upsert('ws-1', makeUpdate({ sessionSummaries: [first, second] }), 'seed', 100);
+      handler.mockClear();
+
+      const result = store.upsert(
+        'ws-1',
+        { sessionSummaries: [{ ...second }, { ...first }] },
+        'reconciliation',
+        200
+      );
+
+      const entry = store.getByWorkspaceId('ws-1')!;
+      expect(result).toEqual({ accepted: true, changed: false, emitted: false });
+      expect(entry.sessionSummaries).toEqual([first, second]);
+      expect(entry.fieldTimestamps.session).toBe(200);
+      expect(entry.version).toBe(1);
+      expect(handler).not.toHaveBeenCalled();
+    });
+
     it('emits exactly once when a structured field changes', () => {
       const handler = vi.fn();
       store.on(SNAPSHOT_CHANGED, handler);

--- a/src/backend/services/workspace-snapshot-store.service.test.ts
+++ b/src/backend/services/workspace-snapshot-store.service.test.ts
@@ -419,6 +419,23 @@ describe('WorkspaceSnapshotStore', () => {
       expect(handler).toHaveBeenCalledTimes(1);
     });
 
+    it('does not ignore additional session summary fields during stable equality', () => {
+      store.upsert('ws-1', makeUpdate({ sessionSummaries: [makeSessionSummary()] }), 'seed', 100);
+      const expandedSummary = Object.assign(makeSessionSummary(), {
+        futureRuntimeDetail: 'new-value',
+      });
+
+      const result = store.upsert(
+        'ws-1',
+        { sessionSummaries: [expandedSummary] },
+        'event:session_state_change',
+        200
+      );
+
+      expect(result).toEqual({ accepted: true, changed: true, emitted: true });
+      expect(store.getByWorkspaceId('ws-1')!.sessionSummaries).toEqual([expandedSummary]);
+    });
+
     it('newer timestamp overwrites fields', () => {
       store.upsert('ws-1', makeUpdate({ name: 'old' }), 'test', 100);
       store.upsert('ws-1', { name: 'new' }, 'test', 200);

--- a/src/backend/services/workspace-snapshot-store.service.ts
+++ b/src/backend/services/workspace-snapshot-store.service.ts
@@ -205,6 +205,12 @@ export interface SnapshotRemovedEvent {
   projectId: string;
 }
 
+export interface SnapshotUpsertResult {
+  accepted: boolean;
+  changed: boolean;
+  emitted: boolean;
+}
+
 // ---------------------------------------------------------------------------
 // Field-to-group mapping
 // ---------------------------------------------------------------------------
@@ -260,6 +266,94 @@ function createDefaultFieldTimestamps(): Record<SnapshotFieldGroup, number> {
   };
 }
 
+type GitStats = NonNullable<WorkspaceSnapshotEntry['gitStats']>;
+
+function gitStatsEqual(left: GitStats | null, right: GitStats | null): boolean {
+  return (
+    left === right ||
+    (left !== null &&
+      right !== null &&
+      left.total === right.total &&
+      left.additions === right.additions &&
+      left.deletions === right.deletions &&
+      left.hasUncommitted === right.hasUncommitted)
+  );
+}
+
+function sessionSummariesEqual(
+  left: WorkspaceSessionSummary[],
+  right: WorkspaceSessionSummary[]
+): boolean {
+  if (left === right) {
+    return true;
+  }
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  return left.every((summary, index) => {
+    const other = right[index];
+    if (!other) {
+      return false;
+    }
+    const exitsEqual =
+      summary.lastExit === other.lastExit ||
+      (summary.lastExit !== null &&
+        other.lastExit !== null &&
+        summary.lastExit.code === other.lastExit.code &&
+        summary.lastExit.timestamp === other.lastExit.timestamp &&
+        summary.lastExit.unexpected === other.lastExit.unexpected);
+
+    return (
+      summary.sessionId === other.sessionId &&
+      summary.name === other.name &&
+      summary.workflow === other.workflow &&
+      summary.model === other.model &&
+      summary.provider === other.provider &&
+      summary.persistedStatus === other.persistedStatus &&
+      summary.runtimePhase === other.runtimePhase &&
+      summary.processState === other.processState &&
+      summary.activity === other.activity &&
+      summary.updatedAt === other.updatedAt &&
+      exitsEqual &&
+      summary.errorMessage === other.errorMessage
+    );
+  });
+}
+
+function sidebarStatusesEqual(
+  left: WorkspaceSidebarStatus,
+  right: WorkspaceSidebarStatus
+): boolean {
+  return left.activityState === right.activityState && left.ciState === right.ciState;
+}
+
+function statusReasonsEqual(left: WorkspaceStatusReason, right: WorkspaceStatusReason): boolean {
+  return (
+    left.code === right.code &&
+    left.label === right.label &&
+    left.tone === right.tone &&
+    left.needsUser === right.needsUser
+  );
+}
+
+function snapshotFieldValuesEqual(
+  field: SnapshotField,
+  left: WorkspaceSnapshotEntry[SnapshotField],
+  right: WorkspaceSnapshotEntry[SnapshotField]
+): boolean {
+  if (field === 'gitStats') {
+    return gitStatsEqual(left as GitStats | null, right as GitStats | null);
+  }
+  if (field === 'sessionSummaries') {
+    return sessionSummariesEqual(
+      left as WorkspaceSessionSummary[],
+      right as WorkspaceSessionSummary[]
+    );
+  }
+  return Object.is(left, right);
+}
+
 // ---------------------------------------------------------------------------
 // WorkspaceSnapshotStore class
 // ---------------------------------------------------------------------------
@@ -280,11 +374,37 @@ export class WorkspaceSnapshotStore extends EventEmitter {
     entry: WorkspaceSnapshotEntry,
     update: SnapshotUpdateInput,
     field: K
-  ): void {
+  ): boolean {
     const value = update[field];
-    if (value !== undefined) {
-      entry[field] = value as WorkspaceSnapshotEntry[K];
+    if (value === undefined) {
+      return false;
     }
+    const nextValue = value as WorkspaceSnapshotEntry[K];
+    if (snapshotFieldValuesEqual(field, entry[field], nextValue)) {
+      return false;
+    }
+    entry[field] = nextValue;
+    return true;
+  }
+
+  private assignRawField(
+    entry: WorkspaceSnapshotEntry,
+    update: SnapshotUpdateInput,
+    field: SnapshotField
+  ): boolean {
+    if (field !== 'isWorking') {
+      return this.assignField(entry, update, field);
+    }
+
+    const nextIsWorking = update.isWorking;
+    if (
+      nextIsWorking === undefined ||
+      nextIsWorking === this.rawSessionIsWorkingByWorkspaceId.get(entry.workspaceId)
+    ) {
+      return false;
+    }
+    this.rawSessionIsWorkingByWorkspaceId.set(entry.workspaceId, nextIsWorking);
+    return true;
   }
 
   /**
@@ -358,30 +478,30 @@ export class WorkspaceSnapshotStore extends EventEmitter {
     entry: WorkspaceSnapshotEntry,
     update: SnapshotUpdateInput,
     ts: number
-  ): boolean {
-    let merged = false;
+  ): { accepted: boolean; rawChanged: boolean } {
+    let accepted = false;
+    let rawChanged = false;
     for (const mapping of FIELD_GROUP_MAPPINGS) {
       const hasFieldsInGroup = mapping.fields.some((field) => update[field] !== undefined);
       if (!hasFieldsInGroup || ts <= entry.fieldTimestamps[mapping.group]) {
         continue;
       }
-      merged = true;
+      accepted = true;
       entry.fieldTimestamps[mapping.group] = ts;
       for (const field of mapping.fields) {
-        this.assignField(entry, update, field);
-      }
-      if (mapping.group === 'session' && update.isWorking !== undefined) {
-        this.rawSessionIsWorkingByWorkspaceId.set(entry.workspaceId, update.isWorking);
+        if (this.assignRawField(entry, update, field)) {
+          rawChanged = true;
+        }
       }
     }
-    return merged;
+    return { accepted, rawChanged };
   }
 
   /**
    * Recompute all derived state fields on an entry using the injected
    * derivation functions.
    */
-  private recomputeDerivedState(entry: WorkspaceSnapshotEntry): void {
+  private recomputeDerivedState(entry: WorkspaceSnapshotEntry): boolean {
     const sessionIsWorking = this.rawSessionIsWorkingByWorkspaceId.get(entry.workspaceId) ?? false;
     const flowState = this.derive.deriveFlowState({
       prUrl: entry.prUrl,
@@ -411,13 +531,36 @@ export class WorkspaceSnapshotStore extends EventEmitter {
       }
     );
 
-    entry.isWorking = derivedState.isWorking;
-    entry.flowPhase = derivedState.flowPhase;
-    entry.ciObservation = derivedState.ciObservation;
-    entry.ratchetButtonAnimated = derivedState.ratchetButtonAnimated;
-    entry.statusReason = derivedState.statusReason;
-    entry.kanbanColumn = derivedState.kanbanColumn;
-    entry.sidebarStatus = derivedState.sidebarStatus;
+    let changed = false;
+    if (entry.isWorking !== derivedState.isWorking) {
+      entry.isWorking = derivedState.isWorking;
+      changed = true;
+    }
+    if (entry.flowPhase !== derivedState.flowPhase) {
+      entry.flowPhase = derivedState.flowPhase;
+      changed = true;
+    }
+    if (entry.ciObservation !== derivedState.ciObservation) {
+      entry.ciObservation = derivedState.ciObservation;
+      changed = true;
+    }
+    if (entry.ratchetButtonAnimated !== derivedState.ratchetButtonAnimated) {
+      entry.ratchetButtonAnimated = derivedState.ratchetButtonAnimated;
+      changed = true;
+    }
+    if (!statusReasonsEqual(entry.statusReason, derivedState.statusReason)) {
+      entry.statusReason = derivedState.statusReason;
+      changed = true;
+    }
+    if (entry.kanbanColumn !== derivedState.kanbanColumn) {
+      entry.kanbanColumn = derivedState.kanbanColumn;
+      changed = true;
+    }
+    if (!sidebarStatusesEqual(entry.sidebarStatus, derivedState.sidebarStatus)) {
+      entry.sidebarStatus = derivedState.sidebarStatus;
+      changed = true;
+    }
+    return changed;
   }
 
   /**
@@ -457,7 +600,7 @@ export class WorkspaceSnapshotStore extends EventEmitter {
     update: SnapshotUpdateInput,
     source: string,
     timestamp?: number
-  ): void {
+  ): SnapshotUpsertResult {
     const ts = timestamp ?? Date.now();
 
     const removedAt = this.removalTimestamps.get(workspaceId);
@@ -467,7 +610,7 @@ export class WorkspaceSnapshotStore extends EventEmitter {
           workspaceId,
           source,
         });
-        return;
+        return { accepted: false, changed: false, emitted: false };
       }
       this.removalTimestamps.delete(workspaceId);
     }
@@ -486,15 +629,20 @@ export class WorkspaceSnapshotStore extends EventEmitter {
     }
 
     // Field-level timestamp merge
-    const didMerge = this.mergeFieldGroups(entry, update, ts);
+    const mergeResult = this.mergeFieldGroups(entry, update, ts);
 
-    if (!(isNewEntry || didMerge)) {
-      logger.debug('Snapshot update ignored (stale/no-op)', { workspaceId, source });
-      return;
+    if (!(isNewEntry || mergeResult.accepted)) {
+      logger.debug('Snapshot update ignored (stale)', { workspaceId, source });
+      return { accepted: false, changed: false, emitted: false };
     }
 
-    // Recompute derived state from raw fields
-    this.recomputeDerivedState(entry);
+    // Accepted raw values can produce time-sensitive derived changes even when
+    // the raw values themselves are equal (for example, CI grace periods).
+    const derivedChanged = this.recomputeDerivedState(entry);
+    if (!(isNewEntry || mergeResult.rawChanged || derivedChanged)) {
+      logger.debug('Snapshot update accepted without value changes', { workspaceId, source });
+      return { accepted: true, changed: false, emitted: false };
+    }
 
     // Bump version and update metadata
     entry.version += 1;
@@ -513,6 +661,7 @@ export class WorkspaceSnapshotStore extends EventEmitter {
     } satisfies SnapshotChangedEvent);
 
     logger.debug('Snapshot updated', { workspaceId, version: entry.version, source });
+    return { accepted: true, changed: true, emitted: true };
   }
 
   /**

--- a/src/backend/services/workspace-snapshot-store.service.ts
+++ b/src/backend/services/workspace-snapshot-store.service.ts
@@ -16,6 +16,7 @@
  */
 
 import { EventEmitter } from 'node:events';
+import { isDeepStrictEqual } from 'node:util';
 import { assembleWorkspaceDerivedState } from '@/backend/lib/workspace-derived-state';
 import type {
   CIStatus,
@@ -284,41 +285,7 @@ function sessionSummariesEqual(
   left: WorkspaceSessionSummary[],
   right: WorkspaceSessionSummary[]
 ): boolean {
-  if (left === right) {
-    return true;
-  }
-  if (left.length !== right.length) {
-    return false;
-  }
-
-  return left.every((summary, index) => {
-    const other = right[index];
-    if (!other) {
-      return false;
-    }
-    const exitsEqual =
-      summary.lastExit === other.lastExit ||
-      (summary.lastExit !== null &&
-        other.lastExit !== null &&
-        summary.lastExit.code === other.lastExit.code &&
-        summary.lastExit.timestamp === other.lastExit.timestamp &&
-        summary.lastExit.unexpected === other.lastExit.unexpected);
-
-    return (
-      summary.sessionId === other.sessionId &&
-      summary.name === other.name &&
-      summary.workflow === other.workflow &&
-      summary.model === other.model &&
-      summary.provider === other.provider &&
-      summary.persistedStatus === other.persistedStatus &&
-      summary.runtimePhase === other.runtimePhase &&
-      summary.processState === other.processState &&
-      summary.activity === other.activity &&
-      summary.updatedAt === other.updatedAt &&
-      exitsEqual &&
-      summary.errorMessage === other.errorMessage
-    );
-  });
+  return isDeepStrictEqual(left, right);
 }
 
 function sidebarStatusesEqual(

--- a/src/backend/services/workspace-snapshot-store.service.ts
+++ b/src/backend/services/workspace-snapshot-store.service.ts
@@ -285,7 +285,10 @@ function sessionSummariesEqual(
   left: WorkspaceSessionSummary[],
   right: WorkspaceSessionSummary[]
 ): boolean {
-  return isDeepStrictEqual(left, right);
+  return isDeepStrictEqual(
+    [...left].sort((a, b) => a.sessionId.localeCompare(b.sessionId)),
+    [...right].sort((a, b) => a.sessionId.localeCompare(b.sessionId))
+  );
 }
 
 function sidebarStatusesEqual(


### PR DESCRIPTION
## Summary
- Make snapshot upserts distinguish accepted timestamps from actual value changes.
- Suppress no-op version bumps and snapshot deltas while preserving stale-update ordering.
- Report reconciliation scan, change, and emitted-delta counts.

## Changes
- **Snapshot store**: Added value-aware scalar and structured equality, stable deep equality for session summaries, derived-only change detection, and explicit upsert outcomes.
- **Reconciliation**: Aggregated `workspacesScanned`, `workspacesChanged`, and `deltasEmitted`, including successful stale-entry removals.
- **Tests**: Covered equal and changed scalar/structured values, session summaries, stale ordering, removal/recreation races, time-sensitive derived changes, repeated idle reconciliation, and logging.

## Testing
- [x] Tests pass (`NODE_ENV=test pnpm test`: 3,831 passed, 3 skipped)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting/check completes (`pnpm check:fix`; 6 pre-existing `<img>` warnings)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Observe an idle project across multiple reconciliation intervals and confirm snapshot WebSocket/cache update counts remain zero.

Closes #1942

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core snapshot merge, derived-state, and WebSocket fan-out paths; behavior changes are well-tested but ordering and time-sensitive derivation edge cases warrant careful review.
> 
> **Overview**
> Stops periodic reconciliation from treating **unchanged** authoritative data as snapshot updates, which was bumping versions and broadcasting `SNAPSHOT_CHANGED` on every idle pass.
> 
> **`WorkspaceSnapshotStore`** now returns **`SnapshotUpsertResult`** (`accepted`, `changed`, `emitted`). Newer equal values still advance field-group timestamps (so stale events cannot win), but skip version bumps, metadata updates, and events unless raw or **time-sensitive derived** state actually changes. Equality uses targeted comparisons (`Object.is`, `gitStats`, sorted deep equality for `sessionSummaries`, derived-field checks) instead of JSON serialization.
> 
> **`SnapshotReconciliationService`** aggregates upsert outcomes into **`workspacesScanned`**, **`workspacesChanged`**, and **`deltasEmitted`** (including successful stale removals) in results and completion logs.
> 
> Tests cover no-op scalars/structured fields, derived-only changes, and repeated unchanged reconciliation. Design/plan docs were added for the approach.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 844d482b7d2f3f9aa3b968d5ddeda36102b8ba0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

