### PR TITLE
Fix #1984: Prevent chat error order collisions

### DIFF
--- a/docs/superpowers/plans/2026-07-25-chat-error-order-namespace.md
+++ b/docs/superpowers/plans/2026-07-25-chat-error-order-namespace.md
@@ -1,0 +1,175 @@
+# Chat Error Order Namespace Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent locally rendered WebSocket errors from claiming backend transcript orders and blocking live assistant text.
+
+**Architecture:** Assign local transport errors a negative sentinel order, while retaining them in the renderer transcript. Rebuild the agent order lookup from non-negative backend-owned orders only so the first assistant delta at the next backend order creates and indexes its own message.
+
+**Tech Stack:** TypeScript, React reducer state, Vitest, Biome
+
+## Global Constraints
+
+- Change only the client reducer behavior required for issue #1984.
+- Preserve the stable message-ID guard for existing backend messages.
+- Preserve visible error rendering, loading-status recovery, transcript trimming, and normal backend ordering.
+- Use a failing regression test before changing production code.
+- Run `pnpm typecheck && pnpm check:fix && pnpm test && pnpm build` before publishing.
+
+---
+
+### Task 1: Reproduce the Error and Assistant Delta Collision
+
+**Files:**
+- Modify: `src/components/chat/chat-reducer.test.ts`
+
+**Interfaces:**
+- Consumes: `chatReducer(state: ChatState, action: ChatAction): ChatState`
+- Produces: regression coverage for replay → local error → first assistant delta
+
+- [ ] **Step 1: Add the failing reducer regression test**
+
+In the `WS_ASSISTANT_TEXT_DELTA action` describe block, replay eight backend assistant messages,
+dispatch `WS_ERROR`, then dispatch offset-zero text for `messageId: 'session-1-8'` at order 8.
+Assert:
+
+```typescript
+expect(state.messages.find((message) => message.message?.type === 'error')?.order).toBe(-1);
+expect(state.agentMessageOrderToIndex.has(-1)).toBe(false);
+expect(state.messages.find((message) => message.id === 'session-1-8')).toMatchObject({
+  order: 8,
+  message: {
+    type: 'assistant',
+    message: { content: [{ type: 'text', text: 'Visible response' }] },
+  },
+});
+expect(state.agentMessageOrderToIndex.get(8)).toBe(
+  state.messages.findIndex((message) => message.id === 'session-1-8')
+);
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+```bash
+pnpm exec vitest run src/components/chat/chat-reducer.test.ts \
+  -t "keeps assistant text visible when an error arrives at the next backend order"
+```
+
+Expected: the error has order 8, the negative-order assertions fail, and no assistant message with
+ID `session-1-8` exists.
+
+- [ ] **Step 3: Commit the regression test with the implementation**
+
+Keep the failing test unstaged until Task 2 is green so no intentionally failing commit is created.
+
+### Task 2: Separate Local and Backend Order Namespaces
+
+**Files:**
+- Modify: `src/components/chat/reducer/slices/messages/transport.ts`
+- Modify: `src/components/chat/reducer/helpers.ts`
+- Test: `src/components/chat/chat-reducer.test.ts`
+
+**Interfaces:**
+- Produces: module-local `ERROR_MESSAGE_ORDER` with value `-1`
+- Preserves: `agentMessageOrderToIndex: Map<number, number>` for backend-owned non-negative orders
+
+- [ ] **Step 1: Assign local errors the negative sentinel**
+
+Add the constant beside the transport imports and replace the client maximum-order calculation:
+
+```typescript
+const ERROR_MESSAGE_ORDER = -1;
+
+// ...
+order: ERROR_MESSAGE_ORDER,
+```
+
+- [ ] **Step 2: Exclude negative orders from the agent lookup**
+
+Narrow `buildAgentMessageOrderToIndex` to backend-owned orders:
+
+```typescript
+if (message.source === 'agent' && message.order >= 0) {
+  orderToIndex.set(message.order, index);
+}
+```
+
+- [ ] **Step 3: Run the focused test and verify GREEN**
+
+```bash
+pnpm exec vitest run src/components/chat/chat-reducer.test.ts \
+  -t "keeps assistant text visible when an error arrives at the next backend order"
+```
+
+Expected: one test passes and the assistant message is present at backend order 8.
+
+- [ ] **Step 4: Run the complete reducer test file**
+
+```bash
+pnpm exec vitest run src/components/chat/chat-reducer.test.ts
+```
+
+Expected: all reducer tests pass.
+
+- [ ] **Step 5: Commit the focused fix**
+
+```bash
+git add src/components/chat/chat-reducer.test.ts \
+  src/components/chat/reducer/helpers.ts \
+  src/components/chat/reducer/slices/messages/transport.ts
+git commit -m "Fix chat error order collisions (#1984)"
+```
+
+### Task 3: Verify, Review, and Publish
+
+**Files:**
+- Review: all files changed from `origin/main`
+- Create temporarily: `/tmp/pr-body.md`
+
+**Interfaces:**
+- Produces: pushed branch and GitHub pull request closing issue #1984
+
+- [ ] **Step 1: Run the required verification chain**
+
+```bash
+pnpm typecheck && pnpm check:fix && pnpm test && pnpm build
+```
+
+Expected: every command exits 0. Review and explicitly stage any formatting changes made by
+`check:fix`.
+
+- [ ] **Step 2: Review the complete diff and worktree**
+
+```bash
+git diff origin/main
+git status -sb
+```
+
+Confirm there are no debug logs, unrelated edits, or uncommitted scoped changes. This reducer-only
+behavior change does not require a UI screenshot because it introduces no new or changed visual
+state.
+
+- [ ] **Step 3: Commit verification-induced changes if present**
+
+Stage only scoped files and use a short imperative commit message under 72 characters. Do not create
+an empty commit when verification changed nothing.
+
+- [ ] **Step 4: Push the current branch**
+
+```bash
+git push -u origin HEAD
+```
+
+- [ ] **Step 5: Create and verify the pull request**
+
+Write `/tmp/pr-body.md` with summary, changes, testing, `Closes #1984`, and the required Factory
+Factory signature, then run:
+
+```bash
+gh pr create --title "Fix #1984: Prevent chat error order collisions" \
+  --body-file /tmp/pr-body.md
+gh pr view --web
+gh pr view --json url
+```
+
+Expected: GitHub returns the created pull request URL.

