### PR TITLE
Fix #1999: Close session logs after last viewer

### DIFF
--- a/docs/superpowers/plans/2026-07-25-session-log-last-viewer.md
+++ b/docs/superpowers/plans/2026-07-25-session-log-last-viewer.md
@@ -1,0 +1,190 @@
+# Session Log Last-Viewer Closure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep session debug logging open until the final chat WebSocket viewer disconnects.
+
+**Architecture:** Keep `ChatConnectionRegistry` as the single source of truth for active viewers.
+Remove the closing connection before consulting its session viewer count, then close the
+session-scoped logger only when that count reaches zero.
+
+**Tech Stack:** TypeScript, Express WebSocket handlers, Vitest, pnpm
+
+## Global Constraints
+
+- Preserve the active-socket identity guard for same-connection-ID reconnect races.
+- Record `connection_closed` before closing the logger for the final viewer.
+- Do not add UI, schema, dependency, or public API changes.
+- Run `pnpm typecheck && pnpm check:fix && pnpm test && pnpm build`.
+
+---
+
+### Task 1: Gate Session Log Closure on the Final Viewer
+
+**Files:**
+- Modify: `src/backend/routers/websocket/chat.handler.ts:260`
+- Test: `src/backend/routers/websocket/chat.handler.test.ts:244`
+
+**Interfaces:**
+- Consumes: `ChatConnectionRegistry.unregister(connectionId: string): void` and
+  `ChatConnectionRegistry.countViewers(dbSessionId: string | null): number`
+- Produces: a close-handler lifecycle in which the session logger closes only after the registry
+  reports zero viewers
+
+- [ ] **Step 1: Write the failing regression test**
+
+Add a test with two WebSockets returned by consecutive upgrades:
+
+```typescript
+it('keeps the session log open until the last viewer disconnects', () => {
+  const { appContext, sessionFileLogger } = createTestContext(tempRootDir);
+  const handler = createChatUpgradeHandler(appContext);
+  const ws1 = new MockWebSocket();
+  const ws2 = new MockWebSocket();
+  const sockets = [ws1, ws2];
+  const wss = {
+    handleUpgrade: vi.fn(
+      (
+        _request: IncomingMessage,
+        _socket: Duplex,
+        _head: Buffer,
+        callback: (socket: WebSocket) => void
+      ) => callback(sockets.shift() as unknown as WebSocket)
+    ),
+  } as unknown as WebSocketServer;
+  const request = {
+    headers: { origin: allowedOrigin },
+    socket: { remoteAddress: '127.0.0.1' },
+  } as unknown as IncomingMessage;
+  const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
+  const wsAliveMap = new WeakMap<WebSocket, boolean>();
+
+  handler(
+    request,
+    socket,
+    Buffer.alloc(0),
+    new URL('http://localhost/chat?connectionId=conn-1&sessionId=session-1'),
+    wss,
+    wsAliveMap
+  );
+  handler(
+    request,
+    socket,
+    Buffer.alloc(0),
+    new URL('http://localhost/chat?connectionId=conn-2&sessionId=session-1'),
+    wss,
+    wsAliveMap
+  );
+  expect(chatConnectionRegistry.countViewers('session-1')).toBe(2);
+
+  ws1.emit('close');
+
+  expect(chatConnectionRegistry.countViewers('session-1')).toBe(1);
+  expect(sessionFileLogger.closeSession).not.toHaveBeenCalled();
+
+  ws2.emit('close');
+
+  expect(chatConnectionRegistry.countViewers('session-1')).toBe(0);
+  expect(sessionFileLogger.closeSession).toHaveBeenCalledTimes(1);
+  expect(sessionFileLogger.closeSession).toHaveBeenCalledWith('session-1');
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify the regression fails**
+
+Run:
+
+```bash
+pnpm exec vitest run src/backend/routers/websocket/chat.handler.test.ts
+```
+
+Expected: FAIL at `expect(sessionFileLogger.closeSession).not.toHaveBeenCalled()` because the first
+viewer currently closes the shared session log.
+
+- [ ] **Step 3: Implement the minimal close-handler fix**
+
+Change the active-socket close branch to remove the connection before checking viewers:
+
+```typescript
+if (current?.ws === ws) {
+  chatConnectionRegistry.unregister(connectionId);
+  if (dbSessionId) {
+    sessionFileLogger.log(dbSessionId, 'INFO', {
+      event: 'connection_closed',
+      connectionId,
+    });
+    if (chatConnectionRegistry.countViewers(dbSessionId) === 0) {
+      sessionFileLogger.closeSession(dbSessionId);
+    }
+  }
+  disconnected = true;
+  clearSessionIfDisconnectedAndInactive();
+}
+```
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run:
+
+```bash
+pnpm exec vitest run src/backend/routers/websocket/chat.handler.test.ts
+```
+
+Expected: PASS, including the existing single-viewer cleanup and stale-close race tests.
+
+- [ ] **Step 5: Commit the focused implementation**
+
+```bash
+git add src/backend/routers/websocket/chat.handler.ts \
+  src/backend/routers/websocket/chat.handler.test.ts
+git commit -m "Fix session log closure for multiple viewers (#1999)"
+```
+
+### Task 2: Verify and Publish the Fix
+
+**Files:**
+- Verify: `src/backend/routers/websocket/chat.handler.ts`
+- Verify: `src/backend/routers/websocket/chat.handler.test.ts`
+
+**Interfaces:**
+- Consumes: the completed handler and regression test from Task 1
+- Produces: a verified branch and pull request that closes GitHub issue #1999
+
+- [ ] **Step 1: Run the repository verification suite**
+
+```bash
+pnpm typecheck && pnpm check:fix && pnpm test && pnpm build
+```
+
+Expected: all four commands exit successfully.
+
+- [ ] **Step 2: Review the complete branch diff**
+
+```bash
+git diff origin/main
+git status -sb
+```
+
+Expected: only the design, plan, handler, and handler test changes are present before their
+respective commits; no debug code or unrelated edits remain.
+
+- [ ] **Step 3: Push the issue branch**
+
+```bash
+git push -u origin HEAD
+```
+
+Expected: the current branch is published with upstream tracking.
+
+- [ ] **Step 4: Create and verify the pull request**
+
+Create `/tmp/pr-body.md` with the issue summary, changes, completed checks, `Closes #1999`, and the
+required Factory Factory signature, then run:
+
+```bash
+gh pr create --title "Fix #1999: Close session logs after last viewer" \
+  --body-file /tmp/pr-body.md
+gh pr view --json url
+```
+
+Expected: GitHub returns the created pull request URL.

