### PR TITLE
Fix #1998: Prevent double whitespace in file mentions

### DIFF
--- a/src/components/chat/chat-input/hooks/use-file-mentions.test.ts
+++ b/src/components/chat/chat-input/hooks/use-file-mentions.test.ts
@@ -162,16 +162,37 @@ describe('useFileMentions selection', () => {
     expect(rendered.onChange).toHaveBeenCalledWith(expectedValue);
   });
 
-  it('uses the mention at the live cursor position instead of the stored position', () => {
+  it.each([
+    {
+      separator: 'space',
+      value: '@one and @two',
+      expectedValue: '@src/foo.ts and @two',
+    },
+    {
+      separator: 'newline',
+      value: '@one\nand @two',
+      expectedValue: '@src/foo.ts\nand @two',
+    },
+    {
+      separator: 'tab',
+      value: '@one\tand @two',
+      expectedValue: '@src/foo.ts\tand @two',
+    },
+  ])('reuses the $separator at the live cursor after inserting a file mention', ({
+    value,
+    expectedValue,
+  }) => {
     const rendered = renderHook();
-    openMentionMenu(rendered, '@one and @two');
+    openMentionMenu(rendered, value);
 
     rendered.textarea.setSelectionRange(4, 4);
     flushSync(() => {
       rendered.getResult().handleFileMentionSelect('src/foo.ts');
     });
 
-    expect(rendered.textarea.value).toBe('@src/foo.ts  and @two');
-    expect(rendered.onChange).toHaveBeenCalledWith('@src/foo.ts  and @two');
+    expect(rendered.textarea.value).toBe(expectedValue);
+    expect(rendered.textarea.selectionStart).toBe(11);
+    expect(rendered.textarea.selectionEnd).toBe(11);
+    expect(rendered.onChange).toHaveBeenCalledWith(expectedValue);
   });
 });

--- a/src/components/chat/chat-input/hooks/use-file-mentions.ts
+++ b/src/components/chat/chat-input/hooks/use-file-mentions.ts
@@ -133,13 +133,14 @@ export function useFileMentions({
       // Replace from @ to cursor with the selected file path
       const before = currentValue.slice(0, atPos);
       const after = currentValue.slice(cursorPos);
-      const newValue = `${before}@${filePath} ${after}`;
+      const trailingSpace = charAtCursor === undefined ? ' ' : '';
+      const newValue = `${before}@${filePath}${trailingSpace}${after}`;
 
       inputRef.current.value = newValue;
       inputRef.current.focus();
 
-      // Move cursor after the inserted file path + space
-      const newCursorPos = atPos + filePath.length + 2; // +2 for @ and space
+      // Move the cursor after the inserted file path and any added space
+      const newCursorPos = atPos + filePath.length + 1 + trailingSpace.length;
       inputRef.current.setSelectionRange(newCursorPos, newCursorPos);
 
       onChange?.(newValue);

--- a/src/components/chat/chat-input/hooks/use-project-file-mentions.test.ts
+++ b/src/components/chat/chat-input/hooks/use-project-file-mentions.test.ts
@@ -162,16 +162,37 @@ describe('useProjectFileMentions selection', () => {
     expect(rendered.onChange).toHaveBeenCalledWith(expectedValue);
   });
 
-  it('uses the mention at the live cursor position instead of the stored position', () => {
+  it.each([
+    {
+      separator: 'space',
+      value: '@one and @two',
+      expectedValue: '@src/foo.ts and @two',
+    },
+    {
+      separator: 'newline',
+      value: '@one\nand @two',
+      expectedValue: '@src/foo.ts\nand @two',
+    },
+    {
+      separator: 'tab',
+      value: '@one\tand @two',
+      expectedValue: '@src/foo.ts\tand @two',
+    },
+  ])('reuses the $separator at the live cursor after inserting a file mention', ({
+    value,
+    expectedValue,
+  }) => {
     const rendered = renderHook();
-    openMentionMenu(rendered, '@one and @two');
+    openMentionMenu(rendered, value);
 
     rendered.textarea.setSelectionRange(4, 4);
     flushSync(() => {
       rendered.getResult().handleFileMentionSelect('src/foo.ts');
     });
 
-    expect(rendered.textarea.value).toBe('@src/foo.ts  and @two');
-    expect(rendered.onChange).toHaveBeenCalledWith('@src/foo.ts  and @two');
+    expect(rendered.textarea.value).toBe(expectedValue);
+    expect(rendered.textarea.selectionStart).toBe(11);
+    expect(rendered.textarea.selectionEnd).toBe(11);
+    expect(rendered.onChange).toHaveBeenCalledWith(expectedValue);
   });
 });

--- a/src/components/chat/chat-input/hooks/use-project-file-mentions.ts
+++ b/src/components/chat/chat-input/hooks/use-project-file-mentions.ts
@@ -118,12 +118,13 @@ export function useProjectFileMentions({
 
       const before = currentValue.slice(0, atPos);
       const after = currentValue.slice(cursorPos);
-      const newValue = `${before}@${filePath} ${after}`;
+      const trailingSpace = charAtCursor === undefined ? ' ' : '';
+      const newValue = `${before}@${filePath}${trailingSpace}${after}`;
 
       inputRef.current.value = newValue;
       inputRef.current.focus();
 
-      const newCursorPos = atPos + filePath.length + 2;
+      const newCursorPos = atPos + filePath.length + 1 + trailingSpace.length;
       inputRef.current.setSelectionRange(newCursorPos, newCursorPos);
 
       onChange?.(newValue);


### PR DESCRIPTION
## Summary
- Prevent file mention selection from inserting an extra space when the live cursor is already on whitespace.
- Preserve existing spaces, newlines, and tabs while keeping end-of-input insertion behavior unchanged.
- Add regression coverage for workspace and project file mention hooks.

## Changes
- **Chat file mentions**: Add a trailing space only when the cursor is at the end of the input, and calculate the post-insertion cursor position from the separator actually added.
- **Project file mentions**: Apply the same separator and cursor behavior to project-level file mention selection.
- **Tests**: Verify space, newline, and tab separators are reused without duplication in both hooks.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting checks pass (`pnpm check:fix`; existing `<img>` performance warnings remain)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not run; jsdom hook tests verify the resulting textarea value and cursor position.

Closes #1998

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

