### PR TITLE
Fix npm publish Prisma version guard

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -44,8 +44,7 @@ jobs:
         run: pnpm db:generate
 
       - name: Verify Prisma versions are pinned
-        run: |
-          node -e 'const p=require("./package.json"); const adapter=p.dependencies?.["@prisma/adapter-better-sqlite3"]; const client=p.dependencies?.["@prisma/client"]; const prismaDep=p.dependencies?.prisma; const prismaDev=p.devDependencies?.prisma; const pinned=v=>typeof v==="string"&&!/^[~^]/.test(v); if(!pinned(adapter)) throw new Error(`@prisma/adapter-better-sqlite3 must be pinned exactly, got ${adapter}`); if(!pinned(client)) throw new Error(`@prisma/client must be pinned exactly, got ${client}`); if(!pinned(prismaDep)) throw new Error(`dependencies.prisma must be pinned exactly, got ${prismaDep}`); if(!pinned(prismaDev)) throw new Error(`devDependencies.prisma must be pinned exactly, got ${prismaDev}`); if(adapter!==client||client!==prismaDep||prismaDep!==prismaDev) throw new Error(`Prisma versions must match: @prisma/adapter-better-sqlite3=${adapter}, @prisma/client=${client}, dependencies.prisma=${prismaDep}, devDependencies.prisma=${prismaDev}`);'
+        run: node scripts/check-prisma-versions.mjs
 
       - name: Run tests
         run: pnpm test

