### PR TITLE
Fix #1948: Throttle hidden workspace logs

### DIFF
--- a/docs/superpowers/plans/2026-07-17-hidden-workspace-log-throttling.md
+++ b/docs/superpowers/plans/2026-07-17-hidden-workspace-log-throttling.md
@@ -45,7 +45,8 @@ Expected: FAIL because `RollingOutputBuffer` is not exported.
 
 Add a class that stores string chunks, a head index, retained character count,
 and a truncation flag. On append, detect the first overflow, trim leading chunks
-to the correct body capacity, and compact consumed array slots periodically.
+to the correct body capacity, and compact consumed array slots on append once
+the consumed-slot count reaches a threshold relative to the retained chunks.
 `toString()` must join only retained chunks and prepend the bounded marker only
 after truncation.
 

--- a/docs/superpowers/plans/2026-07-17-hidden-workspace-log-throttling.md
+++ b/docs/superpowers/plans/2026-07-17-hidden-workspace-log-throttling.md
@@ -1,0 +1,192 @@
+# Hidden Workspace Log Throttling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve bounded log history and accurate connection indicators while throttling React output and scroll work to the visible workspace log stream.
+
+**Architecture:** Store incoming text in an array-backed `RollingOutputBuffer` outside React state. Give `useLogStream` explicit visibility, immediately snapshot the buffer when shown, throttle live visible snapshots to 100 ms, and scroll once per committed visible snapshot with `requestAnimationFrame`.
+
+**Tech Stack:** TypeScript, React 19 hooks, Zod, Vitest, jsdom
+
+## Global Constraints
+
+- Keep both `/dev-logs` and `/post-run-logs` WebSocket connections mounted.
+- Preserve the 512 KiB workspace-log cap and `[Earlier output truncated]\n` marker semantics.
+- Hidden traffic must not update presentation state or schedule scrolling per chunk.
+- Connection/disconnection indicator state must remain current while hidden.
+- Do not reconnect or lose messages when switching bottom-panel tabs.
+
+---
+
+### Task 1: Add an array-backed rolling output buffer
+
+**Files:**
+- Modify: `src/components/workspace/rolling-output.ts`
+- Test: `src/components/workspace/rolling-output.test.ts`
+
+**Interfaces:**
+- Consumes: `{ maxChars: number; truncationMarker: string }`
+- Produces: `RollingOutputBuffer.append(next: string): void` and `RollingOutputBuffer.toString(): string`
+
+- [ ] **Step 1: Write failing buffer tests**
+
+Add tests that construct `new RollingOutputBuffer(options)`, append multiple
+chunks, and assert that `toString()` preserves sub-cap output, retains only the
+newest capped body with one marker after overflow, handles an oversized chunk,
+and returns an empty string at zero capacity.
+
+- [ ] **Step 2: Verify the new tests fail**
+
+Run: `pnpm exec vitest run src/components/workspace/rolling-output.test.ts`
+
+Expected: FAIL because `RollingOutputBuffer` is not exported.
+
+- [ ] **Step 3: Implement the minimal mutable buffer**
+
+Add a class that stores string chunks, a head index, retained character count,
+and a truncation flag. On append, detect the first overflow, trim leading chunks
+to the correct body capacity, and compact consumed array slots periodically.
+`toString()` must join only retained chunks and prepend the bounded marker only
+after truncation.
+
+- [ ] **Step 4: Verify buffer behavior**
+
+Run: `pnpm exec vitest run src/components/workspace/rolling-output.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the buffer**
+
+```bash
+git add src/components/workspace/rolling-output.ts src/components/workspace/rolling-output.test.ts
+git commit -m "Add chunked workspace log buffer (#1948)"
+```
+
+### Task 2: Make log presentation visibility-aware and throttled
+
+**Files:**
+- Modify: `src/components/workspace/use-log-stream.ts`
+- Test: `src/components/workspace/use-log-stream.test.tsx`
+
+**Interfaces:**
+- Consumes: `useLogStream(endpoint: LogStreamEndpoint, workspaceId: string, isVisible: boolean)` and `RollingOutputBuffer`
+- Produces: unchanged `UseLogStreamResult` shape with throttled `output`, live `connected`/`hasDisconnected`, and `outputEndRef`
+
+- [ ] **Step 1: Write failing visibility and burst tests**
+
+Update the harness with an `isVisible` prop and render counter. Add fake-timer
+tests proving hidden bursts do not rerender output or scroll; becoming visible
+hydrates buffered output immediately; visible bursts commit once after 100 ms;
+disconnect/reconnect announcements and indicator state survive a hidden period;
+and invalid messages remain ignored.
+
+- [ ] **Step 2: Write failing cleanup and scroll tests**
+
+Stub `requestAnimationFrame`, `cancelAnimationFrame`, and `scrollIntoView`. Assert
+that one visible output commit produces one frame-aligned scroll and that hiding
+or unmounting cancels pending flush/frame callbacks.
+
+- [ ] **Step 3: Verify the hook tests fail**
+
+Run: `pnpm exec vitest run src/components/workspace/use-log-stream.test.tsx`
+
+Expected: FAIL because the hook has no visibility input and still updates and
+scrolls once per chunk.
+
+- [ ] **Step 4: Implement visibility-aware buffering**
+
+Create one `RollingOutputBuffer` per endpoint/workspace identity. Append all
+valid transport and lifecycle text to it. Track current visibility in a ref;
+schedule at most one 100 ms flush only while visible; immediately snapshot in a
+layout effect when shown; and cancel flush timers on hide, identity change, and
+unmount.
+
+- [ ] **Step 5: Implement frame-aligned committed-output scrolling**
+
+Replace chunk-level `setTimeout(..., 10)` calls with an effect keyed by visible,
+non-empty `output`. Schedule one animation frame, cancel the prior frame during
+effect cleanup, and scroll the end ref inside that frame.
+
+- [ ] **Step 6: Verify the hook tests pass**
+
+Run: `pnpm exec vitest run src/components/workspace/use-log-stream.test.tsx`
+
+Expected: PASS with no timer or `act` warnings.
+
+- [ ] **Step 7: Commit the hook**
+
+```bash
+git add src/components/workspace/use-log-stream.ts src/components/workspace/use-log-stream.test.tsx
+git commit -m "Throttle workspace log presentation (#1948)"
+```
+
+### Task 3: Connect active-tab visibility and verify the feature
+
+**Files:**
+- Modify: `src/components/workspace/right-panel.tsx`
+
+**Interfaces:**
+- Consumes: `activeBottomTab` and the new `useLogStream(..., isVisible)` signature
+- Produces: exactly one visible log-stream presentation subscription at a time
+
+- [ ] **Step 1: Pass exact tab visibility to each hook**
+
+Call the dev hook with `activeBottomTab === 'dev-logs'` and the post-run hook
+with `activeBottomTab === 'post-run-logs'`. Keep both calls unconditional so the
+connections and status indicators remain mounted.
+
+- [ ] **Step 2: Run focused regression tests**
+
+Run: `pnpm exec vitest run src/components/workspace/rolling-output.test.ts src/components/workspace/use-log-stream.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit the integration**
+
+```bash
+git add src/components/workspace/right-panel.tsx
+git commit -m "Activate log rendering by selected tab (#1948)"
+```
+
+### Task 4: Full verification, review, and pull request
+
+**Files:**
+- Review: all files changed from `origin/main`
+- Optionally create: `.factory-factory/screenshots/<descriptive-name>.png` only if a screenshot can demonstrate the behavior
+
+**Interfaces:**
+- Consumes: completed implementation and test commits
+- Produces: a clean pushed branch and GitHub pull request closing #1948
+
+- [ ] **Step 1: Run required verification**
+
+Run: `pnpm typecheck && pnpm check:fix && pnpm test && pnpm build`
+
+Expected: all commands exit 0. Review and commit any intentional formatting
+changes made by `check:fix`.
+
+- [ ] **Step 2: Review the complete diff**
+
+Run: `git diff origin/main` and `git status --short`.
+
+Expected: no debug output, commented code, unrelated edits, or uncommitted files.
+
+- [ ] **Step 3: Decide screenshot applicability**
+
+Because the change intentionally preserves visible appearance and changes only
+render frequency while a stream is hidden, record screenshot capture as not
+applicable unless manual testing reveals a meaningful visible state to show.
+
+- [ ] **Step 4: Push and create the PR**
+
+Push with `git push -u origin HEAD`. Write `/tmp/pr-body.md` with Summary,
+Changes, Testing, `Closes #1948`, the required horizontal rule, and Factory
+Factory signature. Create with:
+
+```bash
+gh pr create --title "Fix #1948: Throttle hidden workspace logs" --body-file /tmp/pr-body.md
+```
+
+- [ ] **Step 5: Verify and report the PR URL**
+
+Run: `gh pr view --json url,title,state` and confirm the returned PR is open.

