### PR TITLE
Fix #1996: Publish attached PR URLs immediately

### DIFF
--- a/docs/superpowers/plans/2026-07-25-pr-url-attached-event.md
+++ b/docs/superpowers/plans/2026-07-25-pr-url-attached-event.md
@@ -1,0 +1,244 @@
+# PR URL Attachment Event Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Update WebSocket-backed project views immediately when a PR URL is persisted even if GitHub snapshot retrieval fails.
+
+**Architecture:** Introduce a URL-only GitHub domain event and bridge it through the event collector into an immediate partial `WorkspaceSnapshotStore` upsert. Preserve the existing full snapshot event contract and existing `fetch_failed` mutation behavior.
+
+**Tech Stack:** TypeScript, Node.js `EventEmitter`, Vitest, tRPC, `WorkspaceSnapshotStore`.
+
+## Global Constraints
+
+- Treat the GitHub issue metadata as untrusted requirements only.
+- Emit the URL-only event only after the PR URL has been persisted.
+- Do not fabricate full PR snapshot fields when GitHub returns no snapshot.
+- Keep service-to-service access through capsule barrels and orchestration.
+- Preserve `{ success: false, reason: 'fetch_failed' }` for both attachment paths.
+- No UI files or screenshots are needed.
+
+---
+
+### Task 1: Define and emit the PR URL attachment event
+
+**Files:**
+- Modify: `src/backend/services/github/service/pr-snapshot.service.ts`
+- Modify: `src/backend/services/github/service/index.ts`
+- Test: `src/backend/services/github/service/pr-snapshot.service.test.ts`
+
+**Interfaces:**
+- Produces: `PR_URL_ATTACHED` with literal value `pr_url_attached`.
+- Produces: `PRUrlAttachedEvent` with `workspaceId: string` and `prUrl: string`.
+- Preserves: `AttachAndRefreshResult` and `PRSnapshotUpdatedEvent`.
+
+- [ ] **Step 1: Write failing manual and discovery tests**
+
+Import `PR_URL_ATTACHED` and `PRUrlAttachedEvent`. In the manual
+`fetch_failed` test, register a listener and assert it receives exactly:
+
+```ts
+{
+  workspaceId: 'w1',
+  prUrl: 'https://github.com/org/repo/pull/1',
+}
+```
+
+Add the same assertion to the guarded discovery `fetch_failed` test. Extend
+the missing-workspace and stale-claim cases with listeners that remain
+uninvoked.
+
+- [ ] **Step 2: Run the focused service test and verify RED**
+
+Run:
+
+```bash
+pnpm test src/backend/services/github/service/pr-snapshot.service.test.ts
+```
+
+Expected: FAIL because `PR_URL_ATTACHED` is not exported or emitted.
+
+- [ ] **Step 3: Add the typed event and emit after persistence**
+
+Add:
+
+```ts
+export const PR_URL_ATTACHED = 'pr_url_attached' as const;
+
+export interface PRUrlAttachedEvent {
+  workspaceId: string;
+  prUrl: string;
+}
+```
+
+After the manual `recordSnapshot` resolves and after the guarded discovery
+attachment succeeds, emit:
+
+```ts
+this.emit(PR_URL_ATTACHED, {
+  workspaceId,
+  prUrl,
+} satisfies PRUrlAttachedEvent);
+```
+
+Only the `snapshot === null` paths need the new event because successful
+snapshot paths already emit `PR_SNAPSHOT_UPDATED` with `prUrl`.
+
+- [ ] **Step 4: Export the event contract through the GitHub barrel**
+
+Add `PR_URL_ATTACHED` and `PRUrlAttachedEvent` to the PR snapshot exports in
+`src/backend/services/github/service/index.ts`.
+
+- [ ] **Step 5: Run the focused service test and verify GREEN**
+
+Run:
+
+```bash
+pnpm test src/backend/services/github/service/pr-snapshot.service.test.ts
+```
+
+Expected: PASS with one URL event after each persisted `fetch_failed` case
+and no event before persistence.
+
+### Task 2: Bridge URL attachments into WorkspaceSnapshotStore
+
+**Files:**
+- Modify: `src/backend/orchestration/event-collector.orchestrator.ts`
+- Test: `src/backend/orchestration/event-collector.orchestrator.test.ts`
+- Test: `src/backend/orchestration/event-collector-lifecycle.integration.test.ts`
+
+**Interfaces:**
+- Consumes: `PR_URL_ATTACHED` and `PRUrlAttachedEvent`.
+- Produces: immediate `WorkspaceSnapshotStore.upsert` input `{ prUrl: string }`
+  with source `event:pr_url_attached`.
+
+- [ ] **Step 1: Write failing collector mapping and lifecycle tests**
+
+Extend the GitHub module mock with `PR_URL_ATTACHED: 'pr_url_attached'`.
+Assert collector startup registers the new listener, stop removes it, and a
+URL event invokes:
+
+```ts
+workspaceSnapshotStore.upsert(
+  'ws-1',
+  { prUrl: 'https://github.com/org/repo/pull/1' },
+  'event:pr_url_attached',
+  expect.any(Number)
+);
+```
+
+Add the real `PR_URL_ATTACHED` emitter to the lifecycle integration test's
+source list.
+
+- [ ] **Step 2: Run collector tests and verify RED**
+
+Run:
+
+```bash
+pnpm test src/backend/orchestration/event-collector.orchestrator.test.ts src/backend/orchestration/event-collector-lifecycle.integration.test.ts
+```
+
+Expected: FAIL because the collector does not subscribe to the new event.
+
+- [ ] **Step 3: Implement the collector listener**
+
+Import the event constant and type from `@/backend/services/github`. Register
+a handler that calls:
+
+```ts
+coalescer.enqueue(
+  event.workspaceId,
+  { prUrl: event.prUrl },
+  'event:pr_url_attached',
+  { immediate: true }
+);
+```
+
+Add the matching `off` callback to `state.teardownListeners`.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+Run:
+
+```bash
+pnpm test src/backend/services/github/service/pr-snapshot.service.test.ts src/backend/orchestration/event-collector.orchestrator.test.ts src/backend/orchestration/event-collector-lifecycle.integration.test.ts
+```
+
+Expected: PASS with the URL immediately visible through the existing snapshot
+change pipeline.
+
+- [ ] **Step 5: Commit the logical fix**
+
+```bash
+git add docs/superpowers/specs/2026-07-25-pr-url-attached-event-design.md docs/superpowers/plans/2026-07-25-pr-url-attached-event.md src/backend/services/github/service/pr-snapshot.service.ts src/backend/services/github/service/pr-snapshot.service.test.ts src/backend/services/github/service/index.ts src/backend/orchestration/event-collector.orchestrator.ts src/backend/orchestration/event-collector.orchestrator.test.ts src/backend/orchestration/event-collector-lifecycle.integration.test.ts
+git commit -m "Emit PR URL attachment updates (#1996)"
+```
+
+### Task 3: Verify, review, and publish
+
+**Files:**
+- Review: every path changed from `origin/main`.
+
+**Interfaces:**
+- Consumes: the completed event flow and regression tests.
+- Produces: a clean pushed branch and a GitHub pull request closing #1996.
+
+- [ ] **Step 1: Run repository verification**
+
+Run:
+
+```bash
+pnpm typecheck && pnpm check:fix && pnpm test && pnpm build
+```
+
+Expected: every command exits 0.
+
+- [ ] **Step 2: Review and independently inspect the diff**
+
+Run:
+
+```bash
+git diff origin/main
+```
+
+Check for debug logs, commented code, unrelated formatting, weak event
+contracts, missing teardown, and test gaps. Request an independent code review
+against this plan and fix all critical or important findings.
+
+- [ ] **Step 3: Commit review or formatting changes if needed**
+
+Stage only issue-related paths and use a short imperative commit under 72
+characters, for example:
+
+```bash
+git commit -m "Tighten PR URL attachment handling (#1996)"
+```
+
+- [ ] **Step 4: Confirm pre-flight state**
+
+Run:
+
+```bash
+git status --short
+git log --oneline origin/main..HEAD
+```
+
+Expected: a clean worktree and descriptive issue-scoped commits.
+
+- [ ] **Step 5: Push and create the required pull request**
+
+Run `git push -u origin HEAD`, write `/tmp/pr-body.md` with Summary, Changes,
+Testing, `Closes #1996`, and the required Factory Factory signature, then run:
+
+```bash
+gh pr create --title "Fix #1996: Publish attached PR URLs immediately" --body-file /tmp/pr-body.md
+```
+
+- [ ] **Step 6: Verify the pull request URL**
+
+Run:
+
+```bash
+gh pr view --json url,title,state
+```
+
+Expected: the created PR is returned with its URL.

