### PR TITLE
Fix #2002: Preserve workspace hierarchy in backups

### DIFF
--- a/docs/superpowers/plans/2026-07-25-workspace-backup-hierarchy.md
+++ b/docs/superpowers/plans/2026-07-25-workspace-backup-hierarchy.md
@@ -1,0 +1,152 @@
+# Workspace Backup Hierarchy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve parent-child workspace relationships across backup export and restore while accepting older version-4 backups.
+
+**Architecture:** Extend the existing shared workspace backup contract with one backward-compatible nullable field. Thread that field through the service's explicit export and import mappings, and protect the complete data flow with a focused round-trip test.
+
+**Tech Stack:** TypeScript, Zod, Prisma, Vitest.
+
+## Global Constraints
+
+- Keep backup `schemaVersion` at `4`.
+- Parse a missing legacy `parentWorkspaceId` as `null`.
+- Include `parentWorkspaceId` explicitly in every newly exported workspace.
+- Preserve both parent IDs and `null` values on restore.
+- Do not change workspace notification backup behavior or SQLite foreign-key configuration.
+
+---
+
+### Task 1: Preserve workspace hierarchy in backup data
+
+**Files:**
+- Modify: `src/shared/schemas/export-data.schema.ts`
+- Modify: `src/shared/schemas/export-data.schema.test.ts`
+- Modify: `src/backend/orchestration/data-backup.service.ts`
+- Modify: `src/backend/orchestration/data-backup.service.test.ts`
+
+**Interfaces:**
+- Consumes: Prisma `Workspace.parentWorkspaceId: string | null`.
+- Produces: parsed `ExportData.data.workspaces[*].parentWorkspaceId: string | null`.
+- Preserves: version-4 payloads that omit the new field by parsing them as top-level workspaces.
+
+- [ ] **Step 1: Add the schema compatibility RED assertion**
+
+In the existing `defaults legacy workspace mode and auto-iteration config` test, assert:
+
+```typescript
+expect(parsed.parentWorkspaceId).toBeNull();
+```
+
+- [ ] **Step 2: Add the service round-trip RED test**
+
+Create parent and child `Workspace` fixtures from `mockWorkspace`, set the child to `parentWorkspaceId: parentWorkspace.id`, export both, and assert:
+
+```typescript
+expect(exported.data.workspaces[1]?.parentWorkspaceId).toBe(parentWorkspace.id);
+```
+
+Import that exact `exported` value and assert the second workspace create receives:
+
+```typescript
+expect(mockTx.workspace.create).toHaveBeenNthCalledWith(2, {
+  data: expect.objectContaining({
+    id: childWorkspace.id,
+    parentWorkspaceId: parentWorkspace.id,
+  }),
+});
+```
+
+- [ ] **Step 3: Run focused tests to verify RED**
+
+Run:
+
+```bash
+pnpm test src/shared/schemas/export-data.schema.test.ts src/backend/orchestration/data-backup.service.test.ts
+```
+
+Expected: FAIL because parsed legacy workspaces do not default `parentWorkspaceId` and exported child workspaces omit it.
+
+- [ ] **Step 4: Extend the shared workspace schema**
+
+Add this field beside the workspace identity and relationship fields:
+
+```typescript
+parentWorkspaceId: z.string().nullable().optional().default(null),
+```
+
+- [ ] **Step 5: Thread the field through export and import**
+
+Add to `DataBackupService.exportData`:
+
+```typescript
+parentWorkspaceId: w.parentWorkspaceId,
+```
+
+Add to the `tx.workspace.create` input in `importWorkspaces`:
+
+```typescript
+parentWorkspaceId: workspace.parentWorkspaceId,
+```
+
+- [ ] **Step 6: Run focused tests to verify GREEN**
+
+Run:
+
+```bash
+pnpm test src/shared/schemas/export-data.schema.test.ts src/backend/orchestration/data-backup.service.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the focused bug fix**
+
+```bash
+git add src/shared/schemas/export-data.schema.ts src/shared/schemas/export-data.schema.test.ts src/backend/orchestration/data-backup.service.ts src/backend/orchestration/data-backup.service.test.ts
+git commit -m "Preserve workspace hierarchy in backups (#2002)"
+```
+
+### Task 2: Verify and publish
+
+**Files:**
+- Review: all files changed from `origin/main`.
+
+**Interfaces:**
+- Produces: a clean pushed branch and a GitHub pull request closing issue #2002.
+
+- [ ] **Step 1: Run the required verification suite**
+
+Run:
+
+```bash
+pnpm typecheck && pnpm check:fix && pnpm test && pnpm build
+```
+
+Expected: every command exits with status 0.
+
+- [ ] **Step 2: Review formatting and the complete diff**
+
+Run `git status --short`, inspect any `pnpm check:fix` edits, then run `git diff origin/main`. Remove debug code, unrelated formatting, unsafe casts, and unnecessary complexity.
+
+- [ ] **Step 3: Commit verification changes if needed**
+
+Stage only intentional in-scope changes and use an imperative commit message under 72 characters. Verify `git status --short` is empty.
+
+- [ ] **Step 4: Push and create the pull request**
+
+Push with `git push -u origin HEAD`. Write `/tmp/pr-body.md` containing a summary, changes, exact verification results, `Closes #2002`, a horizontal rule, and the required Factory Factory signature. Create the PR with:
+
+```bash
+gh pr create --title "Fix #2002: Preserve workspace hierarchy in backups" --body-file /tmp/pr-body.md
+```
+
+- [ ] **Step 5: Verify the pull request**
+
+Run:
+
+```bash
+gh pr view --json url,title,state
+```
+
+Expected: an open pull request URL for the current branch.

