### PR TITLE
Fix #1985: Publish prompt failure dispatch changes

### DIFF
--- a/docs/superpowers/plans/2026-07-25-ratchet-prompt-failure-invalidation.md
+++ b/docs/superpowers/plans/2026-07-25-ratchet-prompt-failure-invalidation.md
@@ -80,7 +80,7 @@ pnpm test src/backend/services/ratchet/service/ratchet.service.test.ts
 
 Expected: all Ratchet service tests pass.
 
-- [ ] **Step 4: Commit the focused fix**
+- [x] **Step 4: Commit the focused fix**
 
 ```bash
 git add src/backend/services/ratchet/service/ratchet-fixer-dispatch.helpers.ts \
@@ -112,6 +112,6 @@ git diff --check
 git status --short
 ```
 
-- [ ] **Step 3: Push and create the pull request**
+- [x] **Step 3: Push and create the pull request**
 
 Push the current issue branch, create the PR with the required Factory Factory signature and `Closes #1985`, then verify the PR URL with `gh pr view`.

--- a/docs/superpowers/plans/2026-07-25-ratchet-prompt-failure-invalidation.md
+++ b/docs/superpowers/plans/2026-07-25-ratchet-prompt-failure-invalidation.md
@@ -1,0 +1,117 @@
+# Ratchet Prompt Failure Invalidation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Immediately invalidate workspace snapshots when failed Ratchet prompt completion successfully settles a dispatch as `DIED`.
+
+**Architecture:** Keep the conditional workspace settlement in the detached prompt-completion helper so its compare-and-set result remains available. Forward the existing `onDispatchChanged` callback into that helper and invoke it only for the winning settlement, matching the other Ratchet helper paths without coupling the helper back to the `ratchetService` singleton.
+
+**Tech Stack:** TypeScript, Node.js `EventEmitter`, Vitest, pnpm
+
+## Global Constraints
+
+- Preserve the existing compare-and-set race behavior: only a successful settlement emits.
+- Preserve session stopping behavior: stop only the settled session when it is still running.
+- Do not change UI code; snapshot consumers already subscribe to `RATCHET_DISPATCH_CHANGED`.
+
+---
+
+### Task 1: Cover prompt-failure invalidation
+
+**Files:**
+- Modify: `src/backend/services/ratchet/service/ratchet.service.test.ts`
+
+**Interfaces:**
+- Consumes: `ratchetService` event `RATCHET_DISPATCH_CHANGED` with `{ workspaceId: string }`
+- Produces: Regression coverage for successful and losing `recordSessionEnd` CAS outcomes
+
+- [x] **Step 1: Add the successful-settlement regression assertion**
+
+Collect `RATCHET_DISPATCH_CHANGED` events in the existing failed-prompt test. After `workspaceRatchetService.recordSessionEnd` is observed, assert two events for the workspace: one for dispatch persistence and one for prompt-failure settlement.
+
+- [x] **Step 2: Add the losing-CAS edge assertion**
+
+Collect events in the existing stale-prompt test and assert that only the initial dispatch-persistence event is present when `recordSessionEnd` resolves `false`.
+
+- [x] **Step 3: Run the focused test to verify RED**
+
+Run:
+
+```bash
+pnpm test src/backend/services/ratchet/service/ratchet.service.test.ts
+```
+
+Expected: the successful-settlement test fails because it receives one invalidation instead of two; the losing-CAS assertion passes.
+
+### Task 2: Forward the invalidation callback
+
+**Files:**
+- Modify: `src/backend/services/ratchet/service/ratchet-fixer-dispatch.helpers.ts`
+- Test: `src/backend/services/ratchet/service/ratchet.service.test.ts`
+
+**Interfaces:**
+- Consumes: `onDispatchChanged?: (event: { workspaceId: string }) => void`
+- Produces: Immediate invalidation after `recordSessionEnd(workspaceId, sessionId, 'DIED')` resolves `true`
+
+- [x] **Step 1: Pass the callback to the detached continuation**
+
+Include `onDispatchChanged` when `handleStartedFixerResult` calls `settleFailedPromptCompletion`.
+
+- [x] **Step 2: Emit only for the winning settlement**
+
+Add the callback to `settleFailedPromptCompletion` parameters and invoke:
+
+```typescript
+if (!settled) {
+  return;
+}
+onDispatchChanged?.({ workspaceId });
+```
+
+before checking whether the session is still running.
+
+- [x] **Step 3: Run the focused test to verify GREEN**
+
+Run:
+
+```bash
+pnpm test src/backend/services/ratchet/service/ratchet.service.test.ts
+```
+
+Expected: all Ratchet service tests pass.
+
+- [ ] **Step 4: Commit the focused fix**
+
+```bash
+git add src/backend/services/ratchet/service/ratchet-fixer-dispatch.helpers.ts \
+  src/backend/services/ratchet/service/ratchet.service.test.ts \
+  docs/superpowers/plans/2026-07-25-ratchet-prompt-failure-invalidation.md
+git commit -m "Fix Ratchet prompt failure invalidation (#1985)"
+```
+
+### Task 3: Verify and publish
+
+**Files:**
+- Review: all changes relative to `origin/main`
+
+**Interfaces:**
+- Consumes: repository verification scripts and authenticated GitHub remote
+- Produces: pushed branch and pull request closing issue `#1985`
+
+- [x] **Step 1: Run all required verification**
+
+```bash
+pnpm typecheck && pnpm check:fix && pnpm test && pnpm build
+```
+
+- [x] **Step 2: Review and commit any formatter changes**
+
+```bash
+git diff origin/main
+git diff --check
+git status --short
+```
+
+- [ ] **Step 3: Push and create the pull request**
+
+Push the current issue branch, create the PR with the required Factory Factory signature and `Closes #1985`, then verify the PR URL with `gh pr view`.