--- a/docs/superpowers/specs/2026-07-17-hidden-workspace-log-throttling-design.md
+++ b/docs/superpowers/specs/2026-07-17-hidden-workspace-log-throttling-design.md
@@ -1,0 +1,91 @@
+# Hidden Workspace Log Throttling Design
+
+## Goal
+
+Keep dev-log and post-run-log connections, status indicators, and buffered
+history accurate while preventing hidden streams from committing every chunk to
+React state or scheduling scroll work.
+
+## Scope
+
+This change applies to the two push-only workspace log streams rendered by
+`RightPanel`: `/dev-logs` and `/post-run-logs`. It does not change WebSocket
+connection, validation, reconnect, or server replay behavior. Setup logs and
+terminal output keep their existing implementations.
+
+## Design Options
+
+1. **Hook-local bounded buffer with visibility-aware presentation (selected).**
+   Each `useLogStream` instance owns a non-React rolling chunk buffer and accepts
+   whether its panel is visible. Transport callbacks always append to the
+   buffer, while React output updates are scheduled only for the visible stream.
+   This is the smallest boundary that preserves the existing shared connection
+   and status API.
+2. **Disconnect hidden streams.** This would eliminate hidden traffic but would
+   weaken connection indicators, force reconnects on tab changes, and depend on
+   replay timing to avoid gaps.
+3. **Introduce a shared external log store.** This could support multiple
+   subscribers but adds lifecycle and subscription machinery that the current
+   single `RightPanel` consumer does not need.
+
+## Architecture
+
+Extend `rolling-output.ts` with a mutable bounded chunk buffer. Appends update
+an array-backed queue and retained character count without joining the entire
+rolling output. When the cap is crossed, the buffer drops complete leading
+chunks and slices at most one partial leading chunk, then prepends the existing
+workspace truncation marker in snapshots. Consumed queue slots are compacted
+periodically so discarded strings are released.
+
+`useLogStream` receives an `isVisible` argument. WebSocket message and lifecycle
+callbacks append output, connection, disconnection, and reconnection text to the
+buffer regardless of visibility. `connected` and `hasDisconnected` remain
+ordinary lightweight React state supplied to the tab indicators.
+
+For a visible stream, the first pending append schedules one 100 ms flush.
+Additional chunks before that deadline only update the buffer. The flush joins
+the current bounded snapshot once and commits it to React. A hidden stream does
+not schedule a flush. When visibility becomes true, a layout effect immediately
+hydrates React output from the current buffer without reconnecting.
+
+The hook cancels pending flushes when hidden, when the workspace/endpoint
+identity changes, and on unmount. The rolling buffer is recreated for a new
+workspace/endpoint identity so output cannot leak between workspaces.
+
+## Scrolling
+
+Scrolling is driven by committed visible output, not by transport chunks. After
+a non-empty visible output commit, an effect schedules one
+`requestAnimationFrame` callback that scrolls the end marker into view. A newer
+commit or cleanup cancels the old frame. Hidden output never requests a frame or
+calls `scrollIntoView`.
+
+## Error and Lifecycle Behavior
+
+- Schema-invalid and empty output messages remain ignored.
+- Connection and disconnection announcements use the same bounded buffer and
+  retain their existing wording.
+- Connection indicators update while the stream is hidden.
+- Reconnect behavior remains owned by `useWebSocketChannel` and does not depend
+  on active-tab state.
+- Pending timeouts and animation frames are canceled during unmount.
+
+## Testing
+
+Add rolling-buffer unit tests with a small cap to verify normal appends, newest
+output retention, single-marker semantics, oversized chunks, and zero capacity.
+
+Expand the hook tests to verify:
+
+- a high-frequency hidden burst causes no output render and no scroll
+- opening a hidden stream synchronously hydrates all buffered output without a
+  new connection URL
+- a visible burst produces one throttled output commit and one frame-aligned
+  scroll
+- disconnect and reconnect messages buffer while hidden while indicator state
+  remains current
+- invalid messages remain ignored
+- visibility changes and unmount cancel pending timeouts and animation frames
+
+Run the focused workspace tests, then `pnpm typecheck`, `pnpm check:fix`,
+`pnpm test`, and `pnpm build`.