--- a/docs/superpowers/specs/2026-07-25-workspace-backup-hierarchy-design.md
+++ b/docs/superpowers/specs/2026-07-25-workspace-backup-hierarchy-design.md
@@ -1,0 +1,35 @@
+# Workspace Backup Hierarchy Design
+
+## Goal
+
+Preserve `Workspace.parentWorkspaceId` through backup export and restore without making existing schema-version-4 backups invalid.
+
+## Root Cause
+
+The child-workspace feature added the nullable Prisma relation after the version-4 backup contract was established. The backup schema, explicit workspace export mapper, and explicit workspace import mapper were not extended with the new field. Zod therefore strips the relationship from imported payloads, and restored workspace rows receive the database default of `null`.
+
+## Approaches Considered
+
+1. Add a backward-compatible version-4 field and map it in both directions. Define `parentWorkspaceId` as a nullable field that defaults to `null` when absent, export it explicitly, and pass it to Prisma during restore. This is the recommended approach because it repairs new backups and still accepts version-4 backups made before the fix.
+2. Make the new version-4 field required. This matches the current database shape but rejects older version-4 backup files that cannot contain the field.
+3. Introduce schema version 5 and a multi-version importer. This gives the strongest version boundary but adds migration machinery that is unnecessary for one nullable, safely defaultable field.
+
+## Data Flow
+
+`exportedWorkspaceSchema` will expose `parentWorkspaceId` as `z.string().nullable().optional().default(null)`. The inferred parsed/export type therefore always contains `string | null`, while raw legacy payloads may omit it.
+
+`DataBackupService.exportData` will copy `Workspace.parentWorkspaceId` into every exported workspace object. `importWorkspaces` will copy the parsed value into `tx.workspace.create`, preserving both parent IDs and explicit `null` values.
+
+The existing import order remains unchanged. Export snapshots are ordered by workspace creation time, and child workspaces are created from an existing parent. The current database triggers also enforce a maximum hierarchy depth. Reordering or otherwise redesigning restore dependency handling is outside this bug's scope.
+
+## Tests
+
+- Extend the legacy workspace-schema test to prove an omitted `parentWorkspaceId` parses as `null`.
+- Add a service round-trip test with one parent and one child. Export both, assert the child's payload contains the parent ID, import the exported value, and assert the child Prisma create input contains the same parent ID.
+- Keep the existing null-parent workspace fixture so normal top-level workspace export remains covered.
+
+The round-trip test catches removal from the schema, export mapper, or import mapper: any of those mutations either drops the exported value or prevents it from reaching the restore create call.
+
+## Non-Goals
+
+This change does not export workspace notifications, alter hierarchy depth rules, enable SQLite foreign keys, change backup schema versions, or modify UI behavior.

