### PR TITLE
Fix #1961: Remove tRPC errors from application layers

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -170,6 +170,15 @@ module.exports = {
       to: { path: '^src/backend/(routers|trpc)/' },
     },
     {
+      name: 'no-trpc-server-in-services-or-orchestration',
+      severity: 'error',
+      comment: 'Services and orchestration must use transport-neutral application errors.',
+      from: { path: '^src/backend/(services|orchestration)/' },
+      to: {
+        path: '^node_modules/(?:\\.pnpm/[^/]+/node_modules/@trpc/server|@trpc/server)(?:/|$)',
+      },
+    },
+    {
       name: 'no-services-importing-agents',
       severity: 'error',
       comment: 'Services should not depend on agent orchestration internals.',

--- a/docs/superpowers/plans/2026-07-17-transport-neutral-application-errors.md
+++ b/docs/superpowers/plans/2026-07-17-transport-neutral-application-errors.md
@@ -1,0 +1,171 @@
+# Transport-Neutral Application Errors Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace tRPC errors below the transport layer with stable application errors and translate them centrally without changing caller-visible status codes.
+
+**Architecture:** A low-level `ApplicationError` carries stable codes, messages, and causes. Shared tRPC middleware converts it with an exhaustive mapping, while a mapper helper covers procedures that intentionally catch individual errors.
+
+**Tech Stack:** TypeScript, tRPC v11, Vitest, Dependency Cruiser, Biome, pnpm
+
+## Global Constraints
+
+- Services and orchestration have no runtime imports from `@trpc/server`.
+- Existing tRPC caller codes and useful messages remain equivalent.
+- Command stdout and stderr are retained only as internal causes, never public messages.
+- Translation is centralized and exhaustively tested.
+- Dependency checks prevent `@trpc/server` imports from service and orchestration layers.
+
+---
+
+### Task 1: Application Error Contract and tRPC Mapping
+
+**Files:**
+- Create: `src/backend/lib/application-error.ts`
+- Create: `src/backend/lib/application-error.test.ts`
+- Create: `src/backend/trpc/application-error-mapper.ts`
+- Create: `src/backend/trpc/application-error-mapper.test.ts`
+- Modify: `src/backend/trpc/trpc.ts`
+- Modify: `src/backend/trpc/trpc.test.ts`
+
+**Interfaces:**
+- Produces: `ApplicationError`, `ApplicationErrorCode`, `toTRPCError(error: ApplicationError): TRPCError`, and base `publicProcedure` translation.
+- Mapping: `INVALID_INPUT -> BAD_REQUEST`, `NOT_FOUND -> NOT_FOUND`, `PRECONDITION_FAILED -> PRECONDITION_FAILED`, `CONFLICT -> CONFLICT`, `INTERNAL_ERROR -> INTERNAL_SERVER_ERROR`.
+
+- [ ] **Step 1: Write failing contract and mapping tests**
+
+Create table-driven tests that construct every application code, assert message/cause retention, assert the exact tRPC code, and use a `publicProcedure` test router to prove downstream application failures are translated.
+
+- [ ] **Step 2: Run tests and verify the missing modules fail**
+
+Run: `env -u NODE_ENV pnpm exec vitest run src/backend/lib/application-error.test.ts src/backend/trpc/application-error-mapper.test.ts src/backend/trpc/trpc.test.ts`
+
+Expected: FAIL because `application-error.ts` and `application-error-mapper.ts` do not exist.
+
+- [ ] **Step 3: Implement the minimal contract, mapper, and middleware**
+
+Define the stable union and `Error` subclass with `cause`, add an exhaustive `Record<ApplicationErrorCode, TRPCError['code']>`, and inspect unsuccessful tRPC v11 middleware results for an `ApplicationError` cause before throwing the mapped transport error.
+
+- [ ] **Step 4: Run the focused tests**
+
+Run: `env -u NODE_ENV pnpm exec vitest run src/backend/lib/application-error.test.ts src/backend/trpc/application-error-mapper.test.ts src/backend/trpc/trpc.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Run: `git add src/backend/lib/application-error.ts src/backend/lib/application-error.test.ts src/backend/trpc/application-error-mapper.ts src/backend/trpc/application-error-mapper.test.ts src/backend/trpc/trpc.ts src/backend/trpc/trpc.test.ts && git commit -m "Add application error translation (#1961)"`
+
+### Task 2: Transport-Neutral Service and Orchestration Errors
+
+**Files:**
+- Modify: `src/backend/services/git-ops.service.ts`
+- Modify: `src/backend/services/git-ops.service.test.ts`
+- Modify: `src/backend/services/workspace/service/lifecycle/creation.service.ts`
+- Modify: `src/backend/services/workspace/service/lifecycle/creation.service.test.ts`
+- Modify: `src/backend/orchestration/workspace-archive.orchestrator.ts`
+- Modify: `src/backend/orchestration/workspace-archive.orchestrator.test.ts`
+- Modify: `src/backend/orchestration/workspace-children.orchestrator.ts`
+- Modify: `src/backend/orchestration/workspace-children.orchestrator.test.ts`
+- Modify: `src/backend/trpc/workspace.trpc.ts`
+- Modify: `src/backend/trpc/workspace.router.test.ts`
+
+**Interfaces:**
+- Consumes: `new ApplicationError(code, message, { cause })` and `toTRPCError(error)` from Task 1.
+- Produces: service/orchestration failures that transport-neutral callers can inspect without tRPC.
+
+- [ ] **Step 1: Update tests to require application codes and sanitized messages**
+
+Change the git, creation, archive, child-workspace, and bulk-archive tests so fixtures reject with `ApplicationError`; assert the stable application codes; and assert a secret stderr token is absent from the public git message but present in `cause`.
+
+- [ ] **Step 2: Run focused tests and verify current TRPCError implementations fail**
+
+Run: `env -u NODE_ENV pnpm exec vitest run src/backend/services/git-ops.service.test.ts src/backend/services/workspace/service/lifecycle/creation.service.test.ts src/backend/orchestration/workspace-archive.orchestrator.test.ts src/backend/orchestration/workspace-children.orchestrator.test.ts src/backend/trpc/workspace.router.test.ts`
+
+Expected: FAIL because the affected code still throws or recognizes `TRPCError`.
+
+- [ ] **Step 3: Replace transport errors and sanitize command failures**
+
+Import `ApplicationError` from `@/backend/lib/application-error`; preserve each current transport code through the mapping; use concise git operation messages; retain command results and cleanup failures only in causes; and use the mapper for bulk-archive result codes.
+
+- [ ] **Step 4: Run focused tests**
+
+Run: `env -u NODE_ENV pnpm exec vitest run src/backend/services/git-ops.service.test.ts src/backend/services/workspace/service/lifecycle/creation.service.test.ts src/backend/orchestration/workspace-archive.orchestrator.test.ts src/backend/orchestration/workspace-children.orchestrator.test.ts src/backend/trpc/workspace.router.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Run: `git add src/backend/services src/backend/orchestration src/backend/trpc/workspace.trpc.ts src/backend/trpc/workspace.router.test.ts && git commit -m "Remove tRPC errors from application layers (#1961)"`
+
+### Task 3: Dependency Enforcement and Full Verification
+
+**Files:**
+- Modify: `.dependency-cruiser.cjs`
+
+**Interfaces:**
+- Consumes: production code with no `@trpc/server` imports under services or orchestration.
+- Produces: an error-level dependency rule covering npm and pnpm resolved paths.
+
+- [ ] **Step 1: Add the dependency rule before removing the last known imports in a temporary diff state**
+
+Use `from.path: '^src/backend/(services|orchestration)/'` and `to.path: '^node_modules/(?:\\.pnpm/[^/]+/node_modules/)?@trpc/server(?:/|$)'`. Confirm Dependency Cruiser reports the known imports before the Task 2 implementation, or validate the expression against the captured resolved path if Task 2 is already complete.
+
+- [ ] **Step 2: Run boundary and source scans**
+
+Run: `pnpm deps:check`
+
+Expected: PASS with zero violations.
+
+Run: `rg -n "@trpc/server|TRPCError" src/backend/services src/backend/orchestration --glob '!*.test.ts'`
+
+Expected: no output.
+
+- [ ] **Step 3: Run required verification**
+
+Run: `pnpm typecheck && pnpm check:fix && env -u NODE_ENV pnpm test && pnpm build`
+
+Expected: all commands exit 0. Review formatter changes before committing.
+
+- [ ] **Step 4: Review the complete diff**
+
+Run: `git diff origin/main` and `git status --short`.
+
+Expected: only issue-related code, tests, dependency rule, design, and plan files are present; no debug code remains.
+
+- [ ] **Step 5: Commit**
+
+Run: `git add .dependency-cruiser.cjs docs/superpowers && git commit -m "Enforce transport-neutral backend boundaries (#1961)"`
+
+### Task 4: Publish Pull Request
+
+**Files:**
+- Create outside repository: `/tmp/pr-body.md`
+
+**Interfaces:**
+- Consumes: a clean feature branch with all verification passing.
+- Produces: a pushed branch and draft-free GitHub pull request closing issue #1961.
+
+- [ ] **Step 1: Confirm clean pre-flight state and commit history**
+
+Run: `git status --short --branch && git log --oneline origin/main..HEAD`.
+
+Expected: clean working tree and descriptive issue-scoped commits.
+
+- [ ] **Step 2: Push the feature branch**
+
+Run: `git push -u origin HEAD`.
+
+Expected: the current branch tracks its remote counterpart.
+
+- [ ] **Step 3: Create the required PR body and PR**
+
+Write `/tmp/pr-body.md` with Summary, Changes, Testing, `Closes #1961`, and the required Factory Factory signature, then run `gh pr create --title "Fix #1961: Remove tRPC errors from application layers" --body-file /tmp/pr-body.md`.
+
+Expected: GitHub returns the new PR URL.
+
+- [ ] **Step 4: Verify the PR**
+
+Run: `gh pr view --json url,title,state`.
+
+Expected: the URL, requested title, and `OPEN` state are returned.

--- a/docs/superpowers/specs/2026-07-17-transport-neutral-application-errors-design.md
+++ b/docs/superpowers/specs/2026-07-17-transport-neutral-application-errors-design.md
@@ -1,0 +1,55 @@
+# Transport-Neutral Application Errors Design
+
+## Goal
+
+Remove runtime tRPC dependencies from backend services and orchestration while preserving client-visible tRPC codes, useful messages, internal causes, and dependency-boundary enforcement.
+
+## Approaches Considered
+
+1. Use one `ApplicationError` class with stable application codes and translate it in shared tRPC middleware. This is the selected approach because non-transport callers get one small contract and all tRPC procedures share one exhaustive mapping.
+2. Define a separate error subclass in every service capsule. This gives stronger domain naming but adds boilerplate without changing how callers handle these failures.
+3. Catch and translate application errors in each router. This keeps mapping close to individual procedures but duplicates transport policy and can drift as callers are added.
+
+## Architecture
+
+`src/backend/lib/application-error.ts` defines a transport-neutral `ApplicationError`. Its stable codes are `INVALID_INPUT`, `NOT_FOUND`, `PRECONDITION_FAILED`, `CONFLICT`, and `INTERNAL_ERROR`. The class retains its message and optional `cause`, allowing CLI, Electron, orchestration, and tests to inspect failures without importing tRPC.
+
+`src/backend/trpc/application-error-mapper.ts` owns the exhaustive application-to-tRPC mapping. `INVALID_INPUT` maps to the existing `BAD_REQUEST` transport code; the other public codes map directly; `INTERNAL_ERROR` maps to `INTERNAL_SERVER_ERROR`. It creates `TRPCError` only inside the transport layer and retains the `ApplicationError` as the transport error cause.
+
+The base `publicProcedure` uses middleware to translate errors once for all tRPC callers. tRPC v11 returns downstream failures from `next()` as an unsuccessful result, so the middleware inspects `result.error.cause` rather than relying only on `try/catch`. Existing tRPC errors and unknown errors pass through unchanged. The bulk-archive procedure, which intentionally catches individual failures instead of allowing middleware to see them, uses the same mapper to report each result code.
+
+## Service and Orchestration Changes
+
+The four production files currently importing `@trpc/server` will throw `ApplicationError`:
+
+- `git-ops.service.ts`: command failures use `INTERNAL_ERROR`; dirty worktrees use `PRECONDITION_FAILED`.
+- `creation.service.ts`: existing `BAD_REQUEST` cases use `INVALID_INPUT`; missing records use `NOT_FOUND`.
+- `workspace-archive.orchestrator.ts`: cleanup failure uses `INTERNAL_ERROR`; an invalid transition uses `INVALID_INPUT`.
+- `workspace-children.orchestrator.ts`: a missing project uses `NOT_FOUND`.
+
+No semantically tempting transport-code changes are included. For example, an already-checked-out branch remains a tRPC `BAD_REQUEST` via `INVALID_INPUT`, preserving existing callers.
+
+## Sensitive Error Details
+
+Git status, add, and commit failures keep short public messages that name the failed operation but omit stdout and stderr. The original command result is stored only in `ApplicationError.cause`. Runtime cleanup similarly uses an aggregate cause while returning only the operation-specific generic message to tRPC clients.
+
+## Dependency Boundary
+
+Dependency Cruiser will reject `@trpc/server` imports originating anywhere under `src/backend/services/` or `src/backend/orchestration/`. The target expression covers direct npm installs and pnpm's nested package layout. tRPC-layer, client type-only, and server-adapter imports remain allowed.
+
+## Testing
+
+- Unit-test application error fields and cause preservation.
+- Test the exhaustive mapper for every stable application code.
+- Test shared procedure middleware through a tRPC caller, including message/cause preservation and pass-through behavior.
+- Update service and orchestration tests to assert application codes rather than tRPC types.
+- Verify raw git command output is absent from the public message and retained only in the cause.
+- Update bulk archive coverage to throw an application error while returning the existing tRPC code.
+- Run dependency checks, type checking, the full test suite, and production build.
+
+## Edge Cases
+
+- Unknown exceptions remain tRPC internal errors.
+- Existing tRPC-layer `TRPCError` instances retain their original codes.
+- Errors caught inside a procedure, such as per-item bulk archive failures, explicitly use the centralized mapper.
+- Multiple runtime cleanup failures remain available to internal diagnostics without exposing their messages to transport clients.

--- a/src/backend/lib/application-error.test.ts
+++ b/src/backend/lib/application-error.test.ts
@@ -16,6 +16,7 @@ describe('ApplicationError', () => {
 
     expect(error).toBeInstanceOf(Error);
     expect(error).toMatchObject({
+      name: 'ApplicationError',
       code,
       message: 'Public message',
       cause,

--- a/src/backend/lib/application-error.test.ts
+++ b/src/backend/lib/application-error.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { ApplicationError, type ApplicationErrorCode } from './application-error';
+
+const applicationErrorCodes: ApplicationErrorCode[] = [
+  'INVALID_INPUT',
+  'NOT_FOUND',
+  'PRECONDITION_FAILED',
+  'CONFLICT',
+  'INTERNAL_ERROR',
+];
+
+describe('ApplicationError', () => {
+  it.each(applicationErrorCodes)('retains the %s code, message, and cause', (code) => {
+    const cause = new Error('internal detail');
+    const error = new ApplicationError(code, 'Public message', { cause });
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toMatchObject({
+      code,
+      message: 'Public message',
+      cause,
+    });
+  });
+});

--- a/src/backend/lib/application-error.ts
+++ b/src/backend/lib/application-error.ts
@@ -1,0 +1,17 @@
+export type ApplicationErrorCode =
+  | 'INVALID_INPUT'
+  | 'NOT_FOUND'
+  | 'PRECONDITION_FAILED'
+  | 'CONFLICT'
+  | 'INTERNAL_ERROR';
+
+export class ApplicationError extends Error {
+  constructor(
+    public readonly code: ApplicationErrorCode,
+    message: string,
+    options?: ErrorOptions
+  ) {
+    super(message, options);
+    this.name = 'ApplicationError';
+  }
+}

--- a/src/backend/orchestration/workspace-archive.orchestrator.test.ts
+++ b/src/backend/orchestration/workspace-archive.orchestrator.test.ts
@@ -1,5 +1,5 @@
-import { TRPCError } from '@trpc/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApplicationError } from '@/backend/lib/application-error';
 import { unsafeCoerce } from '@/test-utils/unsafe-coerce';
 import type { WorkspaceWithProject } from './types';
 
@@ -118,14 +118,19 @@ describe('archiveWorkspace', () => {
   });
 
   describe('state transition validation', () => {
-    it('throws TRPCError when transition is invalid', async () => {
+    it('throws an invalid-input application error when transition is invalid', async () => {
       vi.mocked(workspaceStateMachine.isValidTransition).mockReturnValue(false);
       const workspace = makeWorkspace({ status: 'NEW' as never });
 
-      await expect(archiveWorkspace(workspace, defaultOptions)).rejects.toThrow(TRPCError);
-      await expect(archiveWorkspace(workspace, defaultOptions)).rejects.toThrow(
-        /Cannot archive workspace from status: NEW/
+      const error = await archiveWorkspace(workspace, defaultOptions).catch(
+        (caught: unknown) => caught
       );
+
+      expect(error).toBeInstanceOf(ApplicationError);
+      expect(error).toMatchObject({
+        code: 'INVALID_INPUT',
+        message: 'Cannot archive workspace from status: NEW',
+      });
     });
 
     it('checks transition from current status to ARCHIVING', async () => {
@@ -229,6 +234,26 @@ describe('archiveWorkspace', () => {
       );
       expect(worktreeLifecycleService.cleanupWorkspaceWorktree).not.toHaveBeenCalled();
       expect(workspaceStateMachine.markArchived).not.toHaveBeenCalled();
+    });
+
+    it('retains multiple runtime cleanup failures as an aggregate cause', async () => {
+      const sessionError = new Error('session stop failed');
+      const terminalError = new Error('terminal destroy failed');
+      vi.mocked(services.sessionService.stopWorkspaceSessions).mockRejectedValue(sessionError);
+      vi.mocked(services.terminalService.destroyWorkspaceTerminals).mockImplementation(() => {
+        throw terminalError;
+      });
+
+      const error = await cleanupWorkspaceRuntimeResources('ws-1', services, 'archive').catch(
+        (caught: unknown) => caught
+      );
+
+      expect(error).toBeInstanceOf(ApplicationError);
+      expect(error).toMatchObject({ code: 'INTERNAL_ERROR' });
+      expect((error as ApplicationError).cause).toBeInstanceOf(AggregateError);
+      expect((error as ApplicationError).cause).toMatchObject({
+        errors: [sessionError, terminalError],
+      });
     });
 
     it('fails archive when run script stop rejects', async () => {

--- a/src/backend/orchestration/workspace-archive.orchestrator.ts
+++ b/src/backend/orchestration/workspace-archive.orchestrator.ts
@@ -1,4 +1,4 @@
-import { TRPCError } from '@trpc/server';
+import { ApplicationError } from '@/backend/lib/application-error';
 import { createLogger } from '@/backend/services/logger.service';
 import {
   workspaceAccessor,
@@ -78,9 +78,10 @@ export async function cleanupWorkspaceRuntimeResources(
         error instanceof Error ? error.message : String(error)
       ),
     });
-    throw new TRPCError({
-      code: 'INTERNAL_SERVER_ERROR',
-      message: `Failed to cleanup workspace resources before ${operation}`,
+    const message = `Failed to cleanup workspace resources before ${operation}`;
+    throw new ApplicationError('INTERNAL_ERROR', message, {
+      cause:
+        cleanupErrors.length === 1 ? cleanupErrors[0] : new AggregateError(cleanupErrors, message),
     });
   }
 }
@@ -178,10 +179,10 @@ export async function archiveWorkspace(
   services: ArchiveWorkspaceDependencies
 ) {
   if (!workspaceStateMachine.isValidTransition(workspace.status, 'ARCHIVING')) {
-    throw new TRPCError({
-      code: 'BAD_REQUEST',
-      message: `Cannot archive workspace from status: ${workspace.status}`,
-    });
+    throw new ApplicationError(
+      'INVALID_INPUT',
+      `Cannot archive workspace from status: ${workspace.status}`
+    );
   }
 
   const { previousStatus: statusBeforeArchive } =

--- a/src/backend/orchestration/workspace-children.orchestrator.test.ts
+++ b/src/backend/orchestration/workspace-children.orchestrator.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApplicationError } from '@/backend/lib/application-error';
 
 // --- Module mocks (before imports) ---
 
@@ -31,8 +32,13 @@ vi.mock('./workspace-init.orchestrator', () => ({
   initializeWorkspaceWorktree: vi.fn(),
 }));
 
-import { workspaceAccessor, workspaceNotificationAccessor } from '@/backend/services/workspace';
 import {
+  projectAccessor,
+  workspaceAccessor,
+  workspaceNotificationAccessor,
+} from '@/backend/services/workspace';
+import {
+  createChildWorkspace,
   persistChildNotification,
   persistParentNotification,
 } from './workspace-children.orchestrator';
@@ -40,6 +46,28 @@ import {
 const mockFindByIdWithProject = vi.mocked(workspaceAccessor.findByIdWithProject);
 const mockFindRawById = vi.mocked(workspaceAccessor.findRawById);
 const mockNotificationCreate = vi.mocked(workspaceNotificationAccessor.create);
+
+describe('createChildWorkspace', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('throws a not-found application error when the target project is missing', async () => {
+    vi.mocked(projectAccessor.findById).mockResolvedValue(null);
+
+    const error = await createChildWorkspace({
+      parentWorkspaceId: 'parent-1',
+      projectId: 'missing-project',
+      name: 'Child workspace',
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(ApplicationError);
+    expect(error).toMatchObject({
+      code: 'NOT_FOUND',
+      message: 'Project not found: missing-project',
+    });
+  });
+});
 
 describe('persistChildNotification', () => {
   beforeEach(() => {

--- a/src/backend/orchestration/workspace-children.orchestrator.ts
+++ b/src/backend/orchestration/workspace-children.orchestrator.ts
@@ -1,5 +1,5 @@
 import type { WorkspaceNotification } from '@prisma-gen/client';
-import { TRPCError } from '@trpc/server';
+import { ApplicationError } from '@/backend/lib/application-error';
 import { DEFAULT_FOLLOWUP } from '@/backend/prompts/workflows';
 import { createLogger } from '@/backend/services/logger.service';
 import { sessionDataService, sessionProviderResolverService } from '@/backend/services/session';
@@ -38,7 +38,7 @@ export async function createChildWorkspace(input: CreateChildWorkspaceInput): Pr
   // Validate that the target project exists
   const project = await projectAccessor.findById(input.projectId);
   if (!project) {
-    throw new TRPCError({ code: 'NOT_FOUND', message: `Project not found: ${input.projectId}` });
+    throw new ApplicationError('NOT_FOUND', `Project not found: ${input.projectId}`);
   }
 
   // WorkspaceCreationService validates parent existence, status, and depth

--- a/src/backend/services/git-ops.service.test.ts
+++ b/src/backend/services/git-ops.service.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApplicationError } from '@/backend/lib/application-error';
 
 const mockGitCommand = vi.hoisted(() => vi.fn());
 const mockGetSnapshot = vi.hoisted(() => vi.fn());
@@ -79,13 +80,6 @@ describe('gitOpsService', () => {
 
     mockGitCommand
       .mockResolvedValueOnce({ code: 0, stdout: '.git', stderr: '' })
-      .mockResolvedValueOnce({ code: 1, stdout: '', stderr: 'status failed' });
-    await expect(gitOpsService.commitIfNeeded('/repo/w1', 'W1', true)).rejects.toMatchObject({
-      code: 'INTERNAL_SERVER_ERROR',
-    });
-
-    mockGitCommand
-      .mockResolvedValueOnce({ code: 0, stdout: '.git', stderr: '' })
       .mockResolvedValueOnce({ code: 0, stdout: '', stderr: '' });
     await expect(gitOpsService.commitIfNeeded('/repo/w1', 'W1', true)).resolves.toBeUndefined();
 
@@ -113,17 +107,43 @@ describe('gitOpsService', () => {
   });
 
   it('invalidates staged archive changes when the commit fails', async () => {
+    const commitResult = { code: 1, stdout: '', stderr: 'commit failed' };
     mockGitCommand
       .mockResolvedValueOnce({ code: 0, stdout: '.git', stderr: '' })
       .mockResolvedValueOnce({ code: 0, stdout: ' M file.ts\n', stderr: '' })
       .mockResolvedValueOnce({ code: 0, stdout: '', stderr: '' })
-      .mockResolvedValueOnce({ code: 1, stdout: '', stderr: 'commit failed' });
+      .mockResolvedValueOnce(commitResult);
 
     await expect(gitOpsService.commitIfNeeded('/repo/w1', 'W1', true)).rejects.toMatchObject({
-      code: 'INTERNAL_SERVER_ERROR',
+      code: 'INTERNAL_ERROR',
+      message: 'Git commit failed',
+      cause: commitResult,
     });
     expect(mockGitStateInvalidate).toHaveBeenCalledOnce();
     expect(mockGitStateInvalidate).toHaveBeenCalledWith('/repo/w1');
+  });
+
+  it('sanitizes git command failures while retaining the raw result as the cause', async () => {
+    const statusResult = {
+      code: 1,
+      stdout: 'status stdout SECRET_STDERR_TOKEN',
+      stderr: 'status stderr SECRET_STDERR_TOKEN',
+    };
+    mockGitCommand
+      .mockResolvedValueOnce({ code: 0, stdout: '.git', stderr: '' })
+      .mockResolvedValueOnce(statusResult);
+
+    const error = await gitOpsService
+      .commitIfNeeded('/repo/w1', 'W1', true)
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(ApplicationError);
+    expect(error).toMatchObject({
+      code: 'INTERNAL_ERROR',
+      message: 'Git status failed',
+      cause: statusResult,
+    });
+    expect((error as Error).message).not.toContain('SECRET_STDERR_TOKEN');
   });
 
   it('removeWorktree uses git when registered and fs fallback otherwise', async () => {

--- a/src/backend/services/git-ops.service.ts
+++ b/src/backend/services/git-ops.service.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import { TRPCError } from '@trpc/server';
 import { GitClientFactory } from '@/backend/clients/git.client';
+import { ApplicationError } from '@/backend/lib/application-error';
 import { pathExists } from '@/backend/lib/file-helpers';
 import { gitCommand } from '@/backend/lib/shell';
 import {
@@ -59,9 +59,8 @@ class GitOpsService {
 
     const statusResult = await gitCommand(['status', '--porcelain'], worktreePath);
     if (statusResult.code !== 0) {
-      throw new TRPCError({
-        code: 'INTERNAL_SERVER_ERROR',
-        message: `Git status failed: ${statusResult.stderr || statusResult.stdout}`,
+      throw new ApplicationError('INTERNAL_ERROR', 'Git status failed', {
+        cause: statusResult,
       });
     }
 
@@ -70,19 +69,16 @@ class GitOpsService {
     }
 
     if (!commitUncommitted) {
-      throw new TRPCError({
-        code: 'PRECONDITION_FAILED',
-        message: 'Workspace has uncommitted changes. Enable commit-before-archive to proceed.',
-      });
+      throw new ApplicationError(
+        'PRECONDITION_FAILED',
+        'Workspace has uncommitted changes. Enable commit-before-archive to proceed.'
+      );
     }
 
     try {
       const addResult = await gitCommand(['add', '-A'], worktreePath);
       if (addResult.code !== 0) {
-        throw new TRPCError({
-          code: 'INTERNAL_SERVER_ERROR',
-          message: `Git add failed: ${addResult.stderr || addResult.stdout}`,
-        });
+        throw new ApplicationError('INTERNAL_ERROR', 'Git add failed', { cause: addResult });
       }
 
       const commitMessage = `Archive workspace ${workspaceName}`;
@@ -91,9 +87,8 @@ class GitOpsService {
         worktreePath
       );
       if (commitResult.code !== 0) {
-        throw new TRPCError({
-          code: 'INTERNAL_SERVER_ERROR',
-          message: `Git commit failed: ${commitResult.stderr || commitResult.stdout}`,
+        throw new ApplicationError('INTERNAL_ERROR', 'Git commit failed', {
+          cause: commitResult,
         });
       }
     } finally {

--- a/src/backend/services/workspace/service/lifecycle/creation.service.test.ts
+++ b/src/backend/services/workspace/service/lifecycle/creation.service.test.ts
@@ -1,5 +1,6 @@
 import type { UserSettings, Workspace } from '@prisma-gen/client';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApplicationError } from '@/backend/lib/application-error';
 import * as gitOpsServiceModule from '@/backend/services/git-ops.service';
 import type { createLogger } from '@/backend/services/logger.service';
 import * as userSettingsAccessorModule from '@/backend/services/settings';
@@ -336,7 +337,13 @@ describe('WorkspaceCreationService', () => {
           },
         });
 
-        await expect(service.create(source)).rejects.toThrow('Invalid auto-iteration config');
+        const error = await service.create(source).catch((caught: unknown) => caught);
+
+        expect(error).toBeInstanceOf(ApplicationError);
+        expect(error).toMatchObject({
+          code: 'INVALID_INPUT',
+          message: expect.stringContaining('Invalid auto-iteration config'),
+        });
         expect(workspaceAccessorModule.workspaceAccessor.create).not.toHaveBeenCalled();
       });
     });
@@ -393,7 +400,10 @@ describe('WorkspaceCreationService', () => {
           branchName: 'existing-branch',
         };
 
-        await expect(service.create(source)).rejects.toThrow('Project not found: proj-1');
+        const error = await service.create(source).catch((caught: unknown) => caught);
+
+        expect(error).toBeInstanceOf(ApplicationError);
+        expect(error).toMatchObject({ code: 'NOT_FOUND', message: 'Project not found: proj-1' });
       });
 
       it('should throw error when branch is already checked out', async () => {
@@ -405,9 +415,13 @@ describe('WorkspaceCreationService', () => {
           branchName: 'existing-branch',
         };
 
-        await expect(service.create(source)).rejects.toThrow(
-          "Branch 'existing-branch' is already checked out in another worktree."
-        );
+        const error = await service.create(source).catch((caught: unknown) => caught);
+
+        expect(error).toBeInstanceOf(ApplicationError);
+        expect(error).toMatchObject({
+          code: 'INVALID_INPUT',
+          message: "Branch 'existing-branch' is already checked out in another worktree.",
+        });
       });
     });
 

--- a/src/backend/services/workspace/service/lifecycle/creation.service.ts
+++ b/src/backend/services/workspace/service/lifecycle/creation.service.ts
@@ -1,5 +1,5 @@
 import type { Prisma, SessionProvider, Workspace } from '@prisma-gen/client';
-import { TRPCError } from '@trpc/server';
+import { ApplicationError } from '@/backend/lib/application-error';
 import type { AutoIterationConfig } from '@/backend/services/auto-iteration';
 import { gitOpsService } from '@/backend/services/git-ops.service';
 import type { createLogger } from '@/backend/services/logger.service';
@@ -180,25 +180,25 @@ export class WorkspaceCreationService {
     source: Extract<WorkspaceCreationSource, { type: 'MANUAL' }>
   ): PreparedWorkspaceCreation {
     if (source.mode === 'AUTO_ITERATION' && !source.autoIterationConfig) {
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: 'autoIterationConfig is required for AUTO_ITERATION workspaces',
-      });
+      throw new ApplicationError(
+        'INVALID_INPUT',
+        'autoIterationConfig is required for AUTO_ITERATION workspaces'
+      );
     }
     if (source.autoIterationConfig && source.mode !== 'AUTO_ITERATION') {
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: 'autoIterationConfig is only allowed for AUTO_ITERATION workspaces',
-      });
+      throw new ApplicationError(
+        'INVALID_INPUT',
+        'autoIterationConfig is only allowed for AUTO_ITERATION workspaces'
+      );
     }
     const configParsed = source.autoIterationConfig
       ? autoIterationConfigSchema.safeParse(source.autoIterationConfig)
       : null;
     if (configParsed && !configParsed.success) {
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: `Invalid auto-iteration config: ${configParsed.error.message}`,
-      });
+      throw new ApplicationError(
+        'INVALID_INPUT',
+        `Invalid auto-iteration config: ${configParsed.error.message}`
+      );
     }
     const autoIterationConfig = configParsed?.success ? configParsed.data : undefined;
 
@@ -236,18 +236,15 @@ export class WorkspaceCreationService {
   ): Promise<PreparedWorkspaceCreation> {
     const project = await projectAccessor.findById(source.projectId);
     if (!project) {
-      throw new TRPCError({
-        code: 'NOT_FOUND',
-        message: `Project not found: ${source.projectId}`,
-      });
+      throw new ApplicationError('NOT_FOUND', `Project not found: ${source.projectId}`);
     }
 
     const isCheckedOut = await gitOpsService.isBranchCheckedOut(project, source.branchName);
     if (isCheckedOut) {
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: `Branch '${source.branchName}' is already checked out in another worktree.`,
-      });
+      throw new ApplicationError(
+        'INVALID_INPUT',
+        `Branch '${source.branchName}' is already checked out in another worktree.`
+      );
     }
 
     return {
@@ -330,22 +327,22 @@ export class WorkspaceCreationService {
   ): Promise<PreparedWorkspaceCreation> {
     const parent = await workspaceAccessor.findRawById(source.parentWorkspaceId);
     if (!parent) {
-      throw new TRPCError({
-        code: 'NOT_FOUND',
-        message: `Parent workspace not found: ${source.parentWorkspaceId}`,
-      });
+      throw new ApplicationError(
+        'NOT_FOUND',
+        `Parent workspace not found: ${source.parentWorkspaceId}`
+      );
     }
     if (parent.status === 'ARCHIVED') {
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: 'Cannot create a child workspace under an archived parent',
-      });
+      throw new ApplicationError(
+        'INVALID_INPUT',
+        'Cannot create a child workspace under an archived parent'
+      );
     }
     if (parent.parentWorkspaceId) {
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: 'Child workspaces cannot have children (max depth 1)',
-      });
+      throw new ApplicationError(
+        'INVALID_INPUT',
+        'Child workspaces cannot have children (max depth 1)'
+      );
     }
 
     const metadata: Record<string, unknown> = {

--- a/src/backend/trpc/application-error-mapper.test.ts
+++ b/src/backend/trpc/application-error-mapper.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { ApplicationError, type ApplicationErrorCode } from '@/backend/lib/application-error';
+import { toTRPCError } from './application-error-mapper';
+
+const mappings: Array<{
+  applicationCode: ApplicationErrorCode;
+  trpcCode:
+    | 'BAD_REQUEST'
+    | 'NOT_FOUND'
+    | 'PRECONDITION_FAILED'
+    | 'CONFLICT'
+    | 'INTERNAL_SERVER_ERROR';
+}> = [
+  { applicationCode: 'INVALID_INPUT', trpcCode: 'BAD_REQUEST' },
+  { applicationCode: 'NOT_FOUND', trpcCode: 'NOT_FOUND' },
+  { applicationCode: 'PRECONDITION_FAILED', trpcCode: 'PRECONDITION_FAILED' },
+  { applicationCode: 'CONFLICT', trpcCode: 'CONFLICT' },
+  { applicationCode: 'INTERNAL_ERROR', trpcCode: 'INTERNAL_SERVER_ERROR' },
+];
+
+describe('toTRPCError', () => {
+  it.each(mappings)('maps $applicationCode to $trpcCode and retains the message and cause', ({
+    applicationCode,
+    trpcCode,
+  }) => {
+    const cause = new Error('internal detail');
+    const applicationError = new ApplicationError(applicationCode, 'Public message', { cause });
+
+    const error = toTRPCError(applicationError);
+
+    expect(error).toMatchObject({
+      code: trpcCode,
+      message: 'Public message',
+    });
+    expect(error.cause).toBe(applicationError);
+  });
+});

--- a/src/backend/trpc/application-error-mapper.ts
+++ b/src/backend/trpc/application-error-mapper.ts
@@ -1,0 +1,18 @@
+import { TRPCError } from '@trpc/server';
+import type { ApplicationError, ApplicationErrorCode } from '@/backend/lib/application-error';
+
+const trpcCodeByApplicationCode: Record<ApplicationErrorCode, TRPCError['code']> = {
+  INVALID_INPUT: 'BAD_REQUEST',
+  NOT_FOUND: 'NOT_FOUND',
+  PRECONDITION_FAILED: 'PRECONDITION_FAILED',
+  CONFLICT: 'CONFLICT',
+  INTERNAL_ERROR: 'INTERNAL_SERVER_ERROR',
+};
+
+export function toTRPCError(error: ApplicationError): TRPCError {
+  return new TRPCError({
+    code: trpcCodeByApplicationCode[error.code],
+    message: error.message,
+    cause: error,
+  });
+}

--- a/src/backend/trpc/trpc.test.ts
+++ b/src/backend/trpc/trpc.test.ts
@@ -1,6 +1,8 @@
+import { TRPCError } from '@trpc/server';
 import type { Request } from 'express';
 import { describe, expect, it } from 'vitest';
-import { createContext } from './trpc';
+import { ApplicationError } from '@/backend/lib/application-error';
+import { createContext, publicProcedure, router } from './trpc';
 
 describe('createContext request trust', () => {
   it('prefers Express proxy-aware req.ip over the socket remote address', () => {
@@ -16,6 +18,51 @@ describe('createContext request trust', () => {
     expect(ctx.requestTrust).toMatchObject({
       remoteAddress: '203.0.113.10',
       isLocal: false,
+    });
+  });
+});
+
+describe('publicProcedure application error translation', () => {
+  it('translates downstream application errors to tRPC errors', async () => {
+    const cause = new Error('internal detail');
+    const testRouter = router({
+      fail: publicProcedure.query(() => {
+        throw new ApplicationError('NOT_FOUND', 'Record not found', { cause });
+      }),
+    });
+
+    await expect(testRouter.createCaller({} as never).fail()).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+      message: 'Record not found',
+      cause: expect.objectContaining({
+        code: 'NOT_FOUND',
+        cause,
+      }),
+    });
+  });
+
+  it('passes through existing tRPC errors', async () => {
+    const error = new TRPCError({ code: 'FORBIDDEN', message: 'Access denied' });
+    const testRouter = router({
+      fail: publicProcedure.query(() => {
+        throw error;
+      }),
+    });
+
+    await expect(testRouter.createCaller({} as never).fail()).rejects.toBe(error);
+  });
+
+  it('passes through unknown errors', async () => {
+    const cause = new Error('Unexpected failure');
+    const testRouter = router({
+      fail: publicProcedure.query(() => {
+        throw cause;
+      }),
+    });
+
+    await expect(testRouter.createCaller({} as never).fail()).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+      cause,
     });
   });
 });

--- a/src/backend/trpc/trpc.ts
+++ b/src/backend/trpc/trpc.ts
@@ -2,11 +2,13 @@ import { initTRPC, TRPCError } from '@trpc/server';
 import type { Request } from 'express';
 import superjson from 'superjson';
 import type { AppContext } from '@/backend/app-context';
+import { ApplicationError } from '@/backend/lib/application-error';
 import {
   isLoopbackRemoteAddress,
   isOriginAllowed,
   isTrustedLocalAddress,
 } from '@/backend/lib/request-trust';
+import { toTRPCError } from './application-error-mapper';
 
 export { isLoopbackRemoteAddress };
 
@@ -67,8 +69,16 @@ const t = initTRPC.context<Context>().create({
 });
 
 export const router = t.router;
-export const publicProcedure = t.procedure;
 export const middleware = t.middleware;
+
+export const publicProcedure = t.procedure.use(async ({ next }) => {
+  const result = await next();
+  if (!result.ok && result.error.cause instanceof ApplicationError) {
+    throw toTRPCError(result.error.cause);
+  }
+
+  return result;
+});
 
 function isTrustedLocalContext(ctx: Context): boolean {
   // In-process callers, including tests and orchestration code using createCaller,

--- a/src/backend/trpc/workspace.router.test.ts
+++ b/src/backend/trpc/workspace.router.test.ts
@@ -1,6 +1,7 @@
 import { PRState, RatchetState, WorkspaceStatus } from '@prisma-gen/client';
 import { TRPCError } from '@trpc/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApplicationError } from '@/backend/lib/application-error';
 import type { CLIHealthStatus } from '@/backend/orchestration/cli-health.service';
 
 const mockWorkspaceDataService = vi.hoisted(() => ({
@@ -334,12 +335,12 @@ describe('workspaceRouter', () => {
     mockWorkspaceQueryService.listWithKanbanState.mockResolvedValue([
       { id: 'w-success' },
       { id: 'w-blocked' },
+      { id: 'w-missing' },
     ]);
     mockArchiveWorkspace
       .mockResolvedValueOnce({ archived: true })
-      .mockRejectedValueOnce(
-        new TRPCError({ code: 'PRECONDITION_FAILED', message: 'Uncommitted changes' })
-      );
+      .mockRejectedValueOnce(new ApplicationError('PRECONDITION_FAILED', 'Uncommitted changes'))
+      .mockRejectedValueOnce(new TRPCError({ code: 'NOT_FOUND', message: 'Workspace not found' }));
     const { caller } = createCaller();
 
     await expect(
@@ -357,8 +358,14 @@ describe('workspaceRouter', () => {
           error: 'Uncommitted changes',
           code: 'PRECONDITION_FAILED',
         },
+        {
+          id: 'w-missing',
+          success: false,
+          error: 'Workspace not found',
+          code: 'NOT_FOUND',
+        },
       ],
-      total: 2,
+      total: 3,
     });
   });
 

--- a/src/backend/trpc/workspace.trpc.ts
+++ b/src/backend/trpc/workspace.trpc.ts
@@ -1,6 +1,7 @@
 import { SessionProvider, WorkspaceProviderSelection } from '@prisma-gen/client';
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
+import { ApplicationError } from '@/backend/lib/application-error';
 import { getProviderUnavailableMessage } from '@/backend/lib/provider-cli-availability';
 import {
   buildWorkspaceSessionSummaries,
@@ -50,6 +51,7 @@ import {
   workspaceNotificationMessageId,
 } from '@/shared/workspace-notifications';
 import { deriveWorkspaceSidebarStatus } from '@/shared/workspace-sidebar-status';
+import { toTRPCError } from './application-error-mapper';
 import { type Context, publicProcedure, router, trustedLocalProcedure } from './trpc';
 import { workspaceFilesRouter } from './workspace/files.trpc';
 import { workspaceGitRouter } from './workspace/git.trpc';
@@ -60,6 +62,13 @@ import { getWorkspaceWithProjectOrThrow } from './workspace/workspace-helpers';
 
 const loggerName = 'workspace-trpc';
 const getLogger = (ctx: Context) => ctx.appContext.services.createLogger(loggerName);
+
+function normalizeBulkArchiveError(error: unknown): TRPCError | undefined {
+  if (error instanceof ApplicationError) {
+    return toTRPCError(error);
+  }
+  return error instanceof TRPCError ? error : undefined;
+}
 
 // Zod schema for workspace creation source discriminated union
 const workspaceCreationSourceSchema = z.discriminatedUnion('type', [
@@ -447,6 +456,7 @@ export const workspaceRouter = router({
           await archiveWorkspace(workspace, { commitUncommitted }, ctx.appContext.services);
           results.push({ id: workspace.id, success: true });
         } catch (error) {
+          const mappedError = normalizeBulkArchiveError(error);
           logger.error('Failed to archive workspace during bulk operation', {
             workspaceId: workspaceWithState.id,
             error: error instanceof Error ? error.message : String(error),
@@ -455,7 +465,7 @@ export const workspaceRouter = router({
             id: workspaceWithState.id,
             success: false,
             error: error instanceof Error ? error.message : String(error),
-            code: error instanceof TRPCError ? error.code : 'INTERNAL_SERVER_ERROR',
+            code: mappedError?.code ?? 'INTERNAL_SERVER_ERROR',
           });
         }
       }


### PR DESCRIPTION
## Summary

- Replace tRPC-specific errors in services and orchestration with stable application errors.
- Translate application failures once at the shared tRPC procedure boundary while preserving existing caller-visible codes.
- Prevent future `@trpc/server` imports below the transport layer with Dependency Cruiser.

## Changes

- **Application errors**: Added a transport-neutral `ApplicationError` contract with stable codes and cause preservation for CLI, Electron, and internal callers.
- **tRPC boundary**: Added an exhaustive application-to-tRPC mapper and shared procedure middleware, including bulk-archive compatibility for per-item failures.
- **Sensitive output**: Sanitized git command failure messages while retaining raw command results only as internal causes.
- **Services and orchestration**: Replaced direct `TRPCError` usage in git operations, workspace creation, workspace archive, and child-workspace orchestration.
- **Dependency enforcement**: Added an error-level rule covering npm and pnpm `@trpc/server` paths under services and orchestration.

## Testing

- [x] Tests pass (`pnpm test`: 3,952 passed, 3 skipped)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Dependency checks pass (`pnpm deps:check`)
- [ ] Manual testing: Not applicable; this is a backend error-boundary refactor covered by focused and full automated tests.

Closes #1961

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workspace create/archive/delete error paths and client-visible codes; behavior is intended to stay equivalent but relies on middleware and bulk-archive mapping staying in sync.
> 
> **Overview**
> Introduces **`ApplicationError`** with stable codes and optional **`cause`**, replacing **`TRPCError`** in git ops, workspace creation, archive orchestration, and child-workspace flows so services and orchestration no longer depend on **`@trpc/server`**.
> 
> **tRPC boundary:** **`toTRPCError`** maps application codes to existing client-visible tRPC codes (e.g. **`INVALID_INPUT` → `BAD_REQUEST`**). **`publicProcedure`** middleware translates failures from **`result.error.cause`** when it is an **`ApplicationError`**; **`trustedLocalProcedure`** inherits this. Bulk archive uses the same mapper for per-item **`code`** fields when errors are caught inside the loop.
> 
> **Safety:** Git status/add/commit failures expose short public messages only; raw command output stays on **`cause`**. Archive runtime cleanup can attach an **`AggregateError`** as **`cause`** while keeping a generic client message.
> 
> **Enforcement:** Dependency Cruiser blocks **`@trpc/server`** imports under **`src/backend/services`** and **`src/backend/orchestration`**. Design/plan docs and focused tests cover mapping, middleware pass-through, and sanitization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b53034f47d070df4d4a1fee4fd5fb0bff04c82a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

