### PR TITLE
Center modal animations

### DIFF
--- a/docs/superpowers/plans/2026-07-28-centered-modal-animation.md
+++ b/docs/superpowers/plans/2026-07-28-centered-modal-animation.md
@@ -1,0 +1,295 @@
+# Centered Modal Animation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every standard and confirmation modal fade and scale at the viewport center without directional travel.
+
+**Architecture:** Keep the behavior in the shared Radix-based `DialogContent` and `AlertDialogContent` primitives so every consumer inherits it without API or call-site changes. Preserve the CSS translations that position content at the viewport center, remove only the animation translation utilities, and override content animation under `prefers-reduced-motion`.
+
+**Tech Stack:** React 19, Radix Dialog and Alert Dialog, Tailwind CSS 4 animation utilities, Vitest 4, jsdom, Storybook
+
+## Global Constraints
+
+- Apply the behavior to `DialogContent` and `AlertDialogContent`.
+- Preserve the existing 200 ms duration, overlay fade, centered layout, and public component APIs.
+- Open with opacity from 0 to 1 and scale from 95% to 100%; reverse those effects on close.
+- Do not add per-modal variants or update individual modal consumers.
+- Do not change sheets, drawers, menus, popovers, tooltips, or other anchored surfaces.
+- Under `prefers-reduced-motion: reduce`, modal content must have no scale or directional animation.
+
+## File Map
+
+- Create `src/components/ui/dialog.test.tsx` to lock the shared regular-modal and confirmation-modal class contract.
+- Create `src/components/ui/dialog.stories.tsx` to provide interactive visual QA for both modal types.
+- Modify `src/components/ui/dialog.tsx` to remove directional content animation and add reduced-motion behavior.
+- Modify `src/components/ui/alert-dialog.tsx` to make the matching confirmation-modal change.
+
+---
+
+### Task 1: Center all shared modal animation
+
+**Files:**
+- Create: `src/components/ui/dialog.test.tsx`
+- Create: `src/components/ui/dialog.stories.tsx`
+- Modify: `src/components/ui/dialog.tsx:30-52`
+- Modify: `src/components/ui/alert-dialog.tsx:27-43`
+
+**Interfaces:**
+- Consumes: Radix `data-state="open" | "closed"` attributes and the existing Tailwind animation utilities.
+- Produces: unchanged `DialogContent` and `AlertDialogContent` React component APIs with a shared centered-motion class contract.
+
+- [ ] **Step 1: Write the failing shared-primitive test**
+
+Create `src/components/ui/dialog.test.tsx`:
+
+```tsx
+// @vitest-environment jsdom
+
+import { act, type ReactElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogTitle,
+} from './alert-dialog';
+import { Dialog, DialogContent, DialogTitle } from './dialog';
+
+Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
+  configurable: true,
+  writable: true,
+  value: true,
+});
+
+describe('centered modal animation', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    void act(() => root.unmount());
+    document.body.innerHTML = '';
+  });
+
+  function render(element: ReactElement): HTMLElement {
+    void act(() => root.render(element));
+    const content = document.querySelector<HTMLElement>(
+      '[role="dialog"], [role="alertdialog"]'
+    );
+    expect(content).not.toBeNull();
+    return content as HTMLElement;
+  }
+
+  function expectCenteredMotion(content: HTMLElement): void {
+    expect(content.className).not.toMatch(/slide-(?:in|out)-/);
+    expect(content.classList.contains('data-[state=open]:fade-in-0')).toBe(true);
+    expect(content.classList.contains('data-[state=closed]:fade-out-0')).toBe(true);
+    expect(content.classList.contains('data-[state=open]:zoom-in-95')).toBe(true);
+    expect(content.classList.contains('data-[state=closed]:zoom-out-95')).toBe(true);
+    expect(content.classList.contains('motion-reduce:data-[state=open]:animate-none')).toBe(true);
+    expect(content.classList.contains('motion-reduce:data-[state=closed]:animate-none')).toBe(true);
+  }
+
+  it('keeps regular dialog animation centered', () => {
+    const content = render(
+      <Dialog open>
+        <DialogContent aria-describedby={undefined}>
+          <DialogTitle>Regular modal</DialogTitle>
+        </DialogContent>
+      </Dialog>
+    );
+
+    expectCenteredMotion(content);
+  });
+
+  it('keeps alert dialog animation centered', () => {
+    const content = render(
+      <AlertDialog open>
+        <AlertDialogContent>
+          <AlertDialogTitle>Confirmation modal</AlertDialogTitle>
+        </AlertDialogContent>
+      </AlertDialog>
+    );
+
+    expectCenteredMotion(content);
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused test and confirm the current classes fail it**
+
+Run:
+
+```bash
+pnpm test -- src/components/ui/dialog.test.tsx
+```
+
+Expected: both tests fail because `DialogContent` and `AlertDialogContent` still contain `slide-in-*` and `slide-out-*` classes.
+
+- [ ] **Step 3: Remove directional animation and add reduced-motion overrides**
+
+In `src/components/ui/dialog.tsx`, replace the `DialogPrimitive.Content` class string with:
+
+```tsx
+'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-3 border bg-background p-4 shadow-sm duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out motion-reduce:data-[state=open]:animate-none motion-reduce:data-[state=closed]:animate-none data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg'
+```
+
+In `src/components/ui/alert-dialog.tsx`, replace the `AlertDialogPrimitive.Content` class string with:
+
+```tsx
+'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-sm duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out motion-reduce:data-[state=open]:animate-none motion-reduce:data-[state=closed]:animate-none data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg'
+```
+
+Do not alter `DialogOverlay`, `AlertDialogOverlay`, or `src/components/ui/sheet.tsx`.
+
+- [ ] **Step 4: Run the focused test and confirm the class contract passes**
+
+Run:
+
+```bash
+pnpm test -- src/components/ui/dialog.test.tsx
+```
+
+Expected: 2 tests pass.
+
+- [ ] **Step 5: Add the interactive Storybook coverage**
+
+Create `src/components/ui/dialog.stories.tsx`:
+
+```tsx
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from './alert-dialog';
+import { Button } from './button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './dialog';
+
+const meta = {
+  title: 'UI/Dialog',
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function ModalAnimationPreview() {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [alertOpen, setAlertOpen] = useState(false);
+
+  return (
+    <div className="flex gap-3">
+      <Button onClick={() => setDialogOpen(true)}>Open regular modal</Button>
+      <Button variant="destructive" onClick={() => setAlertOpen(true)}>
+        Open confirmation modal
+      </Button>
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Regular modal</DialogTitle>
+            <DialogDescription>
+              This content should fade and scale without traveling across the viewport.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button onClick={() => setDialogOpen(false)}>Done</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog open={alertOpen} onOpenChange={setAlertOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Confirmation modal</AlertDialogTitle>
+            <AlertDialogDescription>
+              Confirmation content should use the same centered motion.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction>Continue</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+export const CenteredMotion: Story = {
+  render: () => <ModalAnimationPreview />,
+};
+```
+
+- [ ] **Step 6: Format and run automated verification**
+
+Run:
+
+```bash
+pnpm exec biome check --write src/components/ui/dialog.tsx src/components/ui/alert-dialog.tsx src/components/ui/dialog.test.tsx src/components/ui/dialog.stories.tsx
+pnpm test -- src/components/ui/dialog.test.tsx
+pnpm test
+pnpm typecheck
+pnpm check
+```
+
+Expected: formatting makes no semantic changes, the focused test reports 2 passing tests, and the full test, type-check, and repository-check commands exit with code 0.
+
+- [ ] **Step 7: Perform visual and scope verification**
+
+Run:
+
+```bash
+pnpm storybook
+```
+
+Open the `UI/Dialog` → `Centered Motion` story and verify:
+
+1. The regular modal stays centered throughout its open and close animation.
+2. The confirmation modal uses the same centered fade-and-scale motion.
+3. Browser emulation of `prefers-reduced-motion: reduce` removes content animation.
+
+Stop Storybook, then verify the edit scope:
+
+```bash
+git diff --exit-code -- src/components/ui/sheet.tsx
+git diff --name-only
+```
+
+Expected: the first command exits with code 0 and no output. The second command contains only:
+
+```text
+src/components/ui/alert-dialog.tsx
+src/components/ui/dialog.stories.tsx
+src/components/ui/dialog.test.tsx
+src/components/ui/dialog.tsx
+```
+
+- [ ] **Step 8: Commit the implementation**
+
+```bash
+git add src/components/ui/alert-dialog.tsx src/components/ui/dialog.tsx src/components/ui/dialog.test.tsx src/components/ui/dialog.stories.tsx
+git commit -m "Center modal animations"
+```

--- a/docs/superpowers/specs/2026-07-28-centered-modal-animation-design.md
+++ b/docs/superpowers/specs/2026-07-28-centered-modal-animation-design.md
@@ -1,0 +1,36 @@
+# Centered Modal Animation Design
+
+## Goal
+
+Make every centered modal animate from its resting center position instead of traveling diagonally across the viewport. Provider Settings is the motivating example, but the behavior should be consistent across all standard and confirmation modals.
+
+## Scope
+
+Update the shared `DialogContent` and `AlertDialogContent` primitives. Their consumers should inherit the new behavior without call-site changes.
+
+Side sheets, drawers, menus, popovers, tooltips, and other anchored surfaces are out of scope because their directional motion communicates where they came from.
+
+## Interaction Design
+
+On open, modal content will fade from transparent to opaque and scale subtly from 95% to 100% while remaining centered. On close, the animation will reverse. The existing 200 ms duration and overlay fade will remain unchanged.
+
+Remove the directional enter and exit translation offsets from both centered modal primitives. Retain the layout translation that positions content at the viewport center.
+
+For users who request reduced motion, modal content should appear without scale or directional movement. The overlay may retain a simple opacity transition.
+
+## Implementation Boundaries
+
+- Change `src/components/ui/dialog.tsx`.
+- Change `src/components/ui/alert-dialog.tsx`.
+- Do not add per-modal variants or update individual consumers.
+- Do not change the `Sheet` primitive or anchored overlay components.
+- Keep the public component APIs unchanged.
+
+## Verification
+
+- Confirm Provider Settings opens and closes from the center.
+- Confirm a regular modal and an alert/confirmation modal use the same centered motion.
+- Confirm modal content remains centered at the beginning, during, and after animation.
+- Confirm sheets retain their existing directional animation.
+- Confirm reduced-motion mode removes content scale and travel.
+- Run focused tests for the shared primitives, then run type checking and standard repository checks.

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -33,7 +33,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-sm duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-sm duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out motion-reduce:data-[state=open]:animate-none motion-reduce:data-[state=closed]:animate-none data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg',
         className
       )}
       {...props}

--- a/src/components/ui/dialog.stories.tsx
+++ b/src/components/ui/dialog.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from './alert-dialog';
+import { Button } from './button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './dialog';
+
+const meta = {
+  title: 'UI/Dialog',
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function ModalAnimationPreview() {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [alertOpen, setAlertOpen] = useState(false);
+
+  return (
+    <div className="flex gap-3">
+      <Button onClick={() => setDialogOpen(true)}>Open regular modal</Button>
+      <Button variant="destructive" onClick={() => setAlertOpen(true)}>
+        Open confirmation modal
+      </Button>
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Regular modal</DialogTitle>
+            <DialogDescription>
+              This content should fade and scale without traveling across the viewport.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button onClick={() => setDialogOpen(false)}>Done</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog open={alertOpen} onOpenChange={setAlertOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Confirmation modal</AlertDialogTitle>
+            <AlertDialogDescription>
+              Confirmation content should use the same centered motion.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction>Continue</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+export const CenteredMotion: Story = {
+  render: () => <ModalAnimationPreview />,
+};

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-3 border bg-background p-4 shadow-sm duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-3 border bg-background p-4 shadow-sm duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out motion-reduce:data-[state=open]:animate-none motion-reduce:data-[state=closed]:animate-none data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg',
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

- replace directional travel in shared `DialogContent` and `AlertDialogContent` with centered fade-and-scale motion
- disable modal content animation when `prefers-reduced-motion: reduce` is active
- add a `UI/Dialog` Storybook story covering regular and confirmation modals
- document the design and implementation plan

## Root cause

The shared modal primitives retained legacy directional animation offsets alongside their viewport-centering translation. With the current Tailwind CSS animation setup, those offsets produce visible diagonal travel. Removing the animation translations leaves the layout translation intact, so modal content remains centered while opacity and scale animate.

## Impact

Every standard and confirmation modal inherits the centered animation without call-site changes. Sheets, drawers, menus, popovers, and tooltips retain their directional or anchored behavior.

## Validation

- `pnpm test` — 351 test files passed, 4,480 tests passed
- `pnpm typecheck`
- `pnpm check`
- `pnpm build:storybook`
- inspected generated Storybook CSS to confirm persistent center translation, fade/scale animation, and `animation: none` under reduced motion

A brittle Tailwind class-name unit test was intentionally omitted for this CSS-only behavior; the interactive `UI/Dialog → Centered Motion` story is included for visual review.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only changes to shared UI primitives with no API or logic changes; broad visual impact but low functional risk.
> 
> **Overview**
> **Shared `DialogContent` and `AlertDialogContent` no longer use directional slide enter/exit classes** that caused diagonal travel; they keep center positioning and **fade + zoom (95% ↔ 100%)** only. **`motion-reduce`** disables content animation when the user prefers reduced motion.
> 
> All standard and confirmation modals pick this up with **no API or consumer changes**; sheets and other anchored overlays are untouched.
> 
> Adds a **`UI/Dialog` → Centered Motion** Storybook story for visual QA and **design/implementation docs** under `docs/superpowers/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ef8584985e2dd1d5b1a07ca6f540b005cd64434. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->