--- a/docs/superpowers/specs/2026-07-25-session-log-last-viewer-design.md
+++ b/docs/superpowers/specs/2026-07-25-session-log-last-viewer-design.md
@@ -1,0 +1,60 @@
+# Session Log Last-Viewer Closure Design
+
+## Problem
+
+The chat WebSocket close handler owns a session-scoped debug logger but currently closes that
+logger for every active connection that disconnects. Multiple connection IDs can view the same
+session, so closing one viewer marks the shared logger closed and silently drops later entries from
+the remaining viewers.
+
+The handler also calls `closeSession` before unregistering the closing socket. At that point
+`ChatConnectionRegistry.countViewers` still includes the socket being closed, so the existing
+viewer-count API cannot distinguish the last viewer until registry removal has happened.
+
+## Considered Approaches
+
+1. Unregister the active socket first and close the session logger only when the post-unregister
+   viewer count is zero. This is selected because the registry remains the source of truth, the
+   change matches existing session cleanup semantics, and it requires no new state.
+2. Check whether the pre-unregister viewer count is one. This could work synchronously, but it
+   encodes the closing socket's membership as an implicit assumption and makes the ordering harder
+   to reason about.
+3. Add a separate logger reference count. This duplicates connection-registry state and introduces
+   a second lifecycle that could drift from the actual viewers.
+
+## Design
+
+Within the existing active-socket identity guard, unregister the closing connection before any
+viewer-count decision. If the connection has a session ID, write the existing `connection_closed`
+entry and call `closeSession` only when `countViewers(dbSessionId)` returns zero.
+
+Logging remains before logger closure so the last viewer's close event is recorded. A non-final
+viewer records the same close event without ending the shared log. The existing
+`clearSessionIfDisconnectedAndInactive` call remains after unregistering and continues to see the
+accurate post-disconnect viewer count.
+
+No registry, logger, schema, API, or UI changes are required.
+
+## Edge Cases
+
+- Closing one of two different connection IDs for the same session leaves one viewer registered and
+  must not close the session log.
+- Closing the final viewer removes the last registry subscription and closes the session log once.
+- A stale socket close after the same connection ID has been replaced remains ignored by the
+  existing `current?.ws === ws` guard, so it neither unregisters the replacement nor closes the log.
+- Connections without a session ID continue to unregister without invoking the session logger.
+- In-flight message cleanup continues to wait for message handling and uses the same post-unregister
+  viewer count.
+
+## Testing
+
+Add a handler regression test that opens two sockets with distinct connection IDs for one session.
+After closing the first socket, assert that the registry reports one viewer and `closeSession` has
+not run. Then close the second socket and assert that the registry reports zero viewers and
+`closeSession` ran exactly once for that session.
+
+Run the focused handler test through a red-green cycle, followed by:
+
+```bash
+pnpm typecheck && pnpm check:fix && pnpm test && pnpm build
+```

--- a/src/backend/routers/websocket/chat.handler.test.ts
+++ b/src/backend/routers/websocket/chat.handler.test.ts
@@ -243,6 +243,59 @@ describe('createChatUpgradeHandler', () => {
     expect(sessionFileLogger.closeSession).toHaveBeenCalledWith('session-1');
   });
 