--- a/docs/superpowers/plans/2026-07-25-chat-error-order-namespace.md
+++ b/docs/superpowers/plans/2026-07-25-chat-error-order-namespace.md
@@ -4,7 +4,7 @@
 
 **Goal:** Prevent locally rendered WebSocket errors from claiming backend transcript orders and blocking live assistant text.
 
-**Architecture:** Assign local transport errors a negative sentinel order, while retaining them in the renderer transcript. Rebuild the agent order lookup from non-negative backend-owned orders only so the first assistant delta at the next backend order creates and indexes its own message.
+**Architecture:** Assign local transport errors a negative sentinel order and compare negative local orders as the live renderer tail. Rebuild the agent order lookup from non-negative backend-owned orders only so the first assistant delta at the next backend order creates and indexes its own message without trimming away the local error.
 
 **Tech Stack:** TypeScript, React reducer state, Vitest, Biome
 
@@ -13,6 +13,7 @@
 - Change only the client reducer behavior required for issue #1984.
 - Preserve the stable message-ID guard for existing backend messages.
 - Preserve visible error rendering, loading-status recovery, transcript trimming, and normal backend ordering.
+- Retain newly arrived local errors and assistant deltas at the renderer transcript limit.
 - Use a failing regression test before changing production code.
 - Run `pnpm typecheck && pnpm check:fix && pnpm test && pnpm build` before publishing.
 
@@ -67,10 +68,12 @@ Keep the failing test unstaged until Task 2 is green so no intentionally failing
 **Files:**
 - Modify: `src/components/chat/reducer/slices/messages/transport.ts`
 - Modify: `src/components/chat/reducer/helpers.ts`
+- Modify: `src/shared/acp-protocol/protocol/renderer-window.ts`
 - Test: `src/components/chat/chat-reducer.test.ts`
 
 **Interfaces:**
 - Produces: module-local `ERROR_MESSAGE_ORDER` with value `-1`
+- Produces: `compareTranscriptMessageOrder(left: ChatMessage, right: ChatMessage): number`
 - Preserves: `agentMessageOrderToIndex: Map<number, number>` for backend-owned non-negative orders
 
 - [ ] **Step 1: Assign local errors the negative sentinel**
