### PR TITLE
Fix dark mode status banner colors

### DIFF
--- a/docs/superpowers/plans/2026-07-28-dark-mode-status-banners.md
+++ b/docs/superpowers/plans/2026-07-28-dark-mode-status-banners.md
@@ -1,0 +1,269 @@
+# Dark Mode Status Banners Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make workspace error, warning, and information banners use theme-aware semantic colors in both light and dark mode.
+
+**Architecture:** Put the semantic class mapping in one dependency-free client utility, then consume it from both confirmed light-only workspace banner implementations. Keep banner layout and behavior unchanged, and add a Storybook palette story for direct light/dark visual inspection.
+
+**Tech Stack:** TypeScript, React, Tailwind CSS v4 semantic theme tokens, Vitest, Storybook
+
+## Global Constraints
+
+- Use the existing `destructive`, `warning`, and `info` theme tokens.
+- Preserve banner copy, icons, layout, buttons, and behavior.
+- Do not change unrelated diff colors, status dots, provider branding, or components that already support dark mode.
+- Add or update Storybook coverage for the UI change.
+
+---
+
+### Task 1: Define and test semantic status banner styles
+
+**Files:**
+- Create: `src/client/lib/status-banner-styles.test.ts`
+- Create: `src/client/lib/status-banner-styles.ts`
+
+**Interfaces:**
+- Consumes: `WorkspaceInitBanner['kind']` from `@/shared/workspace-init`
+- Produces: `getStatusBannerClassName(kind: WorkspaceInitBanner['kind']): string`
+
+- [ ] **Step 1: Write the failing semantic mapping tests**
+
+Create `src/client/lib/status-banner-styles.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { getStatusBannerClassName } from './status-banner-styles';
+
+describe('getStatusBannerClassName', () => {
+  it.each([
+    ['error', 'border-destructive/30 bg-destructive/10 text-destructive'],
+    ['warning', 'border-warning/30 bg-warning/10 text-warning'],
+    ['info', 'border-info/30 bg-info/10 text-info'],
+  ] as const)('maps %s banners to theme-aware semantic colors', (kind, expected) => {
+    expect(getStatusBannerClassName(kind)).toBe(expected);
+  });
+
+  it.each(['error', 'warning', 'info'] as const)(
+    'does not use a fixed light-theme palette for %s banners',
+    (kind) => {
+      expect(getStatusBannerClassName(kind)).not.toMatch(
+        /\b(?:bg|border|text)-(?:red|yellow|blue)-/
+      );
+    }
+  );
+});
+```
+
+- [ ] **Step 2: Run the test and verify the red state**
+
+Run:
+
+```bash
+pnpm exec vitest run src/client/lib/status-banner-styles.test.ts
+```
+
+Expected: FAIL because `./status-banner-styles` does not exist.
+
+- [ ] **Step 3: Implement the minimal semantic mapping**
+
+Create `src/client/lib/status-banner-styles.ts`:
+
+```ts
+import type { WorkspaceInitBanner } from '@/shared/workspace-init';
+
+const STATUS_BANNER_CLASS_NAMES: Record<WorkspaceInitBanner['kind'], string> = {
+  error: 'border-destructive/30 bg-destructive/10 text-destructive',
+  warning: 'border-warning/30 bg-warning/10 text-warning',
+  info: 'border-info/30 bg-info/10 text-info',
+};
+
+export function getStatusBannerClassName(kind: WorkspaceInitBanner['kind']): string {
+  return STATUS_BANNER_CLASS_NAMES[kind];
+}
+```
+
+- [ ] **Step 4: Run the focused test and verify the green state**
+
+Run:
+
+```bash
+pnpm exec vitest run src/client/lib/status-banner-styles.test.ts
+```
+
+Expected: both tests pass for all three banner kinds.
+
+### Task 2: Migrate the confirmed workspace banners
+
+**Files:**
+- Modify: `src/client/routes/projects/workspaces/workspace-detail-chat-content.tsx:17-22,127-151`
+- Modify: `src/client/features/workspace/workspace-content-view.tsx:1-10,109-113`
+- Create: `src/client/components/status-banner-palette.stories.tsx`
+
+**Interfaces:**
+- Consumes: `getStatusBannerClassName(kind)` from `@/client/lib/status-banner-styles`
+- Produces: Theme-aware workspace chat initialization banners, empty-workspace warning, and a visual palette story
+
+- [ ] **Step 1: Replace the workspace chat banner’s fixed palette**
+
+Import `getStatusBannerClassName` from `@/client/lib/status-banner-styles`, delete the local `getInitBannerClass`, and change the `InitStatusBanner` class composition to:
+
+```tsx
+className={[
+  'rounded-md border p-3 text-sm flex items-start gap-3',
+  getStatusBannerClassName(banner.kind),
+].join(' ')}
+```
+
+- [ ] **Step 2: Replace the empty-workspace warning’s fixed palette**
+
+Import `getStatusBannerClassName` from `@/client/lib/status-banner-styles`, then change the notice to:
+
+```tsx
+<div
+  className={[
+    'border px-4 py-3 rounded-md text-sm',
+    getStatusBannerClassName('warning'),
+  ].join(' ')}
+>
+  Workspace is initializing... Please wait for the worktree to be created.
+</div>
+```
+
+- [ ] **Step 3: Add a Storybook light/dark comparison story**
+
+Create `src/client/components/status-banner-palette.stories.tsx`:
+
+```tsx
+import { InfoIcon, WarningIcon } from '@phosphor-icons/react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { getStatusBannerClassName } from '@/client/lib/status-banner-styles';
+import type { WorkspaceInitBanner } from '@/shared/workspace-init';
+
+const BANNERS: Pick<WorkspaceInitBanner, 'kind' | 'message'>[] = [
+  { kind: 'error', message: 'Agent failed to start.' },
+  { kind: 'warning', message: 'Workspace setup completed with warnings.' },
+  { kind: 'info', message: 'Workspace setup is still running.' },
+];
+
+function StatusBannerPalette() {
+  return (
+    <div className="w-[32rem] space-y-3 bg-background p-6 text-foreground">
+      {BANNERS.map((banner) => {
+        const Icon = banner.kind === 'info' ? InfoIcon : WarningIcon;
+        return (
+          <div
+            key={banner.kind}
+            className={[
+              'flex items-start gap-3 rounded-md border p-3 text-sm',
+              getStatusBannerClassName(banner.kind),
+            ].join(' ')}
+          >
+            <Icon className="mt-0.5 h-4 w-4 shrink-0" />
+            <div>
+              <p className="font-medium capitalize">{banner.kind}</p>
+              <p>{banner.message}</p>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+const meta = {
+  title: 'Components/StatusBannerPalette',
+  component: StatusBannerPalette,
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof StatusBannerPalette>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const AllStates: Story = {};
+```
+
+- [ ] **Step 4: Run focused automated checks**
+
+Run:
+
+```bash
+pnpm exec vitest run src/client/lib/status-banner-styles.test.ts
+pnpm typecheck
+```
+
+Expected: the focused tests and TypeScript check exit zero.
+
+- [ ] **Step 5: Commit the implementation**
+
+Run:
+
+```bash
+git add src/client/lib/status-banner-styles.ts \
+  src/client/lib/status-banner-styles.test.ts \
+  src/client/components/status-banner-palette.stories.tsx \
+  src/client/routes/projects/workspaces/workspace-detail-chat-content.tsx \
+  src/client/features/workspace/workspace-content-view.tsx
+git commit -m "Fix dark mode status banner colors"
+```
+
+### Task 3: Verify, review, and publish
+
+**Files:**
+- Review: all files changed from `origin/main`
+- Create temporarily: a PR body file under a `mktemp -d` directory
+
+**Interfaces:**
+- Consumes: the committed dark-mode banner fix
+- Produces: verified branch and draft GitHub pull request
+
+- [ ] **Step 1: Inspect the Storybook story in both themes**
+
+Start Storybook with `pnpm storybook`, open `Components/StatusBannerPalette`, and use the Storybook theme control to inspect light and dark mode. Confirm each banner has a subtle tinted surface, legible text and border, and unchanged icon/layout alignment.
+
+- [ ] **Step 2: Run the complete verification chain**
+
+Run:
+
+```bash
+pnpm check:fix
+pnpm test
+pnpm typecheck
+pnpm check
+pnpm build:storybook
+```
+
+Expected: every command exits zero. Review formatter changes and keep only files in scope.
+
+- [ ] **Step 3: Request an independent code review**
+
+Provide the reviewer with the diff from `origin/main`, the approved design spec, and the requirement to catch any remaining light-only banner classes, semantic-token mistakes, regressions, or scope creep. Address every critical or important finding before publishing.
+
+- [ ] **Step 4: Confirm publish scope and GitHub prerequisites**
+
+Run:
+
+```bash
+git status -sb
+git diff --check origin/main
+git diff --stat origin/main
+gh --version
+gh auth status
+```
+
+Expected: only the design, plan, semantic style utility/test/story, and two banner consumers differ from `origin/main`; GitHub CLI is installed and authenticated.
+
+- [ ] **Step 5: Push and create the draft pull request**
+
+Push the current branch with tracking. Create a draft PR targeting the repository’s default branch with:
+
+- A concise summary of the semantic banner mapping and migrated callers.
+- The root cause: fixed light-palette utility classes bypassed dark-theme tokens.
+- User impact: workspace status banners now match both themes.
+- The complete verification commands and results.
+
+- [ ] **Step 6: Report the published result**
+
+Return the branch name, commit SHAs, draft PR URL and target, verification results, and any non-blocking review notes.