--- a/src/components/workspace/right-panel.tsx
+++ b/src/components/workspace/right-panel.tsx
@@ -249,8 +249,12 @@ export function RightPanel({
   const terminalPanelRef = useRef<TerminalPanelRef>(null);
 
   // Single shared dev logs connection for both tab indicator and panel content
-  const devLogs = useLogStream('/dev-logs', workspaceId);
-  const postRunLogs = useLogStream('/post-run-logs', workspaceId);
+  const devLogs = useLogStream('/dev-logs', workspaceId, activeBottomTab === 'dev-logs');
+  const postRunLogs = useLogStream(
+    '/post-run-logs',
+    workspaceId,
+    activeBottomTab === 'post-run-logs'
+  );
 
   // Terminal tab state lifted up from TerminalPanel for inline rendering
   const [terminalTabState, setTerminalTabState] = useState<TerminalTabState | null>(null);

--- a/src/components/workspace/rolling-output.test.ts
+++ b/src/components/workspace/rolling-output.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { appendToRollingOutput, trimRollingOutput } from './rolling-output';
+import { appendToRollingOutput, RollingOutputBuffer, trimRollingOutput } from './rolling-output';
 
 const options = {
   maxChars: 12,
@@ -41,5 +41,57 @@ describe('rolling output', () => {
         truncationMarker: '[cut]\n',
       })
     ).toBe('');
+  });
+});
+
+describe('RollingOutputBuffer', () => {
+  it('retains chunks without materializing a truncation marker below the cap', () => {
+    const buffer = new RollingOutputBuffer(options);
+
+    buffer.append('abc');
+    buffer.append('def');
+
+    expect(buffer.toString()).toBe('abcdef');
+  });
+
+  it('retains the newest body with exactly one marker across later appends', () => {
+    const buffer = new RollingOutputBuffer(options);
+
+    buffer.append('abcdef');
+    buffer.append('ghijklmnop');
+    expect(buffer.toString()).toBe('[cut]\nklmnop');
+
+    buffer.append('qrst');
+    expect(buffer.toString()).toBe('[cut]\nopqrst');
+  });
+
+  it('bounds a single oversized chunk without retaining its discarded prefix', () => {
+    const buffer = new RollingOutputBuffer(options);
+
+    buffer.append('abcdefghijklmnop');
+
+    expect(buffer.toString()).toBe('[cut]\nklmnop');
+  });
+
+  it('bounds the marker itself when it consumes the entire capacity', () => {
+    const buffer = new RollingOutputBuffer({
+      maxChars: 4,
+      truncationMarker: '[cut]\n',
+    });
+
+    buffer.append('abcdef');
+
+    expect(buffer.toString()).toBe('[cut');
+  });
+
+  it('retains no chunks when capacity is non-positive', () => {
+    const buffer = new RollingOutputBuffer({
+      maxChars: 0,
+      truncationMarker: '[cut]\n',
+    });
+
+    buffer.append('abcdef');
+
+    expect(buffer.toString()).toBe('');
   });
 });

--- a/src/components/workspace/rolling-output.test.ts
+++ b/src/components/workspace/rolling-output.test.ts
@@ -94,4 +94,19 @@ describe('RollingOutputBuffer', () => {
 
     expect(buffer.toString()).toBe('');
   });
+
+  it('releases strings from consumed chunk slots', () => {
+    const buffer = new RollingOutputBuffer(options);
+
+    for (let index = 0; index < 63; index += 1) {
+      buffer.append(String(index).padEnd(options.maxChars, 'x'));
+    }
+
+    const chunks = Reflect.get(buffer, 'chunks');
+    expect(Array.isArray(chunks)).toBe(true);
+    const retainedCharacters = Array.isArray(chunks)
+      ? chunks.reduce((total, chunk) => total + (typeof chunk === 'string' ? chunk.length : 0), 0)
+      : 0;
+    expect(retainedCharacters).toBeLessThanOrEqual(options.maxChars);
+  });
 });