@@ -94,7 +97,40 @@ if (message.source === 'agent' && message.order >= 0) {
 }
 ```
 
-- [ ] **Step 3: Run the focused test and verify GREEN**
+- [ ] **Step 3: Keep negative local messages at the live renderer tail**
+
+Export one comparator from `renderer-window.ts` and use it both for renderer normalization and the
+client's binary insertion:
+
+```typescript
+function rendererSortOrder(message: ChatMessage): number {
+  return message.order < 0 ? Number.POSITIVE_INFINITY : message.order;
+}
+
+export function compareTranscriptMessageOrder(left: ChatMessage, right: ChatMessage): number {
+  return rendererSortOrder(left) - rendererSortOrder(right);
+}
+```
+
+This maintains a shared sorted-array invariant: backend orders remain ascending and negative local
+messages remain after them in stable arrival order.
+
+- [ ] **Step 4: Add and run the renderer-limit regression**
+
+Replay `DEFAULT_RENDERER_TRANSCRIPT_LIMIT` backend messages, then dispatch `WS_ERROR` and the first
+assistant delta at the next backend order. Require the messages array to remain capped, the error to
+remain at the tail, the assistant to remain visible, and only the assistant's non-negative order to
+be indexed.
+
+```bash
+pnpm exec vitest run src/components/chat/chat-reducer.test.ts \
+  -t "retains the error and assistant delta at the renderer transcript limit"
+```
+
+Expected before the comparator change: FAIL because the error is trimmed. Expected after the
+comparator change: PASS.
+
+- [ ] **Step 5: Run the original focused test and verify GREEN**
 
 ```bash
 pnpm exec vitest run src/components/chat/chat-reducer.test.ts \
@@ -103,20 +139,22 @@ pnpm exec vitest run src/components/chat/chat-reducer.test.ts \
 
 Expected: one test passes and the assistant message is present at backend order 8.
 
-- [ ] **Step 4: Run the complete reducer test file**
+- [ ] **Step 6: Run the complete reducer and protocol test files**
 
 ```bash
-pnpm exec vitest run src/components/chat/chat-reducer.test.ts
+pnpm exec vitest run src/components/chat/chat-reducer.test.ts \
+  src/shared/acp-protocol/protocol.test.ts
 ```
 
-Expected: all reducer tests pass.
+Expected: all reducer and renderer protocol tests pass.
 
-- [ ] **Step 5: Commit the focused fix**
+- [ ] **Step 7: Commit the focused fix**
 
 ```bash
 git add src/components/chat/chat-reducer.test.ts \
   src/components/chat/reducer/helpers.ts \
-  src/components/chat/reducer/slices/messages/transport.ts
+  src/components/chat/reducer/slices/messages/transport.ts \
+  src/shared/acp-protocol/protocol/renderer-window.ts
 git commit -m "Fix chat error order collisions (#1984)"
 ```
 

--- a/docs/superpowers/plans/2026-07-25-chat-error-order-namespace.md
+++ b/docs/superpowers/plans/2026-07-25-chat-error-order-namespace.md
@@ -70,6 +70,7 @@ Keep the failing test unstaged until Task 2 is green so no intentionally failing
 - Modify: `src/components/chat/reducer/helpers.ts`
 - Modify: `src/shared/acp-protocol/protocol/renderer-window.ts`
 - Test: `src/components/chat/chat-reducer.test.ts`
+- Test: `src/shared/acp-protocol/protocol.test.ts`
 
 **Interfaces:**
 - Produces: module-local `ERROR_MESSAGE_ORDER` with value `-1`