--- a/docs/superpowers/specs/2026-07-28-dark-mode-status-banners-design.md
+++ b/docs/superpowers/specs/2026-07-28-dark-mode-status-banners-design.md
@@ -1,0 +1,60 @@
+# Dark Mode Status Banners Design
+
+## Problem
+
+Workspace initialization banners use fixed Tailwind palette colors such as
+`bg-red-50`, `bg-yellow-50`, and `bg-blue-50`. Those colors remain light in
+dark mode, so error, warning, and informational banners look like light-theme
+panels inside the dark workspace UI. The no-session workspace initialization
+notice repeats the same light-only warning palette.
+
+The rest of the banner audit found correctly themed examples that either use
+semantic theme tokens or provide explicit dark-mode colors. Shared destructive
+alerts already use the mode-aware `destructive` token, so they do not need a
+separate visual redesign.
+
+## Design
+
+Add a small client utility that maps the banner kinds `error`, `warning`, and
+`info` to semantic Tailwind classes:
+
+- Error: `destructive`
+- Warning: `warning`
+- Info: `info`
+
+Each mapping supplies a translucent semantic background, semantic border, and
+semantic foreground. The existing CSS variables provide different values in
+light and dark themes, so callers do not need local `dark:` overrides.
+
+Use the utility in:
+
+- The workspace chat initialization status banner, including runtime errors,
+  setup warnings, and setup progress information.
+- The empty-workspace initialization notice shown before the worktree exists.
+
+Keep layout, icons, copy, and actions unchanged.
+
+## Testing
+
+Add a focused unit test for the semantic banner-style utility. The test will
+assert the exact semantic mapping for all three banner kinds and reject
+light-only fixed palette classes. Run the test before implementation to confirm
+it fails because the utility does not exist, then run it after implementation
+to confirm the mapping.
+
+Render the affected workspace states in Storybook or the local app and inspect
+them in both light and dark themes. Verify that:
+
+- Error, warning, and info banners use a subtle theme-aware tint.
+- Text and borders remain legible in both themes.
+- Buttons and icons retain their existing layout.
+- The empty-workspace initialization notice matches the warning treatment.
+
+Finally run the full test suite, type checking, and repository checks before
+publishing the pull request.
+
+## Scope
+
+This change fixes the two confirmed light-only banner implementations. It does
+not rewrite unrelated diff colors, status dots, provider-specific branding, or
+components that already define correct dark-mode styling.

