### PR TITLE
Fix #1990: Preserve custom IDE commands

### DIFF
--- a/src/client/routes/admin-page.test.tsx
+++ b/src/client/routes/admin-page.test.tsx
@@ -272,6 +272,43 @@ describe('AdminDashboardPage settings tabs', () => {
     root.unmount();
   });
 
+  it('preserves the saved custom command when switching to a built-in IDE', () => {
+    mocks.userSettings.preferredIde = 'custom';
+    mocks.userSettings.customIdeCommand = 'code-insiders {workspace}';
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    flushSync(() => {
+      root.render(createElement(AdminDashboardPage));
+    });
+
+    const trigger = container.querySelector<HTMLElement>('#ide-select');
+
+    flushSync(() => {
+      trigger?.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, button: 0 }));
+      trigger?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const listbox = document.body.querySelector<HTMLElement>('[role="listbox"]');
+    const cursorOption = Array.from(
+      listbox?.querySelectorAll<HTMLElement>('[role="option"]') ?? []
+    ).find((option) => option.textContent === 'Cursor');
+    expect(cursorOption).toBeDefined();
+
+    flushSync(() => {
+      cursorOption?.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, button: 0 }));
+      cursorOption?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(mocks.updateSettingsMutate).toHaveBeenCalledWith({
+      preferredIde: 'cursor',
+    });
+
+    root.unmount();
+  });
+
   it('tests the current custom command before it has been saved', () => {
     mocks.userSettings.preferredIde = 'custom';
     mocks.userSettings.customIdeCommand = null;

--- a/src/client/routes/admin-page.tsx
+++ b/src/client/routes/admin-page.tsx
@@ -370,7 +370,9 @@ function IdeSettingsSection() {
   const handleIdeChange = (value: string) => {
     updateSettings.mutate({
       preferredIde: value as 'cursor' | 'vscode' | 'custom',
-      customIdeCommand: value === 'custom' ? settings?.customIdeCommand || null : null,
+      ...(value === 'custom' && {
+        customIdeCommand: settings?.customIdeCommand || null,
+      }),
     });
   };
 


### PR DESCRIPTION
## Summary
- Preserve saved custom IDE commands when switching to Cursor or VS Code.
- Add a UI regression test that verifies non-custom IDE changes omit `customIdeCommand`.

## Changes
- **Admin IDE settings**: Build the update payload without `customIdeCommand` for built-in IDE selections so Prisma preserves the stored value.
- **Regression coverage**: Exercise the IDE dropdown from a saved Custom configuration and assert the exact non-destructive mutation payload.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting checks pass (`pnpm check:fix`; existing `<img>` performance warnings remain)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not run; the change has no visual difference and is covered by a jsdom UI regression test.

Closes #1990

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