@@ -108,12 +109,18 @@ function rendererSortOrder(message: ChatMessage): number {
 }
 
 export function compareTranscriptMessageOrder(left: ChatMessage, right: ChatMessage): number {
-  return rendererSortOrder(left) - rendererSortOrder(right);
+  const leftOrder = rendererSortOrder(left);
+  const rightOrder = rendererSortOrder(right);
+  if (leftOrder === rightOrder) {
+    return 0;
+  }
+  return leftOrder < rightOrder ? -1 : 1;
 }
 ```
 
 This maintains a shared sorted-array invariant: backend orders remain ascending and negative local
-messages remain after them in stable arrival order.
+messages remain after them in stable arrival order. Add a protocol unit test requiring two negative
+local orders to compare as equal rather than producing `NaN`.
 
 - [ ] **Step 4: Add and run the renderer-limit regression**
 
@@ -154,6 +161,7 @@ Expected: all reducer and renderer protocol tests pass.
 git add src/components/chat/chat-reducer.test.ts \
   src/components/chat/reducer/helpers.ts \
   src/components/chat/reducer/slices/messages/transport.ts \
+  src/shared/acp-protocol/protocol.test.ts \
   src/shared/acp-protocol/protocol/renderer-window.ts
 git commit -m "Fix chat error order collisions (#1984)"
 ```

--- a/docs/superpowers/specs/2026-07-25-chat-error-order-namespace-design.md
+++ b/docs/superpowers/specs/2026-07-25-chat-error-order-namespace-design.md
@@ -36,7 +36,8 @@ to them.
 Renderer sorting and client binary insertion compare negative local orders as the live transcript
 tail. This preserves the array ordering invariant for later backend inserts, keeps a newly received
 error inside a full renderer window, and ensures a following backend message is inserted immediately
-before the local error. Multiple negative local messages retain arrival order through stable sorting.
+before the local error. Multiple negative local messages compare as equal and retain arrival order
+through stable sorting.
 
 No backend, wire-protocol, message-schema, or React component changes are required; the shared
 renderer-window ordering utility owns the local-tail comparison.

--- a/docs/superpowers/specs/2026-07-25-chat-error-order-namespace-design.md
+++ b/docs/superpowers/specs/2026-07-25-chat-error-order-namespace-design.md
@@ -26,36 +26,43 @@ the response remains invisible until replay.
 
 Define a module-local `ERROR_MESSAGE_ORDER` sentinel with value `-1` in the message transport
 slice. `WS_ERROR` continues to add the error message and clear a loading session status exactly as
-it does today, but it no longer inspects transcript orders or claims a backend order. The existing
-renderer normalization sorts the negative sentinel before backend transcript entries; consumers
-must not infer arrival order from this local-only value.
+it does today, but it no longer inspects transcript orders or claims a backend order.
 
 When `applyRendererMessages` rebuilds `agentMessageOrderToIndex`, it indexes only agent messages
 whose order is non-negative. Negative local messages remain renderable and remain eligible for the
 normal renderer transcript limit, but backend message upserts and assistant deltas cannot resolve
 to them.
 
-No protocol, backend, message schema, or rendering component changes are required.
+Renderer sorting and client binary insertion compare negative local orders as the live transcript
+tail. This preserves the array ordering invariant for later backend inserts, keeps a newly received
+error inside a full renderer window, and ensures a following backend message is inserted immediately
+before the local error. Multiple negative local messages retain arrival order through stable sorting.
+
+No backend, wire-protocol, message-schema, or React component changes are required; the shared
+renderer-window ordering utility owns the local-tail comparison.
 
 ## Data Flow
 
 1. Replay installs backend messages at orders 0 through 7 and indexes those orders.
-2. `WS_ERROR` adds a visible local error at order -1; renderer normalization sorts it before the
-   backend transcript and rebuilding indexes omits -1.
+2. `WS_ERROR` adds a visible local error at order -1; renderer normalization keeps it at the live
+   transcript tail and rebuilding indexes omits -1.
 3. The first assistant text delta arrives with backend order 8 and offset 0.
-4. The order lookup misses, so the reducer creates the assistant message with its stable backend ID.
+4. The order lookup misses, so the reducer creates the assistant message with its stable backend ID
+   immediately before the local error.
 5. Rebuilt indexes point order 8 at the assistant message, allowing all later deltas to extend it.
 
 ## Edge Cases
 
 - Multiple errors may share the negative sentinel because local errors are never addressed by
   backend order; each remains a distinct rendered message by ID. Stable sorting retains their
-  relative order, while all negative-order errors appear before backend transcript entries.
+  relative arrival order at the live transcript tail.
 - An error received while loading still moves the session status to ready.
 - Existing non-negative message upsert, duplicate-delta, overlap, gap, and identifier mismatch
   behavior remains unchanged.
 - Renderer trimming still applies to local errors; the order index is rebuilt from retained
   non-negative backend messages only.