--- a/docs/superpowers/plans/2026-07-27-npm-publish-prisma-guard.md
+++ b/docs/superpowers/plans/2026-07-27-npm-publish-prisma-guard.md
@@ -1,0 +1,256 @@
+# npm Publish Prisma Guard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the npm publish workflow accept the intentional runtime-only Prisma dependency placement while continuing to reject missing, ranged, or mismatched Prisma versions.
+
+**Architecture:** Replace the untested JavaScript embedded in the GitHub Actions workflow with a focused Node.js command. Execute that real command from Vitest against temporary package manifests so the CI contract is covered independently of the repository's current manifest.
+
+**Tech Stack:** Node.js ESM, TypeScript, Vitest, GitHub Actions YAML, pnpm
+
+## Global Constraints
+
+- Keep `prisma` in `dependencies`; the published package invokes Prisma at runtime.
+- Require exact, matching versions for `@prisma/adapter-better-sqlite3`, `@prisma/client`, and `prisma`.
+- Do not require or restore `devDependencies.prisma`.
+- Keep the fix limited to the publish guard and its regression coverage.
+
+---
+
+### Task 1: Add the tested Prisma dependency checker
+
+**Files:**
+- Create: `scripts/check-prisma-versions.mjs`
+- Create: `src/backend/testing/check-prisma-versions-script.test.ts`
+
+**Interfaces:**
+- Consumes: An optional package manifest path as `process.argv[2]`; defaults to `package.json` in the current working directory.
+- Produces: Exit code `0` and a confirmation on stdout for aligned exact versions; exit code `1` with a dependency-specific error for invalid manifests.
+
+- [ ] **Step 1: Write the failing regression tests**
+
+Create `src/backend/testing/check-prisma-versions-script.test.ts`:
+
+```ts
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const scriptPath = fileURLToPath(
+  new URL('../../../scripts/check-prisma-versions.mjs', import.meta.url)
+);
+
+describe('check-prisma-versions script', () => {
+  let tempRoot: string | null = null;
+
+  afterEach(() => {
+    if (tempRoot) {
+      rmSync(tempRoot, { recursive: true, force: true });
+      tempRoot = null;
+    }
+  });
+
+  function run(dependencies: Record<string, string>) {
+    tempRoot = mkdtempSync(join(tmpdir(), 'ff-prisma-versions-'));
+    const manifestPath = join(tempRoot, 'package.json');
+    writeFileSync(
+      manifestPath,
+      `${JSON.stringify({ dependencies, devDependencies: {} }, null, 2)}\n`,
+      'utf8'
+    );
+
+    return spawnSync('node', [scriptPath, manifestPath], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  }
+
+  const alignedDependencies = {
+    '@prisma/adapter-better-sqlite3': '7.9.0',
+    '@prisma/client': '7.9.0',
+    prisma: '7.9.0',
+  };
+
+  it('accepts aligned runtime dependencies without devDependencies.prisma', () => {
+    const result = run(alignedDependencies);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Prisma dependencies are pinned to 7.9.0.');
+  });
+
+  it('rejects a missing runtime Prisma dependency', () => {
+    const { prisma: _prisma, ...dependencies } = alignedDependencies;
+    const result = run(dependencies);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('prisma must be pinned exactly in dependencies, got undefined');
+  });
+
+  it('rejects a ranged Prisma version', () => {
+    const result = run({ ...alignedDependencies, prisma: '^7.9.0' });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('prisma must be pinned exactly in dependencies, got ^7.9.0');
+  });
+
+  it('rejects mismatched exact Prisma versions', () => {
+    const result = run({ ...alignedDependencies, prisma: '7.9.1' });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      'Prisma versions must match: @prisma/adapter-better-sqlite3=7.9.0, @prisma/client=7.9.0, prisma=7.9.1'
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```bash
+pnpm exec vitest run src/backend/testing/check-prisma-versions-script.test.ts
+```
+
+Expected: all four tests fail because `scripts/check-prisma-versions.mjs` does not exist.
+
+- [ ] **Step 3: Add the minimal checker**
+
+Create `scripts/check-prisma-versions.mjs`:
+
+```js
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const manifestPath = resolve(process.argv[2] ?? 'package.json');
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+const dependencies = manifest.dependencies ?? {};
+const dependencyNames = [
+  '@prisma/adapter-better-sqlite3',
+  '@prisma/client',
+  'prisma',
+];
+const exactVersion = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+
+const versions = dependencyNames.map((name) => {
+  const version = dependencies[name];
+  if (typeof version !== 'string' || !exactVersion.test(version)) {
+    throw new Error(
+      `${name} must be pinned exactly in dependencies, got ${String(version)}`
+    );
+  }
+  return version;
+});
+
+if (new Set(versions).size !== 1) {
+  throw new Error(
+    `Prisma versions must match: ${dependencyNames
+      .map((name, index) => `${name}=${versions[index]}`)
+      .join(', ')}`
+  );
+}
+
+process.stdout.write(`Prisma dependencies are pinned to ${versions[0]}.\n`);
+```
+
+- [ ] **Step 4: Run the test and verify GREEN**
+
+Run:
+
+```bash
+pnpm exec vitest run src/backend/testing/check-prisma-versions-script.test.ts
+```
+
+Expected: 1 test file and 4 tests pass.
+
+- [ ] **Step 5: Run the checker against the repository manifest**
+
+Run:
+
+```bash
+node scripts/check-prisma-versions.mjs
+```
+
+Expected stdout:
+
+```text
+Prisma dependencies are pinned to 7.9.0.
+```
+
+- [ ] **Step 6: Commit the checker and regression tests**
+
+```bash
+git add scripts/check-prisma-versions.mjs src/backend/testing/check-prisma-versions-script.test.ts
+git commit -m "Test npm publish Prisma version guard"
+```
+
+### Task 2: Route npm publishing through the tested checker
+
+**Files:**
+- Modify: `.github/workflows/npm-publish.yml:46`
+
+**Interfaces:**
+- Consumes: `scripts/check-prisma-versions.mjs` from Task 1.
+- Produces: The `Verify Prisma versions are pinned` workflow step with the same name and corrected manifest contract.
+
+- [ ] **Step 1: Replace the stale inline workflow check**
+
+Change the step to:
+
+```yaml
+      - name: Verify Prisma versions are pinned
+        run: node scripts/check-prisma-versions.mjs
+```
+
+- [ ] **Step 2: Run focused formatting and regression checks**
+
+Run:
+
+```bash
+pnpm exec biome check scripts/check-prisma-versions.mjs src/backend/testing/check-prisma-versions-script.test.ts
+pnpm exec vitest run src/backend/testing/check-prisma-versions-script.test.ts
+node scripts/check-prisma-versions.mjs
+git diff --check
+```
+
+Expected: every command exits `0`.
+
+- [ ] **Step 3: Commit the workflow integration**
+
+```bash
+git add .github/workflows/npm-publish.yml
+git commit -m "Fix npm publish Prisma version guard"
+```
+
+- [ ] **Step 4: Run full repository verification**
+
+Run:
+
+```bash
+pnpm test
+pnpm check
+pnpm typecheck
+pnpm build
+```
+
+Expected: every command exits `0` with no test failures, type errors, dependency violations, or build failure.
+
+- [ ] **Step 5: Reproduce the package portion of the publish workflow**
+
+Run:
+
+```bash
+npm pack --dry-run
+npm publish --dry-run
+```
+
+Expected: both commands exit `0`; no registry write occurs.
+
+- [ ] **Step 6: Review the final diff and publish a draft PR**
+
+Confirm only the spec, plan, checker, test, and workflow files differ from `origin/main`. Push the current branch and open a draft PR targeting `main` with the root cause and all verification commands in the body.

--- a/docs/superpowers/specs/2026-07-27-npm-publish-prisma-guard-design.md
+++ b/docs/superpowers/specs/2026-07-27-npm-publish-prisma-guard-design.md
@@ -1,0 +1,55 @@
+# npm Publish Prisma Guard Design
+
+## Problem
+
+The npm publish workflow fails before tests, packaging, or publishing because
+its inline Prisma version check requires `prisma` to appear in both
+`dependencies` and `devDependencies`.
+
+Commit `2684a415` removed the redundant `devDependencies.prisma` entry while
+retaining `prisma` as an exact runtime dependency. That placement is intentional:
+the published package runs Prisma commands during installation and database
+migration. The workflow guard was not updated with the package manifest.
+
+## Considered Approaches
+
+1. Restore `devDependencies.prisma`.
+   This would satisfy the stale check but duplicate a runtime dependency and
+   preserve an unnecessary manifest invariant.
+2. Edit the inline workflow expression.
+   This is the smallest text change, but leaves a long, untested JavaScript
+   program embedded in YAML and makes future drift easy to miss.
+3. Extract and test the manifest check.
+   This keeps the intended invariant explicit and gives both local and CI users
+   the same executable validation. This is the selected approach.
+
+## Design
+
+Add a small Node.js script under `scripts/` that reads a supplied package
+manifest and verifies:
+
+- `dependencies["@prisma/adapter-better-sqlite3"]` is an exact version.
+- `dependencies["@prisma/client"]` is an exact version.
+- `dependencies.prisma` is an exact version.
+- All three versions are identical.
+
+The script will not require `devDependencies.prisma`. It will accept an optional
+manifest path so tests can execute the real command against temporary fixtures.
+Errors will name the missing, ranged, or mismatched dependency and exit
+non-zero.
+
+The npm publish workflow will invoke this script instead of embedding the check.
+No dependency placement or runtime behavior will change.
+
+## Testing and Validation
+
+Regression tests will execute the real script and cover:
+
+- The current package shape, with Prisma only in `dependencies`, succeeds.
+- A missing runtime Prisma dependency fails.
+- A ranged Prisma version fails.
+- Mismatched exact Prisma versions fail.
+
+Implementation will follow red-green TDD. Final validation will include the
+targeted regression test, the full test suite, `pnpm check`, `pnpm typecheck`,
+and a local build/package dry run matching the workflow as closely as practical.

--- a/scripts/check-prisma-versions.mjs
+++ b/scripts/check-prisma-versions.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const manifestPath = resolve(process.argv[2] ?? 'package.json');
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+const dependencies = manifest.dependencies ?? {};
+const dependencyNames = [
+  '@prisma/adapter-better-sqlite3',
+  '@prisma/client',
+  'prisma',
+];
+const exactVersion = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+
+const versions = dependencyNames.map((name) => {
+  const version = dependencies[name];
+  if (typeof version !== 'string' || !exactVersion.test(version)) {
+    throw new Error(
+      `${name} must be pinned exactly in dependencies, got ${String(version)}`
+    );
+  }
+  return version;
+});
+
+if (new Set(versions).size !== 1) {
+  throw new Error(
+    `Prisma versions must match: ${dependencyNames
+      .map((name, index) => `${name}=${versions[index]}`)
+      .join(', ')}`
+  );
+}
+
+process.stdout.write(`Prisma dependencies are pinned to ${versions[0]}.\n`);

--- a/src/backend/testing/check-prisma-versions-script.test.ts
+++ b/src/backend/testing/check-prisma-versions-script.test.ts
@@ -1,0 +1,73 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const scriptPath = fileURLToPath(
+  new URL('../../../scripts/check-prisma-versions.mjs', import.meta.url)
+);
+
+describe('check-prisma-versions script', () => {
+  let tempRoot: string | null = null;
+
+  afterEach(() => {
+    if (tempRoot) {
+      rmSync(tempRoot, { recursive: true, force: true });
+      tempRoot = null;
+    }
+  });
+
+  function run(dependencies: Record<string, string>) {
+    tempRoot = mkdtempSync(join(tmpdir(), 'ff-prisma-versions-'));
+    const manifestPath = join(tempRoot, 'package.json');
+    writeFileSync(
+      manifestPath,
+      `${JSON.stringify({ dependencies, devDependencies: {} }, null, 2)}\n`,
+      'utf8'
+    );
+
+    return spawnSync('node', [scriptPath, manifestPath], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  }
+
+  const alignedDependencies = {
+    '@prisma/adapter-better-sqlite3': '7.9.0',
+    '@prisma/client': '7.9.0',
+    prisma: '7.9.0',
+  };
+
+  it('accepts aligned runtime dependencies without devDependencies.prisma', () => {
+    const result = run(alignedDependencies);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Prisma dependencies are pinned to 7.9.0.');
+  });
+
+  it('rejects a missing runtime Prisma dependency', () => {
+    const { prisma: _prisma, ...dependencies } = alignedDependencies;
+    const result = run(dependencies);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('prisma must be pinned exactly in dependencies, got undefined');
+  });
+
+  it('rejects a ranged Prisma version', () => {
+    const result = run({ ...alignedDependencies, prisma: '^7.9.0' });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('prisma must be pinned exactly in dependencies, got ^7.9.0');
+  });
+
+  it('rejects mismatched exact Prisma versions', () => {
+    const result = run({ ...alignedDependencies, prisma: '7.9.1' });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      'Prisma versions must match: @prisma/adapter-better-sqlite3=7.9.0, @prisma/client=7.9.0, prisma=7.9.1'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the npm publish workflow's inline Prisma version guard with the tested `scripts/check-prisma-versions.mjs` checker.

## Root cause

The workflow duplicated a stale inline manifest contract that required `prisma` in both `dependencies` and `devDependencies`. The tested checker is the canonical contract and correctly validates the package manifest.

## Validation

- `pnpm exec biome check scripts/check-prisma-versions.mjs src/backend/testing/check-prisma-versions-script.test.ts`
- `pnpm exec vitest run src/backend/testing/check-prisma-versions-script.test.ts`
- `node scripts/check-prisma-versions.mjs`
- `git diff --check`
- `pnpm test`
- `pnpm check`
- `pnpm typecheck`
- `pnpm build`
- `npm pack --dry-run`
- `npm publish --dry-run`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1a357cebd0c749998f0c1ce275e8d2626de9cc41. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->