### PR TITLE
Show linked issues on Kanban task cards

### DIFF
--- a/docs/superpowers/plans/2026-07-28-kanban-card-issue-link.md
+++ b/docs/superpowers/plans/2026-07-28-kanban-card-issue-link.md
@@ -1,0 +1,165 @@
+# Kanban Card Issue Link Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show a clickable GitHub or Linear issue identifier in a linked workspace's Kanban task card.
+
+**Architecture:** Keep the change inside the Kanban feature because the shared workspace payload already contains every required field. Derive one complete `{ label, url }` value, render it through a focused metadata row, and include that value in the existing card metadata visibility calculation.
+
+**Tech Stack:** React, TypeScript, Vitest, jsdom, Tailwind CSS
+
+## Global Constraints
+
+- GitHub issue labels use `#<number>`.
+- Linear issue labels use the stored identifier.
+- A complete Linear link takes precedence over a complete GitHub link.
+- The link opens in a new tab with `noopener,noreferrer`.
+- The link click must prevent workspace-card navigation and stop event propagation.
+- Incomplete issue data must not render a nonfunctional link.
+- No backend, database, schema, or data-fetching changes are in scope.
+
+---
+
+### Task 1: Render Linked Issues on Kanban Cards
+
+**Files:**
+- Modify: `src/client/features/kanban/kanban-card.tsx:1-520`
+- Modify: `src/client/features/kanban/kanban-card.stories.tsx:1-340`
+- Test: `src/client/features/kanban/kanban-card.test.tsx:1-204`
+
+**Interfaces:**
+- Consumes: `WorkspaceWithKanban` fields `githubIssueNumber`, `githubIssueUrl`, `linearIssueIdentifier`, and `linearIssueUrl`
+- Produces: a card-local `IssueLink` value with `{ label: string; url: string }`, rendered as Kanban metadata
+
+- [x] **Step 1: Write the failing GitHub issue-link test**
+
+Add `DotOutlineIcon` to the icon mock, then add a test that renders a workspace containing:
+
+```ts
+githubIssueNumber: 1905,
+githubIssueUrl: 'https://github.com/example/repo/issues/1905',
+```
+
+Spy on `window.open`, click the rendered `#1905` button with a bubbling and cancelable `MouseEvent`, and assert:
+
+```ts
+expect(container.textContent).toContain('#1905');
+expect(container.querySelector('[data-testid="card-content"]')).not.toBeNull();
+expect(click.defaultPrevented).toBe(true);
+expect(openSpy).toHaveBeenCalledWith(
+  'https://github.com/example/repo/issues/1905',
+  '_blank',
+  'noopener,noreferrer'
+);
+```
+
+- [x] **Step 2: Run the focused test and verify the RED state**
+
+Run:
+
+```bash
+pnpm test src/client/features/kanban/kanban-card.test.tsx
+```
+
+Expected: the GitHub test fails because `#1905` and its issue-link button are not rendered.
+
+- [x] **Step 3: Write the failing Linear issue-link test**
+
+Add a second test with:
+
+```ts
+linearIssueIdentifier: 'ENG-42',
+linearIssueUrl: 'https://linear.app/example/issue/ENG-42',
+```
+
+Click the `ENG-42` button and assert that it renders as metadata and calls:
+
+```ts
+expect(openSpy).toHaveBeenCalledWith(
+  'https://linear.app/example/issue/ENG-42',
+  '_blank',
+  'noopener,noreferrer'
+);
+```
+
+Add a guard test that supplies `linearIssueIdentifier` without `linearIssueUrl` and verifies neither the identifier nor card metadata is rendered.
+
+- [x] **Step 4: Run the focused test and verify both tests fail for missing behavior**
+
+Run:
+
+```bash
+pnpm test src/client/features/kanban/kanban-card.test.tsx
+```
+
+Expected: both provider-specific tests fail because Kanban cards do not yet derive or render issue links.
+
+- [x] **Step 5: Implement the minimal issue metadata row**
+
+In `kanban-card.tsx`:
+
+1. Import `DotOutlineIcon`.
+2. Add an `IssueLink` type and a `deriveIssueLink(workspace)` helper that returns a complete Linear link first, then a complete GitHub link, or `null`.
+3. Add `IssueRow({ issue })`, styled like the existing pull-request row, whose button prevents default navigation, stops propagation, and opens `issue.url`.
+4. Derive `issue` in `deriveCardState`, include it in `hasMetadata`, and return it.
+5. Destructure `issue` in `KanbanCard` and render `IssueRow` in `CardContent` before the pull-request row.
+6. Add `GitHubIssue` and `LinearIssue` Storybook examples using complete provider links.
+
+The derivation should follow this shape:
+
+```ts
+type IssueLink = {
+  label: string;
+  url: string;
+};
+
+function deriveIssueLink(workspace: WorkspaceWithKanban): IssueLink | null {
+  if (workspace.linearIssueIdentifier && workspace.linearIssueUrl) {
+    return {
+      label: workspace.linearIssueIdentifier,
+      url: workspace.linearIssueUrl,
+    };
+  }
+  if (workspace.githubIssueNumber != null && workspace.githubIssueUrl) {
+    return {
+      label: `#${workspace.githubIssueNumber}`,
+      url: workspace.githubIssueUrl,
+    };
+  }
+  return null;
+}
+```
+
+- [x] **Step 6: Run the focused test and verify the GREEN state**
+
+Run:
+
+```bash
+pnpm test src/client/features/kanban/kanban-card.test.tsx
+```
+
+Expected: all `KanbanCard` tests pass with no warnings or errors.
+
+- [x] **Step 7: Run feature verification**
+
+Run:
+
+```bash
+pnpm typecheck
+pnpm check
+pnpm check:fix
+```
+
+Expected: all three commands exit successfully.
+
+- [x] **Step 8: Commit the implementation**
+
+Stage only the plan, component, and test:
+
+```bash
+git add docs/superpowers/plans/2026-07-28-kanban-card-issue-link.md \
+  src/client/features/kanban/kanban-card.tsx \
+  src/client/features/kanban/kanban-card.stories.tsx \
+  src/client/features/kanban/kanban-card.test.tsx
+git commit -m "Show linked issues on Kanban cards"
+```

--- a/docs/superpowers/specs/2026-07-28-kanban-card-issue-link-design.md
+++ b/docs/superpowers/specs/2026-07-28-kanban-card-issue-link-design.md
@@ -1,0 +1,40 @@
+# Kanban Card Issue Link Design
+
+## Goal
+
+Show the originating ticket on a workspace's Kanban task card when the workspace was created from a GitHub or Linear issue.
+
+## User Experience
+
+The card metadata includes a compact issue link:
+
+- GitHub issues use the existing `#<number>` label, such as `#1905`.
+- Linear issues use the existing identifier, such as `ENG-1905`.
+- Selecting the link opens the stored issue URL in a new browser tab.
+- Selecting the link does not navigate to the workspace or trigger the card action.
+- A workspace without a linked issue is unchanged.
+
+The issue row uses the same small, muted metadata treatment as the card's branch and pull-request rows.
+
+## Architecture
+
+The shared project workspace payload already supplies `githubIssueNumber`, `githubIssueUrl`, `linearIssueIdentifier`, and `linearIssueUrl`, so no backend, database, schema, or data-fetching changes are needed.
+
+`src/client/features/kanban/kanban-card.tsx` will derive an issue label and URL from those fields, preferring a complete Linear link when present and otherwise using a complete GitHub link. A focused card-local row component will render the link. The card's metadata visibility calculation will include the issue row so a linked issue appears even when it is the card's only metadata.
+
+The implementation remains local to the Kanban feature because the sidebar's issue presentation has a different layout and interaction contract; extracting a shared component would add coupling without removing meaningful duplication.
+
+## Interaction and Error Handling
+
+The issue link will prevent the card's default navigation and stop event propagation before opening the issue URL with `noopener,noreferrer`. Incomplete issue data, such as an identifier without a URL, will not produce a nonfunctional link.
+
+## Testing
+
+Focused `KanbanCard` tests will verify:
+
+- A GitHub-backed workspace renders its `#<number>` label and opens the GitHub issue URL.
+- A Linear-backed workspace renders its identifier and opens the Linear issue URL.
+- Clicking the issue link does not navigate through the enclosing workspace card.
+- The issue link creates card metadata when no other metadata is present.
+
+The existing project checks and type checking will guard formatting, dependency boundaries, and TypeScript correctness.