--- a/src/backend/services/ratchet/service/ratchet-fixer-dispatch.helpers.ts
+++ b/src/backend/services/ratchet/service/ratchet-fixer-dispatch.helpers.ts
@@ -94,6 +94,7 @@ async function handleStartedFixerResult(params: {
         sessionId: result.sessionId,
         promptCompletion: result.promptCompletion,
         sessionBridge,
+        onDispatchChanged,
       });
     }
   }
@@ -119,8 +120,9 @@ async function settleFailedPromptCompletion(params: {
   sessionId: string;
   promptCompletion: Promise<boolean>;
   sessionBridge: RatchetSessionBridge;
+  onDispatchChanged?: (event: { workspaceId: string }) => void;
 }): Promise<void> {
-  const { workspaceId, sessionId, promptCompletion, sessionBridge } = params;
+  const { workspaceId, sessionId, promptCompletion, sessionBridge, onDispatchChanged } = params;
 
   try {
     const completed = await promptCompletion;
@@ -129,7 +131,11 @@ async function settleFailedPromptCompletion(params: {
     }
 
     const settled = await workspaceRatchetService.recordSessionEnd(workspaceId, sessionId, 'DIED');
-    if (settled && sessionBridge.isSessionRunning(sessionId)) {
+    if (!settled) {
+      return;
+    }
+    onDispatchChanged?.({ workspaceId });
+    if (sessionBridge.isSessionRunning(sessionId)) {
       await sessionBridge.stopSession(sessionId);
     }
   } catch (error) {

--- a/src/backend/services/ratchet/service/ratchet.service.test.ts
+++ b/src/backend/services/ratchet/service/ratchet.service.test.ts
@@ -3657,6 +3657,10 @@ describe('ratchet service (state-change + idle dispatch)', () => {
         promptCompletion: Promise.resolve(false),
       });
       vi.mocked(mockSessionBridge.isSessionRunning).mockReturnValue(true);
+      const events: RatchetDispatchChangedEvent[] = [];
+      ratchetService.on(RATCHET_DISPATCH_CHANGED, (event: RatchetDispatchChangedEvent) => {
+        events.push(event);
+      });
 
       const result = await unsafeCoerce<{
         triggerFixer: (w: unknown, prStateInfo: unknown, retryCount: number) => Promise<unknown>;
@@ -3684,6 +3688,12 @@ describe('ratchet service (state-change + idle dispatch)', () => {
         )
       );
       expect(mockSessionBridge.stopSession).toHaveBeenCalledWith('failed-prompt-session');
+      await vi.waitFor(() =>
+        expect(events).toEqual([
+          { workspaceId: 'ws-failed-prompt' },
+          { workspaceId: 'ws-failed-prompt' },
+        ])
+      );
     });
 
     it('does not stop a newer active session when an old prompt completion fails', async () => {
@@ -3695,6 +3705,10 @@ describe('ratchet service (state-change + idle dispatch)', () => {
       });
       vi.mocked(workspaceRatchetService.recordSessionEnd).mockResolvedValue(false);
       vi.mocked(mockSessionBridge.isSessionRunning).mockReturnValue(true);
+      const events: RatchetDispatchChangedEvent[] = [];
+      ratchetService.on(RATCHET_DISPATCH_CHANGED, (event: RatchetDispatchChangedEvent) => {
+        events.push(event);
+      });
 
       await unsafeCoerce<{
         triggerFixer: (w: unknown, prStateInfo: unknown, retryCount: number) => Promise<unknown>;
@@ -3715,6 +3729,7 @@ describe('ratchet service (state-change + idle dispatch)', () => {
 
       await vi.waitFor(() => expect(workspaceRatchetService.recordSessionEnd).toHaveBeenCalled());
       expect(mockSessionBridge.stopSession).not.toHaveBeenCalled();
+      expect(events).toEqual([{ workspaceId: 'ws-replaced-prompt' }]);
     });
 
     it('cleans up a fixer through prompt failure after its dispatch record is persisted', async () => {


### PR DESCRIPTION
## Summary
- Publish a Ratchet dispatch-change event immediately when failed prompt completion wins session-end settlement.
- Keep compare-and-set race handling intact so losing settlement paths do not emit duplicate invalidations.

## Changes
- **Ratchet fixer dispatch**: Forward the existing dispatch-change callback into detached prompt-completion reconciliation and invoke it only after a successful `DIED` settlement.
- **Regression coverage**: Verify successful settlement emits a second invalidation and losing CAS emits only the initial dispatch invalidation.
- **Implementation plan**: Document the root cause, chosen callback boundary, TDD steps, and verification workflow.

## Testing
- [x] Tests pass (`pnpm test --maxWorkers=4 --testTimeout=30000`; 4,296 passed)
- [x] Focused Ratchet tests pass (`pnpm test src/backend/services/ratchet/service/ratchet.service.test.ts`; 121 passed)
- [x] Types pass (`pnpm typecheck`)
- [x] Guardrails pass (`pnpm check`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; backend event behavior is covered by regression tests.

Closes #1985

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow backend event wiring in Ratchet fixer helpers with CAS-guarded emission; behavior is covered by existing and new service tests.
> 
> **Overview**
> Fixes stale workspace snapshots when a Ratchet fixer’s **async prompt delivery fails** after dispatch was already recorded: the detached `settleFailedPromptCompletion` path now forwards **`onDispatchChanged`** and fires it only after **`recordSessionEnd(..., 'DIED')`** wins its compare-and-set, aligned with dispatch persistence and other settlement helpers.
> 
> **Behavior preserved:** losing CAS still emits nothing extra and does not stop a replaced session; session stop still runs only for the winning settlement when the session is still running.
> 
> **Tests** assert two `RATCHET_DISPATCH_CHANGED` events on successful prompt-failure settlement and a single event when `recordSessionEnd` returns false. An implementation plan doc was added for the TDD workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9b81417e2334c71da677f2d5fa2cda5918809b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->