### PR TITLE
Fix #1983: Stop mismatched Ratchet sessions after abort

### DIFF
--- a/docs/superpowers/plans/2026-07-25-ratchet-provider-mismatch-cleanup.md
+++ b/docs/superpowers/plans/2026-07-25-ratchet-provider-mismatch-cleanup.md
@@ -1,0 +1,168 @@
+# Ratchet Provider-Mismatch Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop provider-mismatched Ratchet fixer sessions after an in-flight
+settlement observes cancellation.
+
+**Architecture:** Preserve cancellation barriers for normal Ratchet work, but
+treat session stopping as mandatory best-effort cleanup. Run provider-mismatch
+cleanup from settlement's `finally` path so the original result or error is
+preserved after the stop attempt.
+
+**Tech Stack:** TypeScript, Vitest, Express service capsules, pnpm, Biome
+
+## Global Constraints
+
+- Keep the change inside the Ratchet service capsule.
+- Preserve settlement-before-stop ordering.
+- Preserve the original cancellation reason.
+- Keep stop failures warning-only.
+- Do not change UI behavior.
+
+---
+
+### Task 1: Reproduce the orphaned-session race
+
+**Files:**
+- Test: `src/backend/services/ratchet/service/ratchet.service.test.ts`
+
+**Interfaces:**
+- Consumes: `RatchetService.checkActiveFixerSession(workspace, signal)`
+- Produces: a regression test proving the mismatched session stop is attempted
+  after post-write cancellation
+
+- [ ] **Step 1: Add the failing regression test**
+
+Add a test under `checkActiveFixerSession edge cases` that returns a running
+`CODEX` session while the resolved workspace Ratchet provider is `CLAUDE`.
+Abort the supplied controller inside `mockWorkspaceBridge.recordSessionEnd`
+before resolving `true`.
+
+Assert these literal outcomes:
+
+```typescript
+await expect(check).rejects.toBe(timeoutError);
+expect(mockWorkspaceBridge.recordSessionEnd).toHaveBeenCalledWith(
+  'ws-provider-mismatch-cancelled-after-settlement',
+  'codex-session',
+  'DIED'
+);
+expect(mockSessionBridge.stopSession).toHaveBeenCalledWith('codex-session');
+```
+
+- [ ] **Step 2: Verify the test fails for the reported reason**
+
+Run:
+
+```bash
+pnpm test src/backend/services/ratchet/service/ratchet.service.test.ts
+```
+
+Expected: the new test fails because `stopSession` has zero calls, while the
+check rejects with `timeoutError` and settlement records `DIED`.
+
+### Task 2: Guarantee abort-insensitive mismatch cleanup
+
+**Files:**
+- Modify:
+  `src/backend/services/ratchet/service/ratchet-active-session.helpers.ts`
+- Test: `src/backend/services/ratchet/service/ratchet.service.test.ts`
+
+**Interfaces:**
+- Consumes: `RatchetSessionBridge.stopSession(sessionId): Promise<void>`
+- Produces: best-effort cleanup that never throws and a provider-mismatch branch
+  that attempts cleanup after either settlement success or settlement failure
+
+- [ ] **Step 1: Make `safeStopSession` abort-insensitive**
+
+Remove its `signal` parameter and all abort checks. Keep the existing
+`try`/`catch`, warning message, warning context, and error-string conversion.
+Remove signal plumbing from `stopCompletedRatchetSession`,
+`stopSessionForProviderMismatch`, and their call sites.
+
+- [ ] **Step 2: Run provider-mismatch cleanup in `finally`**
+
+Replace the sequential mismatch settlement and stop with this control-flow
+shape:
+
+```typescript
+try {
+  return await settle(
+    'DIED',
+    `provider mismatch: expected ${resolvedRatchetProvider}, got ${session.provider}`
+  );
+} finally {
+  await stopSessionForProviderMismatch({
+    workspaceId: workspace.id,
+    sessionId: session.id,
+    expectedProvider: resolvedRatchetProvider,
+    actualProvider: session.provider,
+    sessionBridge,
+  });
+}
+```
+
+- [ ] **Step 3: Verify focused behavior**
+
+Run:
+
+```bash
+pnpm test src/backend/services/ratchet/service/ratchet.service.test.ts
+```
+
+Expected: all Ratchet service tests pass, including the new regression test.
+
+### Task 3: Verify, review, and publish
+
+**Files:**
+- Review:
+  `src/backend/services/ratchet/service/ratchet-active-session.helpers.ts`
+- Review: `src/backend/services/ratchet/service/ratchet.service.test.ts`
+- Review:
+  `docs/superpowers/specs/2026-07-25-ratchet-provider-mismatch-cleanup-design.md`
+- Review:
+  `docs/superpowers/plans/2026-07-25-ratchet-provider-mismatch-cleanup.md`
+
+**Interfaces:**
+- Consumes: repository pnpm scripts and GitHub CLI authentication
+- Produces: committed branch and pull request closing issue `#1983`
+
+- [ ] **Step 1: Run the required verification chain**
+
+```bash
+pnpm typecheck && pnpm check:fix && pnpm test && pnpm build
+```
+
+Expected: every command exits zero.
+
+- [ ] **Step 2: Review the complete branch diff**
+
+```bash
+git diff origin/main
+git status -sb
+```
+
+Confirm there are no debug logs, commented-out code, unrelated edits, or UI
+changes.
+
+- [ ] **Step 3: Commit the focused change**
+
+```bash
+git add \
+  docs/superpowers/specs/2026-07-25-ratchet-provider-mismatch-cleanup-design.md \
+  docs/superpowers/plans/2026-07-25-ratchet-provider-mismatch-cleanup.md \
+  src/backend/services/ratchet/service/ratchet-active-session.helpers.ts \
+  src/backend/services/ratchet/service/ratchet.service.test.ts
+git commit -m "Fix Ratchet mismatch cleanup after abort (#1983)"
+```
+
+- [ ] **Step 4: Push and create the pull request**
+
+Push the current branch with upstream tracking. Create a PR titled
+`Fix #1983: Stop mismatched Ratchet sessions after abort` whose body explains
+the root cause, implementation, full verification, `Closes #1983`, and ends
+with the required Factory Factory signature.

