### PR TITLE
Fix #1989: Preserve ratchet setting on first update

### DIFF
--- a/src/backend/services/settings/resources/user-settings.accessor.test.ts
+++ b/src/backend/services/settings/resources/user-settings.accessor.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockUpsert = vi.fn();
+
+vi.mock('@/backend/db', () => ({
+  prisma: {
+    userSettings: {
+      upsert: (...args: unknown[]) => mockUpsert(...args),
+    },
+  },
+}));
+
+import { userSettingsAccessor } from './user-settings.accessor';
+
+describe('userSettingsAccessor.update', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('preserves ratchetEnabled when update creates the settings', async () => {
+    mockUpsert.mockImplementation(async ({ create }: { create: { ratchetEnabled?: boolean } }) => ({
+      ...create,
+      ratchetEnabled: create.ratchetEnabled ?? false,
+    }));
+
+    const settings = await userSettingsAccessor.update({ ratchetEnabled: true });
+
+    expect(settings.ratchetEnabled).toBe(true);
+  });
+});

--- a/src/backend/services/settings/resources/user-settings.accessor.ts
+++ b/src/backend/services/settings/resources/user-settings.accessor.ts
@@ -157,6 +157,7 @@ class UserSettingsAccessor {
         customIdeCommand: data.customIdeCommand ?? null,
         playSoundOnComplete: data.playSoundOnComplete ?? true,
         cachedSlashCommands: data.cachedSlashCommands ?? undefined,
+        ratchetEnabled: data.ratchetEnabled ?? false,
         defaultSessionProvider: data.defaultSessionProvider ?? 'CLAUDE',
         defaultClaudeModel: normalizedClaudeModel ?? 'sonnet',
         defaultCodexModel: normalizedCodexModel ?? 'default',


### PR DESCRIPTION
## Summary
- Persist `ratchetEnabled` when user settings are created through `update()`.
- Add regression coverage for first-write settings initialization.

## Changes
- **Settings accessor**: Include the caller-provided `ratchetEnabled` value in the Prisma upsert create payload.
- **Regression coverage**: Exercise the first-write path and verify enabling Ratchet is preserved instead of falling back to the schema default.

## Testing
- [x] Tests pass (`pnpm test`: 4,295 passed, 3 skipped)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting/lint completed (`pnpm check:fix`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; the accessor regression test covers the non-UI first-write path.

Closes #1989

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