--- a/docs/superpowers/specs/2026-07-25-pr-url-attached-event-design.md
+++ b/docs/superpowers/specs/2026-07-25-pr-url-attached-event-design.md
@@ -1,0 +1,70 @@
+# PR URL Attachment Event Design
+
+## Problem
+
+`PRSnapshotService` has two successful PR URL persistence paths that can fail
+to fetch a GitHub snapshot:
+
+- `attachAndRefreshPR` writes `prUrl` with `recordSnapshot`.
+- `attachDiscoveredPRAndRefresh` writes `prUrl` through the guarded discovery
+  claim update.
+
+Both paths return `fetch_failed` before `PR_SNAPSHOT_UPDATED` is emitted. The
+database and cached kanban column therefore know about the attachment while
+`WorkspaceSnapshotStore` and its WebSocket consumers retain the old `prUrl`
+until reconciliation.
+
+## Design
+
+Add a dedicated `PR_URL_ATTACHED` domain event with a payload containing only
+`workspaceId` and `prUrl`. Emit it after the URL write succeeds in the manual
+path and after the guarded discovery attachment succeeds in the discovery
+path, but only when the subsequent snapshot fetch returns no snapshot.
+
+The event collector will subscribe to this event and immediately enqueue
+`{ prUrl }` into `WorkspaceSnapshotStore` with source
+`event:pr_url_attached`. The store already supports partial PR-field updates,
+field-group timestamps, derived-state recomputation, and WebSocket
+`SNAPSHOT_CHANGED` emission, so it needs no new API.
+
+Keep `PR_SNAPSHOT_UPDATED` unchanged. It continues to mean that real snapshot
+fields are available, avoiding placeholder PR number, state, CI, or review
+values.
+
+## Event Flow
+
+1. The service confirms the workspace or discovery claim and persists the PR
+   URL.
+2. GitHub snapshot retrieval returns `null`.
+3. The service emits `PR_URL_ATTACHED`.
+4. The event collector immediately upserts only `prUrl`.
+5. `WorkspaceSnapshotStore` recomputes derived fields and emits its existing
+   snapshot change event to WebSocket consumers.
+6. The service preserves the existing `{ success: false, reason:
+   'fetch_failed' }` result and tRPC error behavior.
+
+## Error and Ordering Rules
+
+- Do not emit for a missing workspace.
+- Do not emit when the discovery claim is stale and no URL was attached.
+- Do not emit if the persistence operation throws.
+- Emit only after persistence succeeds, so in-memory state never leads the
+  database.
+- Use the collector's immediate upsert option so the URL does not wait for the
+  coalescing window.
+- Preserve the full snapshot event's ratchet, closed-PR, and Linear completion
+  side effects; the URL-only event performs none of them.
+
+## Tests
+
+- Service tests verify the manual and discovery `fetch_failed` paths emit
+  exactly the URL-only event.
+- Existing missing-workspace and stale-claim tests verify no attachment event
+  is emitted.
+- Event collector tests verify listener registration, teardown, and the
+  immediate `{ prUrl }` store update with the dedicated source.
+- The real-emitter lifecycle integration test includes the new listener so
+  startup and shutdown cannot leak it.
+
+No UI screenshot is required because this is a backend event propagation fix
+with no visual or component changes.