+- At the renderer transcript limit, the oldest backend messages are trimmed while the newly arrived
+  error and following assistant delta remain visible and correctly indexed.
 
 ## Testing
 
@@ -63,6 +70,9 @@ Add a reducer regression test that replays backend orders 0 through 7, dispatche
 dispatches the first `WS_ASSISTANT_TEXT_DELTA` at order 8. The test must prove the error has a
 negative order and is absent from `agentMessageOrderToIndex`, while the assistant text is visible
 under its stable ID and order 8 is indexed to it.
+
+Repeat the sequence with a replay at `DEFAULT_RENDERER_TRANSCRIPT_LIMIT` and prove both the local
+error at the tail and the following backend assistant message survive trimming.
 
 Run the focused reducer test through a red-green cycle, followed by:
 

--- a/docs/superpowers/specs/2026-07-25-chat-error-order-namespace-design.md
+++ b/docs/superpowers/specs/2026-07-25-chat-error-order-namespace-design.md
@@ -1,0 +1,71 @@
+# Chat Error Order Namespace Design
+
+## Problem
+
+The chat reducer currently assigns a locally generated `WS_ERROR` message the next apparent
+transcript order (`maxOrder + 1`). Backend assistant streaming independently allocates that same
+non-negative order. Because `applyRendererMessages` indexes every agent message by order, the first
+`WS_ASSISTANT_TEXT_DELTA` finds the local error at its backend order, detects a different message ID,
+and rejects the delta. Later deltas for that assistant message cannot create the missing bubble, so
+the response remains invisible until replay.
+
+## Considered Approaches
+
+1. Put local transport errors in a negative order namespace and omit negative orders from the agent
+   order index. This is selected because backend protocol validation already reserves non-negative
+   orders, the error remains in the renderer message list, and the stable-ID guard for real agent
+   messages stays intact.
+2. Teach `handleAssistantTextDelta` to replace or bypass a non-assistant message at a colliding
+   order. This treats the symptom at the consumer and risks hiding a legitimate backend identity
+   mismatch or displacing the visible error.
+3. Allocate local errors from a different positive sequence. Any client-computed positive value can
+   eventually overlap an independently allocated backend order, so this does not establish a real
+   ownership boundary.
+
+## Design
+
+Define a module-local `ERROR_MESSAGE_ORDER` sentinel with value `-1` in the message transport
+slice. `WS_ERROR` continues to add the error message and clear a loading session status exactly as
+it does today, but it no longer inspects transcript orders or claims a backend order. The existing
+renderer normalization sorts the negative sentinel before backend transcript entries; consumers
+must not infer arrival order from this local-only value.
+
+When `applyRendererMessages` rebuilds `agentMessageOrderToIndex`, it indexes only agent messages
+whose order is non-negative. Negative local messages remain renderable and remain eligible for the
+normal renderer transcript limit, but backend message upserts and assistant deltas cannot resolve
+to them.
+
+No protocol, backend, message schema, or rendering component changes are required.
+
+## Data Flow
+
+1. Replay installs backend messages at orders 0 through 7 and indexes those orders.
+2. `WS_ERROR` adds a visible local error at order -1; renderer normalization sorts it before the
+   backend transcript and rebuilding indexes omits -1.
+3. The first assistant text delta arrives with backend order 8 and offset 0.
+4. The order lookup misses, so the reducer creates the assistant message with its stable backend ID.
+5. Rebuilt indexes point order 8 at the assistant message, allowing all later deltas to extend it.
+
+## Edge Cases
+
+- Multiple errors may share the negative sentinel because local errors are never addressed by
+  backend order; each remains a distinct rendered message by ID. Stable sorting retains their
+  relative order, while all negative-order errors appear before backend transcript entries.
+- An error received while loading still moves the session status to ready.
+- Existing non-negative message upsert, duplicate-delta, overlap, gap, and identifier mismatch
+  behavior remains unchanged.
+- Renderer trimming still applies to local errors; the order index is rebuilt from retained
+  non-negative backend messages only.
+
+## Testing
+
+Add a reducer regression test that replays backend orders 0 through 7, dispatches `WS_ERROR`, then
+dispatches the first `WS_ASSISTANT_TEXT_DELTA` at order 8. The test must prove the error has a
+negative order and is absent from `agentMessageOrderToIndex`, while the assistant text is visible
+under its stable ID and order 8 is indexed to it.
+
+Run the focused reducer test through a red-green cycle, followed by:
+
+```bash
+pnpm typecheck && pnpm check:fix && pnpm test && pnpm build
+```