--- a/src/backend/orchestration/data-backup.service.test.ts
+++ b/src/backend/orchestration/data-backup.service.test.ts
@@ -491,7 +491,7 @@ describe('DataBackupService', () => {
       vi.mocked(prisma.terminalSession.findMany).mockResolvedValue([]);
       vi.mocked(prisma.userSettings.findFirst).mockResolvedValue(null);
 
-      const exported = await dataBackupService.exportData('1.0.0');
+      const exported = exportDataSchema.parse(await dataBackupService.exportData('1.0.0'));
 
       expect(exported.data.workspaces[0]?.parentWorkspaceId).toBeNull();
       expect(exported.data.workspaces[1]?.parentWorkspaceId).toBe(parentWorkspace.id);
@@ -509,6 +509,12 @@ describe('DataBackupService', () => {
       const result = await dataBackupService.importData(exported);
 
       expect(result.workspaces.imported).toBe(2);
+      expect(mockTx.workspace.create).toHaveBeenNthCalledWith(1, {
+        data: expect.objectContaining({
+          id: parentWorkspace.id,
+          parentWorkspaceId: null,
+        }),
+      });
       expect(mockTx.workspace.create).toHaveBeenNthCalledWith(2, {
         data: expect.objectContaining({
           id: childWorkspace.id,

--- a/src/backend/orchestration/data-backup.service.test.ts
+++ b/src/backend/orchestration/data-backup.service.test.ts
@@ -469,6 +469,53 @@ describe('DataBackupService', () => {
         }),
       });
     });
+
+    it('preserves parent-child relationships through export and import', async () => {
+      const parentWorkspace: Workspace = {
+        ...mockWorkspace,
+        id: 'parent-ws',
+        name: 'Parent Workspace',
+      };
+      const childWorkspace: Workspace = {
+        ...mockWorkspace,
+        id: 'child-ws',
+        name: 'Child Workspace',
+        parentWorkspaceId: parentWorkspace.id,
+        createdAt: new Date('2025-01-01T00:01:00.000Z'),
+        updatedAt: new Date('2025-01-01T00:36:00.000Z'),
+      };
+
+      vi.mocked(prisma.project.findMany).mockResolvedValue([mockProject]);
+      vi.mocked(prisma.workspace.findMany).mockResolvedValue([parentWorkspace, childWorkspace]);
+      vi.mocked(prisma.agentSession.findMany).mockResolvedValue([]);
+      vi.mocked(prisma.terminalSession.findMany).mockResolvedValue([]);
+      vi.mocked(prisma.userSettings.findFirst).mockResolvedValue(null);
+
+      const exported = await dataBackupService.exportData('1.0.0');
+
+      expect(exported.data.workspaces[0]?.parentWorkspaceId).toBeNull();
+      expect(exported.data.workspaces[1]?.parentWorkspaceId).toBe(parentWorkspace.id);
+
+      vi.mocked(mockTx.project.findUnique)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValue(mockProject);
+      vi.mocked(mockTx.project.create).mockResolvedValue(mockProject);
+      vi.mocked(mockTx.workspace.findUnique).mockResolvedValue(null);
+      vi.mocked(mockTx.workspace.create)
+        .mockResolvedValueOnce(parentWorkspace)
+        .mockResolvedValueOnce(childWorkspace);
+
+      const result = await dataBackupService.importData(exported);
+
+      expect(result.workspaces.imported).toBe(2);
+      expect(mockTx.workspace.create).toHaveBeenNthCalledWith(2, {
+        data: expect.objectContaining({
+          id: childWorkspace.id,
+          parentWorkspaceId: parentWorkspace.id,
+        }),
+      });
+    });
   });
 
   describe('importData', () => {

--- a/src/backend/orchestration/data-backup.service.test.ts
+++ b/src/backend/orchestration/data-backup.service.test.ts
@@ -501,8 +501,13 @@ describe('DataBackupService', () => {
         .mockResolvedValueOnce(null)
         .mockResolvedValue(mockProject);
       vi.mocked(mockTx.project.create).mockResolvedValue(mockProject);
-      vi.mocked(mockTx.workspace.findUnique).mockResolvedValue(null);
       const importedWorkspaceIds = new Set<string>();
+      vi.mocked(mockTx.workspace.findUnique).mockImplementation(({ where }) => {
+        if (!(where.id && importedWorkspaceIds.has(where.id))) {
+          return Promise.resolve(null);
+        }
+        return Promise.resolve(where.id === parentWorkspace.id ? parentWorkspace : childWorkspace);
+      });
       vi.mocked(mockTx.workspace.create).mockImplementation(({ data }) => {
         if (data.parentWorkspaceId && !importedWorkspaceIds.has(data.parentWorkspaceId as string)) {
           return Promise.reject(new Error('Foreign key constraint failed'));
@@ -615,6 +620,72 @@ describe('DataBackupService', () => {
       vi.mocked(mockTx.project.findUnique).mockResolvedValue(null);
       vi.mocked(mockTx.userSettings.findFirst).mockResolvedValue(null);
       vi.mocked(mockTx.userSettings.create).mockResolvedValue(mockUserSettings);
+
+      const result = await dataBackupService.importData(exportedData);
+
+      expect(result.workspaces.imported).toBe(0);
+      expect(result.workspaces.skipped).toBe(1);
+      expect(mockTx.workspace.create).not.toHaveBeenCalled();
+    });
+
+    it('skips child workspaces when their parent was not imported', async () => {
+      const baseWorkspace = createImportData().data.workspaces[0]!;
+      const exportedData = createImportData({
+        projects: [],
+        workspaces: [
+          {
+            ...baseWorkspace,
+            id: 'child-ws',
+            parentWorkspaceId: 'parent-ws',
+          },
+          {
+            ...baseWorkspace,
+            id: 'parent-ws',
+            projectId: 'missing-project',
+            parentWorkspaceId: null,
+          },
+        ],
+        agentSessions: [],
+        terminalSessions: [],
+        userSettings: null,
+      });
+
+      vi.mocked(mockTx.workspace.findUnique).mockResolvedValue(null);
+      vi.mocked(mockTx.project.findUnique).mockImplementation(({ where }) =>
+        Promise.resolve(where.id === mockProject.id ? mockProject : null)
+      );
+      vi.mocked(mockTx.workspace.create).mockRejectedValue(
+        new Error('Foreign key constraint failed')
+      );
+
+      const result = await dataBackupService.importData(exportedData);
+
+      expect(result.workspaces.imported).toBe(0);
+      expect(result.workspaces.skipped).toBe(2);
+      expect(mockTx.workspace.create).not.toHaveBeenCalled();
+    });
+
+    it('skips child workspaces with an empty parent ID', async () => {
+      const baseWorkspace = createImportData().data.workspaces[0]!;
+      const exportedData = createImportData({
+        projects: [],
+        workspaces: [
+          {
+            ...baseWorkspace,
+            id: 'child-ws',
+            parentWorkspaceId: '',
+          },
+        ],
+        agentSessions: [],
+        terminalSessions: [],
+        userSettings: null,
+      });
+
+      vi.mocked(mockTx.workspace.findUnique).mockResolvedValue(null);
+      vi.mocked(mockTx.project.findUnique).mockResolvedValue(mockProject);
+      vi.mocked(mockTx.workspace.create).mockRejectedValue(
+        new Error('Foreign key constraint failed')
+      );
 
       const result = await dataBackupService.importData(exportedData);
 

--- a/src/backend/orchestration/data-backup.service.test.ts
+++ b/src/backend/orchestration/data-backup.service.test.ts
@@ -486,15 +486,15 @@ describe('DataBackupService', () => {
       };
 
       vi.mocked(prisma.project.findMany).mockResolvedValue([mockProject]);
-      vi.mocked(prisma.workspace.findMany).mockResolvedValue([parentWorkspace, childWorkspace]);
+      vi.mocked(prisma.workspace.findMany).mockResolvedValue([childWorkspace, parentWorkspace]);
       vi.mocked(prisma.agentSession.findMany).mockResolvedValue([]);
       vi.mocked(prisma.terminalSession.findMany).mockResolvedValue([]);
       vi.mocked(prisma.userSettings.findFirst).mockResolvedValue(null);
 
       const exported = exportDataSchema.parse(await dataBackupService.exportData('1.0.0'));
 
-      expect(exported.data.workspaces[0]?.parentWorkspaceId).toBeNull();
-      expect(exported.data.workspaces[1]?.parentWorkspaceId).toBe(parentWorkspace.id);
+      expect(exported.data.workspaces[0]?.parentWorkspaceId).toBe(parentWorkspace.id);
+      expect(exported.data.workspaces[1]?.parentWorkspaceId).toBeNull();
 
       vi.mocked(mockTx.project.findUnique)
         .mockResolvedValueOnce(null)
@@ -502,9 +502,15 @@ describe('DataBackupService', () => {
         .mockResolvedValue(mockProject);
       vi.mocked(mockTx.project.create).mockResolvedValue(mockProject);
       vi.mocked(mockTx.workspace.findUnique).mockResolvedValue(null);
-      vi.mocked(mockTx.workspace.create)
-        .mockResolvedValueOnce(parentWorkspace)
-        .mockResolvedValueOnce(childWorkspace);
+      const importedWorkspaceIds = new Set<string>();
+      vi.mocked(mockTx.workspace.create).mockImplementation(({ data }) => {
+        if (data.parentWorkspaceId && !importedWorkspaceIds.has(data.parentWorkspaceId as string)) {
+          return Promise.reject(new Error('Foreign key constraint failed'));
+        }
+
+        importedWorkspaceIds.add(data.id as string);
+        return Promise.resolve(data.id === parentWorkspace.id ? parentWorkspace : childWorkspace);
+      });
 
       const result = await dataBackupService.importData(exported);
 

--- a/src/backend/orchestration/data-backup.service.ts
+++ b/src/backend/orchestration/data-backup.service.ts
@@ -149,6 +149,7 @@ async function importWorkspaces(
       data: {
         id: workspace.id,
         projectId: workspace.projectId,
+        parentWorkspaceId: workspace.parentWorkspaceId,
         name: workspace.name,
         description: workspace.description,
         status: workspace.status,
@@ -385,6 +386,7 @@ class DataBackupService {
         workspaces: workspaces.map((w) => ({
           id: w.id,
           projectId: w.projectId,
+          parentWorkspaceId: w.parentWorkspaceId,
           name: w.name,
           description: w.description,
           status: w.status,

--- a/src/backend/orchestration/data-backup.service.ts
+++ b/src/backend/orchestration/data-backup.service.ts
@@ -127,8 +127,11 @@ async function importWorkspaces(
   tx: TransactionClient
 ): Promise<ImportCounter> {
   const counter: ImportCounter = { imported: 0, skipped: 0 };
+  const orderedWorkspaces = [...workspaces].sort(
+    (a, b) => Number(a.parentWorkspaceId !== null) - Number(b.parentWorkspaceId !== null)
+  );
 
-  for (const workspace of workspaces) {
+  for (const workspace of orderedWorkspaces) {
     const existing = await tx.workspace.findUnique({ where: { id: workspace.id } });
     if (existing) {
       counter.skipped++;

--- a/src/backend/orchestration/data-backup.service.ts
+++ b/src/backend/orchestration/data-backup.service.ts
@@ -148,6 +148,20 @@ async function importWorkspaces(
       continue;
     }
 
+    if (workspace.parentWorkspaceId !== null) {
+      const parentWorkspace = await tx.workspace.findUnique({
+        where: { id: workspace.parentWorkspaceId },
+      });
+      if (!parentWorkspace) {
+        logger.warn('Skipping workspace due to missing parent workspace', {
+          workspaceId: workspace.id,
+          parentWorkspaceId: workspace.parentWorkspaceId,
+        });
+        counter.skipped++;
+        continue;
+      }
+    }
+
     await tx.workspace.create({
       data: {
         id: workspace.id,

--- a/src/shared/schemas/export-data.schema.test.ts
+++ b/src/shared/schemas/export-data.schema.test.ts
@@ -143,6 +143,7 @@ describe('Enum sync with Prisma schema', () => {
 
     expect(parsed.mode).toBe('STANDARD');
     expect(parsed.autoIterationConfig).toBeNull();
+    expect(parsed.parentWorkspaceId).toBeNull();
   });
 
   it('validates and defaults exported auto-iteration config', () => {

--- a/src/shared/schemas/export-data.schema.ts
+++ b/src/shared/schemas/export-data.schema.ts
@@ -69,6 +69,7 @@ const exportedProjectSchema = z.object({
 const exportedWorkspaceSchema = z.object({
   id: z.string(),
   projectId: z.string(),
+  parentWorkspaceId: z.string().nullable().optional().default(null),
   name: z.string(),
   description: z.string().nullable(),
   status: WorkspaceStatus,


### PR DESCRIPTION
## Summary
- Preserve parent-child workspace relationships across backup export and restore.
- Keep existing schema-v4 backups importable by defaulting a missing parent ID to `null`.
- Add round-trip coverage through the production Zod validation boundary.

## Changes
- **Backup schema**: Add backward-compatible `parentWorkspaceId` validation and normalization.
- **Backup service**: Export and restore `parentWorkspaceId` for every workspace.
- **Regression coverage**: Verify both a top-level workspace and its child retain their relationships through export, validation, and import.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting checks pass (`pnpm check:fix`; existing `<img>` performance warnings remain)
- [x] Build succeeds (`pnpm build`)
- [x] Focused regression passes (`pnpm test src/shared/schemas/export-data.schema.test.ts src/backend/orchestration/data-backup.service.test.ts`)
- [ ] Manual testing: Not applicable; backup serialization and restore inputs are covered by automated round-trip tests.

Closes #2002

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes backup restore behavior for workspace rows and FK ordering; mistakes could flatten hierarchies or skip valid children, though scope is limited to data-backup and covered by round-trip tests.
> 
> **Overview**
> Fixes backup/restore dropping **parent-child workspace links** by extending the v4 export contract with **`parentWorkspaceId`** (optional, defaults to `null` for legacy files) and mapping it in **`DataBackupService`** export and **`importWorkspaces`** create payloads.
> 
> **Import** now sorts workspaces so parents are created before children, verifies the parent row exists before inserting a child, and **skips** workspaces when the parent is missing or when a child references an empty parent ID. **Tests** cover legacy schema parsing, parent/child round-trip export→import, and the skip paths; **design/plan docs** describe the approach for #2002.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cce26df06357bfe015058f10ea01675aeec02907. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->