### PR TITLE
Fix #1995: Ignore reordered session summaries in drift detection

### DIFF
--- a/src/backend/orchestration/snapshot-reconciliation.orchestrator.test.ts
+++ b/src/backend/orchestration/snapshot-reconciliation.orchestrator.test.ts
@@ -244,6 +244,34 @@ describe('detectDrift', () => {
     ]);
   });
 
+  it('ignores reordered session summaries', () => {
+    const first = {
+      sessionId: 'session-1',
+      name: 'First',
+      workflow: 'followup',
+      model: 'claude-sonnet',
+      persistedStatus: 'IDLE',
+      runtimePhase: 'idle',
+      processState: 'alive',
+      activity: 'IDLE',
+      updatedAt: '2026-01-03T10:00:00.000Z',
+      lastExit: null,
+      errorMessage: null,
+    } satisfies WorkspaceSnapshotEntry['sessionSummaries'][number];
+    const second = {
+      ...first,
+      sessionId: 'session-2',
+      name: 'Second',
+      updatedAt: '2026-01-03T11:00:00.000Z',
+    } satisfies WorkspaceSnapshotEntry['sessionSummaries'][number];
+    const existing = createSnapshotEntry({ sessionSummaries: [first, second] });
+    const authoritative: SnapshotUpdateInput = {
+      sessionSummaries: [{ ...second }, { ...first }],
+    };
+
+    expect(detectDrift(existing, authoritative)).toEqual([]);
+  });
+
   it.each([
     {
       field: 'ratchetDispatchOutcome' as const,

--- a/src/backend/orchestration/snapshot-reconciliation.orchestrator.ts
+++ b/src/backend/orchestration/snapshot-reconciliation.orchestrator.ts
@@ -29,6 +29,7 @@ import {
   computePendingRequestType,
   type gitOpsService,
   type SnapshotUpdateInput,
+  sessionSummariesEqual,
   type WorkspaceSnapshotEntry,
   type workspaceMaintenanceService,
   type workspaceSnapshotStore,
@@ -138,7 +139,12 @@ export function detectDrift(
         continue;
       }
       const snapValue = existing[field];
-      if (!isDeepStrictEqual(authValue, snapValue)) {
+      const valuesEqual =
+        field === 'sessionSummaries'
+          ? authoritative.sessionSummaries !== undefined &&
+            sessionSummariesEqual(authoritative.sessionSummaries, existing.sessionSummaries)
+          : isDeepStrictEqual(authValue, snapValue);
+      if (!valuesEqual) {
         drifts.push({
           field,
           group,

--- a/src/backend/services/workspace/service/index.ts
+++ b/src/backend/services/workspace/service/index.ts
@@ -56,6 +56,7 @@ export {
   type SnapshotRemovedEvent,
   type SnapshotUpdateInput,
   type SnapshotUpsertResult,
+  sessionSummariesEqual,
   type WorkspaceSessionSummary,
   type WorkspaceSnapshotEntry,
   WorkspaceSnapshotStore,

--- a/src/backend/services/workspace/service/snapshot/workspace-snapshot-store.service.ts
+++ b/src/backend/services/workspace/service/snapshot/workspace-snapshot-store.service.ts
@@ -230,7 +230,7 @@ function gitStatsEqual(left: GitStats | null, right: GitStats | null): boolean {
   );
 }
 
-function sessionSummariesEqual(
+export function sessionSummariesEqual(
   left: WorkspaceSessionSummary[],
   right: WorkspaceSessionSummary[]
 ): boolean {


### PR DESCRIPTION
## Summary
- Prevent snapshot reconciliation from reporting drift when session summaries are reordered.
- Keep drift detection aligned with the snapshot store's existing semantic equality.
- Add focused regression coverage for reordered summaries.

## Changes
- **Snapshot reconciliation**: Compare `sessionSummaries` order-insensitively while retaining deep equality for every other drift field.
- **Workspace snapshot store**: Export the canonical non-mutating comparator through the workspace service barrel.
- **Regression coverage**: Verify cloned summaries in reverse order produce no drift.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting checks pass (`pnpm check:fix`; existing `<img>` performance warnings remain)
- [x] Build succeeds (`pnpm build`)
- [x] Focused regression passes (`pnpm exec vitest run src/backend/orchestration/snapshot-reconciliation.orchestrator.test.ts src/backend/services/workspace/service/snapshot/workspace-snapshot-store.service.test.ts`)
- [ ] Manual testing: Not applicable; this is a pure backend comparison covered by unit tests.

Closes #1995

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
