### PR TITLE
Fix #1997: Clear stale terminal PID on WebSocket destroy

### DIFF
--- a/src/backend/routers/websocket/terminal.handler.test.ts
+++ b/src/backend/routers/websocket/terminal.handler.test.ts
@@ -596,6 +596,56 @@ describe('createTerminalUpgradeHandler', () => {
     expect(terminalService.destroyTerminal).toHaveBeenCalledWith(workspaceId, 'terminal-1');
   });
 
+  it('clears the persisted PID when a terminal is destroyed via WebSocket', async () => {
+    const workspaceId = 'workspace-1';
+    const terminalId = 'terminal-1';
+    const { terminalService, outputListeners, exitListeners } = createTerminalService();
+    terminalService.getTerminalsForWorkspace.mockReturnValue([
+      {
+        id: terminalId,
+        createdAt: new Date('2026-07-25T00:00:00.000Z'),
+        outputBuffer: '',
+      },
+    ]);
+
+    const logger = createLogger();
+    const appContext = {
+      services: {
+        terminalSessionService,
+        terminalService,
+        workspaceDataService,
+        configService: {
+          getCorsConfig: vi.fn(() => ({ allowedOrigins: [allowedOrigin] })),
+        },
+        createLogger: vi.fn(() => logger),
+      },
+    } as unknown as AppContext;
+    const ws = new MockWebSocket();
+    const handler = createTerminalUpgradeHandler(appContext);
+
+    handler(
+      createRequest(),
+      { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex,
+      Buffer.alloc(0),
+      new URL(`http://localhost/terminal?workspaceId=${workspaceId}`),
+      createWss(ws),
+      new WeakMap<WebSocket, boolean>()
+    );
+
+    await vi.waitFor(() => {
+      expect(exitListeners.get(terminalId)?.size).toBe(1);
+    });
+
+    ws.emit('message', JSON.stringify({ type: 'destroy', terminalId }));
+
+    await vi.waitFor(() => {
+      expect(terminalService.destroyTerminal).toHaveBeenCalledWith(workspaceId, terminalId);
+      expect(mockClearTerminalPid).toHaveBeenCalledWith(workspaceId, terminalId);
+    });
+    expect(outputListeners.get(terminalId)?.size).toBe(0);
+    expect(exitListeners.get(terminalId)?.size).toBe(0);
+  });
+
   it('includes output buffered before listeners attach in the created message', async () => {
     const workspaceId = 'workspace-1';
     const { terminalService } = createTerminalService();

--- a/src/backend/routers/websocket/terminal.handler.ts
+++ b/src/backend/routers/websocket/terminal.handler.ts
@@ -287,10 +287,11 @@ function handleDestroyMessage(
   ws: WebSocket,
   workspaceId: string,
   message: Extract<TerminalMessageInput, { type: 'destroy' }>,
-  terminalService: AppContext['services']['terminalService'],
+  services: TerminalHandlerServices,
   logger: ReturnType<AppContext['services']['createLogger']>
 ): void {
   if (message.terminalId) {
+    const { terminalService } = services;
     logger.info('Destroying terminal', { terminalId: message.terminalId });
     const cleanupMap = terminalListenerCleanup.get(ws);
     const unsubs = cleanupMap?.get(message.terminalId);
@@ -301,6 +302,7 @@ function handleDestroyMessage(
       cleanupMap?.delete(message.terminalId);
     }
     terminalService.destroyTerminal(workspaceId, message.terminalId);
+    void clearTerminalPidWithRetry(workspaceId, message.terminalId, services, logger);
   }
 }
 
@@ -381,7 +383,7 @@ async function handleTerminalMessage(
       handleResizeMessage(workspaceId, message, terminalService, logger);
       break;
     case 'destroy':
-      handleDestroyMessage(ws, workspaceId, message, terminalService, logger);
+      handleDestroyMessage(ws, workspaceId, message, services, logger);
       break;
     case 'set_active':
       handleSetActiveMessage(workspaceId, message, terminalService, logger);


### PR DESCRIPTION
## Summary
- Clear persisted terminal PIDs immediately when terminals are explicitly destroyed over WebSocket.
- Reuse the existing retrying PID cleanup path to handle transient database failures.
- Add a regression test covering terminal destruction, PID release, and listener cleanup.

## Changes
- **Terminal WebSocket handler**: Pass the terminal service bundle through the destroy path and invoke PID cleanup after destroying the PTY.
- **Regression coverage**: Verify explicit destroy releases the persisted PID after listener teardown.

## Testing
- [x] Tests pass (`pnpm test --testTimeout=30000`; timeout extended because the shared host was under extreme unrelated load)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting/lint passes (`pnpm check:fix`; six pre-existing `<img>` performance warnings)
- [x] Build succeeds (`pnpm build`)
- [x] Targeted WebSocket handler tests pass (`14/14`)
- [ ] Manual testing: Not applicable; backend lifecycle behavior is covered by the regression test.

Closes #1997

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to terminal lifecycle cleanup; reuses an existing tested PID-release helper.
> 
> **Overview**
> Explicit **WebSocket `destroy`** now releases the persisted terminal session PID, matching the behavior already used when a PTY **exits** naturally.
> 
> After tearing down listeners and calling `destroyTerminal`, the handler invokes **`clearTerminalPidWithRetry`** (same retrying `releaseSessionPid` path as on exit) so stale PIDs are not left in the database when users close a tab without the shell exiting first.
> 
> A **regression test** asserts destroy triggers PID cleanup and clears output/exit listeners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07a9d9f7e4ab68483edd3a17292d16235c231863. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