--- a/docs/superpowers/specs/2026-07-25-ratchet-provider-mismatch-cleanup-design.md
+++ b/docs/superpowers/specs/2026-07-25-ratchet-provider-mismatch-cleanup-design.md
@@ -1,0 +1,51 @@
+# Ratchet Provider-Mismatch Cleanup Design
+
+## Goal
+
+Ensure a provider-mismatched Ratchet fixer session is stopped even when its
+workspace check is cancelled while the dispatch record is being settled.
+
+## Root Cause
+
+`checkActiveFixerSession` settles a provider-mismatched dispatch before it
+stops the session. If cancellation occurs during `recordSessionEnd`, the write
+can commit and the following abort check throws before the stop helper is
+called. The dispatch is then `DIED` while the mismatched session remains
+`RUNNING`.
+
+The stop helper is also abort-sensitive even though it is cleanup code that is
+intended to be best-effort and never throw. Its abort checks can prevent the
+stop attempt or replace a stop failure warning with a cancellation exception.
+
+## Design
+
+Keep cancellation barriers around ordinary Ratchet work, including before
+settlement and after `recordSessionEnd`. Make session stopping abort-insensitive:
+`safeStopSession` will always attempt `sessionBridge.stopSession`, catch every
+failure, and log the existing warning context.
+
+For the provider-mismatch branch, run the stop helper in a `finally` block
+around settlement. This preserves the existing settlement-before-stop ordering
+and preserves the cancellation rejection, while guaranteeing that cleanup is
+attempted whenever execution has reached the provider-mismatch branch.
+
+The change is deliberately limited to provider-mismatch cleanup. It does not
+change timeout duration, provider resolution, dispatch outcome selection, or
+pre-settlement cancellation behavior.
+
+## Error Handling
+
+- Cancellation observed after a committed settlement remains the caller-visible
+  error after cleanup finishes.
+- A stop failure is logged with the existing warning message and context.
+- A stop failure never masks a settlement or cancellation error.
+- Cancellation before provider mismatch is established still prevents
+  settlement and cleanup side effects.
+
+## Testing
+
+Add a service-level regression test that aborts during
+`recordSessionEnd('DIED')`, asserts that the check rejects with the timeout
+reason, and asserts that `stopSession` was still called for the mismatched
+session. Existing tests continue to cover normal mismatch settlement and
+pre-settlement cancellation.

