### PR TITLE
Stop Ratchet sessions for merged PRs

### DIFF
--- a/docs/superpowers/plans/2026-07-28-ratchet-merged-pr-session-cleanup.md
+++ b/docs/superpowers/plans/2026-07-28-ratchet-merged-pr-session-cleanup.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Add a focused cleanup method to `RatchetService` that enumerates workspace sessions through the existing session bridge, filters active Ratchet workflows, and stops their live runtimes. Invoke it immediately after a fresh `MERGED` PR observation and before decision construction, allowing failures to flow through the existing workspace-check error path so later polls retry.
 
-**Tech Stack:** TypeScript, Express backend service capsules, Vitest, Prisma-backed workspace state.
+**Tech Stack:** TypeScript, Express backend service capsules, Vitest, projected Ratchet state backed by cached PR observations.
 
 ## Global Constraints
 
@@ -39,7 +39,7 @@ sessions, one stopped Ratchet session, and one live manual session:
 vi.mocked(mockSessionBridge.findSessionsByWorkspaceId).mockResolvedValue([
   { id: 'ratchet-running', workflow: 'ratchet', status: SessionStatus.RUNNING },
   { id: 'ratchet-idle', workflow: 'ratchet', status: SessionStatus.IDLE },
-  { id: 'ratchet-stopped', workflow: 'ratchet', status: SessionStatus.STOPPED },
+  { id: 'ratchet-completed', workflow: 'ratchet', status: SessionStatus.COMPLETED },
   { id: 'manual-running', workflow: 'default', status: SessionStatus.RUNNING },
 ] as never);
 vi.mocked(mockSessionBridge.isSessionRunning).mockImplementation((sessionId) =>
@@ -48,8 +48,7 @@ vi.mocked(mockSessionBridge.isSessionRunning).mockImplementation((sessionId) =>
 ```
 
 Assert that only `ratchet-running` and `ratchet-idle` are stopped, and that
-`workspaceRatchetService.transitionStateIfEnabled` persists
-`ratchetState: RatchetState.MERGED`.
+`mockSnapshotBridge.recordPrObservation` persists `prState: 'MERGED'`.
 
 - [ ] **Step 2: Run the focused test and verify RED**
 
@@ -72,7 +71,8 @@ vi.mocked(mockSessionBridge.stopSession).mockRejectedValue(new Error('stop faile
 
 Assert that the result contains
 `{ action: { type: 'ERROR', error: 'stop failed' } }` and that
-`workspaceRatchetService.transitionStateIfEnabled` is not called.
+`workspaceRatchetService.recordCheckIfEnabled` and
+`mockSnapshotBridge.recordPrObservation` are not called.
 
 - [ ] **Step 4: Run both focused tests and verify RED**
 

--- a/docs/superpowers/plans/2026-07-28-ratchet-merged-pr-session-cleanup.md
+++ b/docs/superpowers/plans/2026-07-28-ratchet-merged-pr-session-cleanup.md
@@ -1,0 +1,169 @@
+# Ratchet Merged-PR Session Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop every live Ratchet workflow session before a normal Ratchet check persists a merged pull request as terminal.
+
+**Architecture:** Add a focused cleanup method to `RatchetService` that enumerates workspace sessions through the existing session bridge, filters active Ratchet workflows, and stops their live runtimes. Invoke it immediately after a fresh `MERGED` PR observation and before decision construction, allowing failures to flow through the existing workspace-check error path so later polls retry.
+
+**Tech Stack:** TypeScript, Express backend service capsules, Vitest, Prisma-backed workspace state.
+
+## Global Constraints
+
+- Stop only sessions whose workflow is `ratchet`.
+- Consider persisted `RUNNING` and `IDLE` sessions cleanup candidates.
+- Ignore candidates whose runtime is no longer running.
+- Do not persist Ratchet state `MERGED` unless every required stop succeeds.
+- Preserve the existing best-effort behavior for Ratchet-disable cleanup.
+- Add no schema, UI, or cross-capsule dependency changes.
+
+---
+
+### Task 1: Clean Up Ratchet Sessions on a Fresh Merged-PR Observation
+
+**Files:**
+- Modify: `src/backend/services/ratchet/service/ratchet.service.ts`
+- Test: `src/backend/services/ratchet/service/ratchet.service.test.ts`
+
+**Interfaces:**
+- Consumes: `RatchetSessionBridge.findSessionsByWorkspaceId(workspaceId)`, `RatchetSessionBridge.isSessionRunning(sessionId)`, and `RatchetSessionBridge.stopSession(sessionId)`.
+- Produces: private `RatchetService.stopActiveRatchetSessionsForMergedPr(workspaceId: string, signal: AbortSignal): Promise<void>`.
+
+- [ ] **Step 1: Write the successful-cleanup regression test**
+
+Add a `processWorkspace` test with a workspace whose current Ratchet state is
+`CI_FAILED` and whose fetched state is `MERGED`. Return two live Ratchet
+sessions, one stopped Ratchet session, and one live manual session:
+
+```typescript
+vi.mocked(mockSessionBridge.findSessionsByWorkspaceId).mockResolvedValue([
+  { id: 'ratchet-running', workflow: 'ratchet', status: SessionStatus.RUNNING },
+  { id: 'ratchet-idle', workflow: 'ratchet', status: SessionStatus.IDLE },
+  { id: 'ratchet-stopped', workflow: 'ratchet', status: SessionStatus.STOPPED },
+  { id: 'manual-running', workflow: 'default', status: SessionStatus.RUNNING },
+] as never);
+vi.mocked(mockSessionBridge.isSessionRunning).mockImplementation((sessionId) =>
+  ['ratchet-running', 'ratchet-idle', 'manual-running'].includes(sessionId)
+);
+```
+
+Assert that only `ratchet-running` and `ratchet-idle` are stopped, and that
+`workspaceRatchetService.transitionStateIfEnabled` persists
+`ratchetState: RatchetState.MERGED`.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+pnpm vitest run src/backend/services/ratchet/service/ratchet.service.test.ts -t "stops live ratchet sessions before persisting a merged PR"
+```
+
+Expected: FAIL because `stopSession` has no calls on the merged path.
+
+- [ ] **Step 3: Write the cleanup-failure regression test**
+
+Use the same merged workspace shape with one live Ratchet session, and reject
+its stop:
+
+```typescript
+vi.mocked(mockSessionBridge.stopSession).mockRejectedValue(new Error('stop failed'));
+```
+
+Assert that the result contains
+`{ action: { type: 'ERROR', error: 'stop failed' } }` and that
+`workspaceRatchetService.transitionStateIfEnabled` is not called.
+
+- [ ] **Step 4: Run both focused tests and verify RED**
+
+Run:
+
+```bash
+pnpm vitest run src/backend/services/ratchet/service/ratchet.service.test.ts -t "merged PR"
+```
+
+Expected: both new tests FAIL because merged-PR session cleanup is absent.
+
+- [ ] **Step 5: Implement the merged-PR cleanup method**
+
+Add the private method:
+
+```typescript
+private async stopActiveRatchetSessionsForMergedPr(
+  workspaceId: string,
+  signal: AbortSignal
+): Promise<void> {
+  signal.throwIfAborted();
+  const sessions = await this.session.findSessionsByWorkspaceId(workspaceId);
+  signal.throwIfAborted();
+  const activeRatchetSessions = sessions.filter(
+    (session) =>
+      session.workflow === 'ratchet' &&
+      (session.status === SessionStatus.RUNNING || session.status === SessionStatus.IDLE)
+  );
+
+  for (const session of activeRatchetSessions) {
+    signal.throwIfAborted();
+    if (!this.session.isSessionRunning(session.id)) {
+      continue;
+    }
+    await this.session.stopSession(session.id);
+    signal.throwIfAborted();
+  }
+}
+```
+
+After the fresh PR state has been validated in `processWorkspace`, call it
+before `buildRatchetDecisionContext`:
+
+```typescript
+if (prStateInfo.prState === 'MERGED') {
+  await this.stopActiveRatchetSessionsForMergedPr(workspace.id, signal);
+  signal.throwIfAborted();
+}
+```
+
+- [ ] **Step 6: Run the focused tests and verify GREEN**
+
+Run:
+
+```bash
+pnpm vitest run src/backend/services/ratchet/service/ratchet.service.test.ts -t "merged PR"
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run the complete Ratchet test files**
+
+Run:
+
+```bash
+pnpm vitest run src/backend/services/ratchet/service/ratchet.service.test.ts
+```
+
+Expected: the complete Ratchet service test file PASS with zero failures.
+
+- [ ] **Step 8: Run repository guardrails**
+
+Run:
+
+```bash
+pnpm typecheck
+pnpm check
+```
+
+Expected: both commands exit zero.
+
+- [ ] **Step 9: Review the mutation coverage**
+
+Confirm that deleting the merged cleanup call makes the success test fail and
+that swallowing `stopSession` errors makes the failure test fail. Restore the
+implementation and rerun both focused tests successfully.
+
+- [ ] **Step 10: Commit the implementation**
+
+```bash
+git add src/backend/services/ratchet/service/ratchet.service.ts \
+  src/backend/services/ratchet/service/ratchet.service.test.ts
+git commit -m "Stop Ratchet sessions for merged PRs"
+```

--- a/docs/superpowers/specs/2026-07-28-ratchet-merged-pr-session-cleanup-design.md
+++ b/docs/superpowers/specs/2026-07-28-ratchet-merged-pr-session-cleanup-design.md
@@ -1,0 +1,66 @@
+# Ratchet Merged-PR Session Cleanup Design
+
+## Problem
+
+A normal Ratchet poll can observe that a pull request was merged while a
+Ratchet fixer session is still running. The current merged-PR decision returns
+`COMPLETED` and transitions the workspace to `MERGED`, but active fixer
+inspection only runs for open pull requests. As a result, the session can
+continue after the pull request is merged.
+
+Once the workspace Ratchet state is `MERGED`, it leaves the normal poll set.
+Cleanup therefore must finish before the terminal state is persisted, or a
+failed cleanup would not be retried.
+
+## Behavior
+
+When a normal workspace check fetches a fresh pull-request state of `MERGED`,
+Ratchet will:
+
+1. Find all sessions for the workspace.
+2. Select sessions whose workflow is `ratchet`, whose persisted status is
+   `RUNNING` or `IDLE`, and whose runtime is still running.
+3. Stop every selected session.
+4. Continue through the existing merged-PR decision and persist the workspace
+   Ratchet state as `MERGED` only after all selected sessions stop successfully.
+
+Sessions from other workflows are not stopped. Ratchet sessions that are
+already stopped are ignored.
+
+If any stop fails, the workspace check returns its existing `ERROR` result and
+does not transition the Ratchet state to `MERGED`. The workspace remains in the
+normal poll set, so the next poll retries cleanup.
+
+## Implementation Boundary
+
+The cleanup belongs in the Ratchet service capsule, after the fresh PR state is
+available and before the decision context is built. It uses the existing
+`RatchetSessionBridge` methods and does not introduce cross-capsule imports,
+schema changes, or UI changes.
+
+The existing Ratchet-disable cleanup remains best effort because disabled
+workspaces cannot be retried by the poller. The merged-PR cleanup has stricter
+failure propagation because persisting `MERGED` would otherwise remove the
+workspace from future polls.
+
+## Concurrency and Outcomes
+
+The session runtime can exit between enumeration and stop. Existing session
+lifecycle behavior treats deliberate stops and clean exits as `COMPLETED`, and
+the conditional dispatch settlement prevents stale exit paths from overwriting
+an already-recorded outcome.
+
+The workspace check coordinator continues to serialize checks per workspace.
+Abort signals are checked around session enumeration and stop operations so a
+timed-out check does not proceed to the terminal state transition.
+
+## Tests
+
+Regression tests will exercise the normal workspace-check path and verify:
+
+- a freshly merged pull request stops every live Ratchet workflow session;
+- manual or other-workflow sessions are preserved;
+- already-stopped Ratchet sessions are ignored;
+- the workspace transitions to `MERGED` only after cleanup succeeds; and
+- a stop failure returns `ERROR` without persisting `MERGED`, leaving the next
+  normal poll able to retry.

--- a/src/backend/services/ratchet/service/ratchet.service.test.ts
+++ b/src/backend/services/ratchet/service/ratchet.service.test.ts
@@ -1201,7 +1201,7 @@ describe('ratchet service (state-change + idle dispatch)', () => {
     );
   });
 
-  it('persists a merge observed by the check even when CI status is unchanged', async () => {
+  it('stops live ratchet sessions before persisting a merged PR', async () => {
     // Without this write a merged PR keeps deriving from the cached `OPEN`, which
     // leaves it in the ratchet poll set.
     const workspace = {
@@ -1239,15 +1239,108 @@ describe('ratchet service (state-change + idle dispatch)', () => {
       prNumber: 45,
       reviewComments: [],
     });
-    vi.mocked(mockSessionBridge.findSessionsByWorkspaceId).mockResolvedValue([] as never);
+    vi.mocked(mockSessionBridge.findSessionsByWorkspaceId).mockResolvedValue([
+      {
+        id: 'ratchet-running',
+        workflow: 'ratchet',
+        status: SessionStatus.RUNNING,
+      },
+      {
+        id: 'ratchet-idle',
+        workflow: 'ratchet',
+        status: SessionStatus.IDLE,
+      },
+      {
+        id: 'ratchet-completed',
+        workflow: 'ratchet',
+        status: SessionStatus.COMPLETED,
+      },
+      {
+        id: 'manual-running',
+        workflow: 'default',
+        status: SessionStatus.RUNNING,
+      },
+    ] as never);
+    vi.mocked(mockSessionBridge.isSessionRunning).mockImplementation((sessionId) =>
+      ['ratchet-running', 'ratchet-idle', 'manual-running'].includes(sessionId)
+    );
 
-    await unsafeCoerce<{
+    const result = await unsafeCoerce<{
       processWorkspace: (workspaceArg: typeof workspace) => Promise<WorkspaceRatchetResult>;
     }>(ratchetService).processWorkspace(workspace);
 
+    expect(mockSessionBridge.stopSession).toHaveBeenCalledTimes(2);
+    expect(mockSessionBridge.stopSession).toHaveBeenNthCalledWith(1, 'ratchet-running');
+    expect(mockSessionBridge.stopSession).toHaveBeenNthCalledWith(2, 'ratchet-idle');
     expect(mockSnapshotBridge.recordPrObservation).toHaveBeenCalledWith(
       expect.objectContaining({ workspaceId: 'ws-merged', prState: 'MERGED' })
     );
+    expect(vi.mocked(mockSessionBridge.stopSession).mock.invocationCallOrder.at(-1)).toBeLessThan(
+      vi.mocked(mockSnapshotBridge.recordPrObservation).mock.invocationCallOrder[0] ?? 0
+    );
+    expect(result).toMatchObject({
+      newState: RatchetState.MERGED,
+      action: { type: 'COMPLETED' },
+    });
+  });
+
+  it('does not persist a merged PR when stopping a ratchet session fails', async () => {
+    const workspace = {
+      id: 'ws-merged-stop-failure',
+      prUrl: 'https://github.com/example/repo/pull/46',
+      prNumber: 46,
+      prState: 'OPEN',
+      prReviewState: null,
+      prHasMergeConflict: false,
+      prCiStatus: CIStatus.SUCCESS,
+      ratchetEnabled: true,
+      ratchetState: RatchetState.READY,
+      ratchetActiveSessionId: 'ratchet-running',
+      ratchetDispatchSnapshotKey: 'merged-stop-failure-snapshot',
+      prReviewLastCheckedAt: null,
+      ratchetDispatchOutcome: 'RUNNING',
+      ratchetDispatchRetryCount: 0,
+    };
+
+    vi.spyOn(
+      unsafeCoerce<{
+        fetchPRState: (...args: unknown[]) => Promise<unknown>;
+      }>(ratchetService),
+      'fetchPRState'
+    ).mockResolvedValue({
+      ciStatus: CIStatus.SUCCESS,
+      snapshotKey: 'merged-stop-failure-snapshot',
+      hasChangesRequested: false,
+      hasMergeConflict: false,
+      latestReviewActivityAtMs: null,
+      statusCheckRollup: null,
+      prState: 'MERGED',
+      cachedPrState: 'MERGED',
+      reviewDecision: null,
+      prNumber: 46,
+      reviewComments: [],
+    });
+    vi.mocked(mockSessionBridge.findSessionsByWorkspaceId).mockResolvedValue([
+      {
+        id: 'ratchet-running',
+        workflow: 'ratchet',
+        status: SessionStatus.RUNNING,
+      },
+    ] as never);
+    vi.mocked(mockSessionBridge.isSessionRunning).mockReturnValue(true);
+    vi.mocked(mockSessionBridge.stopSession).mockRejectedValue(new Error('stop failed'));
+
+    const result = await unsafeCoerce<{
+      processWorkspace: (workspaceArg: typeof workspace) => Promise<WorkspaceRatchetResult>;
+    }>(ratchetService).processWorkspace(workspace);
+
+    expect(result).toMatchObject({
+      previousState: RatchetState.READY,
+      newState: RatchetState.READY,
+      action: { type: 'ERROR', error: 'stop failed' },
+    });
+    expect(workspaceRatchetService.recordCheckIfEnabled).not.toHaveBeenCalled();
+    expect(mockSnapshotBridge.recordPrObservation).not.toHaveBeenCalled();
   });
 
   it('persists a newly observed merge conflict even when CI status is unchanged', async () => {

--- a/src/backend/services/ratchet/service/ratchet.service.ts
+++ b/src/backend/services/ratchet/service/ratchet.service.ts
@@ -486,6 +486,10 @@ class RatchetService extends EventEmitter {
 
       const prStateInfo = prStateResult;
       signal.throwIfAborted();
+      if (prStateInfo.prState === 'MERGED') {
+        await this.stopActiveRatchetSessionsForMergedPr(workspace.id, signal);
+        signal.throwIfAborted();
+      }
       const decisionContext = await this.buildRatchetDecisionContext(
         workspace,
         prStateInfo,
@@ -948,6 +952,29 @@ class RatchetService extends EventEmitter {
       },
     });
     return action;
+  }
+
+  private async stopActiveRatchetSessionsForMergedPr(
+    workspaceId: string,
+    signal: AbortSignal
+  ): Promise<void> {
+    signal.throwIfAborted();
+    const sessions = await this.session.findSessionsByWorkspaceId(workspaceId);
+    signal.throwIfAborted();
+    const activeRatchetSessions = sessions.filter(
+      (session) =>
+        session.workflow === 'ratchet' &&
+        (session.status === SessionStatus.RUNNING || session.status === SessionStatus.IDLE)
+    );
+
+    for (const session of activeRatchetSessions) {
+      signal.throwIfAborted();
+      if (!this.session.isSessionRunning(session.id)) {
+        continue;
+      }
+      await this.session.stopSession(session.id);
+      signal.throwIfAborted();
+    }
   }
 
   private async stopActiveRatchetSessionsAfterDisable(workspaceId: string): Promise<void> {


### PR DESCRIPTION
## Summary

- stop every live `ratchet` workflow session when the normal Ratchet poll observes that a PR has merged
- finish session cleanup before recording the merged PR observation
- leave the workspace pollable when a stop fails so the next normal check retries cleanup
- preserve manual, completed, and already-stopped sessions

## Root cause

Active fixer inspection only ran for open PRs. The merged-PR decision therefore returned `COMPLETED` and persisted the terminal PR observation without stopping live Ratchet sessions. Because merged workspaces leave the normal poll set, a lingering session could continue indefinitely.

## Validation

- `pnpm vitest run src/backend/services/ratchet/service/ratchet.service.test.ts` (117 tests)
- `pnpm test`
- `pnpm typecheck`
- `pnpm check`
- `pnpm check:fix`
- mutation check: removing the merged cleanup call makes both new regression cases fail

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Ratchet session lifecycle on merge (stopping live agent sessions) in a critical automation path, though scope is limited to the Ratchet service capsule with regression tests and no schema/UI changes.
> 
> **Overview**
> Fixes **Ratchet fixer sessions continuing after a PR merges** by stopping live `ratchet` workflow sessions **before** the workspace records the merged PR observation and moves to terminal `MERGED` state (merged workspaces leave the normal poll set, so cleanup had to happen first).
> 
> On a fresh `MERGED` observation, `processWorkspace` now calls **`stopActiveRatchetSessionsForMergedPr`**, which finds workspace sessions, stops only **`ratchet`** workflows in **`RUNNING`/`IDLE`** whose runtime is still running, and honors **abort signals** between steps. **Manual/other workflows** and already-stopped sessions are left alone.
> 
> If any **`stopSession`** fails, the check returns **`ERROR`**, **does not** call `recordCheckIfEnabled` / `recordPrObservation`, and the workspace stays pollable for retry—stricter than the existing best-effort cleanup when Ratchet is disabled.
> 
> **Tests** were expanded: success path asserts stop order before merge persistence; failure path asserts no terminal writes. **Design/plan docs** were added under `docs/superpowers/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 464521011ffb201bc5654b08d451d130ef57848e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->