### PR TITLE
Prepare 0.4.1 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to Factory Factory will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-07-17
+
+### Added
+
+- Add configurable Ratchet review-trigger modes for changes-requested feedback, unresolved inline threads, and optional commented review summaries (#1969)
+- Add `TRUST_PROXY_HEADERS` support for deployments behind trusted reverse proxies (#1976)
+
+### Changed
+
+- Derive Kanban columns from next-action ownership so automated CI and Ratchet work remains in Working while explicit human attention moves to Waiting (#1978)
+- Centralize workspace Git reads behind a shared, invalidation-aware snapshot cache (#1968)
+- Batch pull-request discovery by repository with bounded backoff, jitter, and non-overlapping scheduling (#1974)
+- Consolidate backend composition, service ownership, persistence boundaries, application errors, shared snapshot contracts, project issue loading, and child-workspace messaging (#1970, #1972, #1973, #1975, #1979, #1980, #1981)
+- Tighten backend dead-code coverage and remove unused dependencies and request-scoping residue (#1971)
+
+### Fixed
+
+- Harden ACP rendering, initialization cleanup, thinking-budget validation, completed tool-call persistence, and assistant-text streaming (#1925, #1927, #1930, #1938, #1954)
+- Preserve concurrent slash-command caches, reset reopened palette selection, and revalidate file mentions at the live cursor (#1926, #1929, #1935)
+- Preserve closed-session tabs, prevent dismissed setup-warning flashes, keep workspace links from changing selection, and prevent header overlap on smaller displays (#1928, #1931, #1933, #1937)
+- Use unsaved custom IDE commands during testing and preserve agent-selected Codex branch renames (#1939, #1940)
+- Prevent stale auto-iteration cleanup from deleting replacement loops (#1936)
+- Scope pull-request synchronization and Ratchet dispatch snapshots correctly across projects and pull requests (#1932, #1951)
+- Deliver child-workspace report-back instructions and surface actionable child-workspace errors (#1941, #1950)
+- Handle Kanban archive failures, suppress no-op snapshot fan-out, and bound archived-workspace caches (#1952, #1953, #1967)
+- Throttle hidden-workspace log updates while preserving bounded output and live status indicators (#1955)
+- Preserve live Ratchet fixer turns after ACP startup (#1977)
+
+### Documentation
+
+- Refresh the README and product screenshot, and correct chat-flow, child-message-delivery, and coverage documentation (#1934, #1964, #1965, #1966)
+
 ## [0.4.0] - 2026-07-16
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "factory-factory",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Workspace-based coding environment for running multiple Claude Code and Codex sessions in parallel",
   "private": false,
   "license": "MIT",


### PR DESCRIPTION
## Summary

- bump the Factory Factory package version from `0.4.0` to `0.4.1`
- add the `2026-07-17` changelog entry covering all 41 pull requests merged since `v0.4.0`
- group the release notes into added, changed, fixed, and documentation sections

## Why

Prepare the next patch release with a complete user-facing record of the changes shipped since `v0.4.0`.

## Impact

Release metadata only. This PR does not change runtime behavior.

## Validation

- `pnpm check:fix` (passes with six existing `<img>` performance warnings; no files changed)
- `pnpm check`
- `pnpm typecheck`
- `pnpm test` (338 files passed, 2 skipped; 4,250 tests passed, 3 skipped)
- verified every merged PR since `v0.4.0` is referenced in the new changelog section

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/1982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-metadata-only changes with no runtime or dependency updates.
> 
> **Overview**
> Prepares the **0.4.1** patch release by bumping the root `package.json` version from `0.4.0` to `0.4.1` and prepending a **2026-07-17** `CHANGELOG.md` section.
> 
> The new release notes summarize work merged since `v0.4.0` (41 PRs), grouped under **Added**, **Changed**, **Fixed**, and **Documentation**—including Ratchet review-trigger modes, `TRUST_PROXY_HEADERS`, Kanban column ownership, backend consolidation, and assorted UI/ACP/Ratchet fixes referenced by PR numbers.
> 
> No application source, dependencies, or runtime configuration are modified in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e00a27429cb451aa6b2c481fbe567ce8898aa1f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->