--- a/src/backend/services/ratchet/service/ratchet-active-session.helpers.ts
+++ b/src/backend/services/ratchet/service/ratchet-active-session.helpers.ts
@@ -12,15 +12,11 @@ async function safeStopSession(params: {
   sessionId: string;
   warningMessage: string;
   warningContext: Record<string, unknown>;
-  signal?: AbortSignal;
 }): Promise<void> {
-  const { sessionBridge, sessionId, warningMessage, warningContext, signal } = params;
+  const { sessionBridge, sessionId, warningMessage, warningContext } = params;
   try {
-    signal?.throwIfAborted();
     await sessionBridge.stopSession(sessionId);
-    signal?.throwIfAborted();
   } catch (error) {
-    signal?.throwIfAborted();
     logger.warn(warningMessage, {
       ...warningContext,
       error: error instanceof Error ? error.message : String(error),
@@ -32,7 +28,6 @@ async function stopCompletedRatchetSession(params: {
   workspaceId: string;
   sessionId: string;
   sessionBridge: RatchetSessionBridge;
-  signal?: AbortSignal;
 }): Promise<void> {
   await safeStopSession({
     sessionBridge: params.sessionBridge,
@@ -42,7 +37,6 @@ async function stopCompletedRatchetSession(params: {
       workspaceId: params.workspaceId,
       sessionId: params.sessionId,
     },
-    signal: params.signal,
   });
 }
 
@@ -52,7 +46,6 @@ async function stopSessionForProviderMismatch(params: {
   expectedProvider: SessionProvider;
   actualProvider: SessionProvider;
   sessionBridge: RatchetSessionBridge;
-  signal?: AbortSignal;
 }): Promise<void> {
   await safeStopSession({
     sessionBridge: params.sessionBridge,
@@ -64,7 +57,6 @@ async function stopSessionForProviderMismatch(params: {
       expectedProvider: params.expectedProvider,
       actualProvider: params.actualProvider,
     },
-    signal: params.signal,
   });
 }
 
@@ -135,19 +127,20 @@ export async function checkActiveFixerSession(params: {
   }
 
   if (session.provider !== resolvedRatchetProvider) {
-    const result = await settle(
-      'DIED',
-      `provider mismatch: expected ${resolvedRatchetProvider}, got ${session.provider}`
-    );
-    await stopSessionForProviderMismatch({
-      workspaceId: workspace.id,
-      sessionId: session.id,
-      expectedProvider: resolvedRatchetProvider,
-      actualProvider: session.provider,
-      sessionBridge,
-      signal,
-    });
-    return result;
+    try {
+      return await settle(
+        'DIED',
+        `provider mismatch: expected ${resolvedRatchetProvider}, got ${session.provider}`
+      );
+    } finally {
+      await stopSessionForProviderMismatch({
+        workspaceId: workspace.id,
+        sessionId: session.id,
+        expectedProvider: resolvedRatchetProvider,
+        actualProvider: session.provider,
+        sessionBridge,
+      });
+    }
   }
 
   if (session.status !== SessionStatus.RUNNING) {
@@ -169,7 +162,6 @@ export async function checkActiveFixerSession(params: {
       workspaceId: workspace.id,
       sessionId: session.id,
       sessionBridge,
-      signal,
     });
     return result;
   }

--- a/src/backend/services/ratchet/service/ratchet-active-session.helpers.ts
+++ b/src/backend/services/ratchet/service/ratchet-active-session.helpers.ts
@@ -127,20 +127,27 @@ export async function checkActiveFixerSession(params: {
   }
 
   if (session.provider !== resolvedRatchetProvider) {
-    try {
-      return await settle(
-        'DIED',
-        `provider mismatch: expected ${resolvedRatchetProvider}, got ${session.provider}`
-      );
-    } finally {
-      void stopSessionForProviderMismatch({
+    const stopMismatchedSession = () =>
+      stopSessionForProviderMismatch({
         workspaceId: workspace.id,
         sessionId: session.id,
         expectedProvider: resolvedRatchetProvider,
         actualProvider: session.provider,
         sessionBridge,
       });
+    let result: ActiveFixerCheckResult;
+    try {
+      result = await settle(
+        'DIED',
+        `provider mismatch: expected ${resolvedRatchetProvider}, got ${session.provider}`
+      );
+    } catch (error) {
+      // Preserve prompt cancellation while still starting best-effort cleanup.
+      void stopMismatchedSession();
+      throw error;
     }
+    await stopMismatchedSession();
+    return result;
   }
 
   if (session.status !== SessionStatus.RUNNING) {

--- a/src/backend/services/ratchet/service/ratchet-active-session.helpers.ts
+++ b/src/backend/services/ratchet/service/ratchet-active-session.helpers.ts
@@ -133,7 +133,7 @@ export async function checkActiveFixerSession(params: {
         `provider mismatch: expected ${resolvedRatchetProvider}, got ${session.provider}`
       );
     } finally {
-      await stopSessionForProviderMismatch({
+      void stopSessionForProviderMismatch({
         workspaceId: workspace.id,
         sessionId: session.id,
         expectedProvider: resolvedRatchetProvider,

--- a/src/backend/services/ratchet/service/ratchet.service.test.ts
+++ b/src/backend/services/ratchet/service/ratchet.service.test.ts
@@ -3294,6 +3294,41 @@ describe('ratchet service (state-change + idle dispatch)', () => {
       expect(mockSessionBridge.stopSession).toHaveBeenCalledWith('codex-session');
     });
 
+    it('stops a provider-mismatched session after settlement observes cancellation', async () => {
+      const controller = new AbortController();
+      const timeoutError = new Error('Workspace check timed out');
+      vi.mocked(mockSessionBridge.findSessionById).mockResolvedValue({
+        id: 'codex-session',
+        provider: 'CODEX',
+        status: SessionStatus.RUNNING,
+      } as never);
+      vi.mocked(mockSessionBridge.stopSession).mockResolvedValue();
+      vi.mocked(mockWorkspaceBridge.recordSessionEnd).mockImplementation(() => {
+        controller.abort(timeoutError);
+        return Promise.resolve(true);
+      });
+
+      const check = unsafeCoerce<{
+        checkActiveFixerSession: (w: unknown, signal: AbortSignal) => Promise<unknown>;
+      }>(ratchetService).checkActiveFixerSession(
+        {
+          id: 'ws-provider-mismatch-cancelled-after-settlement',
+          ratchetActiveSessionId: 'codex-session',
+          defaultSessionProvider: 'WORKSPACE_DEFAULT',
+          ratchetSessionProvider: 'WORKSPACE_DEFAULT',
+        },
+        controller.signal
+      );
+
+      await expect(check).rejects.toBe(timeoutError);
+      expect(mockWorkspaceBridge.recordSessionEnd).toHaveBeenCalledWith(
+        'ws-provider-mismatch-cancelled-after-settlement',
+        'codex-session',
+        'DIED'
+      );
+      expect(mockSessionBridge.stopSession).toHaveBeenCalledWith('codex-session');
+    });
+
     it('returns the active fixer when the session is working', async () => {
       vi.mocked(mockSessionBridge.findSessionById).mockResolvedValue({
         id: 'working-session',

--- a/src/backend/services/ratchet/service/ratchet.service.test.ts
+++ b/src/backend/services/ratchet/service/ratchet.service.test.ts
@@ -3270,28 +3270,38 @@ describe('ratchet service (state-change + idle dispatch)', () => {
       );
     });
 
-    it('settles a provider-mismatched session as DIED and stops it', async () => {
+    it('waits for provider-mismatch cleanup before returning a successful settlement', async () => {
+      let finishStop!: () => void;
+      const pendingStop = new Promise<void>((resolve) => {
+        finishStop = resolve;
+      });
       vi.mocked(mockSessionBridge.findSessionById).mockResolvedValue({
         id: 'codex-session',
         provider: 'CODEX',
         status: SessionStatus.RUNNING,
       } as never);
-      vi.mocked(mockSessionBridge.stopSession).mockResolvedValue();
+      vi.mocked(mockSessionBridge.stopSession).mockReturnValue(pendingStop);
 
-      const result = await callCheckActiveFixerSession({
+      const check = callCheckActiveFixerSession({
         id: 'ws-5',
         ratchetActiveSessionId: 'codex-session',
         defaultSessionProvider: 'WORKSPACE_DEFAULT',
         ratchetSessionProvider: 'WORKSPACE_DEFAULT',
       });
 
-      expect(result).toEqual({ kind: 'settled', outcome: 'DIED' });
+      await vi.waitFor(() =>
+        expect(mockSessionBridge.stopSession).toHaveBeenCalledWith('codex-session')
+      );
+      await expect(
+        Promise.race([check, Promise.resolve({ kind: 'cleanup_pending' })])
+      ).resolves.toEqual({ kind: 'cleanup_pending' });
       expect(mockWorkspaceBridge.recordSessionEnd).toHaveBeenCalledWith(
         'ws-5',
         'codex-session',
         'DIED'
       );
-      expect(mockSessionBridge.stopSession).toHaveBeenCalledWith('codex-session');
+      finishStop();
+      await expect(check).resolves.toEqual({ kind: 'settled', outcome: 'DIED' });
     });
 
     it('returns cancellation without waiting for provider-mismatch cleanup', async () => {

--- a/src/backend/services/ratchet/service/ratchet.service.test.ts
+++ b/src/backend/services/ratchet/service/ratchet.service.test.ts
@@ -3294,15 +3294,19 @@ describe('ratchet service (state-change + idle dispatch)', () => {
       expect(mockSessionBridge.stopSession).toHaveBeenCalledWith('codex-session');
     });
 
-    it('stops a provider-mismatched session after settlement observes cancellation', async () => {
+    it('returns cancellation without waiting for provider-mismatch cleanup', async () => {
       const controller = new AbortController();
       const timeoutError = new Error('Workspace check timed out');
+      let finishStop!: () => void;
+      const pendingStop = new Promise<void>((resolve) => {
+        finishStop = resolve;
+      });
       vi.mocked(mockSessionBridge.findSessionById).mockResolvedValue({
         id: 'codex-session',
         provider: 'CODEX',
         status: SessionStatus.RUNNING,
       } as never);
-      vi.mocked(mockSessionBridge.stopSession).mockResolvedValue();
+      vi.mocked(mockSessionBridge.stopSession).mockReturnValue(pendingStop);
       vi.mocked(mockWorkspaceBridge.recordSessionEnd).mockImplementation(() => {
         controller.abort(timeoutError);
         return Promise.resolve(true);
@@ -3319,14 +3323,24 @@ describe('ratchet service (state-change + idle dispatch)', () => {
         },
         controller.signal
       );
+      const outcome = check.then(
+        (value) => ({ status: 'resolved' as const, value }),
+        (error: unknown) => ({ status: 'rejected' as const, error })
+      );
 
-      await expect(check).rejects.toBe(timeoutError);
+      await vi.waitFor(() =>
+        expect(mockSessionBridge.stopSession).toHaveBeenCalledWith('codex-session')
+      );
+      await expect(
+        Promise.race([outcome, Promise.resolve({ status: 'pending' as const })])
+      ).resolves.toEqual({ status: 'rejected', error: timeoutError });
       expect(mockWorkspaceBridge.recordSessionEnd).toHaveBeenCalledWith(
         'ws-provider-mismatch-cancelled-after-settlement',
         'codex-session',
         'DIED'
       );
-      expect(mockSessionBridge.stopSession).toHaveBeenCalledWith('codex-session');
+      finishStop();
+      await pendingStop;
     });
 
     it('returns the active fixer when the session is working', async () => {


### PR DESCRIPTION
## Summary
- Stop provider-mismatched Ratchet fixer sessions even when cancellation is observed after dispatch settlement.
- Keep session cleanup best-effort and warning-only while preserving the original timeout error.
- Add regression coverage for the committed-settlement/orphaned-session race.

## Changes
- **Ratchet active-session cleanup**: Removed abort checks from `safeStopSession` so cleanup always attempts `stopSession` and logs failures.
- **Provider mismatch settlement**: Moved the stop attempt into `finally` so post-write cancellation cannot skip cleanup.
- **Tests**: Added a regression that aborts during `recordSessionEnd`, verifies the `DIED` settlement, preserves the timeout rejection, and confirms the session is stopped.

## Testing
- [x] Tests pass (`pnpm test`: 4,295 passed, 3 skipped)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Formatting passes (`pnpm check:fix`; six pre-existing `<img>` performance warnings)
- [x] Manual testing: deterministic service-level race reproduction covered by Vitest; no UI changes

Closes #1983

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Ratchet active-session settlement and stop ordering under cancellation; scope is limited to the Ratchet capsule with new regression tests, but orphaned sessions could still affect dispatch if cleanup fails.
> 
> **Overview**
> Fixes a race where a **provider-mismatched** Ratchet fixer could stay **RUNNING** after the workspace check was cancelled during `recordSessionEnd`: dispatch was settled as **DIED** but `stopSession` never ran.
> 
> **`safeStopSession`** no longer takes an `AbortSignal` or calls `throwIfAborted`, so best-effort cleanup always calls `sessionBridge.stopSession` and only logs failures. **`checkActiveFixerSession`** still settles provider mismatches first; on settlement success it awaits mismatch stop before returning, and on settlement/cancellation errors it kicks off mismatch stop without blocking the caller’s rejection.
> 
> Vitest coverage adds the post-settlement abort regression and asserts successful settlements wait for cleanup while cancellations do not. Design/plan docs were added; no UI changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4d7371931e55fcd4e7d60ca014506e772c3f4de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->