+  it('keeps the session log open until the last viewer disconnects', () => {
+    const { appContext, sessionFileLogger } = createTestContext(tempRootDir);
+    const handler = createChatUpgradeHandler(appContext);
+    const ws1 = new MockWebSocket();
+    const ws2 = new MockWebSocket();
+    const sockets = [ws1, ws2];
+    const wss = {
+      handleUpgrade: vi.fn(
+        (
+          _request: IncomingMessage,
+          _socket: Duplex,
+          _head: Buffer,
+          callback: (socket: WebSocket) => void
+        ) => callback(sockets.shift() as unknown as WebSocket)
+      ),
+    } as unknown as WebSocketServer;
+    const request = {
+      headers: { origin: allowedOrigin },
+      socket: { remoteAddress: '127.0.0.1' },
+    } as unknown as IncomingMessage;
+    const socket = { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex;
+    const wsAliveMap = new WeakMap<WebSocket, boolean>();
+
+    handler(
+      request,
+      socket,
+      Buffer.alloc(0),
+      new URL('http://localhost/chat?connectionId=conn-1&sessionId=session-1'),
+      wss,
+      wsAliveMap
+    );
+    handler(
+      request,
+      socket,
+      Buffer.alloc(0),
+      new URL('http://localhost/chat?connectionId=conn-2&sessionId=session-1'),
+      wss,
+      wsAliveMap
+    );
+    expect(chatConnectionRegistry.countViewers('session-1')).toBe(2);
+
+    ws1.emit('close');
+
+    expect(chatConnectionRegistry.countViewers('session-1')).toBe(1);
+    expect(sessionFileLogger.closeSession).not.toHaveBeenCalled();
+
+    ws2.emit('close');
+
+    expect(chatConnectionRegistry.countViewers('session-1')).toBe(0);
+    expect(sessionFileLogger.closeSession).toHaveBeenCalledTimes(1);
+    expect(sessionFileLogger.closeSession).toHaveBeenCalledWith('session-1');
+  });
+
   it('keeps chat transport dependencies scoped to each application', () => {
     const eventBusA = new SessionEventBus();
     const eventBusB = new SessionEventBus();

--- a/src/backend/routers/websocket/chat.handler.ts
+++ b/src/backend/routers/websocket/chat.handler.ts
@@ -265,14 +265,16 @@ export function createChatUpgradeHandler(appContext: AppContext) {
         // when the old connection's close event fires
         const current = chatConnectionRegistry.get(connectionId);
         if (current?.ws === ws) {
+          chatConnectionRegistry.unregister(connectionId);
           if (dbSessionId) {
             sessionFileLogger.log(dbSessionId, 'INFO', {
               event: 'connection_closed',
               connectionId,
             });
-            sessionFileLogger.closeSession(dbSessionId);
+            if (chatConnectionRegistry.countViewers(dbSessionId) === 0) {
+              sessionFileLogger.closeSession(dbSessionId);
+            }
           }
-          chatConnectionRegistry.unregister(connectionId);
           disconnected = true;
           clearSessionIfDisconnectedAndInactive();
         }


### PR DESCRIPTION
## Summary
- Keep session-scoped WebSocket debug logs open while any viewer remains connected.
- Close the session log only after the final active viewer unregisters.
- Add regression coverage for first-of-two and final-viewer disconnects.

## Changes
- **Chat WebSocket handler**: Unregister the closing socket before checking the session viewer count, while preserving stale-connection protection and close-event logging.
- **Session log lifecycle**: Gate `closeSession` on a post-unregister viewer count of zero.
- **Tests**: Cover two concurrent viewers sharing one session and verify the logger remains open until the second disconnect.

## Testing
- [x] Tests pass (`pnpm test`: 4,274 passed, 3 skipped)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting passes (`pnpm check:fix`; 6 pre-existing warnings)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; this backend log lifecycle is covered by the focused WebSocket handler regression test.

Closes #1999

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized WebSocket close-handler ordering and debug log lifecycle; behavior is covered by new regression tests with no API or schema changes.
> 
> **Overview**
> Fixes **#1999** by changing when session-scoped WebSocket debug logs are torn down when multiple clients watch the same session.
> 
> In the chat WebSocket **close** handler, the closing connection is **unregistered from `ChatConnectionRegistry` before** deciding whether to end the session file logger. **`closeSession`** runs only when **`countViewers(dbSessionId)` is zero** after that unregister; the first of two viewers no longer shuts down the shared log while another connection remains. **`connection_closed`** is still logged before closure on the final disconnect, and the existing **`current?.ws === ws`** guard is unchanged.
> 
> Adds a **regression test** with two connection IDs on one session (no `closeSession` after the first close; exactly once after the second). Includes **design and implementation plan** docs under `docs/superpowers/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b31f8dcb35be54aca34f499dc75088b2814d0ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

