### PR TITLE
Fix #1949: Prune archived workspace caches

### DIFF
--- a/docs/superpowers/plans/2026-07-17-workspace-cache-retention.md
+++ b/docs/superpowers/plans/2026-07-17-workspace-cache-retention.md
@@ -1,0 +1,229 @@
+# Workspace Cache Retention Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bound workspace-scoped in-memory retention and make archive/delete cleanup explicit, idempotent, and reconciliation-safe.
+
+**Architecture:** The event collector owns one workspace cleanup hook because it contains the only collector-local cache. Snapshot tombstones retain logical ordering for ten minutes with physical timer-based expiry; PR and idle refresh registries use explicit removal plus TTL/cap pruning because they are optimization-only.
+
+**Tech Stack:** TypeScript, Node.js timers/EventEmitter, Vitest, Express/tRPC orchestration.
+
+## Global Constraints
+
+- Snapshot removal grace is exactly `10 * 60_000` milliseconds.
+- Abandoned PR in-flight claims expire after exactly `10 * 60_000` milliseconds.
+- Optimization-only workspace registries track at most `1_024` workspaces.
+- Cleanup is idempotent and safe for missing workspace entries.
+- A reconciliation begun before archive cannot recreate a snapshot during the grace window.
+- A valid update newer than removal is accepted immediately.
+- Existing service-capsule barrel import boundaries remain intact.
+
+---
+
+### Task 1: Bound Snapshot Removal Tombstones
+
+**Files:**
+- Modify: `src/backend/services/constants.ts`
+- Modify: `src/backend/services/workspace-snapshot-store.service.ts`
+- Test: `src/backend/services/workspace-snapshot-store.service.test.ts`
+
+**Interfaces:**
+- Consumes: `SERVICE_CACHE_TTL_MS.workspaceSnapshotRemovalGrace`.
+- Produces: `WorkspaceSnapshotStore.removalTombstoneCount(): number` and timer-backed bounded retention behind the existing `remove`/`upsert` API.
+
+- [ ] **Step 1: Write failing tombstone retention tests**
+
+```ts
+it('expires removal protection after the configured grace period', () => {
+  vi.setSystemTime(1_000);
+  store.remove('ws-1', 900);
+  vi.advanceTimersByTime(10 * 60_000);
+  expect(store.removalTombstoneCount()).toBe(0);
+});
+
+it('repeated removal preserves the newest logical timestamp', () => {
+  store.remove('ws-1', 200);
+  store.remove('ws-1', 150);
+  store.upsert('ws-1', makeUpdate(), 'reconciliation', 175);
+  expect(store.getByWorkspaceId('ws-1')).toBeUndefined();
+});
+```
+
+- [ ] **Step 2: Run the focused test and confirm RED**
+
+Run: `pnpm exec vitest run src/backend/services/workspace-snapshot-store.service.test.ts`
+
+Expected: failure because `removalTombstoneCount` and expiry do not exist.
+
+- [ ] **Step 3: Implement timer-backed tombstones**
+
+```ts
+type RemovalTombstone = { removedAt: number; expiresAt: number; timer: NodeJS.Timeout };
+
+private clearRemovalTombstone(workspaceId: string): void {
+  const tombstone = this.removalTimestamps.get(workspaceId);
+  if (tombstone) clearTimeout(tombstone.timer);
+  this.removalTimestamps.delete(workspaceId);
+}
+```
+
+On removal, retain the maximum `removedAt`, schedule an unref'd expiry timer for the configured grace, and replace the prior timer. On newer upsert or `clear()`, cancel the timer before deleting metadata.
+
+- [ ] **Step 4: Run the focused test and confirm GREEN**
+
+Run: `pnpm exec vitest run src/backend/services/workspace-snapshot-store.service.test.ts`
+
+Expected: all snapshot-store tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/backend/services/constants.ts src/backend/services/workspace-snapshot-store.service.ts src/backend/services/workspace-snapshot-store.service.test.ts
+git commit -m "Bound snapshot removal tombstones (#1949)"
+```
+
+### Task 2: Bound the PR Fetch Registry
+
+**Files:**
+- Modify: `src/backend/services/github/service/pr-fetch-registry.ts`
+- Create: `src/backend/services/github/service/pr-fetch-registry.test.ts`
+
+**Interfaces:**
+- Consumes: `SERVICE_LIMITS.workspaceScopedCacheMaxEntries` and `SERVICE_CACHE_TTL_MS.workspacePrFetchInFlight`.
+- Produces: exported `PRFetchRegistry`, `removeWorkspace(workspaceId): void`, and `size(): { completed: number; inFlight: number }`.
+
+- [ ] **Step 1: Write failing registry tests**
+
+```ts
+it('removes completed and in-flight entries for one workspace', () => {
+  registry.startFetch('ws-1');
+  registry.register('ws-1');
+  registry.startFetch('ws-2');
+  registry.removeWorkspace('ws-1');
+  registry.removeWorkspace('ws-2');
+  expect(registry.size()).toEqual({ completed: 0, inFlight: 0 });
+});
+
+it('does not record a completion after workspace cleanup', () => {
+  registry.startFetch('ws-1');
+  registry.removeWorkspace('ws-1');
+  registry.register('ws-1');
+  expect(registry.size()).toEqual({ completed: 0, inFlight: 0 });
+});
+```
+
+Also cover missing/repeated removal, cooldown expiry, abandoned in-flight expiry, capacity eviction, and reuse after cleanup.
+
+- [ ] **Step 2: Run the focused test and confirm RED**
+
+Run: `pnpm exec vitest run src/backend/services/github/service/pr-fetch-registry.test.ts`
+
+Expected: import/API failures because the class and per-workspace methods are unavailable.
+
+- [ ] **Step 3: Implement TTL/cap pruning and removal**
+
+Use timestamp maps for completed and in-flight entries. Prune expired entries before reads/writes, evict the oldest entry when inserting a new workspace at the 1,024-entry cap, and only register a successful completion if an in-flight claim was removed.
+
+- [ ] **Step 4: Run the focused test and confirm GREEN**
+
+Run: `pnpm exec vitest run src/backend/services/github/service/pr-fetch-registry.test.ts`
+
+Expected: all PR registry tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/backend/services/github/service/pr-fetch-registry.ts src/backend/services/github/service/pr-fetch-registry.test.ts
+git commit -m "Bound PR fetch registry retention (#1949)"
+```
+
+### Task 3: Centralize Workspace Cache Cleanup
+
+**Files:**
+- Modify: `src/backend/orchestration/event-collector.orchestrator.ts`
+- Modify: `src/backend/orchestration/event-collector.orchestrator.test.ts`
+- Modify: `src/backend/orchestration/workspace-archive.orchestrator.ts`
+- Modify: `src/backend/orchestration/workspace-archive.orchestrator.test.ts`
+- Modify: `src/backend/trpc/workspace.trpc.ts`
+- Modify: `src/backend/trpc/workspace.router.test.ts`
+
+**Interfaces:**
+- Consumes: `prFetchRegistry.removeWorkspace`, `workspaceSnapshotStore.remove`, and `workspaceActivityService.clearWorkspace`.
+- Produces: `EventCoalescer.removeWorkspace(workspaceId): void`, `EventCollectorOrchestrator.removeWorkspace(workspaceId): void`, and `cleanupWorkspaceScopedCaches(workspaceId): void`.
+
+- [ ] **Step 1: Write failing cleanup integration tests**
+
+```ts
+it('cancels a pending update for an archived workspace', () => {
+  coalescer.enqueue('ws-1', makeFields(), 'test');
+  coalescer.removeWorkspace('ws-1');
+  vi.advanceTimersByTime(150);
+  expect(mockStore.upsert).not.toHaveBeenCalled();
+});
+```
+
+Extend archive-event tests to assert PR-fetch and idle-throttle eviction. Extend archive completion and delete tests to assert the exported hook runs after successful persistence and remains safe when also invoked by the state event.
+
+- [ ] **Step 2: Run the focused tests and confirm RED**
+
+Run: `pnpm exec vitest run src/backend/orchestration/event-collector.orchestrator.test.ts src/backend/orchestration/workspace-archive.orchestrator.test.ts src/backend/trpc/workspace.router.test.ts`
+
+Expected: failures because the central cleanup APIs and calls do not exist.
+
+- [ ] **Step 3: Implement the central hook and defensive idle pruning**
+
+Move idle-refresh timestamps into `EventCollectorState`. Before each idle refresh, delete entries at least 30 seconds old and enforce the 1,024-entry cap. `removeWorkspace` cancels coalescer state, removes the idle timestamp, and clears snapshot, activity, and PR registry state. Call the default wrapper from the ARCHIVED listener, after `markArchived()`, and after successful database deletion.
+
+- [ ] **Step 4: Run the focused tests and confirm GREEN**
+
+Run: `pnpm exec vitest run src/backend/orchestration/event-collector.orchestrator.test.ts src/backend/orchestration/workspace-archive.orchestrator.test.ts src/backend/trpc/workspace.router.test.ts`
+
+Expected: all focused cleanup tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/backend/orchestration/event-collector.orchestrator.ts src/backend/orchestration/event-collector.orchestrator.test.ts src/backend/orchestration/workspace-archive.orchestrator.ts src/backend/orchestration/workspace-archive.orchestrator.test.ts src/backend/trpc/workspace.trpc.ts src/backend/trpc/workspace.router.test.ts
+git commit -m "Centralize workspace cache cleanup (#1949)"
+```
+
+### Task 4: Verify, Review, and Publish
+
+**Files:**
+- Modify only files required by formatter or review findings.
+
+**Interfaces:**
+- Consumes: all prior task behavior and issue #1949 acceptance criteria.
+- Produces: a clean branch and GitHub pull request closing #1949.
+
+- [ ] **Step 1: Run focused regression tests**
+
+Run: `pnpm exec vitest run src/backend/services/workspace-snapshot-store.service.test.ts src/backend/services/github/service/pr-fetch-registry.test.ts src/backend/orchestration/event-collector.orchestrator.test.ts src/backend/orchestration/workspace-archive.orchestrator.test.ts src/backend/trpc/workspace.router.test.ts`
+
+Expected: all focused tests pass.
+
+- [ ] **Step 2: Run repository verification**
+
+Run: `pnpm typecheck && pnpm check:fix && pnpm test && pnpm build`
+
+Expected: every command exits zero; inspect formatter changes before staging.
+
+- [ ] **Step 3: Review the full branch diff**
+
+Run: `git diff origin/main` and `git status --short --branch`.
+
+Expected: only issue-scoped code/tests/docs are present, with no debug output or unrelated edits.
+
+- [ ] **Step 4: Request a whole-branch code review and fix blocking findings**
+
+Review from `git merge-base origin/main HEAD` through `HEAD` against the design and acceptance criteria. Re-run covering tests for every fix.
+
+- [ ] **Step 5: Push and create the pull request**
+
+```bash
+git push -u origin HEAD
+gh pr create --title "Fix #1949: Prune archived workspace caches" --body-file /tmp/pr-body.md
+gh pr view --json url,title,state
+```
+
+Expected: GitHub returns the created pull request URL.

--- a/docs/superpowers/specs/2026-07-17-workspace-cache-retention-design.md
+++ b/docs/superpowers/specs/2026-07-17-workspace-cache-retention-design.md
@@ -18,7 +18,7 @@ The ARCHIVED state listener will call that hook immediately. `completeArchive()`
 
 `WorkspaceSnapshotStore` will store tombstone metadata containing the logical removal timestamp and a wall-clock expiration. A per-tombstone unref'd timer removes it after `SERVICE_CACHE_TTL_MS.workspaceSnapshotRemovalGrace` (ten minutes). A newer upsert clears the tombstone and its timer immediately. Repeated removal keeps the greatest logical removal timestamp and refreshes the grace period, so an older duplicate cannot weaken protection. `clear()` cancels every timer.
 
-`PRFetchRegistry` will expose `removeWorkspace`, prune completed timestamps after their cooldown, prune abandoned in-flight claims after ten minutes, and cap optimization-only tracking at 1,024 workspaces. Successful completion will only be recorded when an in-flight claim still exists, so a fetch that completes after archive cleanup cannot recreate a completed-fetch entry. Idle-refresh timestamps use their existing 30-second cooldown as a TTL and the same 1,024-entry defensive cap.
+`PRFetchRegistry` will expose `removeWorkspace`, prune abandoned in-flight claims after ten minutes, and cap optimization-only tracking at 1,024 workspaces. Completed timestamps are not age-pruned because `isRecentlyFetched` supports arbitrary caller cooldowns; they are bounded by explicit workspace cleanup and oldest-timestamp eviction at capacity. Successful completion will only be recorded when the matching in-flight claim still exists, so a fetch that completes after archive cleanup cannot consume a newer claim or recreate a completed-fetch entry. Idle-refresh timestamps use their existing 30-second cooldown as a TTL and the same 1,024-entry defensive cap.
 
 ## Safety and Reuse
 

--- a/docs/superpowers/specs/2026-07-17-workspace-cache-retention-design.md
+++ b/docs/superpowers/specs/2026-07-17-workspace-cache-retention-design.md
@@ -1,0 +1,34 @@
+# Workspace Cache Retention Design
+
+## Problem
+
+Workspace archive currently removes the visible snapshot and activity state through the event collector, but it leaves three process-lifetime collections behind: snapshot removal tombstones, completed PR-fetch timestamps, and idle PR-refresh timestamps. Deletion follows a separate cleanup path. A pending coalesced update can also flush after archive with a new wall-clock timestamp and bypass the snapshot tombstone.
+
+## Approaches Considered
+
+1. **Bounded tombstones plus one archive cleanup hook (chosen).** Keep timestamp ordering for reconciliation safety, expire tombstones after a ten-minute grace period, and explicitly evict every workspace-scoped optimization cache through one idempotent hook. This is narrowly scoped and preserves the existing reconciliation contract.
+2. **Generations across all workspace updates.** Give every workspace lifecycle and asynchronous operation an incarnation token. This is the strongest reuse model, but it would change event, reconciliation, GitHub-fetch, and session-summary APIs for a cache-retention fix.
+3. **Periodic global sweepers only.** Run background jobs over all maps. This bounds retention eventually, but adds timers and lifecycle management while leaving archive cleanup delayed and the coalescer resurrection race unresolved.
+
+## Design
+
+`EventCollectorOrchestrator` will own the central `removeWorkspace(workspaceId)` operation because it owns the collector-local idle throttle and coalescer. The operation will cancel a pending coalesced update, delete the idle-refresh timestamp, remove the snapshot, clear workspace activity, and call `prFetchRegistry.removeWorkspace`. The default collector exposes this as `cleanupWorkspaceScopedCaches(workspaceId)`.
+
+The ARCHIVED state listener will call that hook immediately. `completeArchive()` will call it again after `markArchived()` so archive cleanup remains reliable when the collector is not configured; the double call is intentionally idempotent. The delete mutation will call the same hook after the database deletion succeeds. Runtime and worktree cleanup remain in their existing orchestration paths.
+
+`WorkspaceSnapshotStore` will store tombstone metadata containing the logical removal timestamp and a wall-clock expiration. A per-tombstone unref'd timer removes it after `SERVICE_CACHE_TTL_MS.workspaceSnapshotRemovalGrace` (ten minutes). A newer upsert clears the tombstone and its timer immediately. Repeated removal keeps the greatest logical removal timestamp and refreshes the grace period, so an older duplicate cannot weaken protection. `clear()` cancels every timer.
+
+`PRFetchRegistry` will expose `removeWorkspace`, prune completed timestamps after their cooldown, prune abandoned in-flight claims after ten minutes, and cap optimization-only tracking at 1,024 workspaces. Successful completion will only be recorded when an in-flight claim still exists, so a fetch that completes after archive cleanup cannot recreate a completed-fetch entry. Idle-refresh timestamps use their existing 30-second cooldown as a TTL and the same 1,024-entry defensive cap.
+
+## Safety and Reuse
+
+- Reconciliation uses its poll-start timestamp. An archive tombstone therefore rejects a pass that began before archive throughout the grace window.
+- A valid update with a timestamp newer than removal is accepted immediately and clears the tombstone, supporting deliberate ID recreation.
+- After grace expiry, the tombstone is physically removed even if no later operation touches the store.
+- Missing and repeated cleanup calls are no-ops except for refreshing the bounded protection window.
+- Canceling the coalescer before removing the snapshot prevents queued pre-archive events from flushing afterward.
+- PR and idle registries are correctness-neutral optimizations; TTL/cap eviction may cause an extra refresh but cannot corrupt persisted state.
+
+## Testing
+
+Focused tests will cover archive during reconciliation, repeated and missing removals, timer expiry, newer updates, clearing timers, PR completed/in-flight eviction, stale completion after cleanup, TTL/cap bounds, idle-throttle eviction, pending coalescer cancellation, explicit archive cleanup, and deletion cleanup. Full typecheck, formatting, test, and build commands will run before publication.

--- a/src/backend/orchestration/domain-bridges.orchestrator.test.ts
+++ b/src/backend/orchestration/domain-bridges.orchestrator.test.ts
@@ -291,10 +291,11 @@ describe('configureDomainBridges', () => {
     });
 
     it('github bridge delegates startFetch to prFetchRegistry', () => {
+      vi.mocked(prFetchRegistry.startFetch).mockReturnValue(41);
       configureDomainBridges();
       const bridge = getBridge(ratchetService.configure);
 
-      bridge.github.startFetch('ws1');
+      expect(bridge.github.startFetch('ws1')).toBe(41);
       expect(prFetchRegistry.startFetch).toHaveBeenCalledWith('ws1');
     });
 
@@ -320,16 +321,16 @@ describe('configureDomainBridges', () => {
       configureDomainBridges();
       const bridge = getBridge(ratchetService.configure);
 
-      bridge.github.registerFetch('ws1');
-      expect(prFetchRegistry.register).toHaveBeenCalledWith('ws1');
+      bridge.github.registerFetch('ws1', 41);
+      expect(prFetchRegistry.register).toHaveBeenCalledWith('ws1', 41);
     });
 
     it('github bridge delegates cancelFetch to prFetchRegistry', () => {
       configureDomainBridges();
       const bridge = getBridge(ratchetService.configure);
 
-      bridge.github.cancelFetch('ws1');
-      expect(prFetchRegistry.cancelFetch).toHaveBeenCalledWith('ws1');
+      bridge.github.cancelFetch('ws1', 41);
+      expect(prFetchRegistry.cancelFetch).toHaveBeenCalledWith('ws1', 41);
     });
   });
 

--- a/src/backend/orchestration/domain-bridges.orchestrator.ts
+++ b/src/backend/orchestration/domain-bridges.orchestrator.ts
@@ -211,8 +211,8 @@ export function configureDomainBridges(services: Partial<BridgeServices> = {}): 
     isRecentlyFetched: (workspaceId) => prFetchRegistry.isRecentlyFetched(workspaceId),
     isFetchInFlight: (workspaceId) => prFetchRegistry.isFetchInFlight(workspaceId),
     startFetch: (workspaceId) => prFetchRegistry.startFetch(workspaceId),
-    registerFetch: (workspaceId) => prFetchRegistry.register(workspaceId),
-    cancelFetch: (workspaceId) => prFetchRegistry.cancelFetch(workspaceId),
+    registerFetch: (workspaceId, claimToken) => prFetchRegistry.register(workspaceId, claimToken),
+    cancelFetch: (workspaceId, claimToken) => prFetchRegistry.cancelFetch(workspaceId, claimToken),
   };
 
   const ratchetSnapshotBridge: RatchetPRSnapshotBridge = {

--- a/src/backend/orchestration/event-collector.orchestrator.test.ts
+++ b/src/backend/orchestration/event-collector.orchestrator.test.ts
@@ -34,6 +34,9 @@ vi.mock('@/backend/services/workspace', () => ({
 
 vi.mock('@/backend/services/github', () => ({
   PR_SNAPSHOT_UPDATED: 'pr_snapshot_updated',
+  prFetchRegistry: {
+    removeWorkspace: vi.fn(),
+  },
   prSnapshotService: {
     on: vi.fn(),
     refreshWorkspace: vi.fn().mockResolvedValue({ success: false, reason: 'no_pr_url' }),
@@ -102,7 +105,7 @@ vi.mock('@/backend/services/logger.service', () => ({
   }),
 }));
 
-import { prSnapshotService } from '@/backend/services/github';
+import { prFetchRegistry, prSnapshotService } from '@/backend/services/github';
 import { ratchetService } from '@/backend/services/ratchet';
 import { runScriptStateMachine } from '@/backend/services/run-script';
 import {
@@ -309,6 +312,18 @@ describe('EventCoalescer', () => {
     );
     expect(coalescer.pendingCount).toBe(0);
   });
+
+  it('cancels a pending update for an archived workspace', () => {
+    const coalescer = new EventCoalescer(mockStore, 150);
+
+    coalescer.enqueue('ws-1', { isWorking: true }, 'test');
+    coalescer.removeWorkspace('ws-1');
+    vi.advanceTimersByTime(150);
+
+    expect(mockStore.remove).toHaveBeenCalledWith('ws-1');
+    expect(mockStore.upsert).not.toHaveBeenCalled();
+    expect(coalescer.pendingCount).toBe(0);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -499,8 +514,15 @@ describe('configureEventCollector', () => {
     expect(sessionDomainService.off).toHaveBeenCalledWith('runtime_changed', expect.any(Function));
   });
 
-  it('ARCHIVED workspace event removes snapshot and cleans up workspace resources immediately', async () => {
+  it('ARCHIVED workspace event evicts all scoped caches and cleans up resources immediately', async () => {
     configureEventCollector();
+
+    const idleCall = vi
+      .mocked(workspaceActivityService.on)
+      .mock.calls.find((call) => call[0] === 'workspace_idle');
+    const idleHandler = idleCall![1] as (event: { workspaceId: string }) => void;
+    idleHandler({ workspaceId: 'ws-archived' });
+    vi.mocked(workspaceSnapshotStore.upsert).mockClear();
 
     // Get the workspace state changed handler
     const onCall = vi
@@ -518,9 +540,13 @@ describe('configureEventCollector', () => {
     // store.remove() called immediately, not through coalescer
     expect(workspaceSnapshotStore.remove).toHaveBeenCalledWith('ws-archived');
     expect(workspaceActivityService.clearWorkspace).toHaveBeenCalledWith('ws-archived');
+    expect(prFetchRegistry.removeWorkspace).toHaveBeenCalledWith('ws-archived');
     expect(sessionService.stopWorkspaceSessions).toHaveBeenCalledWith('ws-archived');
     expect(terminalService.destroyWorkspaceTerminals).toHaveBeenCalledWith('ws-archived');
     expect(workspaceSnapshotStore.upsert).not.toHaveBeenCalled();
+
+    idleHandler({ workspaceId: 'ws-archived' });
+    expect(prSnapshotService.refreshWorkspace).toHaveBeenCalledTimes(2);
   });
 
   it('non-ARCHIVED workspace event is applied immediately', () => {
@@ -1062,6 +1088,22 @@ describe('configureEventCollector', () => {
     );
     expect(prSnapshotService.refreshWorkspace).toHaveBeenCalledWith('ws-1');
     expect(sessionDataService.findAgentSessionsByWorkspaceId).not.toHaveBeenCalled();
+  });
+
+  it('bounds idle refresh timestamps and evicts the oldest workspace at capacity', () => {
+    configureEventCollector();
+
+    const onCall = vi
+      .mocked(workspaceActivityService.on)
+      .mock.calls.find((call) => call[0] === 'workspace_idle');
+    const handler = onCall![1] as (event: { workspaceId: string }) => void;
+
+    for (let index = 0; index <= 1024; index += 1) {
+      handler({ workspaceId: `ws-${index}` });
+    }
+    handler({ workspaceId: 'ws-0' });
+
+    expect(prSnapshotService.refreshWorkspace).toHaveBeenCalledTimes(1026);
   });
 
   it('workspace active transition performs one session summary query', () => {

--- a/src/backend/orchestration/event-collector.orchestrator.test.ts
+++ b/src/backend/orchestration/event-collector.orchestrator.test.ts
@@ -1090,6 +1090,24 @@ describe('configureEventCollector', () => {
     expect(sessionDataService.findAgentSessionsByWorkspaceId).not.toHaveBeenCalled();
   });
 
+  it('suppresses idle PR refresh before 30 seconds and allows it at the boundary', () => {
+    configureEventCollector();
+
+    const onCall = vi
+      .mocked(workspaceActivityService.on)
+      .mock.calls.find((call) => call[0] === 'workspace_idle');
+    const handler = onCall![1] as (event: { workspaceId: string }) => void;
+
+    handler({ workspaceId: 'ws-1' });
+    vi.advanceTimersByTime(29_999);
+    handler({ workspaceId: 'ws-1' });
+    expect(prSnapshotService.refreshWorkspace).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(1);
+    handler({ workspaceId: 'ws-1' });
+    expect(prSnapshotService.refreshWorkspace).toHaveBeenCalledTimes(2);
+  });
+
   it('bounds idle refresh timestamps and evicts the oldest workspace at capacity', () => {
     configureEventCollector();
 

--- a/src/backend/orchestration/event-collector.orchestrator.ts
+++ b/src/backend/orchestration/event-collector.orchestrator.ts
@@ -20,9 +20,11 @@ import {
   buildWorkspaceSessionSummaries,
   hasWorkingSessionSummary,
 } from '@/backend/lib/session-summaries';
+import { SERVICE_LIMITS } from '@/backend/services/constants';
 import {
   PR_SNAPSHOT_UPDATED,
   type PRSnapshotUpdatedEvent,
+  prFetchRegistry,
   prSnapshotService,
 } from '@/backend/services/github';
 import { linearStateSyncService } from '@/backend/services/linear';
@@ -243,6 +245,18 @@ export class EventCoalescer {
   }
 
   /**
+   * Cancel pending work and remove the workspace snapshot immediately.
+   */
+  removeWorkspace(workspaceId: string): void {
+    const pending = this.pending.get(workspaceId);
+    if (pending?.timer) {
+      clearTimeout(pending.timer);
+    }
+    this.pending.delete(workspaceId);
+    this.store.remove(workspaceId);
+  }
+
+  /**
    * Number of workspaces with pending updates (for testing).
    */
   get pendingCount(): number {
@@ -256,10 +270,22 @@ export class EventCoalescer {
 
 class EventCollectorState {
   activeCoalescer: EventCoalescer | null = null;
+  lastIdlePrRefreshByWorkspace = new Map<string, number>();
   pendingRequestChangedHandler: ((event: PendingRequestChangedEvent) => void) | null = null;
   runtimeChangedHandler: ((event: { sessionId: string }) => void) | null = null;
   eventCollectorSessionServices: EventCollectorSessionServices = defaultSessionServices;
   listenerSessionDomainService: EventCollectorSessionServices['sessionDomainService'] | null = null;
+}
+
+function removeWorkspaceWithState(state: EventCollectorState, workspaceId: string): void {
+  if (state.activeCoalescer) {
+    state.activeCoalescer.removeWorkspace(workspaceId);
+  } else {
+    workspaceSnapshotStore.remove(workspaceId);
+  }
+  state.lastIdlePrRefreshByWorkspace.delete(workspaceId);
+  workspaceActivityService.clearWorkspace(workspaceId);
+  prFetchRegistry.removeWorkspace(workspaceId);
 }
 
 async function refreshWorkspaceSessionSummaries(
@@ -443,15 +469,31 @@ function configureEventCollectorWithState(
   };
   const coalescer = new EventCoalescer(workspaceSnapshotStore);
   state.activeCoalescer = coalescer;
-  const lastIdlePrRefreshByWorkspace = new Map<string, number>();
+  state.lastIdlePrRefreshByWorkspace.clear();
 
   const refreshPrSnapshotOnIdle = (workspaceId: string): void => {
     const now = Date.now();
-    const lastRefresh = lastIdlePrRefreshByWorkspace.get(workspaceId) ?? 0;
+    for (const [cachedWorkspaceId, refreshedAt] of state.lastIdlePrRefreshByWorkspace) {
+      if (now - refreshedAt >= IDLE_PR_REFRESH_COOLDOWN_MS) {
+        state.lastIdlePrRefreshByWorkspace.delete(cachedWorkspaceId);
+      }
+    }
+
+    const lastRefresh = state.lastIdlePrRefreshByWorkspace.get(workspaceId) ?? 0;
     if (now - lastRefresh < IDLE_PR_REFRESH_COOLDOWN_MS) {
       return;
     }
-    lastIdlePrRefreshByWorkspace.set(workspaceId, now);
+
+    if (
+      !state.lastIdlePrRefreshByWorkspace.has(workspaceId) &&
+      state.lastIdlePrRefreshByWorkspace.size >= SERVICE_LIMITS.workspaceScopedCacheMaxEntries
+    ) {
+      const oldestWorkspaceId = state.lastIdlePrRefreshByWorkspace.keys().next().value;
+      if (oldestWorkspaceId !== undefined) {
+        state.lastIdlePrRefreshByWorkspace.delete(oldestWorkspaceId);
+      }
+    }
+    state.lastIdlePrRefreshByWorkspace.set(workspaceId, now);
 
     void prSnapshotService
       .refreshWorkspace(workspaceId)
@@ -476,8 +518,7 @@ function configureEventCollectorWithState(
   workspaceStateMachine.on(WORKSPACE_STATE_CHANGED, (event: WorkspaceStateChangedEvent) => {
     if (event.toStatus === 'ARCHIVED') {
       // Immediate removal for UI feedback -- no coalescing delay
-      workspaceSnapshotStore.remove(event.workspaceId);
-      workspaceActivityService.clearWorkspace(event.workspaceId);
+      removeWorkspaceWithState(state, event.workspaceId);
       void Promise.allSettled([
         state.eventCollectorSessionServices.sessionService.stopWorkspaceSessions(event.workspaceId),
         Promise.resolve().then(() => {
@@ -693,6 +734,7 @@ function stopEventCollectorWithState(state: EventCollectorState): void {
   if (state.activeCoalescer) {
     state.activeCoalescer.flushAll();
     state.activeCoalescer = null;
+    state.lastIdlePrRefreshByWorkspace.clear();
     logger.info('Event collector stopped');
   }
 }
@@ -706,6 +748,10 @@ export class EventCollectorOrchestrator {
 
   stop(): void {
     stopEventCollectorWithState(this.state);
+  }
+
+  removeWorkspace(workspaceId: string): void {
+    removeWorkspaceWithState(this.state, workspaceId);
   }
 }
 
@@ -723,4 +769,8 @@ export function configureEventCollector(
 
 export function stopEventCollector(): void {
   defaultEventCollectorOrchestrator.stop();
+}
+
+export function cleanupWorkspaceScopedCaches(workspaceId: string): void {
+  defaultEventCollectorOrchestrator.removeWorkspace(workspaceId);
 }

--- a/src/backend/orchestration/scheduler.service.test.ts
+++ b/src/backend/orchestration/scheduler.service.test.ts
@@ -26,7 +26,7 @@ vi.mock('@/backend/services/github', () => ({
   },
   prFetchRegistry: {
     isRecentlyFetched: () => false,
-    startFetch: vi.fn(),
+    startFetch: vi.fn(() => 41),
     cancelFetch: vi.fn(),
     register: vi.fn(),
   },
@@ -41,6 +41,7 @@ vi.mock('@/backend/services/logger.service', () => ({
   }),
 }));
 
+import { prFetchRegistry } from '@/backend/services/github';
 import { schedulerService } from './scheduler.service';
 
 function createDeferred<T>() {
@@ -89,6 +90,9 @@ describe('SchedulerService', () => {
 
       expect(result).toEqual({ synced: 2, failed: 0 });
       expect(mockRefreshWorkspace).toHaveBeenCalledTimes(2);
+      expect(prFetchRegistry.startFetch).toHaveBeenCalledTimes(2);
+      expect(prFetchRegistry.register).toHaveBeenNthCalledWith(1, 'ws-1', 41);
+      expect(prFetchRegistry.register).toHaveBeenNthCalledWith(2, 'ws-2', 41);
     });
 
     it('counts failed syncs', async () => {
@@ -102,6 +106,7 @@ describe('SchedulerService', () => {
       const result = await schedulerService.syncPRStatuses();
 
       expect(result).toEqual({ synced: 0, failed: 2 });
+      expect(prFetchRegistry.cancelFetch).toHaveBeenCalledWith('ws-1', 41);
     });
   });
 

--- a/src/backend/orchestration/scheduler.service.ts
+++ b/src/backend/orchestration/scheduler.service.ts
@@ -222,16 +222,16 @@ class SchedulerService {
 
     // Claim the workspace synchronously before yielding to the event loop so that
     // concurrent callers see it as in-flight and skip their own redundant fetches.
-    prFetchRegistry.startFetch(workspaceId);
+    const claimToken = prFetchRegistry.startFetch(workspaceId);
     try {
       const prResult = await prSnapshotService.refreshWorkspace(workspaceId, prUrl);
       if (!prResult.success) {
         logger.warn('Failed to fetch PR status', { workspaceId, prUrl });
-        prFetchRegistry.cancelFetch(workspaceId);
+        prFetchRegistry.cancelFetch(workspaceId, claimToken);
         return { success: false, reason: 'fetch_failed' };
       }
 
-      prFetchRegistry.register(workspaceId);
+      prFetchRegistry.register(workspaceId, claimToken);
 
       logger.debug('PR status synced', {
         workspaceId,
@@ -242,7 +242,7 @@ class SchedulerService {
 
       return { success: true };
     } catch (error) {
-      prFetchRegistry.cancelFetch(workspaceId);
+      prFetchRegistry.cancelFetch(workspaceId, claimToken);
       logger.error('PR sync failed for workspace', toError(error), { workspaceId, prUrl });
       return { success: false, reason: 'error' };
     }

--- a/src/backend/orchestration/workspace-archive.orchestrator.test.ts
+++ b/src/backend/orchestration/workspace-archive.orchestrator.test.ts
@@ -3,6 +3,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { unsafeCoerce } from '@/test-utils/unsafe-coerce';
 import type { WorkspaceWithProject } from './types';
 
+const mockCleanupWorkspaceScopedCaches = vi.hoisted(() => vi.fn());
+
+vi.mock('./event-collector.orchestrator', () => ({
+  cleanupWorkspaceScopedCaches: (...args: unknown[]) => mockCleanupWorkspaceScopedCaches(...args),
+}));
+
 vi.mock('./workspace-children.orchestrator', () => ({
   fireLifecycleNotification: vi.fn().mockResolvedValue(undefined),
 }));
@@ -168,6 +174,18 @@ describe('archiveWorkspace', () => {
       expect(workspaceStateMachine.startArchivingWithSourceStatus).toHaveBeenCalledWith('ws-1');
       expect(workspaceStateMachine.markArchived).toHaveBeenCalledWith('ws-1');
       expect(services.runScriptService.evictWorkspaceBuffers).toHaveBeenCalledWith('ws-1');
+    });
+
+    it('cleans workspace caches after the archived state is persisted', async () => {
+      await archiveWorkspace(makeWorkspace(), defaultOptions);
+
+      expect(mockCleanupWorkspaceScopedCaches).toHaveBeenCalledWith('ws-1');
+      const archivedCallOrder = vi.mocked(workspaceStateMachine.markArchived).mock
+        .invocationCallOrder[0];
+      const cleanupCallOrder = mockCleanupWorkspaceScopedCaches.mock.invocationCallOrder[0];
+      expect(archivedCallOrder).toBeDefined();
+      expect(cleanupCallOrder).toBeDefined();
+      expect(cleanupCallOrder!).toBeGreaterThan(archivedCallOrder!);
     });
 
     it('returns the archived workspace', async () => {

--- a/src/backend/orchestration/workspace-archive.orchestrator.ts
+++ b/src/backend/orchestration/workspace-archive.orchestrator.ts
@@ -5,6 +5,7 @@ import {
   workspaceStateMachine,
   worktreeLifecycleService,
 } from '@/backend/services/workspace';
+import { cleanupWorkspaceScopedCaches } from './event-collector.orchestrator';
 import type { WorkspaceWithProject } from './types';
 import { fireLifecycleNotification } from './workspace-children.orchestrator';
 
@@ -144,6 +145,7 @@ async function completeArchive(
   }
 
   const archivedWorkspace = await workspaceStateMachine.markArchived(workspace.id);
+  cleanupWorkspaceScopedCaches(workspace.id);
   services.runScriptService.evictWorkspaceBuffers(workspace.id);
 
   // Notify parent workspace that this child was archived (fire-and-forget)

--- a/src/backend/services/constants.ts
+++ b/src/backend/services/constants.ts
@@ -5,6 +5,7 @@ export const SERVICE_LIMITS = Object.freeze({
   sessionStoreMaxQueueSize: 100,
   startupScriptOutputMaxBytes: 1024 * 1024,
   startupScriptOutputTailBytes: 512 * 1024,
+  workspaceScopedCacheMaxEntries: 1024,
 } as const);
 
 export const SERVICE_TIMEOUT_MS = Object.freeze({
@@ -30,6 +31,7 @@ export const SERVICE_INTERVAL_MS = Object.freeze({
 export const SERVICE_CACHE_TTL_MS = Object.freeze({
   ratchetAuthenticatedUsername: 5 * 60_000,
   cliHealth: 30_000,
+  workspacePrFetchInFlight: 10 * 60_000,
   workspaceSnapshotRemovalGrace: 10 * 60_000,
 } as const);
 

--- a/src/backend/services/constants.ts
+++ b/src/backend/services/constants.ts
@@ -30,6 +30,7 @@ export const SERVICE_INTERVAL_MS = Object.freeze({
 export const SERVICE_CACHE_TTL_MS = Object.freeze({
   ratchetAuthenticatedUsername: 5 * 60_000,
   cliHealth: 30_000,
+  workspaceSnapshotRemovalGrace: 10 * 60_000,
 } as const);
 
 export const SERVICE_THRESHOLDS = Object.freeze({

--- a/src/backend/services/github/service/pr-fetch-registry.test.ts
+++ b/src/backend/services/github/service/pr-fetch-registry.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PRFetchRegistry } from './pr-fetch-registry';
+
+const COOLDOWN_MS = 90_000;
+const IN_FLIGHT_TTL_MS = 10 * 60_000;
+const MAX_ENTRIES = 1024;
+
+describe('PRFetchRegistry', () => {
+  let registry: PRFetchRegistry;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+    registry = new PRFetchRegistry();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('removes completed and in-flight entries for one workspace', () => {
+    registry.startFetch('ws-1');
+    registry.register('ws-1');
+    registry.startFetch('ws-2');
+
+    registry.removeWorkspace('ws-1');
+    registry.removeWorkspace('ws-2');
+
+    expect(registry.size()).toEqual({ completed: 0, inFlight: 0 });
+  });
+
+  it('does not record a completion after workspace cleanup', () => {
+    registry.startFetch('ws-1');
+    registry.removeWorkspace('ws-1');
+
+    registry.register('ws-1');
+
+    expect(registry.size()).toEqual({ completed: 0, inFlight: 0 });
+  });
+
+  it('allows missing and repeated workspace removal', () => {
+    expect(() => registry.removeWorkspace('missing')).not.toThrow();
+
+    registry.startFetch('ws-1');
+    registry.removeWorkspace('ws-1');
+    registry.removeWorkspace('ws-1');
+
+    expect(registry.size()).toEqual({ completed: 0, inFlight: 0 });
+  });
+
+  it('expires completed entries after the cooldown', () => {
+    registry.startFetch('ws-1');
+    registry.register('ws-1');
+
+    vi.advanceTimersByTime(COOLDOWN_MS);
+
+    expect(registry.isRecentlyFetched('ws-1')).toBe(false);
+    expect(registry.size()).toEqual({ completed: 0, inFlight: 0 });
+  });
+
+  it('expires abandoned in-flight entries', () => {
+    registry.startFetch('ws-1');
+
+    vi.advanceTimersByTime(IN_FLIGHT_TTL_MS);
+
+    expect(registry.isFetchInFlight('ws-1')).toBe(false);
+    expect(registry.size()).toEqual({ completed: 0, inFlight: 0 });
+  });
+
+  it('evicts the oldest workspace when capacity is reached', () => {
+    registry.startFetch('oldest-completed');
+    registry.register('oldest-completed');
+
+    for (let index = 0; index < MAX_ENTRIES; index += 1) {
+      vi.advanceTimersByTime(1);
+      registry.startFetch(`in-flight-${index}`);
+    }
+
+    expect(registry.isRecentlyFetched('oldest-completed')).toBe(false);
+    expect(registry.isFetchInFlight('in-flight-0')).toBe(true);
+    expect(registry.size()).toEqual({ completed: 0, inFlight: MAX_ENTRIES });
+  });
+
+  it('reuses a workspace after cleanup', () => {
+    registry.startFetch('ws-1');
+    registry.removeWorkspace('ws-1');
+
+    registry.startFetch('ws-1');
+    registry.register('ws-1');
+
+    expect(registry.isRecentlyFetched('ws-1')).toBe(true);
+    expect(registry.size()).toEqual({ completed: 1, inFlight: 0 });
+  });
+});

--- a/src/backend/services/github/service/pr-fetch-registry.test.ts
+++ b/src/backend/services/github/service/pr-fetch-registry.test.ts
@@ -19,8 +19,8 @@ describe('PRFetchRegistry', () => {
   });
 
   it('removes completed and in-flight entries for one workspace', () => {
-    registry.startFetch('ws-1');
-    registry.register('ws-1');
+    const claimToken = registry.startFetch('ws-1');
+    registry.register('ws-1', claimToken);
     registry.startFetch('ws-2');
 
     registry.removeWorkspace('ws-1');
@@ -30,10 +30,10 @@ describe('PRFetchRegistry', () => {
   });
 
   it('does not record a completion after workspace cleanup', () => {
-    registry.startFetch('ws-1');
+    const claimToken = registry.startFetch('ws-1');
     registry.removeWorkspace('ws-1');
 
-    registry.register('ws-1');
+    registry.register('ws-1', claimToken);
 
     expect(registry.size()).toEqual({ completed: 0, inFlight: 0 });
   });
@@ -49,8 +49,8 @@ describe('PRFetchRegistry', () => {
   });
 
   it('returns false after the default cooldown without deleting the timestamp', () => {
-    registry.startFetch('ws-1');
-    registry.register('ws-1');
+    const claimToken = registry.startFetch('ws-1');
+    registry.register('ws-1', claimToken);
 
     vi.advanceTimersByTime(COOLDOWN_MS);
 
@@ -59,8 +59,8 @@ describe('PRFetchRegistry', () => {
   });
 
   it('honors a longer custom cooldown after an unrelated registry operation', () => {
-    registry.startFetch('ws-1');
-    registry.register('ws-1');
+    const claimToken = registry.startFetch('ws-1');
+    registry.register('ws-1', claimToken);
 
     vi.advanceTimersByTime(COOLDOWN_MS);
     registry.startFetch('ws-2');
@@ -69,8 +69,8 @@ describe('PRFetchRegistry', () => {
   });
 
   it('keeps a default-expired timestamp available to a longer custom cooldown', () => {
-    registry.startFetch('ws-1');
-    registry.register('ws-1');
+    const claimToken = registry.startFetch('ws-1');
+    registry.register('ws-1', claimToken);
 
     vi.advanceTimersByTime(COOLDOWN_MS);
 
@@ -88,8 +88,8 @@ describe('PRFetchRegistry', () => {
   });
 
   it('evicts the oldest workspace when capacity is reached', () => {
-    registry.startFetch('oldest-completed');
-    registry.register('oldest-completed');
+    const claimToken = registry.startFetch('oldest-completed');
+    registry.register('oldest-completed', claimToken);
 
     for (let index = 0; index < MAX_ENTRIES; index += 1) {
       vi.advanceTimersByTime(1);
@@ -102,13 +102,52 @@ describe('PRFetchRegistry', () => {
   });
 
   it('reuses a workspace after cleanup', () => {
-    registry.startFetch('ws-1');
+    const oldClaimToken = registry.startFetch('ws-1');
     registry.removeWorkspace('ws-1');
 
-    registry.startFetch('ws-1');
-    registry.register('ws-1');
+    const newClaimToken = registry.startFetch('ws-1');
+    registry.register('ws-1', newClaimToken);
 
     expect(registry.isRecentlyFetched('ws-1')).toBe(true);
     expect(registry.size()).toEqual({ completed: 1, inFlight: 0 });
+    expect(newClaimToken).toBeGreaterThan(oldClaimToken);
+  });
+
+  it('keeps a newer claim in flight when an older claim registers after cleanup', () => {
+    const oldClaimToken = registry.startFetch('ws-1');
+    registry.removeWorkspace('ws-1');
+    const newClaimToken = registry.startFetch('ws-1');
+
+    registry.register('ws-1', oldClaimToken);
+
+    expect(registry.isFetchInFlight('ws-1')).toBe(true);
+    expect(registry.size()).toEqual({ completed: 0, inFlight: 1 });
+
+    registry.register('ws-1', newClaimToken);
+    expect(registry.isFetchInFlight('ws-1')).toBe(false);
+    expect(registry.size()).toEqual({ completed: 1, inFlight: 0 });
+  });
+
+  it('keeps a newer claim in flight when an older claim cancels after cleanup', () => {
+    const oldClaimToken = registry.startFetch('ws-1');
+    registry.removeWorkspace('ws-1');
+    const newClaimToken = registry.startFetch('ws-1');
+
+    registry.cancelFetch('ws-1', oldClaimToken);
+
+    expect(registry.isFetchInFlight('ws-1')).toBe(true);
+
+    registry.cancelFetch('ws-1', newClaimToken);
+    expect(registry.isFetchInFlight('ws-1')).toBe(false);
+    expect(registry.size()).toEqual({ completed: 0, inFlight: 0 });
+  });
+
+  it('does not reuse claim tokens after clear', () => {
+    const oldClaimToken = registry.startFetch('ws-1');
+    registry.clear();
+
+    const newClaimToken = registry.startFetch('ws-1');
+
+    expect(newClaimToken).toBeGreaterThan(oldClaimToken);
   });
 });

--- a/src/backend/services/github/service/pr-fetch-registry.test.ts
+++ b/src/backend/services/github/service/pr-fetch-registry.test.ts
@@ -48,22 +48,33 @@ describe('PRFetchRegistry', () => {
     expect(registry.size()).toEqual({ completed: 0, inFlight: 0 });
   });
 
-  it('expires completed entries after the cooldown', () => {
+  it('returns false after the default cooldown without deleting the timestamp', () => {
     registry.startFetch('ws-1');
     registry.register('ws-1');
 
     vi.advanceTimersByTime(COOLDOWN_MS);
 
     expect(registry.isRecentlyFetched('ws-1')).toBe(false);
-    expect(registry.size()).toEqual({ completed: 0, inFlight: 0 });
+    expect(registry.size()).toEqual({ completed: 1, inFlight: 0 });
   });
 
-  it('honors a custom cooldown longer than the default cooldown', () => {
+  it('honors a longer custom cooldown after an unrelated registry operation', () => {
+    registry.startFetch('ws-1');
+    registry.register('ws-1');
+
+    vi.advanceTimersByTime(COOLDOWN_MS);
+    registry.startFetch('ws-2');
+
+    expect(registry.isRecentlyFetched('ws-1', 120_000)).toBe(true);
+  });
+
+  it('keeps a default-expired timestamp available to a longer custom cooldown', () => {
     registry.startFetch('ws-1');
     registry.register('ws-1');
 
     vi.advanceTimersByTime(COOLDOWN_MS);
 
+    expect(registry.isRecentlyFetched('ws-1')).toBe(false);
     expect(registry.isRecentlyFetched('ws-1', 120_000)).toBe(true);
   });
 

--- a/src/backend/services/github/service/pr-fetch-registry.test.ts
+++ b/src/backend/services/github/service/pr-fetch-registry.test.ts
@@ -58,6 +58,15 @@ describe('PRFetchRegistry', () => {
     expect(registry.size()).toEqual({ completed: 0, inFlight: 0 });
   });
 
+  it('honors a custom cooldown longer than the default cooldown', () => {
+    registry.startFetch('ws-1');
+    registry.register('ws-1');
+
+    vi.advanceTimersByTime(COOLDOWN_MS);
+
+    expect(registry.isRecentlyFetched('ws-1', 120_000)).toBe(true);
+  });
+
   it('expires abandoned in-flight entries', () => {
     registry.startFetch('ws-1');
 

--- a/src/backend/services/github/service/pr-fetch-registry.ts
+++ b/src/backend/services/github/service/pr-fetch-registry.ts
@@ -17,45 +17,54 @@ import { SERVICE_CACHE_TTL_MS, SERVICE_LIMITS } from '@/backend/services/constan
 
 const DEFAULT_COOLDOWN_MS = 90_000; // 90 seconds
 
+interface InFlightFetchClaim {
+  startedAt: number;
+  claimToken: number;
+}
+
 export class PRFetchRegistry {
   // Completed timestamps cannot be age-pruned because callers may supply any cooldown.
   // Explicit cleanup and oldest-workspace capacity eviction bound their retention.
   private readonly lastFetchedAt = new Map<string, number>();
-  private readonly inFlightStartedAt = new Map<string, number>();
+  private readonly inFlightClaims = new Map<string, InFlightFetchClaim>();
+  private nextClaimToken = 0;
 
   private pruneExpiredInFlight(now: number): void {
-    for (const [workspaceId, startedAt] of this.inFlightStartedAt) {
-      if (now - startedAt >= SERVICE_CACHE_TTL_MS.workspacePrFetchInFlight) {
-        this.inFlightStartedAt.delete(workspaceId);
+    for (const [workspaceId, claim] of this.inFlightClaims) {
+      if (now - claim.startedAt >= SERVICE_CACHE_TTL_MS.workspacePrFetchInFlight) {
+        this.inFlightClaims.delete(workspaceId);
       }
     }
   }
 
   private ensureCapacityFor(workspaceId: string): void {
-    if (this.lastFetchedAt.has(workspaceId) || this.inFlightStartedAt.has(workspaceId)) {
+    if (this.lastFetchedAt.has(workspaceId) || this.inFlightClaims.has(workspaceId)) {
       return;
     }
 
-    const workspaceIds = new Set([...this.lastFetchedAt.keys(), ...this.inFlightStartedAt.keys()]);
+    const workspaceIds = new Set([...this.lastFetchedAt.keys(), ...this.inFlightClaims.keys()]);
     if (workspaceIds.size < SERVICE_LIMITS.workspaceScopedCacheMaxEntries) {
       return;
     }
 
     let oldestWorkspaceId: string | undefined;
     let oldestTimestamp = Number.POSITIVE_INFINITY;
-    for (const [candidateWorkspaceId, timestamp] of [
-      ...this.lastFetchedAt,
-      ...this.inFlightStartedAt,
-    ]) {
+    for (const [candidateWorkspaceId, timestamp] of this.lastFetchedAt) {
       if (timestamp < oldestTimestamp) {
         oldestWorkspaceId = candidateWorkspaceId;
         oldestTimestamp = timestamp;
       }
     }
+    for (const [candidateWorkspaceId, claim] of this.inFlightClaims) {
+      if (claim.startedAt < oldestTimestamp) {
+        oldestWorkspaceId = candidateWorkspaceId;
+        oldestTimestamp = claim.startedAt;
+      }
+    }
 
     if (oldestWorkspaceId !== undefined) {
       this.lastFetchedAt.delete(oldestWorkspaceId);
-      this.inFlightStartedAt.delete(oldestWorkspaceId);
+      this.inFlightClaims.delete(oldestWorkspaceId);
     }
   }
 
@@ -64,33 +73,40 @@ export class PRFetchRegistry {
    * Subsequent `isRecentlyFetched` calls will return true until the claim is
    * registered, canceled, expired, evicted at capacity, or removed by cleanup.
    */
-  startFetch(workspaceId: string): void {
+  startFetch(workspaceId: string): number {
     const now = Date.now();
     this.pruneExpiredInFlight(now);
     this.ensureCapacityFor(workspaceId);
-    this.inFlightStartedAt.set(workspaceId, now);
+    this.nextClaimToken += 1;
+    const claimToken = this.nextClaimToken;
+    this.inFlightClaims.set(workspaceId, { startedAt: now, claimToken });
+    return claimToken;
   }
 
   /**
    * Record that a GitHub PR fetch was performed for a workspace.
-   * Clears any in-flight claim set by `startFetch`.
+   * Clears only the matching in-flight claim set by `startFetch`.
    * Call this after a successful fetch.
    */
-  register(workspaceId: string): void {
+  register(workspaceId: string, claimToken: number): void {
     const now = Date.now();
     this.pruneExpiredInFlight(now);
-    if (this.inFlightStartedAt.delete(workspaceId)) {
-      this.lastFetchedAt.set(workspaceId, now);
+    if (this.inFlightClaims.get(workspaceId)?.claimToken !== claimToken) {
+      return;
     }
+    this.inFlightClaims.delete(workspaceId);
+    this.lastFetchedAt.set(workspaceId, now);
   }
 
   /**
-   * Release an in-flight claim without recording a successful fetch timestamp.
+   * Release the matching in-flight claim without recording a successful fetch timestamp.
    * Call this when a fetch fails so the workspace becomes eligible again.
    */
-  cancelFetch(workspaceId: string): void {
+  cancelFetch(workspaceId: string, claimToken: number): void {
     this.pruneExpiredInFlight(Date.now());
-    this.inFlightStartedAt.delete(workspaceId);
+    if (this.inFlightClaims.get(workspaceId)?.claimToken === claimToken) {
+      this.inFlightClaims.delete(workspaceId);
+    }
   }
 
   /**
@@ -100,7 +116,7 @@ export class PRFetchRegistry {
   isRecentlyFetched(workspaceId: string, cooldownMs = DEFAULT_COOLDOWN_MS): boolean {
     const now = Date.now();
     this.pruneExpiredInFlight(now);
-    if (this.inFlightStartedAt.has(workspaceId)) {
+    if (this.inFlightClaims.has(workspaceId)) {
       return true;
     }
     const lastFetch = this.lastFetchedAt.get(workspaceId);
@@ -117,7 +133,7 @@ export class PRFetchRegistry {
    */
   isFetchInFlight(workspaceId: string): boolean {
     this.pruneExpiredInFlight(Date.now());
-    return this.inFlightStartedAt.has(workspaceId);
+    return this.inFlightClaims.has(workspaceId);
   }
 
   /**
@@ -126,7 +142,7 @@ export class PRFetchRegistry {
   removeWorkspace(workspaceId: string): void {
     this.pruneExpiredInFlight(Date.now());
     this.lastFetchedAt.delete(workspaceId);
-    this.inFlightStartedAt.delete(workspaceId);
+    this.inFlightClaims.delete(workspaceId);
   }
 
   /**
@@ -136,16 +152,16 @@ export class PRFetchRegistry {
     this.pruneExpiredInFlight(Date.now());
     return {
       completed: this.lastFetchedAt.size,
-      inFlight: this.inFlightStartedAt.size,
+      inFlight: this.inFlightClaims.size,
     };
   }
 
   /**
-   * Clear all entries. Useful in tests.
+   * Clear all entries without resetting claim identity. Useful in tests.
    */
   clear(): void {
     this.lastFetchedAt.clear();
-    this.inFlightStartedAt.clear();
+    this.inFlightClaims.clear();
   }
 }
 

--- a/src/backend/services/github/service/pr-fetch-registry.ts
+++ b/src/backend/services/github/service/pr-fetch-registry.ts
@@ -21,8 +21,17 @@ export class PRFetchRegistry {
   private readonly lastFetchedAt = new Map<string, number>();
   private readonly inFlightStartedAt = new Map<string, number>();
 
-  private pruneExpired(now: number): void {
+  private pruneExpired(
+    now: number,
+    completedEntryToPreserve?: { workspaceId: string; cooldownMs: number }
+  ): void {
     for (const [workspaceId, lastFetchedAt] of this.lastFetchedAt) {
+      if (
+        workspaceId === completedEntryToPreserve?.workspaceId &&
+        now - lastFetchedAt < completedEntryToPreserve.cooldownMs
+      ) {
+        continue;
+      }
       if (now - lastFetchedAt >= DEFAULT_COOLDOWN_MS) {
         this.lastFetchedAt.delete(workspaceId);
       }
@@ -65,8 +74,8 @@ export class PRFetchRegistry {
 
   /**
    * Claim this workspace synchronously before starting an async fetch.
-   * Subsequent `isRecentlyFetched` calls will return true until `register` or
-   * `cancelFetch` is called.
+   * Subsequent `isRecentlyFetched` calls will return true until the claim is
+   * registered, canceled, expired, evicted at capacity, or removed by cleanup.
    */
   startFetch(workspaceId: string): void {
     const now = Date.now();
@@ -103,7 +112,7 @@ export class PRFetchRegistry {
    */
   isRecentlyFetched(workspaceId: string, cooldownMs = DEFAULT_COOLDOWN_MS): boolean {
     const now = Date.now();
-    this.pruneExpired(now);
+    this.pruneExpired(now, { workspaceId, cooldownMs });
     if (this.inFlightStartedAt.has(workspaceId)) {
       return true;
     }

--- a/src/backend/services/github/service/pr-fetch-registry.ts
+++ b/src/backend/services/github/service/pr-fetch-registry.ts
@@ -13,11 +13,55 @@
  * from racing past the check and issuing duplicate GitHub API calls.
  */
 
+import { SERVICE_CACHE_TTL_MS, SERVICE_LIMITS } from '@/backend/services/constants';
+
 const DEFAULT_COOLDOWN_MS = 90_000; // 90 seconds
 
-class PRFetchRegistry {
+export class PRFetchRegistry {
   private readonly lastFetchedAt = new Map<string, number>();
-  private readonly inFlight = new Set<string>();
+  private readonly inFlightStartedAt = new Map<string, number>();
+
+  private pruneExpired(now: number): void {
+    for (const [workspaceId, lastFetchedAt] of this.lastFetchedAt) {
+      if (now - lastFetchedAt >= DEFAULT_COOLDOWN_MS) {
+        this.lastFetchedAt.delete(workspaceId);
+      }
+    }
+
+    for (const [workspaceId, startedAt] of this.inFlightStartedAt) {
+      if (now - startedAt >= SERVICE_CACHE_TTL_MS.workspacePrFetchInFlight) {
+        this.inFlightStartedAt.delete(workspaceId);
+      }
+    }
+  }
+
+  private ensureCapacityFor(workspaceId: string): void {
+    if (this.lastFetchedAt.has(workspaceId) || this.inFlightStartedAt.has(workspaceId)) {
+      return;
+    }
+
+    const workspaceIds = new Set([...this.lastFetchedAt.keys(), ...this.inFlightStartedAt.keys()]);
+    if (workspaceIds.size < SERVICE_LIMITS.workspaceScopedCacheMaxEntries) {
+      return;
+    }
+
+    let oldestWorkspaceId: string | undefined;
+    let oldestTimestamp = Number.POSITIVE_INFINITY;
+    for (const [candidateWorkspaceId, timestamp] of [
+      ...this.lastFetchedAt,
+      ...this.inFlightStartedAt,
+    ]) {
+      if (timestamp < oldestTimestamp) {
+        oldestWorkspaceId = candidateWorkspaceId;
+        oldestTimestamp = timestamp;
+      }
+    }
+
+    if (oldestWorkspaceId !== undefined) {
+      this.lastFetchedAt.delete(oldestWorkspaceId);
+      this.inFlightStartedAt.delete(oldestWorkspaceId);
+    }
+  }
 
   /**
    * Claim this workspace synchronously before starting an async fetch.
@@ -25,7 +69,10 @@ class PRFetchRegistry {
    * `cancelFetch` is called.
    */
   startFetch(workspaceId: string): void {
-    this.inFlight.add(workspaceId);
+    const now = Date.now();
+    this.pruneExpired(now);
+    this.ensureCapacityFor(workspaceId);
+    this.inFlightStartedAt.set(workspaceId, now);
   }
 
   /**
@@ -34,8 +81,11 @@ class PRFetchRegistry {
    * Call this after a successful fetch.
    */
   register(workspaceId: string): void {
-    this.inFlight.delete(workspaceId);
-    this.lastFetchedAt.set(workspaceId, Date.now());
+    const now = Date.now();
+    this.pruneExpired(now);
+    if (this.inFlightStartedAt.delete(workspaceId)) {
+      this.lastFetchedAt.set(workspaceId, now);
+    }
   }
 
   /**
@@ -43,7 +93,8 @@ class PRFetchRegistry {
    * Call this when a fetch fails so the workspace becomes eligible again.
    */
   cancelFetch(workspaceId: string): void {
-    this.inFlight.delete(workspaceId);
+    this.pruneExpired(Date.now());
+    this.inFlightStartedAt.delete(workspaceId);
   }
 
   /**
@@ -51,14 +102,16 @@ class PRFetchRegistry {
    * the cooldown window. Use this to skip redundant fetches.
    */
   isRecentlyFetched(workspaceId: string, cooldownMs = DEFAULT_COOLDOWN_MS): boolean {
-    if (this.inFlight.has(workspaceId)) {
+    const now = Date.now();
+    this.pruneExpired(now);
+    if (this.inFlightStartedAt.has(workspaceId)) {
       return true;
     }
     const lastFetch = this.lastFetchedAt.get(workspaceId);
     if (lastFetch === undefined) {
       return false;
     }
-    return Date.now() - lastFetch < cooldownMs;
+    return now - lastFetch < cooldownMs;
   }
 
   /**
@@ -67,7 +120,28 @@ class PRFetchRegistry {
    * avoid issuing a duplicate concurrent GitHub call.
    */
   isFetchInFlight(workspaceId: string): boolean {
-    return this.inFlight.has(workspaceId);
+    this.pruneExpired(Date.now());
+    return this.inFlightStartedAt.has(workspaceId);
+  }
+
+  /**
+   * Remove all state retained for one workspace.
+   */
+  removeWorkspace(workspaceId: string): void {
+    this.pruneExpired(Date.now());
+    this.lastFetchedAt.delete(workspaceId);
+    this.inFlightStartedAt.delete(workspaceId);
+  }
+
+  /**
+   * Return retained entry counts after discarding expired state.
+   */
+  size(): { completed: number; inFlight: number } {
+    this.pruneExpired(Date.now());
+    return {
+      completed: this.lastFetchedAt.size,
+      inFlight: this.inFlightStartedAt.size,
+    };
   }
 
   /**
@@ -75,7 +149,7 @@ class PRFetchRegistry {
    */
   clear(): void {
     this.lastFetchedAt.clear();
-    this.inFlight.clear();
+    this.inFlightStartedAt.clear();
   }
 }
 

--- a/src/backend/services/github/service/pr-fetch-registry.ts
+++ b/src/backend/services/github/service/pr-fetch-registry.ts
@@ -18,25 +18,12 @@ import { SERVICE_CACHE_TTL_MS, SERVICE_LIMITS } from '@/backend/services/constan
 const DEFAULT_COOLDOWN_MS = 90_000; // 90 seconds
 
 export class PRFetchRegistry {
+  // Completed timestamps cannot be age-pruned because callers may supply any cooldown.
+  // Explicit cleanup and oldest-workspace capacity eviction bound their retention.
   private readonly lastFetchedAt = new Map<string, number>();
   private readonly inFlightStartedAt = new Map<string, number>();
 
-  private pruneExpired(
-    now: number,
-    completedEntryToPreserve?: { workspaceId: string; cooldownMs: number }
-  ): void {
-    for (const [workspaceId, lastFetchedAt] of this.lastFetchedAt) {
-      if (
-        workspaceId === completedEntryToPreserve?.workspaceId &&
-        now - lastFetchedAt < completedEntryToPreserve.cooldownMs
-      ) {
-        continue;
-      }
-      if (now - lastFetchedAt >= DEFAULT_COOLDOWN_MS) {
-        this.lastFetchedAt.delete(workspaceId);
-      }
-    }
-
+  private pruneExpiredInFlight(now: number): void {
     for (const [workspaceId, startedAt] of this.inFlightStartedAt) {
       if (now - startedAt >= SERVICE_CACHE_TTL_MS.workspacePrFetchInFlight) {
         this.inFlightStartedAt.delete(workspaceId);
@@ -79,7 +66,7 @@ export class PRFetchRegistry {
    */
   startFetch(workspaceId: string): void {
     const now = Date.now();
-    this.pruneExpired(now);
+    this.pruneExpiredInFlight(now);
     this.ensureCapacityFor(workspaceId);
     this.inFlightStartedAt.set(workspaceId, now);
   }
@@ -91,7 +78,7 @@ export class PRFetchRegistry {
    */
   register(workspaceId: string): void {
     const now = Date.now();
-    this.pruneExpired(now);
+    this.pruneExpiredInFlight(now);
     if (this.inFlightStartedAt.delete(workspaceId)) {
       this.lastFetchedAt.set(workspaceId, now);
     }
@@ -102,7 +89,7 @@ export class PRFetchRegistry {
    * Call this when a fetch fails so the workspace becomes eligible again.
    */
   cancelFetch(workspaceId: string): void {
-    this.pruneExpired(Date.now());
+    this.pruneExpiredInFlight(Date.now());
     this.inFlightStartedAt.delete(workspaceId);
   }
 
@@ -112,7 +99,7 @@ export class PRFetchRegistry {
    */
   isRecentlyFetched(workspaceId: string, cooldownMs = DEFAULT_COOLDOWN_MS): boolean {
     const now = Date.now();
-    this.pruneExpired(now, { workspaceId, cooldownMs });
+    this.pruneExpiredInFlight(now);
     if (this.inFlightStartedAt.has(workspaceId)) {
       return true;
     }
@@ -129,7 +116,7 @@ export class PRFetchRegistry {
    * avoid issuing a duplicate concurrent GitHub call.
    */
   isFetchInFlight(workspaceId: string): boolean {
-    this.pruneExpired(Date.now());
+    this.pruneExpiredInFlight(Date.now());
     return this.inFlightStartedAt.has(workspaceId);
   }
 
@@ -137,16 +124,16 @@ export class PRFetchRegistry {
    * Remove all state retained for one workspace.
    */
   removeWorkspace(workspaceId: string): void {
-    this.pruneExpired(Date.now());
+    this.pruneExpiredInFlight(Date.now());
     this.lastFetchedAt.delete(workspaceId);
     this.inFlightStartedAt.delete(workspaceId);
   }
 
   /**
-   * Return retained entry counts after discarding expired state.
+   * Return retained entry counts after discarding expired in-flight claims.
    */
   size(): { completed: number; inFlight: number } {
-    this.pruneExpired(Date.now());
+    this.pruneExpiredInFlight(Date.now());
     return {
       completed: this.lastFetchedAt.size,
       inFlight: this.inFlightStartedAt.size,

--- a/src/backend/services/ratchet/service/bridges.ts
+++ b/src/backend/services/ratchet/service/bridges.ts
@@ -130,9 +130,9 @@ export interface RatchetGitHubBridge {
   /** True only while another service's PR fetch is actively in flight for this workspace. */
   isFetchInFlight(workspaceId: string): boolean;
   /** Claim this workspace as in-flight before starting an async fetch (dedup optimization). */
-  startFetch(workspaceId: string): void;
+  startFetch(workspaceId: string): number;
   /** Record that a PR fetch completed successfully for this workspace (dedup optimization). */
-  registerFetch(workspaceId: string): void;
+  registerFetch(workspaceId: string, claimToken: number): void;
   /** Release an in-flight claim without recording a successful fetch (call on failure). */
-  cancelFetch(workspaceId: string): void;
+  cancelFetch(workspaceId: string, claimToken: number): void;
 }

--- a/src/backend/services/ratchet/service/ratchet-pr-state.helpers.test.ts
+++ b/src/backend/services/ratchet/service/ratchet-pr-state.helpers.test.ts
@@ -166,7 +166,7 @@ describe('fetchPRState', () => {
       fetchAndComputePRState: vi.fn(),
       isRecentlyFetched: vi.fn(() => false),
       isFetchInFlight: vi.fn(() => false),
-      startFetch: vi.fn(),
+      startFetch: vi.fn(() => 41),
       registerFetch: vi.fn(),
       cancelFetch: vi.fn(),
       ...overrides,
@@ -225,7 +225,7 @@ describe('fetchPRState', () => {
     expect(result.prState).toBe('OPEN');
     // The bypassed fetch still claims and registers in the dedup registry.
     expect(github.startFetch).toHaveBeenCalledWith('ws-1');
-    expect(github.registerFetch).toHaveBeenCalledWith('ws-1');
+    expect(github.registerFetch).toHaveBeenCalledWith('ws-1', 41);
   });
 
   it('still skips a bypassed fetch while another fetch is actively in flight', async () => {
@@ -287,7 +287,7 @@ describe('fetchPRState', () => {
       123,
       controller.signal
     );
-    expect(github.cancelFetch).toHaveBeenCalledWith('ws-1');
+    expect(github.cancelFetch).toHaveBeenCalledWith('ws-1', 41);
     expect(backoff.handleError).not.toHaveBeenCalled();
   });
 });
@@ -417,7 +417,7 @@ describe('fetchPRState', () => {
       fetchAndComputePRState: vi.fn(),
       isRecentlyFetched: vi.fn(() => false),
       isFetchInFlight: vi.fn(() => false),
-      startFetch: vi.fn(),
+      startFetch: vi.fn(() => 41),
       registerFetch: vi.fn(),
       cancelFetch: vi.fn(),
       ...overrides,

--- a/src/backend/services/ratchet/service/ratchet-pr-state.helpers.ts
+++ b/src/backend/services/ratchet/service/ratchet-pr-state.helpers.ts
@@ -371,11 +371,12 @@ export async function fetchPRState(params: {
     return { skipped: true, reason: 'recently_fetched' };
   }
 
+  let claimToken: number | undefined;
   try {
     // Claim this workspace as in-flight before the async fetch so concurrent
     // scheduler/ratchet calls see it and skip redundant fetches.
     signal?.throwIfAborted();
-    github.startFetch(workspace.id);
+    claimToken = github.startFetch(workspace.id);
 
     const [prDetails, reviewComments, resolvedReviewCommentIds] = await Promise.all([
       github.getPRFullDetails(prContext.repo, prContext.prNumber, signal),
@@ -461,7 +462,7 @@ export async function fetchPRState(params: {
 
     // Record successful fetch completion so the dedup registry tracks this workspace.
     signal?.throwIfAborted();
-    github.registerFetch(workspace.id);
+    github.registerFetch(workspace.id, claimToken);
 
     return {
       ciStatus,
@@ -476,7 +477,9 @@ export async function fetchPRState(params: {
     };
   } catch (error) {
     // Release the in-flight claim so the workspace is eligible for a future retry.
-    github.cancelFetch(workspace.id);
+    if (claimToken !== undefined) {
+      github.cancelFetch(workspace.id, claimToken);
+    }
     signal?.throwIfAborted();
     backoff.handleError(
       error,

--- a/src/backend/services/ratchet/service/ratchet.service.test.ts
+++ b/src/backend/services/ratchet/service/ratchet.service.test.ts
@@ -87,7 +87,7 @@ const mockGitHubBridge: RatchetGitHubBridge = {
   fetchAndComputePRState: vi.fn(),
   isRecentlyFetched: vi.fn(),
   isFetchInFlight: vi.fn(),
-  startFetch: vi.fn(),
+  startFetch: vi.fn(() => 41),
   registerFetch: vi.fn(),
   cancelFetch: vi.fn(),
 };

--- a/src/backend/services/workspace-snapshot-store.service.test.ts
+++ b/src/backend/services/workspace-snapshot-store.service.test.ts
@@ -295,8 +295,7 @@ describe('WorkspaceSnapshotStore', () => {
     });
 
     it('expires removal protection after the configured grace period', () => {
-      // biome-ignore lint/style/useNumericSeparators: Match the issue's specified test value.
-      vi.setSystemTime(1_000);
+      vi.setSystemTime(1000);
       store.remove('ws-1', 900);
       vi.advanceTimersByTime(10 * 60_000);
       expect(store.removalTombstoneCount()).toBe(0);

--- a/src/backend/services/workspace-snapshot-store.service.test.ts
+++ b/src/backend/services/workspace-snapshot-store.service.test.ts
@@ -338,6 +338,41 @@ describe('WorkspaceSnapshotStore', () => {
       expect(store.getByWorkspaceId('ws-1')).toBeDefined();
     });
 
+    it('preserves the tombstone when a newer first upsert is structurally invalid', () => {
+      store.remove('ws-1', 200);
+
+      expect(() => store.upsert('ws-1', { name: 'Invalid' }, 'test', 300)).toThrow(
+        'projectId is required on first upsert'
+      );
+      store.upsert('ws-1', makeUpdate(), 'reconciliation', 150);
+
+      expect(store.getByWorkspaceId('ws-1')).toBeUndefined();
+    });
+
+    it('cancels tombstone expiry when a valid newer update recreates the workspace', () => {
+      const isolatedStore = new WorkspaceSnapshotStore();
+      isolatedStore.configure({
+        deriveFlowState: (_input) => ({
+          phase: 'NO_PR' as const,
+          ciObservation: 'CHECKS_UNKNOWN' as const,
+          hasActivePr: false,
+          isWorking: false,
+          shouldAnimateRatchetButton: false,
+        }),
+        computeKanbanColumn: (_input) => KanbanColumn.WORKING,
+        deriveSidebarStatus: (_input) => ({
+          activityState: 'IDLE' as const,
+          ciState: 'NONE' as const,
+        }),
+      });
+      isolatedStore.remove('ws-1', 200);
+      expect(vi.getTimerCount()).toBe(1);
+
+      isolatedStore.upsert('ws-1', makeUpdate(), 'test', 300);
+
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
     it('records a tombstone even when the store has no entry for the workspace', () => {
       // Archive event can arrive before reconciliation ever populated the
       // entry (e.g. right after startup); a stale reconcile pass must still

--- a/src/backend/services/workspace-snapshot-store.service.test.ts
+++ b/src/backend/services/workspace-snapshot-store.service.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { serviceNames } from '@/backend/services/registry';
 
 // Mock logger (standard pattern)
@@ -286,6 +286,29 @@ describe('WorkspaceSnapshotStore', () => {
   // Removal tombstones: stale reconcile passes must not resurrect entries
   // -------------------------------------------------------------------------
   describe('Removal tombstones', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('expires removal protection after the configured grace period', () => {
+      // biome-ignore lint/style/useNumericSeparators: Match the issue's specified test value.
+      vi.setSystemTime(1_000);
+      store.remove('ws-1', 900);
+      vi.advanceTimersByTime(10 * 60_000);
+      expect(store.removalTombstoneCount()).toBe(0);
+    });
+
+    it('repeated removal preserves the newest logical timestamp', () => {
+      store.remove('ws-1', 200);
+      store.remove('ws-1', 150);
+      store.upsert('ws-1', makeUpdate(), 'reconciliation', 175);
+      expect(store.getByWorkspaceId('ws-1')).toBeUndefined();
+    });
+
     it('ignores upserts whose timestamp predates the removal', () => {
       store.upsert('ws-1', makeUpdate(), 'test', 100);
       store.remove('ws-1', 200);

--- a/src/backend/services/workspace-snapshot-store.service.ts
+++ b/src/backend/services/workspace-snapshot-store.service.ts
@@ -593,7 +593,6 @@ export class WorkspaceSnapshotStore extends EventEmitter {
         });
         return { accepted: false, changed: false, emitted: false };
       }
-      this.clearRemovalTombstone(workspaceId);
     }
 
     let entry = this.entries.get(workspaceId);
@@ -607,6 +606,9 @@ export class WorkspaceSnapshotStore extends EventEmitter {
         );
       }
       entry = this.createDefaultEntry(workspaceId, update.projectId);
+    }
+    if (tombstone) {
+      this.clearRemovalTombstone(workspaceId);
     }
 
     // Field-level timestamp merge

--- a/src/backend/services/workspace-snapshot-store.service.ts
+++ b/src/backend/services/workspace-snapshot-store.service.ts
@@ -31,6 +31,7 @@ import { findWorkspaceSessionRuntimeError } from '@/shared/session-runtime';
 import type { WorkspaceCiObservation, WorkspaceFlowPhase } from '@/shared/workspace-flow-state';
 import type { WorkspaceSidebarStatus } from '@/shared/workspace-sidebar-status';
 import type { WorkspaceStatusReason } from '@/shared/workspace-status-reason';
+import { SERVICE_CACHE_TTL_MS } from './constants';
 import { createLogger } from './logger.service';
 
 // ---------------------------------------------------------------------------
@@ -232,6 +233,8 @@ const RECONCILIATION_FIELDS = ['gitStats', 'lastActivityAt'] as const;
 
 type SnapshotField = keyof SnapshotUpdateInput & keyof WorkspaceSnapshotEntry;
 
+type RemovalTombstone = { removedAt: number; expiresAt: number; timer: NodeJS.Timeout };
+
 type FieldGroupMapping = {
   group: SnapshotFieldGroup;
   fields: readonly SnapshotField[];
@@ -338,7 +341,15 @@ export class WorkspaceSnapshotStore extends EventEmitter {
    * than the removal is ignored, so a reconcile pass that read the DB before
    * an archive committed cannot momentarily resurrect the removed entry.
    */
-  private removalTimestamps = new Map<string, number>();
+  private removalTimestamps = new Map<string, RemovalTombstone>();
+
+  private clearRemovalTombstone(workspaceId: string): void {
+    const tombstone = this.removalTimestamps.get(workspaceId);
+    if (tombstone) {
+      clearTimeout(tombstone.timer);
+    }
+    this.removalTimestamps.delete(workspaceId);
+  }
 
   private assignField<K extends SnapshotField>(
     entry: WorkspaceSnapshotEntry,
@@ -573,16 +584,16 @@ export class WorkspaceSnapshotStore extends EventEmitter {
   ): SnapshotUpsertResult {
     const ts = timestamp ?? Date.now();
 
-    const removedAt = this.removalTimestamps.get(workspaceId);
-    if (removedAt !== undefined) {
-      if (ts <= removedAt) {
+    const tombstone = this.removalTimestamps.get(workspaceId);
+    if (tombstone) {
+      if (ts <= tombstone.removedAt) {
         logger.debug('Snapshot update ignored (workspace removed after update was computed)', {
           workspaceId,
           source,
         });
         return { accepted: false, changed: false, emitted: false };
       }
-      this.removalTimestamps.delete(workspaceId);
+      this.clearRemovalTombstone(workspaceId);
     }
 
     let entry = this.entries.get(workspaceId);
@@ -645,7 +656,22 @@ export class WorkspaceSnapshotStore extends EventEmitter {
    * been upserted here.
    */
   remove(workspaceId: string, timestamp?: number): boolean {
-    this.removalTimestamps.set(workspaceId, timestamp ?? Date.now());
+    const priorTombstone = this.removalTimestamps.get(workspaceId);
+    const removedAt = Math.max(
+      priorTombstone?.removedAt ?? Number.NEGATIVE_INFINITY,
+      timestamp ?? Date.now()
+    );
+    this.clearRemovalTombstone(workspaceId);
+
+    const expiresAt = Date.now() + SERVICE_CACHE_TTL_MS.workspaceSnapshotRemovalGrace;
+    const timer = setTimeout(() => {
+      const tombstone = this.removalTimestamps.get(workspaceId);
+      if (tombstone?.expiresAt === expiresAt) {
+        this.removalTimestamps.delete(workspaceId);
+      }
+    }, SERVICE_CACHE_TTL_MS.workspaceSnapshotRemovalGrace);
+    timer.unref();
+    this.removalTimestamps.set(workspaceId, { removedAt, expiresAt, timer });
 
     const entry = this.entries.get(workspaceId);
     if (!entry) {
@@ -720,12 +746,22 @@ export class WorkspaceSnapshotStore extends EventEmitter {
   }
 
   /**
+   * Get the number of retained removal tombstones (for testing/debugging).
+   */
+  removalTombstoneCount(): number {
+    return this.removalTimestamps.size;
+  }
+
+  /**
    * Clear all entries and indexes. Useful for testing and server shutdown.
    */
   clear(): void {
     this.entries.clear();
     this.projectIndex.clear();
     this.rawSessionIsWorkingByWorkspaceId.clear();
+    for (const tombstone of this.removalTimestamps.values()) {
+      clearTimeout(tombstone.timer);
+    }
     this.removalTimestamps.clear();
     logger.info('Snapshot store cleared');
   }

--- a/src/backend/trpc/workspace.router.test.ts
+++ b/src/backend/trpc/workspace.router.test.ts
@@ -25,6 +25,7 @@ const mockWorkspaceCreationCreate = vi.hoisted(() => vi.fn());
 const mockClearWorkspaceActivity = vi.hoisted(() => vi.fn());
 const mockArchiveWorkspace = vi.hoisted(() => vi.fn());
 const mockCleanupWorkspaceRuntimeResources = vi.hoisted(() => vi.fn());
+const mockCleanupWorkspaceScopedCaches = vi.hoisted(() => vi.fn());
 const mockInitializeWorkspaceWorktree = vi.hoisted(() => vi.fn());
 const mockBuildSessionSummaries = vi.hoisted(() => vi.fn());
 const mockHasWorkingSessionSummary = vi.hoisted(() => vi.fn());
@@ -111,6 +112,10 @@ vi.mock('@/backend/orchestration/workspace-archive.orchestrator', () => ({
   archiveWorkspace: (...args: unknown[]) => mockArchiveWorkspace(...args),
   cleanupWorkspaceRuntimeResources: (...args: unknown[]) =>
     mockCleanupWorkspaceRuntimeResources(...args),
+}));
+
+vi.mock('@/backend/orchestration/event-collector.orchestrator', () => ({
+  cleanupWorkspaceScopedCaches: (...args: unknown[]) => mockCleanupWorkspaceScopedCaches(...args),
 }));
 
 vi.mock('@/backend/orchestration/workspace-init.orchestrator', () => ({
@@ -607,7 +612,11 @@ describe('workspaceRouter', () => {
     }
     expect(evictionCallOrder).toBeLessThan(deleteCallOrder);
     expect(terminalService.destroyWorkspaceTerminals).toHaveBeenCalledWith('w1');
-    expect(mockClearWorkspaceActivity).toHaveBeenCalledWith('w1');
+    expect(mockCleanupWorkspaceScopedCaches).toHaveBeenCalledWith('w1');
+    const cacheCleanupCallOrder = mockCleanupWorkspaceScopedCaches.mock.invocationCallOrder[0];
+    expect(deleteCallOrder).toBeDefined();
+    expect(cacheCleanupCallOrder).toBeDefined();
+    expect(cacheCleanupCallOrder!).toBeGreaterThan(deleteCallOrder!);
 
     await expect(caller.refreshFactoryConfigs({ projectId: 'p1' })).resolves.toEqual({
       refreshed: 3,
@@ -632,6 +641,15 @@ describe('workspaceRouter', () => {
     expect(runScriptService.evictWorkspaceBuffers).not.toHaveBeenCalled();
     expect(terminalService.destroyWorkspaceTerminals).toHaveBeenCalledWith('w1');
     expect(mockWorkspaceDataService.delete).not.toHaveBeenCalled();
+  });
+
+  it('does not clean workspace caches when database deletion fails', async () => {
+    mockWorkspaceDataService.delete.mockRejectedValue(new Error('database delete failed'));
+    const { caller } = createCaller();
+
+    await expect(caller.delete({ id: 'w1' })).rejects.toThrow('database delete failed');
+
+    expect(mockCleanupWorkspaceScopedCaches).not.toHaveBeenCalled();
   });
 
   it('does not delete when workspace session cleanup throws', async () => {

--- a/src/backend/trpc/workspace.trpc.ts
+++ b/src/backend/trpc/workspace.trpc.ts
@@ -7,6 +7,7 @@ import {
   hasWorkingSessionSummary,
 } from '@/backend/lib/session-summaries';
 import { assembleWorkspaceDerivedState } from '@/backend/lib/workspace-derived-state';
+import { cleanupWorkspaceScopedCaches } from '@/backend/orchestration/event-collector.orchestrator';
 import {
   archiveWorkspace,
   cleanupWorkspaceRuntimeResources,
@@ -35,7 +36,6 @@ import {
   deriveWorkspaceFlowStateFromWorkspace,
   WorkspaceCreationService,
   workspaceAccessor,
-  workspaceActivityService,
   workspaceDataService,
   workspaceNotificationAccessor,
   workspaceQueryService,
@@ -467,8 +467,9 @@ export const workspaceRouter = router({
     // Clean up running sessions, terminals, and dev processes before deleting
     await cleanupWorkspaceRuntimeResources(input.id, ctx.appContext.services, 'delete');
     ctx.appContext.services.runScriptService.evictWorkspaceBuffers(input.id);
-    workspaceActivityService.clearWorkspace(input.id);
-    return workspaceDataService.delete(input.id);
+    const result = await workspaceDataService.delete(input.id);
+    cleanupWorkspaceScopedCaches(input.id);
+    return result;
   }),
 
   // Refresh factory-factory.json configuration for all workspaces


### PR DESCRIPTION
## Summary
- Bound snapshot removal tombstones with a reconciliation-safe ten-minute grace period.
- Centralize idempotent workspace cache cleanup across archive and deletion paths.
- Bound PR/idle registries and make PR fetch claims generation-safe for workspace reuse.

## Changes
- **Snapshot store**: Expire removal tombstones, preserve the newest removal timestamp, cancel timers on valid recreation, and retain protection after invalid updates.
- **PR fetch registry**: Add per-workspace removal, TTL/cap bounds, and claim tokens so stale async completions cannot consume replacement claims.
- **Archive lifecycle**: Clear snapshot, activity, PR-fetch, idle-refresh, and pending coalescer state through one shared cleanup hook after successful persistence.
- **Tests and docs**: Cover reconciliation/archive races, repeated and missing cleanup, expiry boundaries, capacity bounds, ID reuse, and stale claim interleavings.

## Testing
- [x] Tests pass (`NODE_ENV=test pnpm test`: 3,890 passed, 3 skipped)
- [x] Types pass (`NODE_ENV=test pnpm typecheck`)
- [x] Build succeeds (`NODE_ENV=test pnpm build`)
- [x] Repository checks pass (`NODE_ENV=test pnpm check`)
- [ ] Manual testing: Not applicable; backend lifecycle behavior is covered by focused and full automated suites.

Closes #1949

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workspace lifecycle, snapshot reconciliation tombstones, and shared PR dedup across scheduler/ratchet/event paths; mistakes could cause stale UI or extra GitHub fetches, but persisted state stays authoritative and cleanup is designed to be idempotent.
> 
> **Overview**
> Bounds **in-memory workspace caches** so archive/delete does not leave tombstones, PR dedup state, or idle-refresh maps growing for the process lifetime, and stops **coalesced snapshot updates** from resurrecting archived workspaces.
> 
> **Snapshot store** removal tombstones now use a **10-minute timer-backed grace** (max logical `removedAt` on repeat removal), with timers cleared on valid recreation or `clear()`.
> 
> **PR fetch registry** adds **claim tokens** on `startFetch` so stale async `register`/`cancel` cannot affect a workspace after cleanup or a newer claim; adds **`removeWorkspace`**, **10-minute in-flight expiry**, and a **1,024-workspace cap** with oldest eviction.
> 
> **Event collector** exposes **`cleanupWorkspaceScopedCaches`** / **`removeWorkspace`**: cancel pending coalescer work, drop idle PR-refresh entries (30s TTL + cap), remove snapshot, clear activity, and evict PR registry state—wired on **ARCHIVED** events, **after `markArchived()`**, and **after successful workspace delete** (idempotent double cleanup on archive).
> 
> Design/plan docs and focused tests cover reconciliation races, expiry, capacity, and stale completions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e522c13283ea707b044fc9223d622c55d465d797. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->