--- a/src/client/features/kanban/kanban-card.stories.tsx
+++ b/src/client/features/kanban/kanban-card.stories.tsx
@@ -78,6 +78,31 @@ export const NoPR: Story = {
   },
 };
 
+export const GitHubIssue: Story = {
+  args: {
+    workspace: {
+      ...baseWorkspace,
+      name: 'Fix session timeout handling',
+      githubIssueNumber: 1905,
+      githubIssueUrl: 'https://github.com/example/repo/issues/1905',
+    },
+    projectSlug: 'my-project',
+  },
+};
+
+export const LinearIssue: Story = {
+  args: {
+    workspace: {
+      ...baseWorkspace,
+      name: 'Add SSO configuration',
+      linearIssueId: 'linear-42',
+      linearIssueIdentifier: 'ENG-42',
+      linearIssueUrl: 'https://linear.app/example/issue/ENG-42',
+    },
+    projectSlug: 'my-project',
+  },
+};
+
 export const DraftPR: Story = {
   args: {
     workspace: {

--- a/src/client/features/kanban/kanban-card.test.tsx
+++ b/src/client/features/kanban/kanban-card.test.tsx
@@ -10,6 +10,7 @@ vi.mock('@phosphor-icons/react', () => ({
   ArchiveIcon: () => null,
   ArrowsClockwiseIcon: () => null,
   ChatIcon: () => null,
+  DotOutlineIcon: () => null,
   GitBranchIcon: () => null,
   GitPullRequestIcon: () => null,
   PencilIcon: () => null,
@@ -83,17 +84,24 @@ const baseWorkspace = {
   pendingRequestType: null,
 } as unknown as WorkspaceWithKanban;
 
-function renderCard(workspace: WorkspaceWithKanban): { container: HTMLDivElement; root: Root } {
+function renderCard(
+  workspace: WorkspaceWithKanban,
+  onCardClick?: () => void
+): { container: HTMLDivElement; root: Root } {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const root = createRoot(container);
 
   flushSync(() => {
     root.render(
-      createElement(KanbanCard, {
-        workspace,
-        projectSlug: 'project',
-      })
+      createElement(
+        'div',
+        { onClick: onCardClick },
+        createElement(KanbanCard, {
+          workspace,
+          projectSlug: 'project',
+        })
+      )
     );
   });
 
@@ -197,6 +205,103 @@ describe('KanbanCard', () => {
 
     expect(container.textContent).toContain('Needs permission');
     expect(container.querySelector('[data-testid="card-content"]')).not.toBeNull();
+
+    root.unmount();
+    container.remove();
+  });
+
+  it('opens a linked GitHub issue without navigating through the workspace card', () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const onCardClick = vi.fn();
+    const { container, root } = renderCard(
+      {
+        ...baseWorkspace,
+        githubIssueNumber: 1905,
+        githubIssueUrl: 'https://github.com/example/repo/issues/1905',
+      },
+      onCardClick
+    );
+    const button = container.querySelector('button');
+    const click = new MouseEvent('click', { bubbles: true, cancelable: true });
+
+    expect(container.textContent).toContain('#1905');
+    expect(container.querySelector('[data-testid="card-content"]')).not.toBeNull();
+    expect(button).not.toBeNull();
+
+    button?.dispatchEvent(click);
+
+    expect(click.defaultPrevented).toBe(true);
+    expect(onCardClick).not.toHaveBeenCalled();
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://github.com/example/repo/issues/1905',
+      '_blank',
+      'noopener,noreferrer'
+    );
+
+    root.unmount();
+    container.remove();
+  });
+
+  it('opens a linked Linear issue from card metadata', () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const { container, root } = renderCard({
+      ...baseWorkspace,
+      linearIssueIdentifier: 'ENG-42',
+      linearIssueUrl: 'https://linear.app/example/issue/ENG-42',
+    });
+    const button = container.querySelector('button');
+
+    expect(container.textContent).toContain('ENG-42');
+    expect(container.querySelector('[data-testid="card-content"]')).not.toBeNull();
+    expect(button).not.toBeNull();
+
+    button?.click();
+
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://linear.app/example/issue/ENG-42',
+      '_blank',
+      'noopener,noreferrer'
+    );
+
+    root.unmount();
+    container.remove();
+  });
+
+  it('prefers a complete Linear link when both issue providers are present', () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const { container, root } = renderCard({
+      ...baseWorkspace,
+      githubIssueNumber: 1905,
+      githubIssueUrl: 'https://github.com/example/repo/issues/1905',
+      linearIssueIdentifier: 'ENG-42',
+      linearIssueUrl: 'https://linear.app/example/issue/ENG-42',
+    });
+    const button = container.querySelector('button');
+
+    expect(container.textContent).toContain('ENG-42');
+    expect(container.textContent).not.toContain('#1905');
+
+    button?.click();
+
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://linear.app/example/issue/ENG-42',
+      '_blank',
+      'noopener,noreferrer'
+    );
+
+    root.unmount();
+    container.remove();
+  });
+
+  it('does not render an issue identifier without its URL', () => {
+    const { container, root } = renderCard({
+      ...baseWorkspace,
+      linearIssueIdentifier: 'ENG-42',
+      linearIssueUrl: null,
+    });
+
+    expect(container.textContent).not.toContain('ENG-42');
+    expect(container.querySelector('[data-testid="card-content"]')).toBeNull();
 
     root.unmount();
     container.remove();

--- a/src/client/features/kanban/kanban-card.tsx
+++ b/src/client/features/kanban/kanban-card.tsx
@@ -2,6 +2,7 @@ import {
   ArchiveIcon,
   ArrowsClockwiseIcon,
   ChatIcon,
+  DotOutlineIcon,
   GitBranchIcon,
   GitPullRequestIcon,
   PencilIcon,
@@ -87,6 +88,50 @@ function PullRequestRow({
       >
         <GitPullRequestIcon className="h-3 w-3 shrink-0" />
         <span>#{workspace.prNumber}</span>
+      </button>
+    </div>
+  );
+}
+
+type IssueLink = {
+  label: string;
+  url: string;
+};
+
+function deriveIssueLink(workspace: WorkspaceWithKanban): IssueLink | null {
+  if (workspace.linearIssueIdentifier && workspace.linearIssueUrl) {
+    return {
+      label: workspace.linearIssueIdentifier,
+      url: workspace.linearIssueUrl,
+    };
+  }
+  if (workspace.githubIssueNumber != null && workspace.githubIssueUrl) {
+    return {
+      label: `#${workspace.githubIssueNumber}`,
+      url: workspace.githubIssueUrl,
+    };
+  }
+  return null;
+}
+
+function IssueRow({ issue }: { issue: IssueLink | null }) {
+  if (!issue) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center gap-2 text-[11px] text-muted-foreground min-w-0">
+      <button
+        type="button"
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          window.open(issue.url, '_blank', 'noopener,noreferrer');
+        }}
+        className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground"
+      >
+        <DotOutlineIcon className="h-3 w-3 shrink-0" />
+        <span>{issue.label}</span>
       </button>
     </div>
   );
@@ -285,6 +330,7 @@ function CardTitleIcons({
 
 function deriveCardState(workspace: WorkspaceWithKanban) {
   const showPR = Boolean(workspace.prState !== 'NONE' && workspace.prNumber && workspace.prUrl);
+  const issue = deriveIssueLink(workspace);
   const isArchived = workspace.status === 'ARCHIVING' || workspace.status === 'ARCHIVED';
   const ratchetEnabled = workspace.ratchetEnabled ?? true;
   const sidebarStatus = deriveWorkspaceSidebarStatus({
@@ -307,11 +353,13 @@ function deriveCardState(workspace: WorkspaceWithKanban) {
     showCi ||
     showBranch ||
     showPR ||
+    !!issue ||
     !!sessionRuntimeError ||
     workspace.mode === 'AUTO_ITERATION' ||
     workspace.creationSource === 'CHILD_WORKSPACE';
   return {
     showPR,
+    issue,
     isArchived,
     ratchetEnabled,
     sidebarStatus,
@@ -364,6 +412,7 @@ export function KanbanCard({
 }: KanbanCardProps) {
   const {
     showPR,
+    issue,
     isArchived,
     ratchetEnabled,
     sidebarStatus,
@@ -488,6 +537,7 @@ export function KanbanCard({
                 <BranchRow branchName={workspace.branchName} />
               </div>
             )}
+            <IssueRow issue={issue} />
             {showPR && (
               <div className="flex items-center">
                 <PullRequestRow workspace={workspace} showPR={showPR} />


### PR DESCRIPTION
## Summary

- show the originating GitHub issue number or Linear identifier on linked workspace Kanban cards
- open issue links in a new tab without triggering workspace-card navigation
- add provider-specific tests and Storybook examples

## Why

Workspaces created from tickets already carry their issue identifiers and URLs, but the Kanban card did not include those fields in its metadata. Users therefore lost the ticket context after starting work from the intake column.

## Impact

GitHub-backed cards now show labels such as `#1905`, while Linear-backed cards show labels such as `ENG-42`. Workspaces without a complete issue identifier and URL remain unchanged.

## Validation

- `pnpm test src/client/features/kanban/kanban-card.test.tsx`
- `pnpm typecheck`
- `pnpm check`
- `pnpm check:fix`
- `pnpm exec vitest run --maxWorkers=4` (351 files passed, 4,484 tests passed)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only Kanban UI using existing workspace fields; behavior matches the established PR metadata link pattern with no API or data-layer changes.
> 
> **Overview**
> Kanban task cards now surface the originating ticket in card metadata when the workspace payload includes a complete GitHub or Linear issue link.
> 
> **`kanban-card.tsx`** derives a single `{ label, url }` via `deriveIssueLink` (Linear wins when both providers are present; GitHub uses `#<number>`). An **`IssueRow`** mirrors the existing PR row: muted metadata styling, `window.open` with `noopener,noreferrer`, and click handlers that **`preventDefault` / `stopPropagation`** so the enclosing workspace card link is not triggered. **`hasMetadata`** counts a resolved issue so metadata can appear when the issue row is the only extra field.
> 
> **Tests** cover GitHub and Linear opens, Linear-over-GitHub preference, and hiding identifiers without URLs. **Storybook** adds `GitHubIssue` and `LinearIssue` stories. Design/plan docs were added under `docs/superpowers/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 041fa23db6adf967c8c13a04304445511d16d588. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->