### PR TITLE
Fix #1992: Distinguish workspace retry CAS failures

### DIFF
--- a/src/backend/services/workspace/service/lifecycle/state-machine.service.test.ts
+++ b/src/backend/services/workspace/service/lifecycle/state-machine.service.test.ts
@@ -36,7 +36,10 @@ import {
 
 describe('WorkspaceStateMachineService', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    mockFindUnique.mockReset();
+    mockFindUniqueOrThrow.mockReset();
+    mockUpdate.mockReset();
+    mockUpdateMany.mockReset();
   });
 
   describe('isValidTransition', () => {
@@ -424,12 +427,64 @@ describe('WorkspaceStateMachineService', () => {
     it('should return null when max retries exceeded', async () => {
       const workspace = { id: 'ws-1', status: 'FAILED', initRetryCount: 3 };
 
-      mockFindUnique.mockResolvedValue(workspace);
+      mockFindUnique.mockResolvedValueOnce(workspace).mockResolvedValueOnce(workspace);
       mockUpdateMany.mockResolvedValue({ count: 0 }); // No update happened
 
       const result = await workspaceStateMachine.startProvisioning('ws-1');
 
       expect(result).toBeNull();
+    });
+
+    it('should throw when the status changes during a retry CAS', async () => {
+      const workspace = { id: 'ws-1', status: 'FAILED', initRetryCount: 1 };
+      const concurrentlyUpdatedWorkspace = {
+        ...workspace,
+        status: 'PROVISIONING',
+        initRetryCount: 2,
+      };
+
+      mockFindUnique
+        .mockResolvedValueOnce(workspace)
+        .mockResolvedValueOnce(concurrentlyUpdatedWorkspace);
+      mockUpdateMany.mockResolvedValue({ count: 0 });
+
+      await expect(workspaceStateMachine.startProvisioning('ws-1')).rejects.toMatchObject({
+        name: 'WorkspaceStateMachineError',
+        workspaceId: 'ws-1',
+        fromStatus: 'FAILED',
+        toStatus: 'PROVISIONING',
+        message: 'Transition failed: status changed by another process',
+      });
+    });
+
+    it('should throw when the workspace is deleted during a retry CAS', async () => {
+      const workspace = { id: 'ws-1', status: 'FAILED', initRetryCount: 1 };
+
+      mockFindUnique.mockResolvedValueOnce(workspace).mockResolvedValueOnce(null);
+      mockUpdateMany.mockResolvedValue({ count: 0 });
+
+      await expect(workspaceStateMachine.startProvisioning('ws-1')).rejects.toMatchObject({
+        name: 'WorkspaceStateMachineError',
+        workspaceId: 'ws-1',
+        fromStatus: 'FAILED',
+        toStatus: 'PROVISIONING',
+        message: 'Transition failed: status changed by another process',
+      });
+    });
+
+    it('should throw when a failed retry CAS re-read is still below the retry limit', async () => {
+      const workspace = { id: 'ws-1', status: 'FAILED', initRetryCount: 1 };
+
+      mockFindUnique.mockResolvedValueOnce(workspace).mockResolvedValueOnce(workspace);
+      mockUpdateMany.mockResolvedValue({ count: 0 });
+
+      await expect(workspaceStateMachine.startProvisioning('ws-1')).rejects.toMatchObject({
+        name: 'WorkspaceStateMachineError',
+        workspaceId: 'ws-1',
+        fromStatus: 'FAILED',
+        toStatus: 'PROVISIONING',
+        message: 'Transition failed: status changed by another process',
+      });
     });
 
     it('should respect custom maxRetries option', async () => {
@@ -547,6 +602,41 @@ describe('WorkspaceStateMachineService', () => {
         data: expect.objectContaining({
           initErrorMessage: 'Timeout exceeded',
         }),
+      });
+    });
+  });
+
+  describe('startProvisioningFromReady', () => {
+    it('should return null when max retries exceeded', async () => {
+      const workspace = { id: 'ws-1', status: 'READY', initRetryCount: 3 };
+
+      mockFindUnique.mockResolvedValueOnce(workspace).mockResolvedValueOnce(workspace);
+      mockUpdateMany.mockResolvedValue({ count: 0 });
+
+      const result = await workspaceStateMachine.startProvisioningFromReady('ws-1');
+
+      expect(result).toBeNull();
+    });
+
+    it('should throw when the status changes during a retry CAS', async () => {
+      const workspace = { id: 'ws-1', status: 'READY', initRetryCount: 1 };
+      const concurrentlyUpdatedWorkspace = {
+        ...workspace,
+        status: 'PROVISIONING',
+        initRetryCount: 2,
+      };
+
+      mockFindUnique
+        .mockResolvedValueOnce(workspace)
+        .mockResolvedValueOnce(concurrentlyUpdatedWorkspace);
+      mockUpdateMany.mockResolvedValue({ count: 0 });
+
+      await expect(workspaceStateMachine.startProvisioningFromReady('ws-1')).rejects.toMatchObject({
+        name: 'WorkspaceStateMachineError',
+        workspaceId: 'ws-1',
+        fromStatus: 'READY',
+        toStatus: 'PROVISIONING',
+        message: 'Transition failed: status changed by another process',
       });
     });
   });
@@ -692,12 +782,34 @@ describe('WorkspaceStateMachineService', () => {
     it('should return null when max retries exceeded', async () => {
       const workspace = { id: 'ws-1', status: 'FAILED', initRetryCount: 3 };
 
-      mockFindUnique.mockResolvedValue(workspace);
+      mockFindUnique.mockResolvedValueOnce(workspace).mockResolvedValueOnce(workspace);
       mockUpdateMany.mockResolvedValue({ count: 0 }); // No update happened
 
       const result = await workspaceStateMachine.resetToNew('ws-1');
 
       expect(result).toBeNull();
+    });
+
+    it('should throw when the status changes during a reset CAS', async () => {
+      const workspace = { id: 'ws-1', status: 'FAILED', initRetryCount: 1 };
+      const concurrentlyUpdatedWorkspace = {
+        ...workspace,
+        status: 'NEW',
+        initRetryCount: 2,
+      };
+
+      mockFindUnique
+        .mockResolvedValueOnce(workspace)
+        .mockResolvedValueOnce(concurrentlyUpdatedWorkspace);
+      mockUpdateMany.mockResolvedValue({ count: 0 });
+
+      await expect(workspaceStateMachine.resetToNew('ws-1')).rejects.toMatchObject({
+        name: 'WorkspaceStateMachineError',
+        workspaceId: 'ws-1',
+        fromStatus: 'FAILED',
+        toStatus: 'NEW',
+        message: 'Transition failed: status changed by another process',
+      });
     });
 
     it('should respect custom maxRetries option', async () => {

--- a/src/backend/services/workspace/service/lifecycle/state-machine.service.ts
+++ b/src/backend/services/workspace/service/lifecycle/state-machine.service.ts
@@ -57,6 +57,26 @@ export class WorkspaceStateMachineError extends Error {
   }
 }
 
+async function findRetryLimitWorkspaceOrThrowCasError(
+  workspaceId: string,
+  fromStatus: WorkspaceStatus,
+  toStatus: WorkspaceStatus,
+  maxRetries: number
+): Promise<Workspace> {
+  const workspace = await workspaceAccessor.findRawById(workspaceId);
+
+  if (!workspace || workspace.status !== fromStatus || workspace.initRetryCount < maxRetries) {
+    throw new WorkspaceStateMachineError(
+      workspaceId,
+      fromStatus,
+      toStatus,
+      'Transition failed: status changed by another process'
+    );
+  }
+
+  return workspace;
+}
+
 export interface TransitionOptions {
   /** Worktree path to set (for READY transition) */
   worktreePath?: string;
@@ -312,10 +332,17 @@ class WorkspaceStateMachineService extends EventEmitter {
       );
 
       if (result.count === 0) {
+        const retryLimitWorkspace = await findRetryLimitWorkspaceOrThrowCasError(
+          workspaceId,
+          'FAILED',
+          'PROVISIONING',
+          maxRetries
+        );
+
         logger.warn('Max retries exceeded for workspace', {
           workspaceId,
           maxRetries,
-          currentRetryCount: workspace.initRetryCount,
+          currentRetryCount: retryLimitWorkspace.initRetryCount,
         });
         return null; // Max retries exceeded
       }
@@ -464,10 +491,17 @@ class WorkspaceStateMachineService extends EventEmitter {
     );
 
     if (result.count === 0) {
+      const retryLimitWorkspace = await findRetryLimitWorkspaceOrThrowCasError(
+        workspaceId,
+        'READY',
+        'PROVISIONING',
+        maxRetries
+      );
+
       logger.warn('Max retries exceeded for workspace setup script retry', {
         workspaceId,
         maxRetries,
-        currentRetryCount: workspace.initRetryCount,
+        currentRetryCount: retryLimitWorkspace.initRetryCount,
       });
       return null;
     }
@@ -509,10 +543,17 @@ class WorkspaceStateMachineService extends EventEmitter {
     const result = await workspaceAccessor.resetToNewIfAllowed(workspaceId, maxRetries);
 
     if (result.count === 0) {
+      const retryLimitWorkspace = await findRetryLimitWorkspaceOrThrowCasError(
+        workspaceId,
+        'FAILED',
+        'NEW',
+        maxRetries
+      );
+
       logger.warn('Max retries exceeded for workspace reset', {
         workspaceId,
         maxRetries,
-        currentRetryCount: workspace.initRetryCount,
+        currentRetryCount: retryLimitWorkspace.initRetryCount,
       });
       return null; // Max retries exceeded
     }


### PR DESCRIPTION
## Summary
- Distinguish concurrent workspace retry CAS losses from genuine retry exhaustion.
- Preserve the existing retry-limit response while surfacing races as `WorkspaceStateMachineError`.
- Cover all three affected workspace retry transitions with focused regression tests.

## Changes
- **Workspace state machine**: Re-read the workspace after a zero-row retry CAS and return `null` only when the fresh source state is still retry-exhausted; otherwise throw the established concurrent-transition error.
- **Regression coverage**: Test races in `startProvisioning`, `startProvisioningFromReady`, and `resetToNew`, plus genuine exhaustion, deletion, and below-budget invariant cases.

## Testing
- [x] Tests pass (`pnpm test --maxWorkers=2 --no-file-parallelism --testTimeout=30000` — 4,279 passed, 3 skipped)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Formatting passes (`pnpm check:fix`; 6 pre-existing image warnings)
- [ ] Manual testing: Not applicable; concurrency behavior is covered by deterministic state-machine regression tests.

Closes #1992

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0d52ad9530e32baae78b9ab6f5c40efd73bd168c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