--- a/src/client/components/status-banner-palette.stories.tsx
+++ b/src/client/components/status-banner-palette.stories.tsx
@@ -1,0 +1,48 @@
+import { InfoIcon, WarningIcon } from '@phosphor-icons/react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { getStatusBannerClassName } from '@/client/lib/status-banner-styles';
+import type { WorkspaceInitBanner } from '@/shared/workspace-init';
+
+const BANNERS: Pick<WorkspaceInitBanner, 'kind' | 'message'>[] = [
+  { kind: 'error', message: 'Agent failed to start.' },
+  { kind: 'warning', message: 'Workspace setup completed with warnings.' },
+  { kind: 'info', message: 'Workspace setup is still running.' },
+];
+
+function StatusBannerPalette() {
+  return (
+    <div className="w-[32rem] space-y-3 bg-background p-6 text-foreground">
+      {BANNERS.map((banner) => {
+        const Icon = banner.kind === 'info' ? InfoIcon : WarningIcon;
+        return (
+          <div
+            key={banner.kind}
+            className={[
+              'flex items-start gap-3 rounded-md border p-3 text-sm',
+              getStatusBannerClassName(banner.kind),
+            ].join(' ')}
+          >
+            <Icon className="mt-0.5 h-4 w-4 shrink-0" />
+            <div>
+              <p className="font-medium capitalize">{banner.kind}</p>
+              <p>{banner.message}</p>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+const meta = {
+  title: 'Components/StatusBannerPalette',
+  component: StatusBannerPalette,
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof StatusBannerPalette>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const AllStates: Story = {};

--- a/src/client/features/workspace/workspace-content-view.tsx
+++ b/src/client/features/workspace/workspace-content-view.tsx
@@ -1,5 +1,6 @@
 import type { inferRouterOutputs } from '@trpc/server';
 import type { Dispatch, ReactNode, SetStateAction } from 'react';
+import { getStatusBannerClassName } from '@/client/lib/status-banner-styles';
 import type { AppRouter } from '@/client/lib/trpc';
 import type { SessionProviderValue } from '@/lib/session-provider-selection';
 
@@ -107,7 +108,12 @@ export function WorkspaceContentView({
               </div>
 
               {!hasWorktreePath && (
-                <div className="bg-yellow-50 border border-yellow-200 text-yellow-800 px-4 py-3 rounded-md text-sm">
+                <div
+                  className={[
+                    'border px-4 py-3 rounded-md text-sm',
+                    getStatusBannerClassName('warning'),
+                  ].join(' ')}
+                >
                   Workspace is initializing... Please wait for the worktree to be created.
                 </div>
               )}

--- a/src/client/lib/status-banner-styles.test.ts
+++ b/src/client/lib/status-banner-styles.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { getStatusBannerClassName } from './status-banner-styles';
+
+describe('getStatusBannerClassName', () => {
+  it.each([
+    ['error', 'border-destructive/30 bg-destructive/10 text-destructive'],
+    ['warning', 'border-warning/30 bg-warning/10 text-warning'],
+    ['info', 'border-info/30 bg-info/10 text-info'],
+  ] as const)('maps %s banners to theme-aware semantic colors', (kind, expected) => {
+    expect(getStatusBannerClassName(kind)).toBe(expected);
+  });
+
+  it.each([
+    'error',
+    'warning',
+    'info',
+  ] as const)('does not use a fixed light-theme palette for %s banners', (kind) => {
+    expect(getStatusBannerClassName(kind)).not.toMatch(/\b(?:bg|border|text)-(?:red|yellow|blue)-/);
+  });
+});

--- a/src/client/lib/status-banner-styles.ts
+++ b/src/client/lib/status-banner-styles.ts
@@ -1,0 +1,11 @@
+import type { WorkspaceInitBanner } from '@/shared/workspace-init';
+
+const STATUS_BANNER_CLASS_NAMES: Record<WorkspaceInitBanner['kind'], string> = {
+  error: 'border-destructive/30 bg-destructive/10 text-destructive',
+  warning: 'border-warning/30 bg-warning/10 text-warning',
+  info: 'border-info/30 bg-info/10 text-info',
+};
+
+export function getStatusBannerClassName(kind: WorkspaceInitBanner['kind']): string {
+  return STATUS_BANNER_CLASS_NAMES[kind];
+}

--- a/src/client/routes/projects/workspaces/workspace-detail-chat-content.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-chat-content.tsx
@@ -14,6 +14,7 @@ import {
   RewindConfirmationDialog,
   VirtualizedMessageList,
 } from '@/client/features/chat';
+import { getStatusBannerClassName } from '@/client/lib/status-banner-styles';
 import { Button } from '@/components/ui/button';
 import type { CommandInfo, TokenStats } from '@/lib/chat-protocol';
 import { filterDuplicateResultMessages, groupAdjacentToolCalls } from '@/lib/chat-protocol';
@@ -124,16 +125,6 @@ function getInputPlaceholder({
   return 'Type a message...';
 }
 
-function getInitBannerClass(kind: WorkspaceInitBanner['kind']): string {
-  if (kind === 'error') {
-    return 'border-red-200 bg-red-50 text-red-900';
-  }
-  if (kind === 'warning') {
-    return 'border-yellow-200 bg-yellow-50 text-yellow-900';
-  }
-  return 'border-blue-200 bg-blue-50 text-blue-900';
-}
-
 const InitStatusBanner = memo(function InitStatusBanner({
   banner,
   retryPending,
@@ -147,7 +138,7 @@ const InitStatusBanner = memo(function InitStatusBanner({
       <div
         className={[
           'rounded-md border p-3 text-sm flex items-start gap-3',
-          getInitBannerClass(banner.kind),
+          getStatusBannerClassName(banner.kind),
         ].join(' ')}
       >
         {banner.kind === 'info' ? (


### PR DESCRIPTION
## Summary

- replace fixed light-palette workspace status banner colors with shared semantic `destructive`, `warning`, and `info` theme tokens
- migrate both the chat initialization banner and the empty-workspace initialization notice
- add focused regression coverage and a Storybook palette for light/dark visual QA

## Root cause

The affected banners used fixed `red-50`, `yellow-50`, and `blue-50` backgrounds with matching light-theme border and text colors. Those utilities bypassed the application’s dark-theme variables, so the banners remained light panels in dark mode.

## User impact

Workspace error, warning, and informational banners now use subtle, legible colors in both themes while preserving their existing copy, layout, icons, and actions.

## Validation

- `pnpm check:fix`
- `pnpm test` — 351 files passed, 4,472 tests passed, 2 files / 3 tests skipped
- `pnpm typecheck`
- `pnpm check`
- `pnpm build:storybook`
- Storybook light/dark screenshot review of all three semantic banner states
- independent code review: no critical, important, or minor findings

`pnpm check` completed successfully. Its Codex schema comparison used the documented local skip because the installed CLI is 0.145.0 while the repository pins 0.101.0; CI installs the pinned version and enforces that comparison.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI class-name refactor with no auth, data, or behavior changes; regression risk is limited to banner appearance in workspace views.
> 
> **Overview**
> Workspace **error, warning, and info banners** no longer use fixed light Tailwind palettes (`red-50`, `yellow-50`, `blue-50`) that stayed bright in dark mode. A shared **`getStatusBannerClassName`** helper maps `WorkspaceInitBanner` kinds to semantic **`destructive`**, **`warning`**, and **`info`** tokens (tinted border/background/text).
> 
> **`InitStatusBanner`** in workspace chat and the empty-workspace “initializing” notice now call that helper instead of local hard-coded classes. Layout, copy, icons, and actions are unchanged.
> 
> Adds **Vitest** coverage for the mapping (including a guard against fixed `red`/`yellow`/`blue` utilities) and a **Storybook** `StatusBannerPalette` story for light/dark visual QA. Design and implementation plan docs are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c52490074da6a433ef54e296e0a8e9eb7cd5d47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->