--- a/src/components/chat/chat-reducer.test.ts
+++ b/src/components/chat/chat-reducer.test.ts
@@ -987,6 +987,51 @@ describe('chatReducer', () => {
       expect(next.agentMessageOrderToIndex.get(7)).toBe(0);
     });
 
+    it('keeps assistant text visible when an error arrives at the next backend order', () => {
+      const replayEvents: WebSocketMessage[] = Array.from({ length: 8 }, (_, order) => ({
+        type: 'agent_message',
+        messageId: `session-1-${order}`,
+        order,
+        data: {
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: `Replayed response ${order}` }],
+          },
+        },
+      }));
+      let state = chatReducer(initialState, {
+        type: 'SESSION_REPLAY_BATCH',
+        payload: { replayEvents },
+      });
+
+      state = chatReducer(state, {
+        type: 'WS_ERROR',
+        payload: { message: 'Streaming connection warning' },
+      });
+      state = chatReducer(
+        state,
+        textDelta(0, 'Visible response', { messageId: 'session-1-8', order: 8 })
+      );
+
+      const errorMessage = state.messages.find((message) => message.message?.type === 'error');
+      const assistantIndex = state.messages.findIndex((message) => message.id === 'session-1-8');
+      expect(errorMessage?.order).toBe(-1);
+      expect(state.agentMessageOrderToIndex.has(-1)).toBe(false);
+      expect(state.messages[assistantIndex]).toMatchObject({
+        id: 'session-1-8',
+        order: 8,
+        message: {
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'Visible response' }],
+          },
+        },
+      });
+      expect(state.agentMessageOrderToIndex.get(8)).toBe(assistantIndex);
+    });
+
     it('applies many sequential deltas to one indexed assistant message', () => {
       let state = initialState;
       for (let offset = 0; offset < 200; offset += 1) {

--- a/src/components/chat/chat-reducer.test.ts
+++ b/src/components/chat/chat-reducer.test.ts
@@ -1032,6 +1032,58 @@ describe('chatReducer', () => {
       expect(state.agentMessageOrderToIndex.get(8)).toBe(assistantIndex);
     });
 
+    it('retains the error and assistant delta at the renderer transcript limit', () => {
+      const replayEvents: WebSocketMessage[] = Array.from(
+        { length: DEFAULT_RENDERER_TRANSCRIPT_LIMIT },
+        (_, order) => ({
+          type: 'agent_message',
+          messageId: `session-1-${order}`,
+          order,
+          data: {
+            type: 'assistant',
+            message: {
+              role: 'assistant',
+              content: [{ type: 'text', text: `Replayed response ${order}` }],
+            },
+          },
+        })
+      );
+      let state = chatReducer(initialState, {
+        type: 'SESSION_REPLAY_BATCH',
+        payload: { replayEvents },
+      });
+
+      state = chatReducer(state, {
+        type: 'WS_ERROR',
+        payload: { message: 'Streaming connection warning' },
+      });
+      state = chatReducer(
+        state,
+        textDelta(0, 'Visible response', {
+          messageId: `session-1-${DEFAULT_RENDERER_TRANSCRIPT_LIMIT}`,
+          order: DEFAULT_RENDERER_TRANSCRIPT_LIMIT,
+        })
+      );
+
+      const errorIndex = state.messages.findIndex((message) => message.message?.type === 'error');
+      const assistantIndex = state.messages.findIndex(
+        (message) => message.id === `session-1-${DEFAULT_RENDERER_TRANSCRIPT_LIMIT}`
+      );
+      expect(state.messages).toHaveLength(DEFAULT_RENDERER_TRANSCRIPT_LIMIT);
+      expect(errorIndex).toBe(DEFAULT_RENDERER_TRANSCRIPT_LIMIT - 1);
+      expect(state.agentMessageOrderToIndex.has(-1)).toBe(false);
+      expect(state.messages[assistantIndex]).toMatchObject({
+        order: DEFAULT_RENDERER_TRANSCRIPT_LIMIT,
+        message: {
+          type: 'assistant',
+          message: { content: [{ type: 'text', text: 'Visible response' }] },
+        },
+      });
+      expect(state.agentMessageOrderToIndex.get(DEFAULT_RENDERER_TRANSCRIPT_LIMIT)).toBe(
+        assistantIndex
+      );
+    });
+
     it('applies many sequential deltas to one indexed assistant message', () => {
       let state = initialState;
       for (let offset = 0; offset < 200; offset += 1) {

--- a/src/components/chat/reducer/helpers.ts
+++ b/src/components/chat/reducer/helpers.ts
@@ -6,6 +6,7 @@ import type {
   UserQuestionRequest,
 } from '@/lib/chat-protocol';
 import {
+  compareTranscriptMessageOrder,
   DEFAULT_RENDERER_TRANSCRIPT_LIMIT,
   getToolUseIdFromEvent,
   isReasoningToolCall,
@@ -97,8 +98,6 @@ export function insertMessageByOrder(
   messages: ChatMessage[],
   newMessage: ChatMessage
 ): ChatMessage[] {
-  const newOrder = newMessage.order;
-
   // Binary search to find insertion point based on order
   let low = 0;
   let high = messages.length;
@@ -109,7 +108,7 @@ export function insertMessageByOrder(
     if (!midMessage) {
       throw new Error(`Missing message at index ${mid}`);
     }
-    if (midMessage.order <= newOrder) {
+    if (compareTranscriptMessageOrder(midMessage, newMessage) <= 0) {
       low = mid + 1;
     } else {
       high = mid;

--- a/src/components/chat/reducer/helpers.ts
+++ b/src/components/chat/reducer/helpers.ts
@@ -146,7 +146,7 @@ function buildToolUseIdToIndex(messages: ChatMessage[]): Map<string, number> {
 function buildAgentMessageOrderToIndex(messages: ChatMessage[]): Map<number, number> {
   const orderToIndex = new Map<number, number>();
   messages.forEach((message, index) => {
-    if (message.source === 'agent') {
+    if (message.source === 'agent' && message.order >= 0) {
       orderToIndex.set(message.order, index);
     }
   });

--- a/src/components/chat/reducer/slices/messages/transport.ts
+++ b/src/components/chat/reducer/slices/messages/transport.ts
@@ -7,6 +7,8 @@ import {
 import type { ChatAction, ChatState } from '@/components/chat/reducer/types';
 import type { AgentMessage, ChatMessage } from '@/lib/chat-protocol';
 
+const ERROR_MESSAGE_ORDER = -1;
+
 export function reduceMessageTransportSlice(state: ChatState, action: ChatAction): ChatState {
   switch (action.type) {
     case 'WS_AGENT_MESSAGE':
@@ -19,7 +21,6 @@ export function reduceMessageTransportSlice(state: ChatState, action: ChatAction
     case 'WS_ASSISTANT_TEXT_DELTA':
       return handleAssistantTextDelta(state, action.payload);
     case 'WS_ERROR': {
-      const maxOrder = state.messages.reduce((max, m) => Math.max(max, m.order), -1);
       const errorMsg: AgentMessage = {
         type: 'error',
         error: action.payload.message,
@@ -30,7 +31,7 @@ export function reduceMessageTransportSlice(state: ChatState, action: ChatAction
         source: 'agent',
         message: errorMsg,
         timestamp: new Date().toISOString(),
-        order: maxOrder + 1,
+        order: ERROR_MESSAGE_ORDER,
       };
       // Clear loading state if error occurs while loading (e.g., load_session fails)
       const sessionStatus =

--- a/src/shared/acp-protocol/protocol.test.ts
+++ b/src/shared/acp-protocol/protocol.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   type AgentContentItem,
   type ChatMessage,
+  compareTranscriptMessageOrder,
   hasRenderableAssistantContent,
   isImageContent,
   isRenderableAssistantContentItem,
@@ -34,6 +35,13 @@ describe('renderer transcript window', () => {
 
     expect(sorted.map((message) => message.id)).toEqual(['m-1', 'm-2']);
     expect(messages.map((message) => message.id)).toEqual(['m-2', 'm-1']);
+  });
+
+  it('treats negative local orders as an equal renderer tail namespace', () => {
+    const firstError = rendererMessage('error-1', -1);
+    const secondError = rendererMessage('error-2', -1);
+
+    expect(compareTranscriptMessageOrder(firstError, secondError)).toBe(0);
   });
 });
 

--- a/src/shared/acp-protocol/protocol/renderer-window.ts
+++ b/src/shared/acp-protocol/protocol/renderer-window.ts
@@ -36,15 +36,23 @@ function isSafeRendererWindowStart(message: ChatMessage): boolean {
   return !(isToolResultMessage(message.message) || isStreamFragment(message.message));
 }
 
+function rendererSortOrder(message: ChatMessage): number {
+  return message.order < 0 ? Number.POSITIVE_INFINITY : message.order;
+}
+
+export function compareTranscriptMessageOrder(left: ChatMessage, right: ChatMessage): number {
+  return rendererSortOrder(left) - rendererSortOrder(right);
+}
+
 export function trimTranscriptForRenderer(
   messages: ChatMessage[],
   limit = DEFAULT_RENDERER_TRANSCRIPT_LIMIT
 ): ChatMessage[] {
   const isOrdered = messages.every(
     (message, index) =>
-      index === 0 || (messages[index - 1]?.order ?? message.order) <= message.order
+      index === 0 || compareTranscriptMessageOrder(messages[index - 1] ?? message, message) <= 0
   );
-  const sortedMessages = isOrdered ? messages : [...messages].sort((a, b) => a.order - b.order);
+  const sortedMessages = isOrdered ? messages : [...messages].sort(compareTranscriptMessageOrder);
   if (sortedMessages.length <= limit) {
     return sortedMessages;
   }

--- a/src/shared/acp-protocol/protocol/renderer-window.ts
+++ b/src/shared/acp-protocol/protocol/renderer-window.ts
@@ -41,7 +41,12 @@ function rendererSortOrder(message: ChatMessage): number {
 }
 
 export function compareTranscriptMessageOrder(left: ChatMessage, right: ChatMessage): number {
-  return rendererSortOrder(left) - rendererSortOrder(right);
+  const leftOrder = rendererSortOrder(left);
+  const rightOrder = rendererSortOrder(right);
+  if (leftOrder === rightOrder) {
+    return 0;
+  }
+  return leftOrder < rightOrder ? -1 : 1;
 }
 
 export function trimTranscriptForRenderer(


### PR DESCRIPTION
## Summary
- Isolate locally generated WebSocket errors from backend-owned chat message orders
- Keep live assistant text visible when an error arrives during streaming
- Preserve local errors and assistant deltas at the renderer transcript limit

## Changes
- **Chat reducer**: Assign `WS_ERROR` messages a negative local sentinel and exclude local orders from the backend agent-order index
- **Renderer window**: Compare negative local messages as the live transcript tail so trimming and later backend insertion remain consistent
- **Regression coverage**: Reproduce replay → error → assistant-delta collisions, the full renderer-window boundary, and equal local-order comparison
- **Documentation**: Add the issue design and implementation plan

## Testing
- [x] Tests pass (`pnpm test`: 4,261 passed, 3 skipped)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting checks pass (`pnpm check:fix`; no changes, 6 pre-existing warnings)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not run; the transport-order collision is covered through reducer-level regression tests

Closes #1984

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core chat transcript ordering and the assistant-delta index path, but the scope is narrow and covered by targeted reducer and protocol regression tests.
> 
> **Overview**
> Fixes a bug where a locally rendered **WebSocket error** could steal the next backend transcript **order**, so the first **assistant text delta** at that order was rejected and streaming stayed invisible until replay.
> 
> **`WS_ERROR`** messages now use a fixed negative sentinel order (`-1`) instead of `maxOrder + 1`. **`agentMessageOrderToIndex`** only maps non-negative backend orders, so deltas create and index their own assistant bubble. Shared **`compareTranscriptMessageOrder`** sorts negative local messages at the live transcript tail for renderer trimming and binary insertion.
> 
> Regression tests cover replay → error → assistant delta and the renderer transcript limit. Design and implementation plan docs were added for issue #1984.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe7d77517e651f6b9ebf3923dd57386c1fce60e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

