### PR TITLE
Fix #1988: Bound port fallback to valid range

### DIFF
--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -41,6 +41,8 @@ import {
 import { appRouter, createContext } from './trpc/index';
 import type { ServerInstance } from './types/server-instance';
 
+const MAX_PORT = 65_535;
+
 export { createApplication, disposeApplication } from './app-context';
 export type { ServerInstance };
 
@@ -140,6 +142,9 @@ export function createServer(application: Application, requestedPort?: number): 
 
     for (let attempt = 0; attempt < PORT_BIND_MAX_ATTEMPTS; attempt++) {
       const candidatePort = REQUESTED_PORT + attempt;
+      if (candidatePort > MAX_PORT) {
+        break;
+      }
 
       try {
         await listenOnPort(candidatePort);

--- a/src/backend/server.upgrade.test.ts
+++ b/src/backend/server.upgrade.test.ts
@@ -631,6 +631,36 @@ describe('server websocket upgrade routing', () => {
     }
   });
 
+  it('does not try to bind ports above the valid TCP range', async () => {
+    const harness = createTestHarness({ backendHost: '127.0.0.1' });
+    const server = createTestServer(harness.application, 65_535);
+    const httpServer = server.getHttpServer();
+    const addressInUseError = Object.assign(new Error('address in use'), {
+      code: 'EADDRINUSE',
+    });
+    const listenSpy = vi
+      .spyOn(httpServer, 'listen')
+      .mockImplementationOnce(() => {
+        queueMicrotask(() => httpServer.emit('error', addressInUseError));
+        return httpServer;
+      })
+      .mockImplementation(() => {
+        throw Object.assign(new RangeError('bad port'), {
+          code: 'ERR_SOCKET_BAD_PORT',
+        });
+      });
+
+    try {
+      await expect(server.start()).rejects.toThrow(
+        'Could not bind server to an available port starting from 65535'
+      );
+      expect(listenSpy).toHaveBeenCalledOnce();
+      expect(listenSpy).toHaveBeenCalledWith(65_535, '127.0.0.1');
+    } finally {
+      listenSpy.mockRestore();
+    }
+  });
+
   it('rejects start when http server emits an error', async () => {
     const harness = createTestHarness();
     const server = createTestServer(harness.application, 0);

--- a/src/backend/services/port.service.test.ts
+++ b/src/backend/services/port.service.test.ts
@@ -202,5 +202,19 @@ describe('port.service', () => {
 
       expect(attemptCount).toBe(3);
     });
+
+    it('should not probe ports above the valid TCP range', async () => {
+      Object.defineProperty(process, 'platform', { value: 'darwin' });
+      mockExec.mockResolvedValue({ stdout: '12345\n', stderr: '' });
+
+      await expect(findAvailablePort(65_535)).rejects.toThrow(
+        'Could not find an available port starting from 65535'
+      );
+
+      expect(mockExec).toHaveBeenCalledOnce();
+      expect(mockExec).toHaveBeenCalledWith('lsof -i :65535 -sTCP:LISTEN -t', {
+        timeout: 2000,
+      });
+    });
   });
 });

--- a/src/backend/services/port.service.ts
+++ b/src/backend/services/port.service.ts
@@ -12,6 +12,7 @@ import { createLogger } from './logger.service';
 
 const logger = createLogger('port-service');
 const execAsync = promisify(exec);
+const MAX_PORT = 65_535;
 
 /**
  * Check if a port is in use by checking actual listening processes.
@@ -66,6 +67,9 @@ export async function isPortAvailable(port: number): Promise<boolean> {
 export async function findAvailablePort(startPort: number, maxAttempts = 10): Promise<number> {
   for (let i = 0; i < maxAttempts; i++) {
     const port = startPort + i;
+    if (port > MAX_PORT) {
+      break;
+    }
     if (await isPortAvailable(port)) {
       if (i > 0) {
         logger.info('Found available port', { startPort, foundPort: port, attempts: i + 1 });

--- a/src/cli/runtime-utils.test.ts
+++ b/src/cli/runtime-utils.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockExec = vi.fn();
+
+vi.mock('node:child_process', () => ({
+  exec: (...args: unknown[]) => mockExec(...args),
+}));
+
+vi.mock('node:util', () => ({
+  promisify: (fn: unknown) => fn,
+}));
+
+import { findAvailablePort } from './runtime-utils';
+
+describe('findAvailablePort', () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('does not probe ports above the valid TCP range', async () => {
+    mockExec.mockResolvedValue({ stdout: '12345\n', stderr: '' });
+
+    await expect(findAvailablePort(65_535)).rejects.toThrow(
+      'Could not find an available port starting from 65535'
+    );
+
+    expect(mockExec).toHaveBeenCalledOnce();
+    expect(mockExec).toHaveBeenCalledWith('lsof -i :65535 -sTCP:LISTEN -t', {
+      timeout: 2000,
+    });
+  });
+});

--- a/src/cli/runtime-utils.ts
+++ b/src/cli/runtime-utils.ts
@@ -6,6 +6,7 @@ import { promisify } from 'node:util';
 import treeKill from 'tree-kill';
 
 const execPromise = promisify(exec);
+const MAX_PORT = 65_535;
 
 export function ensureDataDir(databasePath: string): void {
   const dir = dirname(databasePath);
@@ -93,6 +94,9 @@ export async function findAvailablePort(
   const { maxAttempts = 10, excludePorts = [] } = options;
   for (let i = 0; i < maxAttempts; i += 1) {
     const port = startPort + i;
+    if (port > MAX_PORT) {
+      break;
+    }
     if (excludePorts.includes(port)) {
       continue;
     }


### PR DESCRIPTION
## Summary
- Stop CLI and backend port fallback scans before they exceed port 65535.
- Preserve the existing user-friendly exhaustion errors instead of exposing `ERR_SOCKET_BAD_PORT`.
- Add regression coverage for Unix discovery and direct backend binding paths.

## Changes
- **CLI port discovery**: Stop sequential probes before an invalid TCP port can reach `lsof` or Node's bind fallback.
- **Backend port service**: Apply the same upper bound while retaining the existing `Could not find an available port` error.
- **Backend startup**: Stop bind fallback at port 65535 and preserve the existing `Could not bind server` error and cause.
- **Tests**: Verify all three paths probe or bind port 65535 once and never attempt port 65536.

## Testing
- [x] Tests pass (`pnpm test`: 4,299 passed, 3 skipped)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Formatting passes (`pnpm check:fix`; six pre-existing `<img>` performance warnings)
- [x] Manual testing: deterministic boundary reproduction covered by Vitest; no UI changes

Closes #1988

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small guardrails on local port selection at startup/CLI; no auth, data, or API behavior changes beyond avoiding invalid port probes.
> 
> **Overview**
> Fixes port fallback when the requested port is **65535** (or near the top of the range): sequential scans no longer try **65536**, which would surface `ERR_SOCKET_BAD_PORT` instead of the existing exhaustion messages.
> 
> **Backend** `bindServerWithPortFallback` in `server.ts`, **`findAvailablePort`** in `port.service.ts`, and **CLI** `findAvailablePort` in `runtime-utils.ts` each stop the loop when `candidatePort` / `port` exceeds **65535**, then fail with the same errors as before (`Could not bind server…` / `Could not find an available port…`).
> 
> Regression tests cover backend bind (only one `listen` on 65535), backend port service, and CLI discovery (only one `lsof` on 65535).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4e98172aa60dbb65737160fa13d187bec4930e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->