--- a/src/components/workspace/rolling-output.ts
+++ b/src/components/workspace/rolling-output.ts
@@ -54,6 +54,7 @@ export class RollingOutputBuffer {
 
       if (firstChunk.length <= overflow) {
         this.bufferedChars -= firstChunk.length;
+        this.chunks[this.startIndex] = '';
         this.startIndex += 1;
         this.compactIfNeeded();
         continue;

--- a/src/components/workspace/rolling-output.ts
+++ b/src/components/workspace/rolling-output.ts
@@ -9,6 +9,77 @@ interface RollingOutputOptions {
   truncationMarker: string;
 }
 
+export class RollingOutputBuffer {
+  private chunks: string[] = [];
+  private startIndex = 0;
+  private bufferedChars = 0;
+  private truncated = false;
+  private readonly maxChars: number;
+  private readonly boundedMarker: string;
+
+  constructor({ maxChars, truncationMarker }: RollingOutputOptions) {
+    this.maxChars = Math.max(0, maxChars);
+    this.boundedMarker = truncationMarker.slice(0, this.maxChars);
+  }
+
+  append(next: string): void {
+    if (this.maxChars === 0 || next.length === 0) {
+      return;
+    }
+
+    this.chunks.push(next);
+    this.bufferedChars += next.length;
+
+    if (!this.truncated && this.bufferedChars > this.maxChars) {
+      this.truncated = true;
+    }
+
+    const bodyCapacity = this.truncated ? this.maxChars - this.boundedMarker.length : this.maxChars;
+    this.trimTo(bodyCapacity);
+  }
+
+  toString(): string {
+    const body = this.bufferedChars === 0 ? '' : this.chunks.slice(this.startIndex).join('');
+    return this.truncated ? this.boundedMarker + body : body;
+  }
+
+  private trimTo(maxBodyChars: number): void {
+    while (this.bufferedChars > maxBodyChars && this.startIndex < this.chunks.length) {
+      const overflow = this.bufferedChars - maxBodyChars;
+      const firstChunk = this.chunks[this.startIndex];
+      if (firstChunk === undefined) {
+        this.resetChunks();
+        return;
+      }
+
+      if (firstChunk.length <= overflow) {
+        this.bufferedChars -= firstChunk.length;
+        this.startIndex += 1;
+        this.compactIfNeeded();
+        continue;
+      }
+
+      this.chunks[this.startIndex] = firstChunk.slice(overflow);
+      this.bufferedChars -= overflow;
+    }
+  }
+
+  private compactIfNeeded(): void {
+    if (this.startIndex < 64 || this.startIndex * 2 < this.chunks.length) {
+      return;
+    }
+
+    this.chunks = this.chunks.slice(this.startIndex);
+    this.startIndex = 0;
+  }
+
+  private resetChunks(): void {
+    this.chunks = [];
+    this.startIndex = 0;
+    this.bufferedChars = 0;
+  }
+}
+
 export function appendToRollingOutput(
   current: string,
   next: string,

--- a/src/components/workspace/use-log-stream.test.tsx
+++ b/src/components/workspace/use-log-stream.test.tsx
@@ -5,6 +5,7 @@ import { flushSync } from 'react-dom';
 import { createRoot } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { UseWebSocketTransportOptions } from '@/hooks/use-websocket-transport';
+import { WORKSPACE_LOG_OUTPUT_MAX_CHARS, WORKSPACE_LOG_TRUNCATION_MARKER } from './rolling-output';
 import { type UseLogStreamResult, useLogStream } from './use-log-stream';
 
 let capturedOptions: UseWebSocketTransportOptions | null = null;
@@ -19,97 +20,283 @@ vi.mock('@/hooks/use-websocket-transport', () => ({
 interface HarnessProps {
   endpoint: '/dev-logs' | '/post-run-logs';
   workspaceId: string;
+  isVisible: boolean;
   resultRef: { current: UseLogStreamResult | null };
+  renderCountRef: { current: number };
 }
 
-function Harness({ endpoint, workspaceId, resultRef }: HarnessProps) {
-  resultRef.current = useLogStream(endpoint, workspaceId);
+function Harness({ endpoint, workspaceId, isVisible, resultRef, renderCountRef }: HarnessProps) {
+  renderCountRef.current += 1;
+  resultRef.current = useLogStream(endpoint, workspaceId, isVisible);
   return null;
 }
 
 describe('useLogStream', () => {
   let container: HTMLDivElement;
   let root: ReturnType<typeof createRoot>;
+  let mounted: boolean;
+  let nextAnimationFrameId: number;
+  let animationFrames: Map<number, FrameRequestCallback>;
+  let requestAnimationFrameMock: ReturnType<typeof vi.fn>;
+  let cancelAnimationFrameMock: ReturnType<typeof vi.fn>;
+  let scrollIntoViewMock: ReturnType<typeof vi.fn>;
   const resultRef: { current: UseLogStreamResult | null } = { current: null };
+  const renderCountRef = { current: 0 };
 
-  function render(endpoint: '/dev-logs' | '/post-run-logs' = '/dev-logs') {
+  function render(
+    isVisible = false,
+    endpoint: '/dev-logs' | '/post-run-logs' = '/dev-logs',
+    workspaceId = 'ws-1'
+  ) {
     flushSync(() => {
-      root.render(createElement(Harness, { endpoint, workspaceId: 'ws-1', resultRef }));
+      root.render(
+        createElement(Harness, {
+          endpoint,
+          workspaceId,
+          isVisible,
+          resultRef,
+          renderCountRef,
+        })
+      );
     });
   }
 
-  beforeEach(() => {
-    capturedOptions = null;
-    resultRef.current = null;
-    container = document.createElement('div');
-    document.body.appendChild(container);
-    root = createRoot(container);
-  });
+  function attachOutputEndMarker() {
+    const marker = document.createElement('div');
+    Object.defineProperty(marker, 'scrollIntoView', { value: scrollIntoViewMock });
+    if (resultRef.current) {
+      resultRef.current.outputEndRef.current = marker;
+    }
+  }
 
-  afterEach(() => {
+  function runAnimationFrames() {
+    const pendingFrames = [...animationFrames.entries()];
+    animationFrames.clear();
+    for (const [, callback] of pendingFrames) {
+      callback(0);
+    }
+  }
+
+  function unmount() {
+    if (!mounted) {
+      return;
+    }
     flushSync(() => {
       root.unmount();
     });
+    mounted = false;
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    capturedOptions = null;
+    resultRef.current = null;
+    renderCountRef.current = 0;
+    nextAnimationFrameId = 1;
+    animationFrames = new Map();
+    requestAnimationFrameMock = vi.fn((callback: FrameRequestCallback) => {
+      const frameId = nextAnimationFrameId;
+      nextAnimationFrameId += 1;
+      animationFrames.set(frameId, callback);
+      return frameId;
+    });
+    cancelAnimationFrameMock = vi.fn((frameId: number) => {
+      animationFrames.delete(frameId);
+    });
+    scrollIntoViewMock = vi.fn();
+    vi.stubGlobal('requestAnimationFrame', requestAnimationFrameMock);
+    vi.stubGlobal('cancelAnimationFrame', cancelAnimationFrameMock);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mounted = true;
+  });
+
+  afterEach(() => {
+    unmount();
     container.remove();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
   });
 
   it('connects to the given endpoint with the workspace id and drop queue policy', () => {
-    render('/post-run-logs');
+    render(false, '/post-run-logs');
 
     expect(capturedOptions?.url).toContain('/post-run-logs');
     expect(capturedOptions?.url).toContain('workspaceId=ws-1');
     expect(capturedOptions?.queuePolicy).toBe('drop');
   });
 
-  it('appends output messages to the rolling output', () => {
+  it('buffers a high-frequency hidden burst without rerendering or scrolling', () => {
     render();
+    attachOutputEndMarker();
+    const rendersAfterMount = renderCountRef.current;
 
+    flushSync(() => {
+      for (let index = 0; index < 100; index += 1) {
+        capturedOptions?.onMessage?.({ type: 'output', data: `line ${index}\n` });
+      }
+      vi.runAllTimers();
+    });
+
+    expect(renderCountRef.current).toBe(rendersAfterMount);
+    expect(resultRef.current?.output).toBe('');
+    expect(requestAnimationFrameMock).not.toHaveBeenCalled();
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+  });
+
+  it('immediately hydrates buffered output when the stream becomes visible', () => {
+    render();
+    const originalUrl = capturedOptions?.url;
     flushSync(() => {
       capturedOptions?.onMessage?.({ type: 'output', data: 'line one\n' });
       capturedOptions?.onMessage?.({ type: 'output', data: 'line two\n' });
     });
 
+    render(true);
+
     expect(resultRef.current?.output).toBe('line one\nline two\n');
+    expect(capturedOptions?.url).toBe(originalUrl);
   });
 
-  it('ignores messages that do not match the output schema', () => {
-    render();
+  it('commits one output update for a high-frequency visible burst', () => {
+    render(true);
+    const rendersAfterMount = renderCountRef.current;
 
     flushSync(() => {
-      capturedOptions?.onMessage?.({ type: 'exit', code: 1 });
-      capturedOptions?.onMessage?.('garbage');
+      for (let index = 0; index < 100; index += 1) {
+        capturedOptions?.onMessage?.({ type: 'output', data: `${index},` });
+      }
     });
 
     expect(resultRef.current?.output).toBe('');
+    expect(renderCountRef.current).toBe(rendersAfterMount);
+
+    flushSync(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(resultRef.current?.output).toBe(
+      Array.from({ length: 100 }, (_, index) => `${index},`).join('')
+    );
+    expect(renderCountRef.current).toBe(rendersAfterMount + 1);
   });
 
-  it('announces Connected on first connect and Reconnected after output exists', () => {
+  it('buffers lifecycle announcements while keeping disconnection state current', () => {
     render();
 
     flushSync(() => {
       capturedOptions?.onConnected?.();
-    });
-    expect(resultRef.current?.output).toBe('Connected!\n\n');
-
-    flushSync(() => {
-      capturedOptions?.onDisconnected?.();
-      capturedOptions?.onConnected?.();
-    });
-    expect(resultRef.current?.output).toContain('Reconnected!\n\n');
-  });
-
-  it('tracks disconnected state and announces reconnection attempts', () => {
-    render();
-
-    flushSync(() => {
       capturedOptions?.onDisconnected?.();
     });
     expect(resultRef.current?.hasDisconnected).toBe(true);
-    expect(resultRef.current?.output).toContain('Disconnected. Reconnecting...\n');
+    expect(resultRef.current?.output).toBe('');
 
     flushSync(() => {
+      capturedOptions?.onMessage?.({ type: 'output', data: 'while hidden\n' });
       capturedOptions?.onConnected?.();
     });
     expect(resultRef.current?.hasDisconnected).toBe(false);
+    expect(resultRef.current?.output).toBe('');
+
+    render(true);
+    expect(resultRef.current?.output).toBe(
+      'Connected!\n\nDisconnected. Reconnecting...\nwhile hidden\nReconnected!\n\n'
+    );
+  });
+
+  it('bounds hidden buffered output with one truncation marker', () => {
+    render();
+    const chunk = 'x'.repeat(WORKSPACE_LOG_OUTPUT_MAX_CHARS / 2);
+
+    flushSync(() => {
+      capturedOptions?.onMessage?.({ type: 'output', data: chunk });
+      capturedOptions?.onMessage?.({ type: 'output', data: chunk });
+      capturedOptions?.onMessage?.({ type: 'output', data: 'newest' });
+    });
+    render(true);
+
+    const output = resultRef.current?.output ?? '';
+    expect(output).toHaveLength(WORKSPACE_LOG_OUTPUT_MAX_CHARS);
+    expect(output.startsWith(WORKSPACE_LOG_TRUNCATION_MARKER)).toBe(true);
+    expect(output.match(/\[Earlier output truncated\]/g)).toHaveLength(1);
+    expect(output.endsWith('newest')).toBe(true);
+  });
+
+  it('scrolls once on an animation frame after visible output is committed', () => {
+    render(true);
+    attachOutputEndMarker();
+
+    flushSync(() => {
+      capturedOptions?.onMessage?.({ type: 'output', data: 'one\n' });
+      capturedOptions?.onMessage?.({ type: 'output', data: 'two\n' });
+      capturedOptions?.onMessage?.({ type: 'output', data: 'three\n' });
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(requestAnimationFrameMock).toHaveBeenCalledTimes(1);
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+
+    flushSync(() => {
+      runAnimationFrames();
+    });
+    expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'smooth' });
+  });
+
+  it('cancels a pending visible flush when the stream becomes hidden', () => {
+    render(true);
+    flushSync(() => {
+      capturedOptions?.onMessage?.({ type: 'output', data: 'pending\n' });
+    });
+    expect(vi.getTimerCount()).toBe(1);
+
+    render(false);
+    expect(vi.getTimerCount()).toBe(0);
+
+    flushSync(() => {
+      vi.runAllTimers();
+    });
+    expect(resultRef.current?.output).toBe('');
+
+    render(true);
+    expect(resultRef.current?.output).toBe('pending\n');
+  });
+
+  it('cancels pending flush and animation-frame work on unmount', () => {
+    render(true);
+    attachOutputEndMarker();
+    flushSync(() => {
+      capturedOptions?.onMessage?.({ type: 'output', data: 'first\n' });
+      vi.advanceTimersByTime(100);
+      capturedOptions?.onMessage?.({ type: 'output', data: 'second\n' });
+    });
+    expect(vi.getTimerCount()).toBe(1);
+    expect(animationFrames.size).toBe(1);
+
+    unmount();
+
+    expect(vi.getTimerCount()).toBe(0);
+    expect(animationFrames.size).toBe(0);
+    expect(cancelAnimationFrameMock).toHaveBeenCalledTimes(1);
+    flushSync(() => {
+      vi.runAllTimers();
+      runAnimationFrames();
+    });
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+  });
+
+  it('ignores empty and schema-invalid messages', () => {
+    render(true);
+
+    flushSync(() => {
+      capturedOptions?.onMessage?.({ type: 'output', data: '' });
+      capturedOptions?.onMessage?.({ type: 'exit', code: 1 });
+      capturedOptions?.onMessage?.('garbage');
+      vi.runAllTimers();
+    });
+
+    expect(resultRef.current?.output).toBe('');
+    expect(requestAnimationFrameMock).not.toHaveBeenCalled();
   });
 });

--- a/src/components/workspace/use-log-stream.test.tsx
+++ b/src/components/workspace/use-log-stream.test.tsx
@@ -159,6 +159,24 @@ describe('useLogStream', () => {
     expect(capturedOptions?.url).toBe(originalUrl);
   });
 
+  it('ignores stale callbacks after the workspace identity changes', () => {
+    render(true);
+    const staleOptions = capturedOptions;
+
+    render(true, '/dev-logs', 'ws-2');
+    expect(resultRef.current?.output).toBe('');
+    expect(resultRef.current?.hasDisconnected).toBe(false);
+
+    flushSync(() => {
+      staleOptions?.onMessage?.({ type: 'output', data: 'stale workspace output\n' });
+      staleOptions?.onDisconnected?.();
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(resultRef.current?.output).toBe('');
+    expect(resultRef.current?.hasDisconnected).toBe(false);
+  });
+
   it('commits one output update for a high-frequency visible burst', () => {
     render(true);
     const rendersAfterMount = renderCountRef.current;
@@ -261,6 +279,25 @@ describe('useLogStream', () => {
 
     render(true);
     expect(resultRef.current?.output).toBe('pending\n');
+  });
+
+  it('cancels a pending animation frame when the stream becomes hidden', () => {
+    render(true);
+    attachOutputEndMarker();
+    flushSync(() => {
+      capturedOptions?.onMessage?.({ type: 'output', data: 'visible\n' });
+      vi.advanceTimersByTime(100);
+    });
+    expect(animationFrames.size).toBe(1);
+
+    render(false);
+
+    expect(animationFrames.size).toBe(0);
+    expect(cancelAnimationFrameMock).toHaveBeenCalledTimes(1);
+    flushSync(() => {
+      runAnimationFrames();
+    });
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
   });
 
   it('cancels pending flush and animation-frame work on unmount', () => {

--- a/src/components/workspace/use-log-stream.ts
+++ b/src/components/workspace/use-log-stream.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { z } from 'zod';
 import { useWebSocketChannel } from '@/hooks/use-websocket-channel';
 import { buildWebSocketUrl } from '@/lib/websocket-config';
@@ -32,6 +32,16 @@ export interface UseLogStreamResult {
   outputEndRef: React.RefObject<HTMLDivElement | null>;
 }
 
+interface LogStreamBuffer {
+  streamKey: string;
+  output: RollingOutputBuffer;
+}
+
+interface PendingOutputFlush {
+  streamBuffer: LogStreamBuffer;
+  timeoutId: ReturnType<typeof setTimeout>;
+}
+
 // =============================================================================
 // Hook
 // =============================================================================
@@ -58,53 +68,59 @@ export function useLogStream(
   const [hasDisconnected, setHasDisconnected] = useState(false);
   const outputEndRef = useRef<HTMLDivElement | null>(null);
   const visibleRef = useRef(isVisible);
-  const flushTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const presentedBufferRef = useRef<RollingOutputBuffer | null>(null);
-  const streamBufferRef = useRef<{
-    streamKey: string;
-    buffer: RollingOutputBuffer;
-  } | null>(null);
+  const pendingFlushRef = useRef<PendingOutputFlush | null>(null);
   const streamKey = `${endpoint}:${workspaceId}`;
-  if (streamBufferRef.current?.streamKey !== streamKey) {
-    streamBufferRef.current = {
+  const streamBuffer = useMemo<LogStreamBuffer>(
+    () => ({
       streamKey,
-      buffer: new RollingOutputBuffer(LOG_ROLLING_OUTPUT_OPTIONS),
-    };
-  }
-  const buffer = streamBufferRef.current.buffer;
-
-  visibleRef.current = isVisible;
+      output: new RollingOutputBuffer(LOG_ROLLING_OUTPUT_OPTIONS),
+    }),
+    [streamKey]
+  );
+  const committedStreamBufferRef = useRef(streamBuffer);
 
   const url = buildWebSocketUrl(endpoint, { workspaceId });
 
   const cancelPendingFlush = useCallback(() => {
-    if (flushTimeoutRef.current === null) {
+    if (pendingFlushRef.current === null) {
       return;
     }
-    clearTimeout(flushTimeoutRef.current);
-    flushTimeoutRef.current = null;
+    clearTimeout(pendingFlushRef.current.timeoutId);
+    pendingFlushRef.current = null;
   }, []);
 
-  const flushOutput = useCallback(() => {
-    flushTimeoutRef.current = null;
-    if (visibleRef.current) {
-      setOutput(buffer.toString());
-    }
-  }, [buffer]);
-
   const scheduleVisibleFlush = useCallback(() => {
-    if (!visibleRef.current || flushTimeoutRef.current !== null) {
+    if (
+      committedStreamBufferRef.current !== streamBuffer ||
+      !visibleRef.current ||
+      pendingFlushRef.current !== null
+    ) {
       return;
     }
-    flushTimeoutRef.current = setTimeout(flushOutput, LOG_OUTPUT_FLUSH_INTERVAL_MS);
-  }, [flushOutput]);
+    const timeoutId = setTimeout(() => {
+      if (
+        pendingFlushRef.current?.timeoutId !== timeoutId ||
+        pendingFlushRef.current.streamBuffer !== streamBuffer
+      ) {
+        return;
+      }
+      pendingFlushRef.current = null;
+      if (committedStreamBufferRef.current === streamBuffer && visibleRef.current) {
+        setOutput(streamBuffer.output.toString());
+      }
+    }, LOG_OUTPUT_FLUSH_INTERVAL_MS);
+    pendingFlushRef.current = { streamBuffer, timeoutId };
+  }, [streamBuffer]);
 
   const appendOutput = useCallback(
     (next: string) => {
-      buffer.append(next);
+      if (committedStreamBufferRef.current !== streamBuffer) {
+        return;
+      }
+      streamBuffer.output.append(next);
       scheduleVisibleFlush();
     },
-    [buffer, scheduleVisibleFlush]
+    [scheduleVisibleFlush, streamBuffer]
   );
 
   const handleMessage = useCallback(
@@ -117,29 +133,36 @@ export function useLogStream(
   );
 
   const handleConnected = useCallback(() => {
+    if (committedStreamBufferRef.current !== streamBuffer) {
+      return;
+    }
     setHasDisconnected(false);
-    appendOutput(buffer.toString() ? 'Reconnected!\n\n' : 'Connected!\n\n');
-  }, [appendOutput, buffer]);
+    appendOutput(streamBuffer.output.toString() ? 'Reconnected!\n\n' : 'Connected!\n\n');
+  }, [appendOutput, streamBuffer]);
 
   const handleDisconnected = useCallback(() => {
+    if (committedStreamBufferRef.current !== streamBuffer) {
+      return;
+    }
     setHasDisconnected(true);
     appendOutput('Disconnected. Reconnecting...\n');
-  }, [appendOutput]);
+  }, [appendOutput, streamBuffer]);
 
   useLayoutEffect(() => {
-    const bufferChanged = presentedBufferRef.current !== buffer;
-    presentedBufferRef.current = buffer;
+    const bufferChanged = committedStreamBufferRef.current !== streamBuffer;
+    committedStreamBufferRef.current = streamBuffer;
+    visibleRef.current = isVisible;
     cancelPendingFlush();
 
     if (bufferChanged) {
       setHasDisconnected(false);
     }
     if (isVisible) {
-      setOutput(buffer.toString());
+      setOutput(streamBuffer.output.toString());
     } else if (bufferChanged) {
       setOutput('');
     }
-  }, [buffer, cancelPendingFlush, isVisible]);
+  }, [cancelPendingFlush, isVisible, streamBuffer]);
 
   useEffect(
     () => () => {

--- a/src/components/workspace/use-log-stream.ts
+++ b/src/components/workspace/use-log-stream.ts
@@ -1,9 +1,9 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { z } from 'zod';
 import { useWebSocketChannel } from '@/hooks/use-websocket-channel';
 import { buildWebSocketUrl } from '@/lib/websocket-config';
 import {
-  appendToRollingOutput,
+  RollingOutputBuffer,
   WORKSPACE_LOG_OUTPUT_MAX_CHARS,
   WORKSPACE_LOG_TRUNCATION_MARKER,
 } from './rolling-output';
@@ -17,6 +17,7 @@ const LOG_ROLLING_OUTPUT_OPTIONS = {
   maxChars: WORKSPACE_LOG_OUTPUT_MAX_CHARS,
   truncationMarker: WORKSPACE_LOG_TRUNCATION_MARKER,
 };
+const LOG_OUTPUT_FLUSH_INTERVAL_MS = 100;
 
 // =============================================================================
 // Types
@@ -48,47 +49,117 @@ export interface UseLogStreamResult {
  * Uses useWebSocketChannel for schema validation and automatic reconnection
  * with exponential backoff.
  */
-export function useLogStream(endpoint: LogStreamEndpoint, workspaceId: string): UseLogStreamResult {
+export function useLogStream(
+  endpoint: LogStreamEndpoint,
+  workspaceId: string,
+  isVisible: boolean
+): UseLogStreamResult {
   const [output, setOutput] = useState<string>('');
   const [hasDisconnected, setHasDisconnected] = useState(false);
   const outputEndRef = useRef<HTMLDivElement | null>(null);
+  const visibleRef = useRef(isVisible);
+  const flushTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const presentedBufferRef = useRef<RollingOutputBuffer | null>(null);
+  const streamBufferRef = useRef<{
+    streamKey: string;
+    buffer: RollingOutputBuffer;
+  } | null>(null);
+  const streamKey = `${endpoint}:${workspaceId}`;
+  if (streamBufferRef.current?.streamKey !== streamKey) {
+    streamBufferRef.current = {
+      streamKey,
+      buffer: new RollingOutputBuffer(LOG_ROLLING_OUTPUT_OPTIONS),
+    };
+  }
+  const buffer = streamBufferRef.current.buffer;
+
+  visibleRef.current = isVisible;
 
   const url = buildWebSocketUrl(endpoint, { workspaceId });
 
-  const scrollToBottom = useCallback(() => {
-    outputEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  const cancelPendingFlush = useCallback(() => {
+    if (flushTimeoutRef.current === null) {
+      return;
+    }
+    clearTimeout(flushTimeoutRef.current);
+    flushTimeoutRef.current = null;
   }, []);
+
+  const flushOutput = useCallback(() => {
+    flushTimeoutRef.current = null;
+    if (visibleRef.current) {
+      setOutput(buffer.toString());
+    }
+  }, [buffer]);
+
+  const scheduleVisibleFlush = useCallback(() => {
+    if (!visibleRef.current || flushTimeoutRef.current !== null) {
+      return;
+    }
+    flushTimeoutRef.current = setTimeout(flushOutput, LOG_OUTPUT_FLUSH_INTERVAL_MS);
+  }, [flushOutput]);
+
+  const appendOutput = useCallback(
+    (next: string) => {
+      buffer.append(next);
+      scheduleVisibleFlush();
+    },
+    [buffer, scheduleVisibleFlush]
+  );
 
   const handleMessage = useCallback(
     (message: z.infer<typeof LogStreamMessageSchema>) => {
       if (message.data) {
-        setOutput((prev) =>
-          appendToRollingOutput(prev, message.data ?? '', LOG_ROLLING_OUTPUT_OPTIONS)
-        );
-        // Scroll to bottom after a short delay to allow render
-        setTimeout(scrollToBottom, 10);
+        appendOutput(message.data);
       }
     },
-    [scrollToBottom]
+    [appendOutput]
   );
 
   const handleConnected = useCallback(() => {
     setHasDisconnected(false);
-    setOutput((prev) =>
-      appendToRollingOutput(
-        prev,
-        prev ? 'Reconnected!\n\n' : 'Connected!\n\n',
-        LOG_ROLLING_OUTPUT_OPTIONS
-      )
-    );
-  }, []);
+    appendOutput(buffer.toString() ? 'Reconnected!\n\n' : 'Connected!\n\n');
+  }, [appendOutput, buffer]);
 
   const handleDisconnected = useCallback(() => {
     setHasDisconnected(true);
-    setOutput((prev) =>
-      appendToRollingOutput(prev, 'Disconnected. Reconnecting...\n', LOG_ROLLING_OUTPUT_OPTIONS)
-    );
-  }, []);
+    appendOutput('Disconnected. Reconnecting...\n');
+  }, [appendOutput]);
+
+  useLayoutEffect(() => {
+    const bufferChanged = presentedBufferRef.current !== buffer;
+    presentedBufferRef.current = buffer;
+    cancelPendingFlush();
+
+    if (bufferChanged) {
+      setHasDisconnected(false);
+    }
+    if (isVisible) {
+      setOutput(buffer.toString());
+    } else if (bufferChanged) {
+      setOutput('');
+    }
+  }, [buffer, cancelPendingFlush, isVisible]);
+
+  useEffect(
+    () => () => {
+      cancelPendingFlush();
+    },
+    [cancelPendingFlush]
+  );
+
+  useEffect(() => {
+    if (!(isVisible && output)) {
+      return;
+    }
+
+    const animationFrameId = requestAnimationFrame(() => {
+      outputEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    });
+    return () => {
+      cancelAnimationFrame(animationFrameId);
+    };
+  }, [isVisible, output]);
 
   const { connected } = useWebSocketChannel({
     url,


### PR DESCRIPTION
## Summary
- Keep dev and post-run log connections and indicators live while buffering hidden output outside React state.
- Throttle visible output commits to 100 ms, hydrate immediately on tab activation, and scroll once per committed frame.
- Preserve the 512 KiB truncation semantics with a chunked buffer that releases discarded strings.

## Changes
- **Log buffering**: Add a bounded chunk queue that materializes strings only for visible snapshots and clears consumed slots.
- **Presentation lifecycle**: Gate messages, lifecycle callbacks, timers, and scrolling to the committed workspace stream generation.
- **Right panel**: Pass exact active-tab visibility while keeping both WebSocket hooks mounted.
- **Tests**: Cover high-frequency hidden and visible traffic, activation hydration, reconnect messages, truncation, stale workspace callbacks, scrolling, and cleanup.

## Testing
- [x] Tests pass (`NODE_ENV=test pnpm test` — 3,838 passed, 3 skipped)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting passes (`pnpm check:fix`; six pre-existing `<img>` performance warnings)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: profile a noisy dev or post-run stream while viewing Terminal, then switch to its log tab and confirm buffered output appears immediately.

Closes #1948

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live log streaming and React update timing in the workspace panel; behavior is heavily tested but regressions could affect log display, scrolling, or connection indicators when switching tabs.
> 
> **Overview**
> **Throttles workspace log UI work** while dev and post-run WebSockets stay connected and tab indicators stay live.
> 
> Adds **`RollingOutputBuffer`** so log text accumulates in a bounded chunk queue outside React, keeping the existing 512 KiB cap and truncation marker without rebuilding the full string on every chunk. **`useLogStream`** now takes **`isVisible`**: hidden streams append to the buffer only (no React output updates, no scroll); visible streams flush to state at most every **100 ms** and scroll once per commit via **`requestAnimationFrame`**. Showing a tab **hydrates** buffered output immediately without reconnecting. **`right-panel`** passes visibility from the active bottom tab while both hooks remain mounted.
> 
> Tests cover buffer truncation, hidden/visible bursts, lifecycle buffering, stale workspace callbacks, and timer/rAF cleanup. Design/plan docs are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee10f4f39e0e238212ed606e3177711f10b426ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

