### PR TITLE
Fix #2001: Prevent stopped prompts from reviving sessions

### DIFF
--- a/src/backend/services/session/service/lifecycle/session.service.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.service.test.ts
@@ -2350,10 +2350,10 @@ describe('SessionService', () => {
     sessionEventBus.registerViewerCountProvider((viewedSessionId) =>
       viewedSessionId === sessionId ? 1 : 0
     );
+    const publishToSessionSpy = vi.spyOn(sessionEventBus, 'publishToSession');
     try {
       const prompt = createDeferred<{ stopReason: string }>();
       const onPromptTurnComplete = vi.fn().mockResolvedValue(undefined);
-      const publishToSessionSpy = vi.spyOn(sessionEventBus, 'publishToSession');
       sessionService.setPromptTurnCompleteHandler(onPromptTurnComplete);
       vi.mocked(acpRuntimeManager.sendPrompt).mockReturnValue(prompt.promise as never);
       vi.mocked(acpRuntimeManager.stopClient).mockResolvedValue();
@@ -2386,15 +2386,77 @@ describe('SessionService', () => {
       expect(publishToSessionSpy).not.toHaveBeenCalledWith(
         sessionId,
         expect.objectContaining({
-          type: 'session_runtime_updated',
-          sessionRuntime: expect.objectContaining({ processState: 'alive' }),
+          type: 'session_delta',
+          data: expect.objectContaining({
+            type: 'session_runtime_updated',
+            sessionRuntime: expect.objectContaining({ processState: 'alive' }),
+          }),
         })
       );
       expect(onPromptTurnComplete).not.toHaveBeenCalled();
     } finally {
+      publishToSessionSpy.mockRestore();
       sessionEventBus.registerViewerCountProvider(null);
       vi.useRealTimers();
     }
+  });
+
+  it('does not finalize a restarted prompt when a stopped prompt later times out', async () => {
+    const sessionId = 'session-restarted-before-old-prompt-timeout';
+    const stoppedPrompt = createDeferred<{ stopReason: string }>();
+    const restartedPrompt = createDeferred<{ stopReason: string }>();
+    vi.mocked(acpRuntimeManager.sendPrompt)
+      .mockReturnValueOnce(stoppedPrompt.promise as never)
+      .mockReturnValueOnce(restartedPrompt.promise as never);
+    vi.mocked(acpRuntimeManager.stopClient).mockResolvedValue();
+
+    const stoppedSend = sessionService.sendAcpMessage(sessionId, [
+      { type: 'text', text: 'before stop' },
+    ]);
+    const stoppedSendRejection = expect(stoppedSend).rejects.toThrow('Prompt timed out');
+    await vi.waitFor(() => {
+      expect(acpRuntimeManager.sendPrompt).toHaveBeenCalledTimes(1);
+    });
+    await sessionService.stopSession(sessionId);
+
+    const restartedSend = sessionService.sendAcpMessage(sessionId, [
+      { type: 'text', text: 'after restart' },
+    ]);
+    await vi.waitFor(() => {
+      expect(acpRuntimeManager.sendPrompt).toHaveBeenCalledTimes(2);
+    });
+
+    const pendingToolCalls = getAcpProcessorState().pendingAcpToolCalls as Map<
+      string,
+      Map<string, { toolUseId: string; toolName: string }>
+    >;
+    pendingToolCalls.set(
+      sessionId,
+      new Map([
+        [
+          'restarted-call',
+          {
+            toolUseId: 'restarted-call',
+            toolName: 'Run tests',
+          },
+        ],
+      ])
+    );
+    const appendClaudeEventSpy = vi
+      .spyOn(sessionDomainService, 'appendClaudeEvent')
+      .mockReturnValue(88);
+
+    stoppedPrompt.reject(new Error('Prompt timed out'));
+    await stoppedSendRejection;
+    const restartedToolCallSurvived = pendingToolCalls.get(sessionId)?.has('restarted-call');
+    const stalePromptFinalizedToolCall = appendClaudeEventSpy.mock.calls.length > 0;
+
+    pendingToolCalls.delete(sessionId);
+    restartedPrompt.resolve({ stopReason: 'end_turn' });
+    await expect(restartedSend).resolves.toBe('end_turn');
+
+    expect(restartedToolCallSurvived).toBe(true);
+    expect(stalePromptFinalizedToolCall).toBe(false);
   });
 
   it('swallows prompt-turn completion callback failures', async () => {

--- a/src/backend/services/session/service/lifecycle/session.service.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.service.test.ts
@@ -2344,6 +2344,59 @@ describe('SessionService', () => {
     }
   });
 
+  it('preserves stopped runtime when an in-flight prompt times out after stop completes', async () => {
+    vi.useFakeTimers();
+    const sessionId = 'session-prompt-timeout-after-stop';
+    sessionEventBus.registerViewerCountProvider((viewedSessionId) =>
+      viewedSessionId === sessionId ? 1 : 0
+    );
+    try {
+      const prompt = createDeferred<{ stopReason: string }>();
+      const onPromptTurnComplete = vi.fn().mockResolvedValue(undefined);
+      const publishToSessionSpy = vi.spyOn(sessionEventBus, 'publishToSession');
+      sessionService.setPromptTurnCompleteHandler(onPromptTurnComplete);
+      vi.mocked(acpRuntimeManager.sendPrompt).mockReturnValue(prompt.promise as never);
+      vi.mocked(acpRuntimeManager.stopClient).mockResolvedValue();
+
+      const sendPromise = sessionService.sendAcpMessage(sessionId, [
+        { type: 'text', text: 'hello' },
+      ]);
+      const sendRejection = expect(sendPromise).rejects.toThrow('Prompt timed out');
+      await vi.waitFor(() => {
+        expect(acpRuntimeManager.sendPrompt).toHaveBeenCalledWith(
+          sessionId,
+          [{ type: 'text', text: 'hello' }],
+          undefined
+        );
+      });
+
+      await sessionService.stopSession(sessionId);
+      expect(sessionService.isSessionStopping(sessionId)).toBe(false);
+      publishToSessionSpy.mockClear();
+
+      prompt.reject(new Error('Prompt timed out'));
+      await sendRejection;
+      await vi.runOnlyPendingTimersAsync();
+
+      expect(sessionService.getRuntimeSnapshot(sessionId)).toMatchObject({
+        phase: 'idle',
+        processState: 'stopped',
+        activity: 'IDLE',
+      });
+      expect(publishToSessionSpy).not.toHaveBeenCalledWith(
+        sessionId,
+        expect.objectContaining({
+          type: 'session_runtime_updated',
+          sessionRuntime: expect.objectContaining({ processState: 'alive' }),
+        })
+      );
+      expect(onPromptTurnComplete).not.toHaveBeenCalled();
+    } finally {
+      sessionEventBus.registerViewerCountProvider(null);
+      vi.useRealTimers();
+    }
+  });
+
   it('swallows prompt-turn completion callback failures', async () => {
     vi.useFakeTimers();
     try {

--- a/src/backend/services/session/service/lifecycle/session.service.ts
+++ b/src/backend/services/session/service/lifecycle/session.service.ts
@@ -357,6 +357,7 @@ export class SessionService {
     prompt: ContentBlock[],
     timeoutMs?: number
   ): Promise<string> {
+    const stopGeneration = this.getStopGeneration(sessionId);
     const workspaceId = this.acpEventProcessor.getWorkspaceId(sessionId);
     let workspaceActivityGeneration: number | undefined;
     let promptCompleted = false;
@@ -384,7 +385,7 @@ export class SessionService {
         sessionId,
         `stop_reason:${result.stopReason}`
       );
-      this.sessionDomainService.setRuntimeSnapshot(sessionId, {
+      this.setRuntimeSnapshotForPrompt(sessionId, stopGeneration, {
         phase: 'idle',
         processState: 'alive',
         activity: 'IDLE',
@@ -396,7 +397,7 @@ export class SessionService {
       promptErrorSet = true;
       this.acpEventProcessor.finishPromptTurn(sessionId);
       this.acpEventProcessor.finalizeOrphanedToolCalls(sessionId, 'prompt_error');
-      this.sessionDomainService.setRuntimeSnapshot(sessionId, {
+      this.setRuntimeSnapshotForPrompt(sessionId, stopGeneration, {
         phase: 'error',
         processState: 'alive',
         activity: 'IDLE',
@@ -414,11 +415,23 @@ export class SessionService {
       }
       if (
         (promptCompleted || (promptErrorSet && !this.isTurnAlreadyInProgressError(promptError))) &&
-        !this.isSessionStopping(sessionId)
+        !this.isSessionStopping(sessionId) &&
+        this.getStopGeneration(sessionId) === stopGeneration
       ) {
         this.promptTurnCompletionService.schedule(sessionId);
       }
     }
+  }
+
+  private setRuntimeSnapshotForPrompt(
+    sessionId: string,
+    stopGeneration: number,
+    runtime: SessionRuntimeState
+  ): void {
+    if (this.getStopGeneration(sessionId) !== stopGeneration) {
+      return;
+    }
+    this.sessionDomainService.setRuntimeSnapshot(sessionId, runtime);
   }
 
   private isTurnAlreadyInProgressError(error: unknown): boolean {

--- a/src/backend/services/session/service/lifecycle/session.service.ts
+++ b/src/backend/services/session/service/lifecycle/session.service.ts
@@ -380,24 +380,22 @@ export class SessionService {
     try {
       const result = await this.runtimeManager.sendPrompt(sessionId, prompt, timeoutMs);
       promptCompleted = true;
-      this.acpEventProcessor.finishPromptTurn(sessionId);
-      this.acpEventProcessor.finalizeOrphanedToolCalls(
+      this.completePromptTurnIfCurrent(
         sessionId,
-        `stop_reason:${result.stopReason}`
+        stopGeneration,
+        `stop_reason:${result.stopReason}`,
+        {
+          phase: 'idle',
+          processState: 'alive',
+          activity: 'IDLE',
+          updatedAt: new Date().toISOString(),
+        }
       );
-      this.setRuntimeSnapshotForPrompt(sessionId, stopGeneration, {
-        phase: 'idle',
-        processState: 'alive',
-        activity: 'IDLE',
-        updatedAt: new Date().toISOString(),
-      });
       return result.stopReason;
     } catch (error) {
       promptError = error;
       promptErrorSet = true;
-      this.acpEventProcessor.finishPromptTurn(sessionId);
-      this.acpEventProcessor.finalizeOrphanedToolCalls(sessionId, 'prompt_error');
-      this.setRuntimeSnapshotForPrompt(sessionId, stopGeneration, {
+      this.completePromptTurnIfCurrent(sessionId, stopGeneration, 'prompt_error', {
         phase: 'error',
         processState: 'alive',
         activity: 'IDLE',
@@ -423,14 +421,17 @@ export class SessionService {
     }
   }
 
-  private setRuntimeSnapshotForPrompt(
+  private completePromptTurnIfCurrent(
     sessionId: string,
     stopGeneration: number,
+    orphanedToolCallReason: string,
     runtime: SessionRuntimeState
   ): void {
     if (this.getStopGeneration(sessionId) !== stopGeneration) {
       return;
     }
+    this.acpEventProcessor.finishPromptTurn(sessionId);
+    this.acpEventProcessor.finalizeOrphanedToolCalls(sessionId, orphanedToolCallReason);
     this.sessionDomainService.setRuntimeSnapshot(sessionId, runtime);
   }
 


### PR DESCRIPTION
## Summary
- Prevent ACP prompts that settle after a completed stop from reviving the stopped runtime snapshot
- Block stale prompt-turn completion callbacks that could auto-dispatch queued messages
- Keep late stopped-prompt cleanup from mutating a newer prompt after session restart

## Changes
- **Session lifecycle**: Capture the lifecycle stop generation at prompt start and apply post-prompt cleanup only while that generation remains current
- **Runtime updates**: Suppress stale `processState: alive` snapshot writes and WebSocket runtime deltas
- **Prompt completion**: Require both a current stop generation and no active stop before scheduling completion callbacks
- **Regression coverage**: Reproduce the post-stop timeout race and verify restarted prompt tool state remains intact

## Testing
- [x] Tests pass (`pnpm test` — 4,260 passed, 3 skipped)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting/checks pass (`pnpm check:fix`)
- [x] Build succeeds (`pnpm build`)
- [x] Manual testing: Not applicable; deterministic backend race regressions cover the affected paths

Closes #2001

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