--- a/src/backend/orchestration/event-collector-lifecycle.integration.test.ts
+++ b/src/backend/orchestration/event-collector-lifecycle.integration.test.ts
@@ -3,6 +3,7 @@ import { createDefaultApplicationDependencies } from '@/backend/app-context';
 import {
   PR_DISPATCH_INVALIDATED,
   PR_SNAPSHOT_UPDATED,
+  PR_URL_ATTACHED,
   prSnapshotService,
 } from '@/backend/services/github';
 import {
@@ -24,6 +25,7 @@ describe('event collector listener lifecycle', () => {
     const sources = [
       [workspaceStateMachine, WORKSPACE_STATE_CHANGED],
       [prSnapshotService, PR_SNAPSHOT_UPDATED],
+      [prSnapshotService, PR_URL_ATTACHED],
       [prSnapshotService, PR_DISPATCH_INVALIDATED],
       [ratchetService, RATCHET_STATE_CHANGED],
       [ratchetService, RATCHET_TOGGLED],

--- a/src/backend/orchestration/event-collector.orchestrator.test.ts
+++ b/src/backend/orchestration/event-collector.orchestrator.test.ts
@@ -59,6 +59,7 @@ vi.mock('@/backend/services/workspace', () => ({
 vi.mock('@/backend/services/github', () => ({
   PR_DISPATCH_INVALIDATED: 'pr_dispatch_invalidated',
   PR_SNAPSHOT_UPDATED: 'pr_snapshot_updated',
+  PR_URL_ATTACHED: 'pr_url_attached',
   prSnapshotService: {
     on: vi.fn(),
     off: vi.fn(),
@@ -530,7 +531,7 @@ describe('configureEventCollector', () => {
     stopEventCollector();
   });
 
-  it('registers 12 event listeners on domain singletons', () => {
+  it('registers 13 event listeners on domain singletons', () => {
     configureEventCollector();
 
     // workspaceStateMachine: 1 listener (WORKSPACE_STATE_CHANGED)
@@ -541,6 +542,7 @@ describe('configureEventCollector', () => {
 
     // prSnapshotService: PR updates and dispatch invalidation
     expect(prSnapshotService.on).toHaveBeenCalledWith('pr_snapshot_updated', expect.any(Function));
+    expect(prSnapshotService.on).toHaveBeenCalledWith('pr_url_attached', expect.any(Function));
     expect(prSnapshotService.on).toHaveBeenCalledWith(
       'pr_dispatch_invalidated',
       expect.any(Function)
@@ -1090,6 +1092,32 @@ describe('configureEventCollector', () => {
         prCiStatus: 'SUCCESS',
       },
       'event:pr_snapshot_updated',
+      expect.any(Number)
+    );
+  });
+
+  it('pr_url_attached immediately updates only prUrl in the store', () => {
+    vi.mocked(workspaceSnapshotStore.getByWorkspaceId).mockReturnValue({
+      projectId: 'proj-1',
+      prUrl: null,
+    } as ReturnType<typeof workspaceSnapshotStore.getByWorkspaceId>);
+
+    configureEventCollector();
+
+    const onCall = vi
+      .mocked(prSnapshotService.on)
+      .mock.calls.find((call) => call[0] === 'pr_url_attached');
+    const handler = onCall![1] as (event: { workspaceId: string; prUrl: string }) => void;
+
+    handler({
+      workspaceId: 'ws-1',
+      prUrl: 'https://github.com/org/repo/pull/1',
+    });
+
+    expect(workspaceSnapshotStore.upsert).toHaveBeenCalledWith(
+      'ws-1',
+      { prUrl: 'https://github.com/org/repo/pull/1' },
+      'event:pr_url_attached',
       expect.any(Number)
     );
   });

--- a/src/backend/orchestration/event-collector.orchestrator.ts
+++ b/src/backend/orchestration/event-collector.orchestrator.ts
@@ -24,8 +24,10 @@ import { SERVICE_LIMITS } from '@/backend/services/constants';
 import {
   PR_DISPATCH_INVALIDATED,
   PR_SNAPSHOT_UPDATED,
+  PR_URL_ATTACHED,
   type PRDispatchInvalidatedEvent,
   type PRSnapshotUpdatedEvent,
+  type PRUrlAttachedEvent,
   type prFetchRegistry,
   type prSnapshotService,
 } from '@/backend/services/github';
@@ -790,6 +792,16 @@ function startEventCollectorWithState(state: EventCollectorState): void {
     dependencies.prSnapshotService.off(PR_SNAPSHOT_UPDATED, prSnapshotUpdatedHandler)
   );
 
+  const prUrlAttachedHandler = (event: PRUrlAttachedEvent) => {
+    coalescer.enqueue(event.workspaceId, { prUrl: event.prUrl }, 'event:pr_url_attached', {
+      immediate: true,
+    });
+  };
+  dependencies.prSnapshotService.on(PR_URL_ATTACHED, prUrlAttachedHandler);
+  state.teardownListeners.push(() =>
+    dependencies.prSnapshotService.off(PR_URL_ATTACHED, prUrlAttachedHandler)
+  );
+
   const prDispatchInvalidatedHandler = (event: PRDispatchInvalidatedEvent) => {
     coalescer.enqueue(
       event.workspaceId,
@@ -958,7 +970,7 @@ function startEventCollectorWithState(state: EventCollectorState): void {
     dependencies.sessionDomainService.off('runtime_changed', runtimeChangedHandler)
   );
 
-  state.logger.info('Event collector started with 12 event subscriptions');
+  state.logger.info('Event collector started with 13 event subscriptions');
 }
 
 // ---------------------------------------------------------------------------

--- a/src/backend/services/github/service/index.ts
+++ b/src/backend/services/github/service/index.ts
@@ -23,8 +23,10 @@ export {
   type AttachAndRefreshResult,
   PR_DISPATCH_INVALIDATED,
   PR_SNAPSHOT_UPDATED,
+  PR_URL_ATTACHED,
   type PRDispatchInvalidatedEvent,
   type PRSnapshotRefreshResult,
   type PRSnapshotUpdatedEvent,
+  type PRUrlAttachedEvent,
   prSnapshotService,
 } from './pr-snapshot.service';

--- a/src/backend/services/github/service/pr-snapshot.service.test.ts
+++ b/src/backend/services/github/service/pr-snapshot.service.test.ts
@@ -147,11 +147,18 @@ describe('PRSnapshotService', () => {
       prSnapshotService.off(PR_URL_ATTACHED, listener);
 
       expect(result).toEqual({ success: false, reason: 'error' });
+      expect(mockUpdate).toHaveBeenCalledWith('w1', {
+        prUrl: 'https://github.com/org/repo/pull/1',
+        prUpdatedAt: expect.any(Date),
+      });
       expect(listener).toHaveBeenCalledOnce();
       expect(listener).toHaveBeenCalledWith({
         workspaceId: 'w1',
         prUrl: 'https://github.com/org/repo/pull/1',
       });
+      expect(mockUpdate.mock.invocationCallOrder[0]!).toBeLessThan(
+        listener.mock.invocationCallOrder[0]!
+      );
     });
 
     it('attaches PR URL and persists full snapshot with kanban cache update', async () => {

--- a/src/backend/services/github/service/pr-snapshot.service.test.ts
+++ b/src/backend/services/github/service/pr-snapshot.service.test.ts
@@ -51,7 +51,9 @@ vi.mock('@/backend/services/logger.service', () => ({
 import {
   PR_DISPATCH_INVALIDATED,
   PR_SNAPSHOT_UPDATED,
+  PR_URL_ATTACHED,
   type PRSnapshotUpdatedEvent,
+  type PRUrlAttachedEvent,
   prSnapshotService,
 } from './pr-snapshot.service';
 
@@ -67,6 +69,7 @@ describe('PRSnapshotService', () => {
       dispatchReset: false,
     });
     mockUpdatePRSnapshotIfUrlMatches.mockResolvedValue(true);
+    mockUpdateCachedKanbanColumn.mockResolvedValue(undefined);
     // Configure bridge with mock kanban dependency
     prSnapshotService.configure({
       kanban: {
@@ -90,25 +93,32 @@ describe('PRSnapshotService', () => {
   describe('attachAndRefreshPR', () => {
     it('returns workspace_not_found when workspace does not exist', async () => {
       mockFindById.mockResolvedValue(null);
+      const listener = vi.fn<(event: PRUrlAttachedEvent) => void>();
+      prSnapshotService.on(PR_URL_ATTACHED, listener);
 
       const result = await prSnapshotService.attachAndRefreshPR(
         'w1',
         'https://github.com/org/repo/pull/1'
       );
+      prSnapshotService.off(PR_URL_ATTACHED, listener);
 
       expect(result).toEqual({ success: false, reason: 'workspace_not_found' });
       expect(mockUpdate).not.toHaveBeenCalled();
       expect(mockUpdateCachedKanbanColumn).not.toHaveBeenCalled();
+      expect(listener).not.toHaveBeenCalled();
     });
 
-    it('attaches PR URL even when snapshot fetch fails', async () => {
+    it('publishes the attached PR URL even when snapshot fetch fails', async () => {
       mockFindById.mockResolvedValue({ id: 'w1', prUrl: null });
       mockFetchAndComputePRState.mockResolvedValue(null);
+      const listener = vi.fn<(event: PRUrlAttachedEvent) => void>();
+      prSnapshotService.on(PR_URL_ATTACHED, listener);
 
       const result = await prSnapshotService.attachAndRefreshPR(
         'w1',
         'https://github.com/org/repo/pull/1'
       );
+      prSnapshotService.off(PR_URL_ATTACHED, listener);
 
       expect(result).toEqual({ success: false, reason: 'fetch_failed' });
       expect(mockUpdate).toHaveBeenCalledWith('w1', {
@@ -116,6 +126,32 @@ describe('PRSnapshotService', () => {
         prUpdatedAt: expect.any(Date),
       });
       expect(mockUpdateCachedKanbanColumn).toHaveBeenCalledWith('w1');
+      expect(listener).toHaveBeenCalledOnce();
+      expect(listener).toHaveBeenCalledWith({
+        workspaceId: 'w1',
+        prUrl: 'https://github.com/org/repo/pull/1',
+      });
+    });
+
+    it('publishes the persisted PR URL before a kanban cache update fails', async () => {
+      mockFindById.mockResolvedValue({ id: 'w1', prUrl: null });
+      mockFetchAndComputePRState.mockResolvedValue(null);
+      mockUpdateCachedKanbanColumn.mockRejectedValue(new Error('cache unavailable'));
+      const listener = vi.fn<(event: PRUrlAttachedEvent) => void>();
+      prSnapshotService.on(PR_URL_ATTACHED, listener);
+
+      const result = await prSnapshotService.attachAndRefreshPR(
+        'w1',
+        'https://github.com/org/repo/pull/1'
+      );
+      prSnapshotService.off(PR_URL_ATTACHED, listener);
+
+      expect(result).toEqual({ success: false, reason: 'error' });
+      expect(listener).toHaveBeenCalledOnce();
+      expect(listener).toHaveBeenCalledWith({
+        workspaceId: 'w1',
+        prUrl: 'https://github.com/org/repo/pull/1',
+      });
     });
 
     it('attaches PR URL and persists full snapshot with kanban cache update', async () => {
@@ -178,6 +214,8 @@ describe('PRSnapshotService', () => {
 
     it('does not attach or fetch when activity invalidated the discovery claim', async () => {
       mockAttachDiscoveredPRIfClaimMatches.mockResolvedValue(false);
+      const listener = vi.fn<(event: PRUrlAttachedEvent) => void>();
+      prSnapshotService.on(PR_URL_ATTACHED, listener);
 
       await expect(
         prSnapshotService.attachDiscoveredPRAndRefresh(
@@ -186,6 +224,7 @@ describe('PRSnapshotService', () => {
           claim
         )
       ).resolves.toEqual({ success: false, reason: 'claim_stale' });
+      prSnapshotService.off(PR_URL_ATTACHED, listener);
 
       expect(mockAttachDiscoveredPRIfClaimMatches).toHaveBeenCalledWith(
         'w1',
@@ -196,6 +235,7 @@ describe('PRSnapshotService', () => {
       expect(mockFetchAndComputePRState).not.toHaveBeenCalled();
       expect(mockUpdate).not.toHaveBeenCalled();
       expect(mockUpdateCachedKanbanColumn).not.toHaveBeenCalled();
+      expect(listener).not.toHaveBeenCalled();
     });
 
     it('refreshes the snapshot without correcting a newer branch after guarded attachment', async () => {
@@ -281,6 +321,8 @@ describe('PRSnapshotService', () => {
     it('keeps the guarded PR attachment when snapshot fetch fails', async () => {
       mockAttachDiscoveredPRIfClaimMatches.mockResolvedValue(true);
       mockFetchAndComputePRState.mockResolvedValue(null);
+      const listener = vi.fn<(event: PRUrlAttachedEvent) => void>();
+      prSnapshotService.on(PR_URL_ATTACHED, listener);
 
       await expect(
         prSnapshotService.attachDiscoveredPRAndRefresh(
@@ -289,8 +331,14 @@ describe('PRSnapshotService', () => {
           claim
         )
       ).resolves.toEqual({ success: false, reason: 'fetch_failed' });
+      prSnapshotService.off(PR_URL_ATTACHED, listener);
 
       expect(mockUpdateCachedKanbanColumn).toHaveBeenCalledWith('w1');
+      expect(listener).toHaveBeenCalledOnce();
+      expect(listener).toHaveBeenCalledWith({
+        workspaceId: 'w1',
+        prUrl: 'https://github.com/org/repo/pull/1',
+      });
     });
   });
 

--- a/src/backend/services/github/service/pr-snapshot.service.ts
+++ b/src/backend/services/github/service/pr-snapshot.service.ts
@@ -41,6 +41,7 @@ export type AttachAndRefreshResult =
     };
 
 export const PR_SNAPSHOT_UPDATED = 'pr_snapshot_updated' as const;
+export const PR_URL_ATTACHED = 'pr_url_attached' as const;
 export const PR_DISPATCH_INVALIDATED = 'pr_dispatch_invalidated' as const;
 
 export interface PRDispatchInvalidatedEvent {
@@ -57,6 +58,11 @@ export interface PRSnapshotUpdatedEvent {
   prReviewState: string | null;
   /** The PR write may have reset dispatch ownership; consumers must re-read it. */
   ratchetDispatchChanged?: true;
+}
+
+export interface PRUrlAttachedEvent {
+  workspaceId: string;
+  prUrl: string;
 }
 
 interface CIObservationInput {
@@ -199,6 +205,10 @@ class PRSnapshotService extends EventEmitter {
           prUrl,
           prUpdatedAt: new Date(),
         });
+        this.emit(PR_URL_ATTACHED, {
+          workspaceId,
+          prUrl,
+        } satisfies PRUrlAttachedEvent);
         await this.kanban.updateCachedKanbanColumn(workspaceId);
         logger.warn('Attached PR URL but could not fetch snapshot', { workspaceId, prUrl });
         return { success: false, reason: 'fetch_failed' };
@@ -294,6 +304,10 @@ class PRSnapshotService extends EventEmitter {
 
       const snapshot = await githubCLIService.fetchAndComputePRState(prUrl);
       if (!snapshot) {
+        this.emit(PR_URL_ATTACHED, {
+          workspaceId,
+          prUrl,
+        } satisfies PRUrlAttachedEvent);
         await this.kanban.updateCachedKanbanColumn(workspaceId);
         logger.warn('Attached discovered PR URL but could not fetch snapshot', {
           workspaceId,


### PR DESCRIPTION
## Summary
- Publish persisted PR URLs to WebSocket-backed project views immediately when GitHub snapshot fetching fails.
- Preserve the full PR snapshot event contract and existing `fetch_failed` mutation behavior.

## Changes
- **GitHub service**: Add a typed `PR_URL_ATTACHED` event and emit it after successful manual or guarded-discovery URL persistence.
- **Event collector**: Map URL attachment events to immediate, URL-only `WorkspaceSnapshotStore` updates with symmetric listener teardown.
- **Tests**: Cover both attachment paths, persistence/cache ordering, partial store mapping, and real listener lifecycle cleanup.

## Testing
- [x] Tests pass (`pnpm test`: 4,275 passed, 3 skipped)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting passes (`pnpm check:fix`; 6 pre-existing warnings)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; this backend event propagation path is covered by focused service, collector, and lifecycle tests.

Closes #1996

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backend event propagation only; no API contract changes beyond a new internal event, with broad test coverage and no fabricated snapshot fields.
> 
> **Overview**
> Fixes a gap where **persisted PR URLs** did not reach WebSocket-backed project views when GitHub snapshot fetch failed, because only `PR_SNAPSHOT_UPDATED` drove `WorkspaceSnapshotStore` updates.
> 
> Adds **`PR_URL_ATTACHED`** (`pr_url_attached`) with `workspaceId` and `prUrl`. `PRSnapshotService` emits it after a successful URL write on manual attach and guarded discovery when `fetchAndComputePRState` returns null, while still returning `{ success: false, reason: 'fetch_failed' }`. Full snapshot paths and `PR_SNAPSHOT_UPDATED` semantics are unchanged.
> 
> The **event collector** subscribes with teardown and immediately upserts `{ prUrl }` with source `event:pr_url_attached`, reusing existing partial snapshot and WebSocket propagation. Tests cover emission rules, collector wiring, ordering vs kanban cache failures, and listener lifecycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f86654a44c3d1e4b1974bdc0385e1cd8140715dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->