### PR TITLE
Always commit workspace changes before archive

### DIFF
--- a/docs/superpowers/plans/2026-07-28-always-commit-before-archive.md
+++ b/docs/superpowers/plans/2026-07-28-always-commit-before-archive.md
@@ -1,0 +1,123 @@
+# Always Commit Before Workspace Archive Implementation Plan
+
+**Goal:** Make archive always preserve uncommitted work, keep confirmation available without a Git
+status preflight, and turn Git index-lock failures into an explicit remove-and-retry recovery flow.
+
+**Architecture:** The backend owns the safety invariant. Archive APIs remove the commit choice and
+accept only an optional one-shot `removeGitIndexLock` recovery action. Git operations classify an
+exact worktree index lock with a machine-readable application-error kind propagated through tRPC.
+Workspace detail and Kanban restore optimistic state on failure and show a shared recovery dialog.
+
+**Tech stack:** TypeScript, Express/tRPC, React, React Query, Vitest, jsdom
+
+## Constraints
+
+- Never delete an index lock automatically.
+- Never accept a filesystem path from the client.
+- Resolve and remove only the current worktree's server-derived `index.lock`.
+- Preserve archive rollback and cache-restoration behavior for every failure.
+- Startup recovery must not remove locks because no user is present to approve it.
+- Keep unrelated Git failures as ordinary archive errors.
+
+## Task 1: Backend always-commit and lock classification
+
+**Files:**
+
+- Modify `src/backend/lib/application-error.ts`
+- Modify `src/backend/trpc/trpc.ts`
+- Modify `src/backend/services/workspace/service/worktree/git-ops.service.ts`
+- Modify colocated tests
+
+1. Add failing tests for an optional application-error kind and tRPC
+   `applicationErrorKind` data.
+2. Add failing Git service tests proving:
+   - dirty worktrees always stage and commit;
+   - a failed add with the exact lock present returns `GIT_INDEX_LOCKED`;
+   - unrelated add failures remain internal errors;
+   - explicit recovery removes only the derived lock before staging;
+   - missing locks are harmless and removal failures stop archive.
+3. Run the focused tests and confirm the expected failures.
+4. Add the application-error metadata and safe lock-resolution implementation.
+5. Re-run the focused tests to green.
+
+## Task 2: Archive orchestration and API contracts
+
+**Files:**
+
+- Modify `src/backend/services/workspace/service/worktree/worktree-lifecycle.service.ts`
+- Modify `src/backend/orchestration/workspace-archive.orchestrator.ts`
+- Modify `src/backend/trpc/workspace.trpc.ts`
+- Modify `src/backend/trpc/workspace/children.trpc.ts`
+- Modify `src/backend/services/session/service/acp/child-workspace-mcp-server.ts`
+- Modify related tests and test utilities
+
+1. Add failing tests for option-free normal archive, explicit lock recovery, bulk error
+   discrimination, and startup recovery without lock removal.
+2. Remove `commitUncommitted` from schemas and callers.
+3. Thread `removeGitIndexLock` only through explicit single/child recovery calls.
+4. Return `applicationErrorKind` for per-workspace bulk failures.
+5. Allow the child-workspace tool to request lock removal only via an explicit optional flag whose
+   description requires user confirmation.
+6. Run router, orchestration, lifecycle, and child-tool tests to green.
+
+## Task 3: Confirmation and recovery dialogs
+
+**Files:**
+
+- Modify `src/client/features/workspace/archive-workspace-dialog.tsx`
+- Modify `src/client/features/workspace/archive-workspace-dialog.test.tsx`
+- Create `src/client/features/workspace/archive-git-lock-dialog.tsx`
+- Create `src/client/features/workspace/archive-git-lock-dialog.test.tsx`
+- Modify `src/client/features/workspace/index.ts`
+
+1. Replace the existing loading/checkbox test with a failing regression proving archive is enabled
+   and confirms with no Boolean argument.
+2. Add failing recovery-dialog tests for Cancel, Retry, and Remove Lock and Archive.
+3. Simplify archive confirmation copy and props.
+4. Implement and export the shared recovery dialog.
+5. Run both dialog test files to green.
+
+## Task 4: Workspace-detail integration
+
+**Files:**
+
+- Modify `src/client/routes/projects/workspaces/workspace-detail-container.tsx`
+- Modify `src/client/routes/projects/workspaces/workspace-detail-view.tsx`
+- Modify `src/client/routes/projects/workspaces/use-workspace-detail.ts`
+- Modify related utility and view tests
+
+1. Add failing coverage for option-free archive input and recognition of
+   `GIT_INDEX_LOCKED`.
+2. Remove the archive-only Git-status query and loading/dirty dialog props.
+3. Open the recovery dialog after rollback instead of showing a generic toast for a lock conflict.
+4. Retry normally or with the one-shot lock-removal action.
+5. Run workspace-detail tests to green.
+
+## Task 5: Kanban single and bulk recovery
+
+**Files:**
+
+- Modify `src/client/features/kanban/kanban-context.tsx`
+- Modify `src/client/features/kanban/kanban-context.test.tsx`
+- Modify `src/client/features/kanban/kanban-board.tsx`
+- Modify `src/client/features/kanban/kanban-card.tsx`
+- Modify `src/client/features/kanban/kanban-column.tsx`
+- Modify related Kanban tests
+
+1. Add failing provider tests proving single and bulk lock failures restore cached workspaces and
+   expose only locked IDs for recovery.
+2. Add failing tests proving recovery retries only those IDs and sends
+   `removeGitIndexLock: true` only for the explicit destructive action.
+3. Remove commit-choice callback parameters and bulk checkbox UI.
+4. Render the shared recovery dialog from the board.
+5. Preserve generic toasts for non-lock failures.
+6. Run focused Kanban tests to green.
+
+## Task 6: Verification
+
+1. Format scoped files with Biome.
+2. Run all focused backend and client tests touched by the change.
+3. Run `pnpm typecheck`.
+4. Run `pnpm check`.
+5. Run `pnpm test`.
+6. Review `git diff`, `git diff --check`, and `git status` for unrelated changes.

--- a/docs/superpowers/specs/2026-07-28-always-commit-before-archive-design.md
+++ b/docs/superpowers/specs/2026-07-28-always-commit-before-archive-design.md
@@ -1,0 +1,68 @@
+# Always Commit Before Workspace Archive
+
+## Problem and goal
+
+Workspace archive currently exposes a `commitUncommitted` choice across the client, tRPC
+routers, orchestration layer, and worktree services. The workspace-detail dialog also fetches a
+full Git snapshot and disables archive while that request is running. This can prevent a user from
+archiving even though the archive backend already defaults to preserving work.
+
+Archiving must have one invariant: if a valid workspace worktree contains uncommitted changes,
+Factory Factory stages and commits them before removing the worktree. Users will no longer choose
+whether to commit during archive, and archive availability will not depend on a Git-status query.
+
+## Considered approaches
+
+1. Remove the option end-to-end and enforce always-commit in the backend. This applies the invariant
+   to workspace detail, Kanban cards, bulk archive, child archive, and startup recovery. This is the
+   selected approach.
+2. Remove the option only in the client and continue sending `commitUncommitted: true`. This is a
+   smaller change, but it leaves an obsolete backend path that can still reject or discard a future
+   archive request.
+3. Keep the option and only remove the dialog's loading guard. This fixes the immediate disabled
+   button but preserves inconsistent semantics and unnecessary Git-status work.
+
+## Design
+
+`ArchiveWorkspaceDialog` will become a confirmation-only component. It will no longer own checkbox
+state, accept Git-status or commit-option props, or pass a Boolean to `onConfirm`. Its description
+will state that uncommitted changes are committed before the worktree is removed. Child-workspace
+warnings and caller-supplied bulk descriptions remain supported.
+
+Workspace detail will stop loading Git status solely for archive confirmation. Kanban card and bulk
+archive callbacks will no longer thread a commit choice. Client archive mutations will send only
+the workspace or column identity.
+
+The workspace and child tRPC archive inputs will remove `commitUncommitted`. The archive
+orchestrator and worktree lifecycle APIs will remove `WorktreeCleanupOptions`. `commitIfNeeded`
+will retain its existing repository validation, status check, staging, archive commit, and cache
+invalidation behavior, but will no longer accept or branch on a Boolean. Any detected changes are
+always committed.
+
+Startup recovery uses the same option-free archive completion path, so an interrupted archive
+continues preserving changes before cleanup.
+
+## Error handling
+
+Invalid repositories continue to skip the commit attempt so corrupt or already-removed worktrees
+can follow the existing cleanup path. Failures from Git status, add, commit, or worktree removal
+continue aborting archive and rolling the workspace status back. The obsolete
+`PRECONDITION_FAILED` error for disabling commit-before-archive is removed.
+
+The archive dialog closes after confirmation as it does today. Mutation failures continue restoring
+optimistically removed workspaces and displaying the underlying error.
+
+## Testing
+
+Tests will prove that:
+
+- an archive confirmation is enabled without waiting for Git status and invokes a no-argument
+  confirmation callback;
+- workspace-detail, Kanban card, and bulk archive flows send option-free mutations;
+- workspace and child archive routers call orchestration without a commit option;
+- worktree cleanup always stages and commits detected changes before removal;
+- clean worktrees and invalid repositories retain their current behavior;
+- Git add or commit failures still fail archive and preserve rollback behavior;
+- startup recovery uses the same always-commit path.
+
+Focused tests will run first, followed by type checking and the repository guardrails.

--- a/docs/superpowers/specs/2026-07-28-always-commit-before-archive-design.md
+++ b/docs/superpowers/specs/2026-07-28-always-commit-before-archive-design.md
@@ -48,10 +48,10 @@ bulk archive callbacks will no longer thread a commit choice. The first archive 
 only the workspace or column identity.
 
 The workspace and child tRPC archive inputs will remove `commitUncommitted`. The archive
-orchestrator and worktree lifecycle APIs will remove `WorktreeCleanupOptions`. `commitIfNeeded`
-will retain its existing repository validation, status check, staging, archive commit, and cache
-invalidation behavior, but will no longer accept or branch on a Boolean. Any detected changes are
-always committed.
+orchestrator and worktree lifecycle APIs will replace that option with a one-shot index-lock
+resolution action used only by the recovery flow. `commitIfNeeded` will retain its existing
+repository validation, status check, staging, archive commit, and cache invalidation behavior, but
+will no longer let callers disable committing. Any detected changes are always committed.
 
 Startup recovery uses the same option-free archive completion path, so an interrupted archive
 continues preserving changes before cleanup.

--- a/docs/superpowers/specs/2026-07-28-always-commit-before-archive-design.md
+++ b/docs/superpowers/specs/2026-07-28-always-commit-before-archive-design.md
@@ -2,14 +2,19 @@
 
 ## Problem and goal
 
-Workspace archive currently exposes a `commitUncommitted` choice across the client, tRPC
-routers, orchestration layer, and worktree services. The workspace-detail dialog also fetches a
-full Git snapshot and disables archive while that request is running. This can prevent a user from
+Workspace archive currently exposes a `commitUncommitted` choice across the client, tRPC routers,
+orchestration layer, and worktree services. The workspace-detail dialog also fetches a full Git
+snapshot and disables archive while that request is running. This can prevent a user from
 archiving even though the archive backend already defaults to preserving work.
 
 Archiving must have one invariant: if a valid workspace worktree contains uncommitted changes,
 Factory Factory stages and commits them before removing the worktree. Users will no longer choose
 whether to commit during archive, and archive availability will not depend on a Git-status query.
+
+Archive can also fail when Git cannot create its worktree-specific `index.lock`. Git lock files do
+not contain an owning process identifier, so Factory Factory cannot prove that a lock is stale.
+Instead of returning a generic Git error or deleting the lock automatically, the application must
+identify this conflict and let the user retry normally or explicitly remove the lock and retry.
 
 ## Considered approaches
 
@@ -22,6 +27,15 @@ whether to commit during archive, and archive availability will not depend on a 
 3. Keep the option and only remove the dialog's loading guard. This fixes the immediate disabled
    button but preserves inconsistent semantics and unnecessary Git-status work.
 
+For Git lock recovery:
+
+1. Return a structured conflict and offer Retry or Remove Lock and Archive. This preserves the safe
+   default while making stale locks recoverable in the application. This is the selected approach.
+2. Automatically remove locks older than a chosen threshold. This is smoother, but lock age cannot
+   prove that no legitimate Git process still relies on it.
+3. Keep returning a generic failure and require manual command-line cleanup. This is safe but does
+   not provide an acceptable archive experience.
+
 ## Design
 
 `ArchiveWorkspaceDialog` will become a confirmation-only component. It will no longer own checkbox
@@ -29,9 +43,9 @@ state, accept Git-status or commit-option props, or pass a Boolean to `onConfirm
 will state that uncommitted changes are committed before the worktree is removed. Child-workspace
 warnings and caller-supplied bulk descriptions remain supported.
 
-Workspace detail will stop loading Git status solely for archive confirmation. Kanban card and bulk
-archive callbacks will no longer thread a commit choice. Client archive mutations will send only
-the workspace or column identity.
+Workspace detail will stop loading Git status solely for archive confirmation. Kanban card and
+bulk archive callbacks will no longer thread a commit choice. The first archive request will send
+only the workspace or column identity.
 
 The workspace and child tRPC archive inputs will remove `commitUncommitted`. The archive
 orchestrator and worktree lifecycle APIs will remove `WorktreeCleanupOptions`. `commitIfNeeded`
@@ -42,6 +56,39 @@ always committed.
 Startup recovery uses the same option-free archive completion path, so an interrupted archive
 continues preserving changes before cleanup.
 
+## Git index-lock recovery
+
+If staging fails, the Git service will resolve the worktree's own index-lock path and check whether
+that exact lock exists. A staging failure with a present lock becomes an application conflict with
+a machine-readable `GIT_INDEX_LOCKED` discriminator and a specific user-facing explanation. The
+tRPC error boundary will preserve that discriminator alongside its standard `CONFLICT` code so
+clients do not identify the condition by parsing prose. Other staging failures retain their
+existing internal error behavior. The archive orchestrator still rolls the workspace status back
+after either failure.
+
+Single-workspace archive callers will recognize the conflict after their normal optimistic rollback
+and open a recovery dialog. The dialog explains that another Git operation may be active or a
+previous operation may have stopped unexpectedly. It offers:
+
+- **Cancel**, which leaves the workspace unchanged;
+- **Retry**, which repeats archive without touching the lock;
+- **Remove Lock and Archive**, which makes a one-time recovery request.
+
+The recovery request contains only the workspace identity and an explicit lock-resolution action;
+it never accepts a path from the client. Immediately before staging, the backend resolves the
+worktree's index-lock path again, removes only that file if present, and continues through the
+normal always-commit archive path. The action is not persisted as a preference.
+
+Bulk archive will continue processing independent workspaces. Its result will distinguish
+index-locked workspaces from other failures. If any are locked, the Kanban UI will offer the same
+recovery choice for that failed subset. Retry and Remove Lock and Archive will issue individual
+archive requests only for those workspace IDs, so successfully archived workspaces are not
+processed again and locks are never removed from workspaces that did not report the conflict.
+
+Child archive uses the same explicit recovery input and backend path. Startup recovery never
+removes a lock automatically because no user is present to make the choice; it reports the
+conflict and leaves the workspace failed for manual recovery.
+
 ## Error handling
 
 Invalid repositories continue to skip the commit attempt so corrupt or already-removed worktrees
@@ -51,6 +98,11 @@ continue aborting archive and rolling the workspace status back. The obsolete
 
 The archive dialog closes after confirmation as it does today. Mutation failures continue restoring
 optimistically removed workspaces and displaying the underlying error.
+
+Removing a lock is best effort only in the sense that a lock may disappear between detection and
+the recovery request. A missing lock is treated as already resolved and archive proceeds. A file
+removal error aborts archive, preserves the workspace, and is shown to the user. If another Git
+process recreates the lock, staging returns the same recoverable conflict again.
 
 ## Testing
 
@@ -63,6 +115,15 @@ Tests will prove that:
 - worktree cleanup always stages and commits detected changes before removal;
 - clean worktrees and invalid repositories retain their current behavior;
 - Git add or commit failures still fail archive and preserve rollback behavior;
-- startup recovery uses the same always-commit path.
+- a staging failure with the exact index lock present becomes a conflict, while unrelated staging
+  failures do not;
+- ordinary retry does not remove a lock;
+- explicit recovery resolves and removes only the server-derived worktree index lock before
+  retrying staging;
+- a lock that disappears before recovery is harmless, while lock-removal failure preserves the
+  workspace;
+- single, child, and bulk archive surfaces offer recovery only for index-lock conflicts;
+- bulk recovery retries only the locked failed subset;
+- startup recovery uses the always-commit path but never removes locks automatically.
 
 Focused tests will run first, followed by type checking and the repository guardrails.

--- a/src/backend/lib/application-error.test.ts
+++ b/src/backend/lib/application-error.test.ts
@@ -22,4 +22,16 @@ describe('ApplicationError', () => {
       cause,
     });
   });
+
+  it('retains a machine-readable error kind', () => {
+    const error = new ApplicationError('CONFLICT', 'Git index is locked', {
+      kind: 'GIT_INDEX_LOCKED',
+    });
+
+    expect(error).toMatchObject({
+      code: 'CONFLICT',
+      kind: 'GIT_INDEX_LOCKED',
+      message: 'Git index is locked',
+    });
+  });
 });

--- a/src/backend/lib/application-error.ts
+++ b/src/backend/lib/application-error.ts
@@ -5,13 +5,22 @@ export type ApplicationErrorCode =
   | 'CONFLICT'
   | 'INTERNAL_ERROR';
 
+export type ApplicationErrorKind = 'GIT_INDEX_LOCKED';
+
+export interface ApplicationErrorOptions extends ErrorOptions {
+  kind?: ApplicationErrorKind;
+}
+
 export class ApplicationError extends Error {
+  public readonly kind: ApplicationErrorKind | undefined;
+
   constructor(
     public readonly code: ApplicationErrorCode,
     message: string,
-    options?: ErrorOptions
+    options?: ApplicationErrorOptions
   ) {
     super(message, options);
     this.name = 'ApplicationError';
+    this.kind = options?.kind;
   }
 }

--- a/src/backend/orchestration/workspace-archive.orchestrator.test.ts
+++ b/src/backend/orchestration/workspace-archive.orchestrator.test.ts
@@ -62,7 +62,7 @@ function makeWorkspace(overrides: Partial<WorkspaceWithProject> = {}): Workspace
   });
 }
 
-const defaultOptions = { commitUncommitted: false };
+const defaultOptions = {};
 
 const services = unsafeCoerce<ArchiveWorkspaceDependencies>({
   cleanupWorkspaceScopedCaches: mockCleanupWorkspaceScopedCaches,
@@ -201,12 +201,12 @@ describe('archiveWorkspace', () => {
       expect(result).toBe(archivedWs);
     });
 
-    it('passes commitUncommitted option to worktree cleanup', async () => {
+    it('passes an explicit Git index-lock recovery action to worktree cleanup', async () => {
       const workspace = makeWorkspace();
-      await archiveWorkspace(workspace, { commitUncommitted: true });
+      await archiveWorkspace(workspace, { removeGitIndexLock: true });
 
       expect(worktreeLifecycleService.cleanupWorkspaceWorktree).toHaveBeenCalledWith(workspace, {
-        commitUncommitted: true,
+        removeGitIndexLock: true,
       });
     });
   });
@@ -570,9 +570,7 @@ describe('recoverStaleArchivingWorkspaces', () => {
     expect(services.sessionLifecycleService.stopWorkspaceSessions).toHaveBeenCalledWith('ws-1');
     expect(services.runScriptService.stopRunScript).toHaveBeenCalledWith('ws-1');
     expect(services.terminalService.destroyWorkspaceTerminals).toHaveBeenCalledWith('ws-1');
-    expect(worktreeLifecycleService.cleanupWorkspaceWorktree).toHaveBeenCalledWith(workspace, {
-      commitUncommitted: true,
-    });
+    expect(worktreeLifecycleService.cleanupWorkspaceWorktree).toHaveBeenCalledWith(workspace, {});
     expect(workspaceStateMachine.markArchived).toHaveBeenCalledWith('ws-1');
     expect(services.runScriptService.evictWorkspaceBuffers).toHaveBeenCalledWith('ws-1');
   });

--- a/src/backend/orchestration/workspace-archive.orchestrator.ts
+++ b/src/backend/orchestration/workspace-archive.orchestrator.ts
@@ -10,8 +10,8 @@ import { fireLifecycleNotification } from './workspace-children.orchestrator';
 
 const logger = createLogger('workspace-archive-orchestrator');
 
-interface WorktreeCleanupOptions {
-  commitUncommitted: boolean;
+interface ArchiveWorkspaceOptions {
+  removeGitIndexLock?: boolean;
 }
 
 export type ArchiveWorkspaceDependencies = {
@@ -130,7 +130,7 @@ async function handleGitHubIssueOnArchive(
 
 async function completeArchive(
   workspace: WorkspaceWithProject,
-  options: WorktreeCleanupOptions,
+  options: ArchiveWorkspaceOptions,
   services: ArchiveWorkspaceDependencies
 ) {
   await cleanupWorkspaceRuntimeResources(workspace.id, services, 'archive');
@@ -175,7 +175,7 @@ async function completeArchive(
  */
 export async function archiveWorkspace(
   workspace: WorkspaceWithProject,
-  options: WorktreeCleanupOptions,
+  options: ArchiveWorkspaceOptions,
   services: ArchiveWorkspaceDependencies
 ) {
   if (!workspaceStateMachine.isValidTransition(workspace.status, 'ARCHIVING')) {
@@ -212,7 +212,7 @@ export async function archiveWorkspace(
  */
 export async function recoverStaleArchivingWorkspaces(
   services: ArchiveWorkspaceDependencies,
-  options: WorktreeCleanupOptions = { commitUncommitted: true }
+  options: ArchiveWorkspaceOptions = {}
 ): Promise<ArchiveRecoveryResult> {
   const staleWorkspaces = await workspaceMaintenanceService.findStaleArchiving();
   const result: ArchiveRecoveryResult = { archived: [], failed: [] };

--- a/src/backend/services/session/service/acp/child-workspace-mcp-server.test.ts
+++ b/src/backend/services/session/service/acp/child-workspace-mcp-server.test.ts
@@ -26,13 +26,27 @@ type ToolResponse = z.infer<typeof toolResponseSchema>;
 async function callToolWithHttpResponse(options: {
   body: unknown;
   status: number;
-  toolName: 'spawn_child_workspace' | 'list_projects';
-}): Promise<{ requestMethod: string | undefined; response: ToolResponse }> {
+  toolName: 'spawn_child_workspace' | 'list_projects' | 'archive_child_workspace';
+  toolArguments?: Record<string, unknown>;
+}): Promise<{
+  requestBody: unknown;
+  requestMethod: string | undefined;
+  response: ToolResponse;
+}> {
   let requestMethod: string | undefined;
+  let requestBody: unknown;
   const server = createServer((req, res) => {
     requestMethod = req.method;
-    res.writeHead(options.status, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify(options.body));
+    let rawBody = '';
+    req.setEncoding('utf8');
+    req.on('data', (chunk) => {
+      rawBody += chunk;
+    });
+    req.on('end', () => {
+      requestBody = rawBody ? JSON.parse(rawBody) : undefined;
+      res.writeHead(options.status, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(options.body));
+    });
   });
   server.listen(0, '127.0.0.1');
   await once(server, 'listening');
@@ -73,9 +87,10 @@ async function callToolWithHttpResponse(options: {
         params: {
           name: options.toolName,
           arguments:
-            options.toolName === 'spawn_child_workspace'
+            options.toolArguments ??
+            (options.toolName === 'spawn_child_workspace'
               ? { projectId: 'missing-project', name: 'Child workspace' }
-              : {},
+              : {}),
         },
       })}\n`
     );
@@ -83,7 +98,11 @@ async function callToolWithHttpResponse(options: {
     const [exitCode] = await once(child, 'exit');
     expect(exitCode).toBe(0);
     expect(stderr).toBe('');
-    return { requestMethod, response: toolResponseSchema.parse(JSON.parse(stdout.trim())) };
+    return {
+      requestBody,
+      requestMethod,
+      response: toolResponseSchema.parse(JSON.parse(stdout.trim())),
+    };
   } finally {
     server.close();
     await once(server, 'close');
@@ -144,5 +163,26 @@ describe('child workspace MCP tRPC errors', () => {
     });
 
     expect(response.result.content[0]?.text).toBe('Error: HTTP 503');
+  });
+
+  it('passes explicit Git index-lock recovery for child archive', async () => {
+    const { requestBody, response } = await callToolWithHttpResponse({
+      status: 200,
+      toolName: 'archive_child_workspace',
+      toolArguments: {
+        childWorkspaceId: 'child-1',
+        removeGitIndexLock: true,
+      },
+      body: { result: { data: { json: { archived: true } } } },
+    });
+
+    expect(requestBody).toEqual({
+      json: {
+        parentWorkspaceId: 'parent-workspace',
+        childWorkspaceId: 'child-1',
+        removeGitIndexLock: true,
+      },
+    });
+    expect(response.result.content[0]?.text).toBe('Child workspace archived successfully.');
   });
 });

--- a/src/backend/services/session/service/acp/child-workspace-mcp-server.ts
+++ b/src/backend/services/session/service/acp/child-workspace-mcp-server.ts
@@ -97,6 +97,11 @@ const ARCHIVE_CHILD_TOOL = {
     type: 'object',
     properties: {
       childWorkspaceId: { type: 'string', description: 'ID of the child workspace to archive' },
+      removeGitIndexLock: {
+        type: 'boolean',
+        description:
+          'Remove the child worktree Git index lock before retrying archive. Set true only after explicit user confirmation in response to a Git lock error.',
+      },
     },
     required: ['childWorkspaceId'],
   },
@@ -272,6 +277,7 @@ async function handleArchiveChildTool(
   const { error } = await callTrpcMutation(apiBase, 'workspace.archiveChild', {
     parentWorkspaceId: workspaceId,
     childWorkspaceId: args.childWorkspaceId,
+    ...(args.removeGitIndexLock === true ? { removeGitIndexLock: true } : {}),
   });
   if (error) {
     send({

--- a/src/backend/services/workspace/service/worktree/git-ops.service.test.ts
+++ b/src/backend/services/workspace/service/worktree/git-ops.service.test.ts
@@ -74,21 +74,14 @@ describe('gitOpsService', () => {
     expect(mockGetStats).toHaveBeenCalledWith(snapshot);
   });
 
-  it('commitIfNeeded skips invalid repo, validates status, and commits when requested', async () => {
+  it('commitIfNeeded skips invalid repos, clean worktrees, and always commits dirty worktrees', async () => {
     mockGitCommand.mockResolvedValueOnce({ code: 1, stdout: '', stderr: 'not a repo' });
-    await expect(gitOpsService.commitIfNeeded('/repo/w1', 'W1', true)).resolves.toBeUndefined();
+    await expect(gitOpsService.commitIfNeeded('/repo/w1', 'W1')).resolves.toBeUndefined();
 
     mockGitCommand
       .mockResolvedValueOnce({ code: 0, stdout: '.git', stderr: '' })
       .mockResolvedValueOnce({ code: 0, stdout: '', stderr: '' });
-    await expect(gitOpsService.commitIfNeeded('/repo/w1', 'W1', true)).resolves.toBeUndefined();
-
-    mockGitCommand
-      .mockResolvedValueOnce({ code: 0, stdout: '.git', stderr: '' })
-      .mockResolvedValueOnce({ code: 0, stdout: ' M file.ts\n', stderr: '' });
-    await expect(gitOpsService.commitIfNeeded('/repo/w1', 'W1', false)).rejects.toMatchObject({
-      code: 'PRECONDITION_FAILED',
-    });
+    await expect(gitOpsService.commitIfNeeded('/repo/w1', 'W1')).resolves.toBeUndefined();
 
     mockGitCommand
       .mockResolvedValueOnce({ code: 0, stdout: '.git', stderr: '' })
@@ -96,7 +89,7 @@ describe('gitOpsService', () => {
       .mockResolvedValueOnce({ code: 0, stdout: '', stderr: '' })
       .mockResolvedValueOnce({ code: 0, stdout: '[main] Archive workspace W1', stderr: '' });
 
-    await expect(gitOpsService.commitIfNeeded('/repo/w1', 'W1', true)).resolves.toBeUndefined();
+    await expect(gitOpsService.commitIfNeeded('/repo/w1', 'W1')).resolves.toBeUndefined();
     expect(mockGitCommand).toHaveBeenCalledWith(['add', '-A'], '/repo/w1');
     expect(mockGitCommand).toHaveBeenCalledWith(
       ['commit', '-m', 'Archive workspace W1', '--no-verify'],
@@ -104,6 +97,91 @@ describe('gitOpsService', () => {
     );
     expect(mockGitStateInvalidate).toHaveBeenCalledOnce();
     expect(mockGitStateInvalidate).toHaveBeenCalledWith('/repo/w1');
+  });
+
+  it('classifies a failed add with the worktree index lock present', async () => {
+    const addResult = {
+      code: 128,
+      stdout: '',
+      stderr: 'fatal: Unable to create index.lock: File exists.',
+    };
+    mockGitCommand
+      .mockResolvedValueOnce({ code: 0, stdout: '.git', stderr: '' })
+      .mockResolvedValueOnce({ code: 0, stdout: ' M file.ts\n', stderr: '' })
+      .mockResolvedValueOnce(addResult)
+      .mockResolvedValueOnce({
+        code: 0,
+        stdout: '/repo/.git/worktrees/w1\n',
+        stderr: '',
+      });
+    mockPathExists.mockResolvedValueOnce(true);
+
+    await expect(gitOpsService.commitIfNeeded('/repo/w1', 'W1')).rejects.toMatchObject({
+      code: 'CONFLICT',
+      kind: 'GIT_INDEX_LOCKED',
+      message: expect.stringContaining('Git is locked'),
+      cause: addResult,
+    });
+    expect(mockPathExists).toHaveBeenCalledWith('/repo/.git/worktrees/w1/index.lock');
+  });
+
+  it('removes only the derived worktree index lock for explicit recovery', async () => {
+    mockGitCommand
+      .mockResolvedValueOnce({ code: 0, stdout: '.git', stderr: '' })
+      .mockResolvedValueOnce({
+        code: 0,
+        stdout: '/repo/.git/worktrees/w1\n',
+        stderr: '',
+      })
+      .mockResolvedValueOnce({ code: 0, stdout: ' M file.ts\n', stderr: '' })
+      .mockResolvedValueOnce({ code: 0, stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ code: 0, stdout: '[main] Archive workspace W1', stderr: '' });
+
+    await expect(
+      gitOpsService.commitIfNeeded('/repo/w1', 'W1', { removeGitIndexLock: true })
+    ).resolves.toBeUndefined();
+
+    expect(mockRm).toHaveBeenCalledWith('/repo/.git/worktrees/w1/index.lock', { force: true });
+    expect(mockGitCommand).toHaveBeenCalledWith(['add', '-A'], '/repo/w1');
+  });
+
+  it('removes an explicitly approved lock even when the worktree became clean', async () => {
+    mockGitCommand
+      .mockResolvedValueOnce({ code: 0, stdout: '.git', stderr: '' })
+      .mockResolvedValueOnce({
+        code: 0,
+        stdout: '/repo/.git/worktrees/w1\n',
+        stderr: '',
+      })
+      .mockResolvedValueOnce({ code: 0, stdout: '', stderr: '' });
+
+    await expect(
+      gitOpsService.commitIfNeeded('/repo/w1', 'W1', { removeGitIndexLock: true })
+    ).resolves.toBeUndefined();
+
+    expect(mockRm).toHaveBeenCalledWith('/repo/.git/worktrees/w1/index.lock', { force: true });
+    expect(mockGitCommand).not.toHaveBeenCalledWith(['add', '-A'], '/repo/w1');
+  });
+
+  it('stops before status and staging when an approved lock cannot be removed', async () => {
+    const removeError = Object.assign(new Error('permission denied'), { code: 'EACCES' });
+    mockGitCommand
+      .mockResolvedValueOnce({ code: 0, stdout: '.git', stderr: '' })
+      .mockResolvedValueOnce({
+        code: 0,
+        stdout: '/repo/.git/worktrees/w1\n',
+        stderr: '',
+      });
+    mockRm.mockRejectedValueOnce(removeError);
+
+    await expect(
+      gitOpsService.commitIfNeeded('/repo/w1', 'W1', { removeGitIndexLock: true })
+    ).rejects.toMatchObject({
+      code: 'INTERNAL_ERROR',
+      message: 'Failed to remove Git index lock',
+      cause: removeError,
+    });
+    expect(mockGitCommand).toHaveBeenCalledTimes(2);
   });
 
   it('invalidates staged archive changes when the commit fails', async () => {
@@ -114,7 +192,7 @@ describe('gitOpsService', () => {
       .mockResolvedValueOnce({ code: 0, stdout: '', stderr: '' })
       .mockResolvedValueOnce(commitResult);
 
-    await expect(gitOpsService.commitIfNeeded('/repo/w1', 'W1', true)).rejects.toMatchObject({
+    await expect(gitOpsService.commitIfNeeded('/repo/w1', 'W1')).rejects.toMatchObject({
       code: 'INTERNAL_ERROR',
       message: 'Git commit failed',
       cause: commitResult,
@@ -134,7 +212,7 @@ describe('gitOpsService', () => {
       .mockResolvedValueOnce(statusResult);
 
     const error = await gitOpsService
-      .commitIfNeeded('/repo/w1', 'W1', true)
+      .commitIfNeeded('/repo/w1', 'W1')
       .catch((caught: unknown) => caught);
 
     expect(error).toBeInstanceOf(ApplicationError);

--- a/src/backend/services/workspace/service/worktree/git-ops.service.test.ts
+++ b/src/backend/services/workspace/service/worktree/git-ops.service.test.ts
@@ -190,7 +190,13 @@ describe('gitOpsService', () => {
       .mockResolvedValueOnce({ code: 0, stdout: '.git', stderr: '' })
       .mockResolvedValueOnce({ code: 0, stdout: ' M file.ts\n', stderr: '' })
       .mockResolvedValueOnce({ code: 0, stdout: '', stderr: '' })
-      .mockResolvedValueOnce(commitResult);
+      .mockResolvedValueOnce(commitResult)
+      .mockResolvedValueOnce({
+        code: 0,
+        stdout: '/repo/.git/worktrees/w1\n',
+        stderr: '',
+      });
+    mockPathExists.mockResolvedValueOnce(false);
 
     await expect(gitOpsService.commitIfNeeded('/repo/w1', 'W1')).rejects.toMatchObject({
       code: 'INTERNAL_ERROR',
@@ -198,6 +204,34 @@ describe('gitOpsService', () => {
       cause: commitResult,
     });
     expect(mockGitStateInvalidate).toHaveBeenCalledOnce();
+    expect(mockGitStateInvalidate).toHaveBeenCalledWith('/repo/w1');
+  });
+
+  it('classifies a failed commit with the worktree index lock present', async () => {
+    const commitResult = {
+      code: 128,
+      stdout: '',
+      stderr: 'fatal: Unable to create index.lock: File exists.',
+    };
+    mockGitCommand
+      .mockResolvedValueOnce({ code: 0, stdout: '.git', stderr: '' })
+      .mockResolvedValueOnce({ code: 0, stdout: ' M file.ts\n', stderr: '' })
+      .mockResolvedValueOnce({ code: 0, stdout: '', stderr: '' })
+      .mockResolvedValueOnce(commitResult)
+      .mockResolvedValueOnce({
+        code: 0,
+        stdout: '/repo/.git/worktrees/w1\n',
+        stderr: '',
+      });
+    mockPathExists.mockResolvedValueOnce(true);
+
+    await expect(gitOpsService.commitIfNeeded('/repo/w1', 'W1')).rejects.toMatchObject({
+      code: 'CONFLICT',
+      kind: 'GIT_INDEX_LOCKED',
+      message: expect.stringContaining('Git is locked'),
+      cause: commitResult,
+    });
+    expect(mockPathExists).toHaveBeenCalledWith('/repo/.git/worktrees/w1/index.lock');
     expect(mockGitStateInvalidate).toHaveBeenCalledWith('/repo/w1');
   });
 

--- a/src/backend/services/workspace/service/worktree/git-ops.service.ts
+++ b/src/backend/services/workspace/service/worktree/git-ops.service.ts
@@ -17,6 +17,10 @@ interface ProjectPaths {
   worktreeBasePath: string;
 }
 
+interface CommitIfNeededOptions {
+  removeGitIndexLock?: boolean;
+}
+
 class GitOpsService {
   private normalizeBranchName(branchName: string): string {
     if (branchName.startsWith('origin/')) {
@@ -59,16 +63,66 @@ class GitOpsService {
     return result.code === 0;
   }
 
+  private async resolveIndexLockPath(worktreePath: string): Promise<string> {
+    const gitDirResult = await gitCommand(['rev-parse', '--absolute-git-dir'], worktreePath);
+    const gitDir = gitDirResult.stdout.trim();
+    if (gitDirResult.code !== 0 || gitDir.length === 0) {
+      throw new ApplicationError('INTERNAL_ERROR', 'Failed to resolve Git index lock', {
+        cause: gitDirResult,
+      });
+    }
+    return path.join(path.resolve(worktreePath, gitDir), 'index.lock');
+  }
+
+  private async createGitAddError(
+    worktreePath: string,
+    addResult: Awaited<ReturnType<typeof gitCommand>>
+  ): Promise<ApplicationError> {
+    try {
+      const indexLockPath = await this.resolveIndexLockPath(worktreePath);
+      if (await pathExists(indexLockPath)) {
+        return new ApplicationError(
+          'CONFLICT',
+          'Git is locked. Another Git operation may be running, or an earlier operation may have stopped unexpectedly.',
+          {
+            cause: addResult,
+            kind: 'GIT_INDEX_LOCKED',
+          }
+        );
+      }
+    } catch {
+      // Classification is best-effort. Preserve the original add failure when
+      // the worktree's Git metadata cannot be inspected safely.
+    }
+
+    return new ApplicationError('INTERNAL_ERROR', 'Git add failed', { cause: addResult });
+  }
+
+  private async removeGitIndexLock(worktreePath: string): Promise<void> {
+    const indexLockPath = await this.resolveIndexLockPath(worktreePath);
+    try {
+      await fs.rm(indexLockPath, { force: true });
+    } catch (error) {
+      throw new ApplicationError('INTERNAL_ERROR', 'Failed to remove Git index lock', {
+        cause: error,
+      });
+    }
+  }
+
   async commitIfNeeded(
     worktreePath: string,
     workspaceName: string,
-    commitUncommitted: boolean
+    options: CommitIfNeededOptions = {}
   ): Promise<void> {
     // Check if this is a valid git repo first - if not, skip commit
     // This can happen if the worktree was corrupted or the .git file was removed
     const isValid = await this.isValidGitRepo(worktreePath);
     if (!isValid) {
       return;
+    }
+
+    if (options.removeGitIndexLock) {
+      await this.removeGitIndexLock(worktreePath);
     }
 
     const statusResult = await gitCommand(['status', '--porcelain'], worktreePath);
@@ -82,17 +136,10 @@ class GitOpsService {
       return;
     }
 
-    if (!commitUncommitted) {
-      throw new ApplicationError(
-        'PRECONDITION_FAILED',
-        'Workspace has uncommitted changes. Enable commit-before-archive to proceed.'
-      );
-    }
-
     try {
       const addResult = await gitCommand(['add', '-A'], worktreePath);
       if (addResult.code !== 0) {
-        throw new ApplicationError('INTERNAL_ERROR', 'Git add failed', { cause: addResult });
+        throw await this.createGitAddError(worktreePath, addResult);
       }
 
       const commitMessage = `Archive workspace ${workspaceName}`;

--- a/src/backend/services/workspace/service/worktree/git-ops.service.ts
+++ b/src/backend/services/workspace/service/worktree/git-ops.service.ts
@@ -74,9 +74,10 @@ class GitOpsService {
     return path.join(path.resolve(worktreePath, gitDir), 'index.lock');
   }
 
-  private async createGitAddError(
+  private async createGitOperationError(
     worktreePath: string,
-    addResult: Awaited<ReturnType<typeof gitCommand>>
+    result: Awaited<ReturnType<typeof gitCommand>>,
+    fallbackMessage: string
   ): Promise<ApplicationError> {
     try {
       const indexLockPath = await this.resolveIndexLockPath(worktreePath);
@@ -85,17 +86,17 @@ class GitOpsService {
           'CONFLICT',
           'Git is locked. Another Git operation may be running, or an earlier operation may have stopped unexpectedly.',
           {
-            cause: addResult,
+            cause: result,
             kind: 'GIT_INDEX_LOCKED',
           }
         );
       }
     } catch {
-      // Classification is best-effort. Preserve the original add failure when
+      // Classification is best-effort. Preserve the original Git failure when
       // the worktree's Git metadata cannot be inspected safely.
     }
 
-    return new ApplicationError('INTERNAL_ERROR', 'Git add failed', { cause: addResult });
+    return new ApplicationError('INTERNAL_ERROR', fallbackMessage, { cause: result });
   }
 
   private async removeGitIndexLock(worktreePath: string): Promise<void> {
@@ -139,7 +140,7 @@ class GitOpsService {
     try {
       const addResult = await gitCommand(['add', '-A'], worktreePath);
       if (addResult.code !== 0) {
-        throw await this.createGitAddError(worktreePath, addResult);
+        throw await this.createGitOperationError(worktreePath, addResult, 'Git add failed');
       }
 
       const commitMessage = `Archive workspace ${workspaceName}`;
@@ -148,9 +149,7 @@ class GitOpsService {
         worktreePath
       );
       if (commitResult.code !== 0) {
-        throw new ApplicationError('INTERNAL_ERROR', 'Git commit failed', {
-          cause: commitResult,
-        });
+        throw await this.createGitOperationError(worktreePath, commitResult, 'Git commit failed');
       }
     } finally {
       workspaceGitStateService.invalidate(worktreePath);

--- a/src/backend/services/workspace/service/worktree/worktree-lifecycle.service.test.ts
+++ b/src/backend/services/workspace/service/worktree/worktree-lifecycle.service.test.ts
@@ -79,9 +79,7 @@ describe('worktreeLifecycleService cleanup', () => {
 
     try {
       await expect(
-        worktreeLifecycleService.cleanupWorkspaceWorktree(workspace, {
-          commitUncommitted: true,
-        })
+        worktreeLifecycleService.cleanupWorkspaceWorktree(workspace, {})
       ).rejects.toThrow(WorktreePathSafetyError);
       expect(commitSpy).not.toHaveBeenCalled();
       expect(removeSpy).not.toHaveBeenCalled();
@@ -107,9 +105,8 @@ describe('worktreeLifecycleService cleanup', () => {
     });
 
     try {
-      await worktreeLifecycleService.cleanupWorkspaceWorktree(workspace, {
-        commitUncommitted: true,
-      });
+      await worktreeLifecycleService.cleanupWorkspaceWorktree(workspace, {});
+      expect(gitOpsService.commitIfNeeded).toHaveBeenCalledWith(worktreePath, 'Workspace');
       expect(removeStateSpy).not.toHaveBeenCalled();
     } finally {
       await rm(tempRoot, { recursive: true, force: true });
@@ -129,9 +126,7 @@ describe('worktreeLifecycleService cleanup', () => {
       project: { repoPath: '/tmp/repo', worktreeBasePath: '/tmp/worktrees' },
     });
 
-    await worktreeLifecycleService.cleanupWorkspaceWorktree(workspace, {
-      commitUncommitted: true,
-    });
+    await worktreeLifecycleService.cleanupWorkspaceWorktree(workspace, {});
 
     expect(removeStateSpy).toHaveBeenCalledWith(worktreePath);
     expect(gitOpsService.commitIfNeeded).not.toHaveBeenCalled();
@@ -156,11 +151,37 @@ describe('worktreeLifecycleService cleanup', () => {
 
     try {
       await expect(
-        worktreeLifecycleService.cleanupWorkspaceWorktree(workspace, {
-          commitUncommitted: true,
-        })
+        worktreeLifecycleService.cleanupWorkspaceWorktree(workspace, {})
       ).rejects.toThrow('remove failed');
       expect(removeStateSpy).not.toHaveBeenCalled();
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('passes an explicit Git index-lock recovery action to Git operations', async () => {
+    const tempRoot = await mkdtemp(path.join(tmpdir(), 'ff-worktree-cleanup-'));
+    const worktreeBasePath = path.join(tempRoot, 'worktrees');
+    const worktreePath = path.join(worktreeBasePath, 'workspace');
+    await mkdir(worktreePath, { recursive: true });
+    const commitSpy = vi.spyOn(gitOpsService, 'commitIfNeeded').mockResolvedValue(undefined);
+    vi.spyOn(gitOpsService, 'removeWorktree').mockResolvedValue(undefined);
+    const workspace = unsafeCoerce<
+      Parameters<typeof worktreeLifecycleService.cleanupWorkspaceWorktree>[0]
+    >({
+      name: 'Workspace',
+      worktreePath,
+      project: { repoPath: path.join(tempRoot, 'repo'), worktreeBasePath },
+    });
+
+    try {
+      await worktreeLifecycleService.cleanupWorkspaceWorktree(workspace, {
+        removeGitIndexLock: true,
+      });
+
+      expect(commitSpy).toHaveBeenCalledWith(worktreePath, 'Workspace', {
+        removeGitIndexLock: true,
+      });
     } finally {
       await rm(tempRoot, { recursive: true, force: true });
     }

--- a/src/backend/services/workspace/service/worktree/worktree-lifecycle.service.ts
+++ b/src/backend/services/workspace/service/worktree/worktree-lifecycle.service.ts
@@ -75,8 +75,8 @@ type WorkspaceWithProject = Exclude<
   null | undefined
 >;
 
-interface WorktreeCleanupOptions {
-  commitUncommitted: boolean;
+interface WorktreeArchiveOptions {
+  removeGitIndexLock?: boolean;
 }
 
 function getProjectOrThrow(workspace: WorkspaceWithProject) {
@@ -121,7 +121,7 @@ class WorktreeLifecycleService {
 
   async cleanupWorkspaceWorktree(
     workspace: WorkspaceWithProject,
-    options: WorktreeCleanupOptions
+    options: WorktreeArchiveOptions
   ): Promise<void> {
     const worktreePath = workspace.worktreePath;
     if (!worktreePath) {
@@ -137,7 +137,13 @@ class WorktreeLifecycleService {
       return;
     }
 
-    await gitOpsService.commitIfNeeded(worktreePath, workspace.name, options.commitUncommitted);
+    if (options.removeGitIndexLock) {
+      await gitOpsService.commitIfNeeded(worktreePath, workspace.name, {
+        removeGitIndexLock: true,
+      });
+    } else {
+      await gitOpsService.commitIfNeeded(worktreePath, workspace.name);
+    }
     await gitOpsService.removeWorktree(worktreePath, project);
   }
 }

--- a/src/backend/trpc/trpc.ts
+++ b/src/backend/trpc/trpc.ts
@@ -49,6 +49,16 @@ export const createContext =
 
 const t = initTRPC.context<Context>().create({
   transformer: superjson,
+  errorFormatter({ shape, error }) {
+    const applicationError = error.cause instanceof ApplicationError ? error.cause : undefined;
+    return {
+      ...shape,
+      data: {
+        ...shape.data,
+        applicationErrorKind: applicationError?.kind ?? null,
+      },
+    };
+  },
 });
 
 export const router = t.router;

--- a/src/backend/trpc/workspace.router.test.ts
+++ b/src/backend/trpc/workspace.router.test.ts
@@ -348,9 +348,23 @@ describe('workspaceCoreRouter', () => {
     expect(mockCheckWorkspaceById).toHaveBeenCalledWith('w-created');
 
     await expect(caller.archive({ id: 'w-created' })).resolves.toEqual({ archived: true });
+    expect(mockArchiveWorkspace).toHaveBeenLastCalledWith(
+      expect.objectContaining({ id: 'w-created' }),
+      {},
+      expect.anything()
+    );
+
+    await expect(caller.archive({ id: 'w-created', removeGitIndexLock: true })).resolves.toEqual({
+      archived: true,
+    });
+    expect(mockArchiveWorkspace).toHaveBeenLastCalledWith(
+      expect.objectContaining({ id: 'w-created' }),
+      { removeGitIndexLock: true },
+      expect.anything()
+    );
   });
 
-  it('includes error codes for individual bulk archive failures', async () => {
+  it('includes error codes and application kinds for individual bulk archive failures', async () => {
     mockWorkspaceQueryService.findWorkspaceIdsInKanbanColumn.mockResolvedValue([
       'w-success',
       'w-blocked',
@@ -358,7 +372,9 @@ describe('workspaceCoreRouter', () => {
     ]);
     mockArchiveWorkspace
       .mockResolvedValueOnce({ archived: true })
-      .mockRejectedValueOnce(new ApplicationError('PRECONDITION_FAILED', 'Uncommitted changes'))
+      .mockRejectedValueOnce(
+        new ApplicationError('CONFLICT', 'Git is locked', { kind: 'GIT_INDEX_LOCKED' })
+      )
       .mockRejectedValueOnce(new TRPCError({ code: 'NOT_FOUND', message: 'Workspace not found' }));
     const { caller } = createCaller();
 
@@ -366,7 +382,6 @@ describe('workspaceCoreRouter', () => {
       caller.bulkArchive({
         projectId: 'p1',
         kanbanColumn: 'WAITING',
-        commitUncommitted: false,
       })
     ).resolves.toEqual({
       results: [
@@ -374,14 +389,16 @@ describe('workspaceCoreRouter', () => {
         {
           id: 'w-blocked',
           success: false,
-          error: 'Uncommitted changes',
-          code: 'PRECONDITION_FAILED',
+          error: 'Git is locked',
+          code: 'CONFLICT',
+          applicationErrorKind: 'GIT_INDEX_LOCKED',
         },
         {
           id: 'w-missing',
           success: false,
           error: 'Workspace not found',
           code: 'NOT_FOUND',
+          applicationErrorKind: null,
         },
       ],
       total: 3,

--- a/src/backend/trpc/workspace.trpc.ts
+++ b/src/backend/trpc/workspace.trpc.ts
@@ -39,6 +39,16 @@ function normalizeBulkArchiveError(error: unknown): TRPCError | undefined {
   return error instanceof TRPCError ? error : undefined;
 }
 
+function getApplicationErrorKind(error: unknown) {
+  if (error instanceof ApplicationError) {
+    return error.kind ?? null;
+  }
+  if (error instanceof TRPCError && error.cause instanceof ApplicationError) {
+    return error.cause.kind ?? null;
+  }
+  return null;
+}
+
 // Zod schema for workspace creation source discriminated union
 const workspaceCreationSourceSchema = z.discriminatedUnion('type', [
   z
@@ -357,15 +367,13 @@ export const workspaceCoreRouter = router({
 
   // Archive a workspace
   archive: publicProcedure
-    .input(z.object({ id: z.string(), commitUncommitted: z.boolean().optional() }))
+    .input(z.object({ id: z.string(), removeGitIndexLock: z.literal(true).optional() }))
     .mutation(async ({ ctx, input }) => {
       const { archiveWorkspace, workspaceDataService } = ctx.appContext.services;
       const workspace = await getWorkspaceWithProjectOrThrow(workspaceDataService, input.id);
       return archiveWorkspace(
         workspace,
-        {
-          commitUncommitted: input.commitUncommitted ?? true,
-        },
+        input.removeGitIndexLock ? { removeGitIndexLock: true } : {},
         ctx.appContext.services
       );
     }),
@@ -376,14 +384,13 @@ export const workspaceCoreRouter = router({
       z.object({
         projectId: z.string(),
         kanbanColumn: z.nativeEnum(KanbanColumn),
-        commitUncommitted: z.boolean().optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
       const logger = getLogger(ctx);
       const { archiveWorkspace, workspaceDataService, workspaceQueryService } =
         ctx.appContext.services;
-      const { projectId, kanbanColumn, commitUncommitted = true } = input;
+      const { projectId, kanbanColumn } = input;
 
       // Get all workspaces in the specified kanban column
       const workspaceIds = await workspaceQueryService.findWorkspaceIdsInKanbanColumn(
@@ -402,7 +409,7 @@ export const workspaceCoreRouter = router({
       for (const workspaceId of workspaceIds) {
         try {
           const workspace = await getWorkspaceWithProjectOrThrow(workspaceDataService, workspaceId);
-          await archiveWorkspace(workspace, { commitUncommitted }, ctx.appContext.services);
+          await archiveWorkspace(workspace, {}, ctx.appContext.services);
           results.push({ id: workspace.id, success: true });
         } catch (error) {
           const mappedError = normalizeBulkArchiveError(error);
@@ -415,6 +422,7 @@ export const workspaceCoreRouter = router({
             success: false,
             error: error instanceof Error ? error.message : String(error),
             code: mappedError?.code ?? 'INTERNAL_SERVER_ERROR',
+            applicationErrorKind: getApplicationErrorKind(error),
           });
         }
       }

--- a/src/backend/trpc/workspace/children.router.test.ts
+++ b/src/backend/trpc/workspace/children.router.test.ts
@@ -357,7 +357,19 @@ describe('workspaceChildrenRouter', () => {
     await expect(
       caller.archiveChild({ parentWorkspaceId: 'parent-1', childWorkspaceId: 'child-1' })
     ).resolves.toEqual({ archived: true });
-    expect(mockArchiveWorkspace).toHaveBeenCalledWith(child, { commitUncommitted: true }, services);
+    expect(mockArchiveWorkspace).toHaveBeenCalledWith(child, {}, services);
+    await expect(
+      caller.archiveChild({
+        parentWorkspaceId: 'parent-1',
+        childWorkspaceId: 'child-1',
+        removeGitIndexLock: true,
+      })
+    ).resolves.toEqual({ archived: true });
+    expect(mockArchiveWorkspace).toHaveBeenLastCalledWith(
+      child,
+      { removeGitIndexLock: true },
+      services
+    );
     await expect(caller.getPendingNotificationCount({ workspaceId: 'parent-1' })).resolves.toBe(3);
   });
 });

--- a/src/backend/trpc/workspace/children.trpc.ts
+++ b/src/backend/trpc/workspace/children.trpc.ts
@@ -200,7 +200,7 @@ export const workspaceChildrenRouter = router({
       z.object({
         parentWorkspaceId: z.string(),
         childWorkspaceId: z.string(),
-        commitUncommitted: z.boolean().optional(),
+        removeGitIndexLock: z.literal(true).optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -220,7 +220,7 @@ export const workspaceChildrenRouter = router({
       }
       return archiveWorkspace(
         child,
-        { commitUncommitted: input.commitUncommitted ?? true },
+        input.removeGitIndexLock ? { removeGitIndexLock: true } : {},
         ctx.appContext.services
       );
     }),

--- a/src/client/features/kanban/kanban-board.test.tsx
+++ b/src/client/features/kanban/kanban-board.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { KanbanBoard } from './kanban-board';
+
+const mocks = vi.hoisted(() => ({
+  dismissArchiveGitLock: vi.fn(),
+  retryGitLockedArchives: vi.fn(),
+}));
+
+vi.mock('@/hooks/use-mobile', () => ({
+  MOBILE_BREAKPOINT: 768,
+  useIsMobile: () => true,
+}));
+
+vi.mock('./kanban-column', () => ({
+  getKanbanColumns: () => [
+    {
+      id: 'WAITING',
+      label: 'Waiting',
+      description: 'Waiting for input',
+    },
+  ],
+  KanbanColumn: () => <div>Mobile column</div>,
+}));
+
+vi.mock('./quick-chat-sheet', () => ({
+  QuickChatSheet: () => null,
+}));
+
+vi.mock('./kanban-context', () => ({
+  useKanban: () => ({
+    projectId: 'project-1',
+    projectSlug: 'project',
+    issueProvider: 'GITHUB',
+    workspaces: [],
+    issues: [],
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+    toggleWorkspaceRatcheting: vi.fn(),
+    togglingWorkspaceId: null,
+    renameWorkspace: vi.fn(),
+    archiveWorkspace: vi.fn(),
+    bulkArchiveColumn: vi.fn(),
+    archiveGitLockWorkspaceIds: ['workspace-1'],
+    dismissArchiveGitLock: mocks.dismissArchiveGitLock,
+    retryGitLockedArchives: mocks.retryGitLockedArchives,
+    isBulkArchiving: false,
+    showInlineForm: false,
+    setShowInlineForm: vi.fn(),
+    quickChatWorkspaceId: null,
+    openQuickChat: vi.fn(),
+    closeQuickChat: vi.fn(),
+  }),
+}));
+
+describe('KanbanBoard', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let originalActEnvironmentDescriptor: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    originalActEnvironmentDescriptor = Object.getOwnPropertyDescriptor(
+      globalThis,
+      'IS_REACT_ACT_ENVIRONMENT'
+    );
+    Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
+      configurable: true,
+      writable: true,
+      value: true,
+    });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    try {
+      void act(() => root.unmount());
+      document.body.innerHTML = '';
+    } finally {
+      if (originalActEnvironmentDescriptor) {
+        Object.defineProperty(
+          globalThis,
+          'IS_REACT_ACT_ENVIRONMENT',
+          originalActEnvironmentDescriptor
+        );
+      } else {
+        Reflect.deleteProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT');
+      }
+    }
+  });
+
+  it('renders Git index-lock recovery on mobile', () => {
+    void act(() => {
+      root.render(createElement(KanbanBoard));
+    });
+
+    expect(document.body.textContent).toContain('Git is locked');
+    expect(document.body.textContent).toContain('Remove Lock and Archive');
+  });
+});

--- a/src/client/features/kanban/kanban-board.tsx
+++ b/src/client/features/kanban/kanban-board.tsx
@@ -1,8 +1,7 @@
 import { ArrowsClockwiseIcon, PlusIcon } from '@phosphor-icons/react';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { ArchiveWorkspaceDialog } from '@/client/features/workspace';
+import { ArchiveGitLockDialog, ArchiveWorkspaceDialog } from '@/client/features/workspace';
 import type { NormalizedIssue } from '@/client/lib/issue-normalization';
-import { isWorkspaceDoneOrMerged } from '@/client/lib/workspace-archive';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -62,6 +61,9 @@ export function KanbanBoard() {
     renameWorkspace,
     archiveWorkspace,
     bulkArchiveColumn,
+    archiveGitLockWorkspaceIds,
+    dismissArchiveGitLock,
+    retryGitLockedArchives,
     isBulkArchiving,
     showInlineForm,
     setShowInlineForm,
@@ -87,9 +89,9 @@ export function KanbanBoard() {
     setBulkArchiveDialogOpen(true);
   };
 
-  const handleBulkArchiveConfirm = async (commitUncommitted: boolean) => {
+  const handleBulkArchiveConfirm = async () => {
     if (bulkArchiveColumnId) {
-      await bulkArchiveColumn(bulkArchiveColumnId, commitUncommitted);
+      await bulkArchiveColumn(bulkArchiveColumnId);
     }
   };
 
@@ -259,10 +261,6 @@ export function KanbanBoard() {
     bulkArchiveColumnId && bulkArchiveColumnId !== 'ISSUES'
       ? (workspacesByColumn[bulkArchiveColumnId as KanbanColumnType] ?? [])
       : [];
-  const shouldWarnForBulkArchive = workspacesInBulkArchiveColumn.some(
-    (workspace) => !isWorkspaceDoneOrMerged(workspace)
-  );
-
   return (
     <>
       <div className="flex flex-row gap-4 pb-4 h-full overflow-y-hidden overflow-x-auto mx-auto w-full max-w-[1800px]">
@@ -302,12 +300,20 @@ export function KanbanBoard() {
       <ArchiveWorkspaceDialog
         open={bulkArchiveDialogOpen}
         onOpenChange={setBulkArchiveDialogOpen}
-        hasUncommitted={shouldWarnForBulkArchive}
-        showCommitOption={shouldWarnForBulkArchive}
         onConfirm={handleBulkArchiveConfirm}
-        description={`This will archive all ${workspacesInBulkArchiveColumn.length} workspace(s) in this column. Archiving will remove the workspace worktrees from disk.`}
-        warningText="Warning: Some workspaces may have uncommitted changes and they will be committed before archiving."
-        checkboxLabel="Commit uncommitted changes before archiving"
+        description={`This will archive all ${workspacesInBulkArchiveColumn.length} workspace(s) in this column. Any uncommitted changes will be committed before the worktrees are removed.`}
+      />
+
+      <ArchiveGitLockDialog
+        open={archiveGitLockWorkspaceIds.length > 0}
+        onOpenChange={(open) => {
+          if (!open) {
+            dismissArchiveGitLock();
+          }
+        }}
+        workspaceCount={archiveGitLockWorkspaceIds.length}
+        onRetry={() => void retryGitLockedArchives(false)}
+        onRemoveLockAndArchive={() => void retryGitLockedArchives(true)}
       />
 
       <QuickChatSheet workspaceId={quickChatWorkspaceId} onClose={closeQuickChat} />

--- a/src/client/features/kanban/kanban-board.tsx
+++ b/src/client/features/kanban/kanban-board.tsx
@@ -152,6 +152,20 @@ export function KanbanBoard() {
     return workspacesByColumn[columnId as KanbanColumnType]?.length ?? 0;
   };
 
+  const archiveGitLockDialog = (
+    <ArchiveGitLockDialog
+      open={archiveGitLockWorkspaceIds.length > 0}
+      onOpenChange={(open) => {
+        if (!open) {
+          dismissArchiveGitLock();
+        }
+      }}
+      workspaceCount={archiveGitLockWorkspaceIds.length}
+      onRetry={() => void retryGitLockedArchives(false)}
+      onRemoveLockAndArchive={() => void retryGitLockedArchives(true)}
+    />
+  );
+
   if (isLoading) {
     return (
       <div className="flex flex-col md:flex-row gap-3 md:gap-4 pb-4 h-full overflow-y-auto md:overflow-y-hidden md:overflow-x-auto mx-auto w-full max-w-[1800px]">
@@ -189,71 +203,75 @@ export function KanbanBoard() {
     }
 
     return (
-      <div className="flex flex-col h-full gap-3">
-        {/* Column pills */}
-        <div className="flex gap-1.5 shrink-0">
-          {columns.map((column) => {
-            const count = getColumnCount(column.id);
-            const isActive = column.id === activeColumnId;
-            return (
-              <button
-                key={column.id}
-                type="button"
-                onClick={() => setActiveColumnId(column.id)}
-                className={cn(
-                  'flex flex-1 items-center justify-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium whitespace-nowrap transition-colors',
-                  isActive
-                    ? 'bg-primary text-primary-foreground'
-                    : 'bg-muted text-muted-foreground hover:bg-muted/80'
-                )}
-              >
-                {column.shortLabel ?? column.label}
-                <span
+      <>
+        <div className="flex flex-col h-full gap-3">
+          {/* Column pills */}
+          <div className="flex gap-1.5 shrink-0">
+            {columns.map((column) => {
+              const count = getColumnCount(column.id);
+              const isActive = column.id === activeColumnId;
+              return (
+                <button
+                  key={column.id}
+                  type="button"
+                  onClick={() => setActiveColumnId(column.id)}
                   className={cn(
-                    'inline-flex items-center justify-center rounded-full min-w-4 h-4 px-1 text-[10px] font-semibold',
-                    isActive ? 'bg-primary-foreground/20' : 'bg-background/50'
+                    'flex flex-1 items-center justify-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium whitespace-nowrap transition-colors',
+                    isActive
+                      ? 'bg-primary text-primary-foreground'
+                      : 'bg-muted text-muted-foreground hover:bg-muted/80'
                   )}
                 >
-                  {count}
-                </span>
-              </button>
-            );
-          })}
+                  {column.shortLabel ?? column.label}
+                  <span
+                    className={cn(
+                      'inline-flex items-center justify-center rounded-full min-w-4 h-4 px-1 text-[10px] font-semibold',
+                      isActive ? 'bg-primary-foreground/20' : 'bg-background/50'
+                    )}
+                  >
+                    {count}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-8 shrink-0 w-full"
+            onClick={handleMobileNewTaskClick}
+          >
+            <PlusIcon className="h-4 w-4" />
+            New Task
+          </Button>
+
+          {/* Active column content */}
+          <div className="flex-1 min-h-0 overflow-y-auto">
+            {activeColumn.id === 'ISSUES' ? (
+              <IssuesColumn column={activeColumn} issues={issues ?? []} projectId={projectId} />
+            ) : (
+              <KanbanColumn
+                column={activeColumn}
+                workspaces={workspacesByColumn[activeColumn.id as KanbanColumnType] ?? []}
+                projectSlug={projectSlug}
+                onToggleRatcheting={toggleWorkspaceRatcheting}
+                togglingWorkspaceId={togglingWorkspaceId}
+                onArchive={archiveWorkspace}
+                onBulkArchive={() => handleBulkArchive(activeColumn.id)}
+                isBulkArchiving={isBulkArchiving}
+                onOpenQuickChat={openQuickChat}
+                onRename={renameWorkspace}
+              />
+            )}
+          </div>
+
+          <QuickChatSheet workspaceId={quickChatWorkspaceId} onClose={closeQuickChat} />
         </div>
 
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className="h-8 shrink-0 w-full"
-          onClick={handleMobileNewTaskClick}
-        >
-          <PlusIcon className="h-4 w-4" />
-          New Task
-        </Button>
-
-        {/* Active column content */}
-        <div className="flex-1 min-h-0 overflow-y-auto">
-          {activeColumn.id === 'ISSUES' ? (
-            <IssuesColumn column={activeColumn} issues={issues ?? []} projectId={projectId} />
-          ) : (
-            <KanbanColumn
-              column={activeColumn}
-              workspaces={workspacesByColumn[activeColumn.id as KanbanColumnType] ?? []}
-              projectSlug={projectSlug}
-              onToggleRatcheting={toggleWorkspaceRatcheting}
-              togglingWorkspaceId={togglingWorkspaceId}
-              onArchive={archiveWorkspace}
-              onBulkArchive={() => handleBulkArchive(activeColumn.id)}
-              isBulkArchiving={isBulkArchiving}
-              onOpenQuickChat={openQuickChat}
-              onRename={renameWorkspace}
-            />
-          )}
-        </div>
-
-        <QuickChatSheet workspaceId={quickChatWorkspaceId} onClose={closeQuickChat} />
-      </div>
+        {archiveGitLockDialog}
+      </>
     );
   }
 
@@ -304,17 +322,7 @@ export function KanbanBoard() {
         description={`This will archive all ${workspacesInBulkArchiveColumn.length} workspace(s) in this column. Any uncommitted changes will be committed before the worktrees are removed.`}
       />
 
-      <ArchiveGitLockDialog
-        open={archiveGitLockWorkspaceIds.length > 0}
-        onOpenChange={(open) => {
-          if (!open) {
-            dismissArchiveGitLock();
-          }
-        }}
-        workspaceCount={archiveGitLockWorkspaceIds.length}
-        onRetry={() => void retryGitLockedArchives(false)}
-        onRemoveLockAndArchive={() => void retryGitLockedArchives(true)}
-      />
+      {archiveGitLockDialog}
 
       <QuickChatSheet workspaceId={quickChatWorkspaceId} onClose={closeQuickChat} />
     </>

--- a/src/client/features/kanban/kanban-card.tsx
+++ b/src/client/features/kanban/kanban-card.tsx
@@ -44,7 +44,7 @@ interface KanbanCardProps {
   projectSlug: string;
   onToggleRatcheting?: (workspaceId: string, enabled: boolean) => void;
   isTogglePending?: boolean;
-  onArchive?: (workspaceId: string, commitUncommitted: boolean) => void;
+  onArchive?: (workspaceId: string) => void;
   onOpenQuickChat?: (workspaceId: string) => void;
   onRename?: (workspaceId: string, name: string) => Promise<void>;
 }
@@ -164,7 +164,7 @@ function CardArchiveButton({
   onArchive,
 }: {
   workspace: WorkspaceWithKanban;
-  onArchive: (workspaceId: string, commitUncommitted: boolean) => void;
+  onArchive: (workspaceId: string) => void;
 }) {
   const [dialogOpen, setDialogOpen] = useState(false);
   const requiresConfirmation = !isWorkspaceDoneOrMerged(workspace);
@@ -179,7 +179,7 @@ function CardArchiveButton({
     e.preventDefault();
     e.stopPropagation();
     if (!requiresConfirmation) {
-      onArchive(workspace.id, true);
+      onArchive(workspace.id);
       return;
     }
     setDialogOpen(true);
@@ -207,8 +207,7 @@ function CardArchiveButton({
         <ArchiveWorkspaceDialog
           open={dialogOpen}
           onOpenChange={setDialogOpen}
-          hasUncommitted={false}
-          onConfirm={(commitUncommitted) => onArchive(workspace.id, commitUncommitted)}
+          onConfirm={() => onArchive(workspace.id)}
           activeChildCount={activeChildCount}
         />
       )}
@@ -233,7 +232,7 @@ function CardTitleIcons({
   isArchived: boolean;
   sessionRuntimeError: string | null;
   onToggleRatcheting?: (workspaceId: string, enabled: boolean) => void;
-  onArchive?: (workspaceId: string, commitUncommitted: boolean) => void;
+  onArchive?: (workspaceId: string) => void;
   onOpenQuickChat?: (workspaceId: string) => void;
   onStartEdit?: () => void;
 }) {

--- a/src/client/features/kanban/kanban-column.tsx
+++ b/src/client/features/kanban/kanban-column.tsx
@@ -43,7 +43,7 @@ interface KanbanColumnProps {
   projectSlug: string;
   onToggleRatcheting?: (workspaceId: string, enabled: boolean) => void;
   togglingWorkspaceId?: string | null;
-  onArchive?: (workspaceId: string, commitUncommitted: boolean) => void;
+  onArchive?: (workspaceId: string) => void;
   onBulkArchive?: () => void;
   isBulkArchiving?: boolean;
   onOpenQuickChat?: (workspaceId: string) => void;

--- a/src/client/features/kanban/kanban-context.test.tsx
+++ b/src/client/features/kanban/kanban-context.test.tsx
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { KanbanProvider, useKanban } from './kanban-context';
 
 interface ArchiveError {
-  data?: { code?: string | null };
+  data?: { code?: string | null; applicationErrorKind?: string | null };
   message?: string;
 }
 
@@ -28,6 +28,7 @@ interface BulkArchiveResult {
   success: boolean;
   error?: string;
   code?: string;
+  applicationErrorKind?: string | null;
 }
 
 interface MutationOptions {
@@ -46,6 +47,8 @@ const mocks = vi.hoisted(() => ({
   refetchWorkspacesMock: vi.fn(),
   refetchGitHubIssuesMock: vi.fn(),
   refetchLinearIssuesMock: vi.fn(),
+  archiveInputs: [] as unknown[],
+  bulkArchiveInputs: [] as unknown[],
   workspaceListState: undefined as ProjectWorkspaceCache | undefined,
 }));
 
@@ -63,11 +66,13 @@ vi.mock('@/client/hooks/use-toggle-ratcheting', () => ({
 
 function rejectingMutation(
   getError: () => ArchiveError | undefined,
-  getSuccessData: () => unknown = () => undefined
+  getSuccessData: () => unknown = () => undefined,
+  recordInput: (input: unknown) => void = () => undefined
 ) {
   return {
     useMutation: (options: MutationOptions = {}) => ({
-      mutateAsync: vi.fn(() => {
+      mutateAsync: vi.fn((input: unknown) => {
+        recordInput(input);
         const error = getError();
         if (!error) {
           return Promise.resolve(getSuccessData());
@@ -131,10 +136,15 @@ vi.mock('@/client/lib/trpc', () => ({
       rename: {
         useMutation: () => ({ mutateAsync: vi.fn() }),
       },
-      archive: rejectingMutation(() => mocks.archiveError),
+      archive: rejectingMutation(
+        () => mocks.archiveError,
+        () => undefined,
+        (input) => mocks.archiveInputs.push(input)
+      ),
       bulkArchive: rejectingMutation(
         () => mocks.bulkArchiveError,
-        () => ({ results: mocks.bulkArchiveResults, total: mocks.bulkArchiveResults.length })
+        () => ({ results: mocks.bulkArchiveResults, total: mocks.bulkArchiveResults.length }),
+        (input) => mocks.bulkArchiveInputs.push(input)
       ),
     },
   },
@@ -189,6 +199,8 @@ beforeEach(() => {
   vi.clearAllMocks();
   mocks.archiveError = undefined;
   mocks.bulkArchiveError = undefined;
+  mocks.archiveInputs = [];
+  mocks.bulkArchiveInputs = [];
   mocks.bulkArchiveResults = [{ id: 'workspace-1', success: true }];
   mocks.refetchWorkspacesMock.mockResolvedValue({ isError: false });
   mocks.workspaceListState = {
@@ -229,23 +241,6 @@ afterEach(() => {
 });
 
 describe('KanbanProvider archive failure handling', () => {
-  it('handles an archive precondition failure and rolls back the optimistic removal', async () => {
-    mocks.archiveError = { data: { code: 'PRECONDITION_FAILED' }, message: 'blocked' };
-    const kanban = renderProvider();
-
-    await expectArchiveToResolve(() => kanban.archiveWorkspace('workspace-1', false));
-
-    expect(mocks.toastErrorMock).toHaveBeenCalledWith(
-      'Archiving blocked: enable commit before archiving to proceed.'
-    );
-    expect(mocks.workspaceListSetDataMock).toHaveBeenCalledTimes(2);
-    expect(mocks.workspaceListState?.workspaces.map((workspace) => workspace.id)).toEqual([
-      'workspace-1',
-      'workspace-2',
-    ]);
-    expectVisibleWorkspaceIds(['workspace-1', 'workspace-2']);
-  });
-
   it('handles an archive service failure and rolls back the optimistic removal', async () => {
     mocks.archiveError = {
       data: { code: 'INTERNAL_SERVER_ERROR' },
@@ -253,7 +248,7 @@ describe('KanbanProvider archive failure handling', () => {
     };
     const kanban = renderProvider();
 
-    await expectArchiveToResolve(() => kanban.archiveWorkspace('workspace-1', false));
+    await expectArchiveToResolve(() => kanban.archiveWorkspace('workspace-1'));
 
     expect(mocks.toastErrorMock).toHaveBeenCalledWith('Archive service unavailable');
     expect(mocks.workspaceListSetDataMock).toHaveBeenCalledTimes(2);
@@ -264,6 +259,28 @@ describe('KanbanProvider archive failure handling', () => {
     expectVisibleWorkspaceIds(['workspace-1', 'workspace-2']);
   });
 
+  it('offers recovery instead of a toast for a Git index-lock conflict', async () => {
+    mocks.archiveError = {
+      data: { code: 'CONFLICT', applicationErrorKind: 'GIT_INDEX_LOCKED' },
+      message: 'Git is locked',
+    };
+    const kanban = renderProvider();
+
+    await expectArchiveToResolve(() => kanban.archiveWorkspace('workspace-1'));
+    rerenderProvider();
+
+    expect(mocks.toastErrorMock).not.toHaveBeenCalled();
+    expect(context?.archiveGitLockWorkspaceIds).toEqual(['workspace-1']);
+
+    mocks.archiveError = undefined;
+    await expectArchiveToResolve(() => context!.retryGitLockedArchives(true));
+
+    expect(mocks.archiveInputs.at(-1)).toEqual({
+      id: 'workspace-1',
+      removeGitIndexLock: true,
+    });
+  });
+
   it('handles a bulk archive failure and rolls back the optimistic removals', async () => {
     mocks.bulkArchiveError = {
       data: { code: 'INTERNAL_SERVER_ERROR' },
@@ -271,7 +288,7 @@ describe('KanbanProvider archive failure handling', () => {
     };
     const kanban = renderProvider();
 
-    await expectArchiveToResolve(() => kanban.bulkArchiveColumn('WAITING', true));
+    await expectArchiveToResolve(() => kanban.bulkArchiveColumn('WAITING'));
 
     expect(mocks.toastErrorMock).toHaveBeenCalledWith('Bulk archive unavailable');
     expect(mocks.workspaceListSetDataMock).toHaveBeenCalledTimes(2);
@@ -286,7 +303,7 @@ describe('KanbanProvider archive failure handling', () => {
     mocks.refetchWorkspacesMock.mockRejectedValueOnce(new Error('Workspace refetch failed'));
     const kanban = renderProvider();
 
-    await expectArchiveToResolve(() => kanban.archiveWorkspace('workspace-1', false));
+    await expectArchiveToResolve(() => kanban.archiveWorkspace('workspace-1'));
     rerenderProvider();
 
     expect(mocks.workspaceListSetDataMock).toHaveBeenCalledTimes(1);
@@ -299,7 +316,7 @@ describe('KanbanProvider archive failure handling', () => {
   it('keeps a successful bulk archive removed when cache invalidation fails', async () => {
     const kanban = renderProvider();
 
-    await expectArchiveToResolve(() => kanban.bulkArchiveColumn('WAITING', true));
+    await expectArchiveToResolve(() => kanban.bulkArchiveColumn('WAITING'));
     rerenderProvider();
 
     expect(mocks.workspaceListSetDataMock).toHaveBeenCalledTimes(1);
@@ -314,14 +331,14 @@ describe('KanbanProvider archive failure handling', () => {
       {
         id: 'workspace-1',
         success: false,
-        error: 'blocked',
-        code: 'PRECONDITION_FAILED',
+        error: 'Archive service unavailable',
+        code: 'INTERNAL_SERVER_ERROR',
       },
     ];
     mocks.refetchWorkspacesMock.mockRejectedValueOnce(new Error('Workspace refetch failed'));
     const kanban = renderProvider();
 
-    await expectArchiveToResolve(() => kanban.bulkArchiveColumn('WAITING', true));
+    await expectArchiveToResolve(() => kanban.bulkArchiveColumn('WAITING'));
     rerenderProvider();
 
     expect(mocks.workspaceListState?.workspaces.map((workspace) => workspace.id)).toEqual([
@@ -329,9 +346,7 @@ describe('KanbanProvider archive failure handling', () => {
       'workspace-2',
     ]);
     expectVisibleWorkspaceIds(['workspace-1', 'workspace-2']);
-    expect(mocks.toastErrorMock).toHaveBeenCalledWith(
-      'Archiving blocked: enable commit before archiving to proceed.'
-    );
+    expect(mocks.toastErrorMock).toHaveBeenCalledWith('Archive service unavailable');
   });
 
   it('keeps workspaces omitted from bulk archive results removed', async () => {
@@ -344,7 +359,7 @@ describe('KanbanProvider archive failure handling', () => {
     mocks.refetchWorkspacesMock.mockRejectedValueOnce(new Error('Workspace refetch failed'));
     const kanban = renderProvider();
 
-    await expectArchiveToResolve(() => kanban.bulkArchiveColumn('WAITING', true));
+    await expectArchiveToResolve(() => kanban.bulkArchiveColumn('WAITING'));
     rerenderProvider();
 
     expect(mocks.workspaceListState?.workspaces.map((workspace) => workspace.id)).toEqual([
@@ -352,5 +367,25 @@ describe('KanbanProvider archive failure handling', () => {
     ]);
     expectVisibleWorkspaceIds(['workspace-2']);
     expect(mocks.toastErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('offers recovery only for the locked subset of a bulk archive', async () => {
+    mocks.bulkArchiveResults = [
+      {
+        id: 'workspace-1',
+        success: false,
+        error: 'Git is locked',
+        code: 'CONFLICT',
+        applicationErrorKind: 'GIT_INDEX_LOCKED',
+      },
+    ];
+    const kanban = renderProvider();
+
+    await expectArchiveToResolve(() => kanban.bulkArchiveColumn('WAITING'));
+    rerenderProvider();
+
+    expect(mocks.toastErrorMock).not.toHaveBeenCalled();
+    expect(context?.archiveGitLockWorkspaceIds).toEqual(['workspace-1']);
+    expect(mocks.bulkArchiveInputs).toEqual([{ projectId: 'project-1', kanbanColumn: 'WAITING' }]);
   });
 });

--- a/src/client/features/kanban/kanban-context.tsx
+++ b/src/client/features/kanban/kanban-context.tsx
@@ -5,6 +5,7 @@ import { useToggleRatcheting } from '@/client/hooks/use-toggle-ratcheting';
 import type { NormalizedIssue } from '@/client/lib/issue-normalization';
 import type { WorkspaceIssueLink } from '@/client/lib/project-issue-visibility';
 import { trpc } from '@/client/lib/trpc';
+import { isArchiveGitIndexLockedError } from '@/client/lib/workspace-archive';
 import {
   removeWorkspaceFromProjectWorkspaceCache,
   removeWorkspacesFromProjectWorkspaceCache,
@@ -28,8 +29,11 @@ interface KanbanContextValue {
   toggleWorkspaceRatcheting: (workspaceId: string, enabled: boolean) => Promise<void>;
   togglingWorkspaceId: string | null;
   renameWorkspace: (workspaceId: string, name: string) => Promise<void>;
-  archiveWorkspace: (workspaceId: string, commitUncommitted: boolean) => Promise<void>;
-  bulkArchiveColumn: (kanbanColumn: string, commitUncommitted: boolean) => Promise<void>;
+  archiveWorkspace: (workspaceId: string, removeGitIndexLock?: boolean) => Promise<void>;
+  bulkArchiveColumn: (kanbanColumn: string) => Promise<void>;
+  archiveGitLockWorkspaceIds: string[];
+  dismissArchiveGitLock: () => void;
+  retryGitLockedArchives: (removeGitIndexLock: boolean) => Promise<void>;
   isBulkArchiving: boolean;
   showInlineForm: boolean;
   setShowInlineForm: (show: boolean) => void;
@@ -93,23 +97,11 @@ export function KanbanProvider({
   const renameMutation = trpc.workspace.rename.useMutation({
     onError: (error) => toast.error(`Failed to rename workspace: ${error.message}`),
   });
-  const handleArchiveError = (error: {
-    data?: { code?: string | null } | null;
-    message?: string;
-  }) => {
-    if (error.data?.code === 'PRECONDITION_FAILED') {
-      toast.error('Archiving blocked: enable commit before archiving to proceed.');
-    } else {
-      toast.error(error.message || 'Failed to archive workspace');
-    }
-  };
-
-  const archiveMutation = trpc.workspace.archive.useMutation({ onError: handleArchiveError });
-  const bulkArchiveMutation = trpc.workspace.bulkArchive.useMutation({
-    onError: handleArchiveError,
-  });
+  const archiveMutation = trpc.workspace.archive.useMutation();
+  const bulkArchiveMutation = trpc.workspace.bulkArchive.useMutation();
   const [togglingWorkspaceId, setTogglingWorkspaceId] = useState<string | null>(null);
   const [archivingWorkspaceIds, setArchivingWorkspaceIds] = useState<Set<string>>(new Set());
+  const [archiveGitLockWorkspaceIds, setArchiveGitLockWorkspaceIds] = useState<string[]>([]);
   const [archivingWorkspaceIssueLinks, setArchivingWorkspaceIssueLinks] = useState<
     Map<string, WorkspaceIssueLink>
   >(new Map());
@@ -128,6 +120,21 @@ export function KanbanProvider({
     []
   );
   const closeQuickChat = useCallback(() => setQuickChatWorkspaceId(null), []);
+
+  const handleArchiveError = (error: unknown, workspaceIds: string[]) => {
+    if (isArchiveGitIndexLockedError(error)) {
+      setArchiveGitLockWorkspaceIds((current) => [...new Set([...current, ...workspaceIds])]);
+      return;
+    }
+    const message =
+      typeof error === 'object' &&
+      error !== null &&
+      'message' in error &&
+      typeof error.message === 'string'
+        ? error.message
+        : 'Failed to archive workspace';
+    toast.error(message);
+  };
 
   const syncAndRefetch = () => {
     syncMutation.mutate({ projectId });
@@ -154,7 +161,7 @@ export function KanbanProvider({
     await Promise.all([refetchWorkspaces(), utils.workspace.get.invalidate({ id: workspaceId })]);
   };
 
-  const archiveWorkspace = async (workspaceId: string, commitUncommitted: boolean) => {
+  const archiveWorkspace = async (workspaceId: string, removeGitIndexLock = false) => {
     const workspace = workspaces?.find((item) => item.id === workspaceId);
 
     await utils.workspace.listForProject.cancel({ projectId });
@@ -180,13 +187,14 @@ export function KanbanProvider({
     });
     try {
       try {
-        await archiveMutation.mutateAsync({ id: workspaceId, commitUncommitted });
-      } catch {
+        await archiveMutation.mutateAsync(
+          removeGitIndexLock ? { id: workspaceId, removeGitIndexLock: true } : { id: workspaceId }
+        );
+      } catch (error) {
         utils.workspace.listForProject.setData({ projectId }, (old) =>
           restoreWorkspacesToProjectWorkspaceCache(old, previousWorkspaces, [workspaceId])
         );
-        // Error feedback is surfaced by the mutation's onError toast;
-        // callers fire-and-forget, so don't propagate an unhandled rejection.
+        handleArchiveError(error, [workspaceId]);
         return;
       }
 
@@ -214,7 +222,7 @@ export function KanbanProvider({
     }
   };
 
-  const bulkArchiveColumn = async (kanbanColumn: string, commitUncommitted: boolean) => {
+  const bulkArchiveColumn = async (kanbanColumn: string) => {
     const workspacesToArchive = (workspaces ?? []).filter(
       (workspace) => workspace.kanbanColumn === kanbanColumn
     );
@@ -252,27 +260,31 @@ export function KanbanProvider({
         const result = await bulkArchiveMutation.mutateAsync({
           projectId,
           kanbanColumn: kanbanColumn as 'WORKING' | 'WAITING' | 'DONE',
-          commitUncommitted,
         });
         const failedResults = result.results.filter((item) => !item.success);
         const failedWorkspaceIds = failedResults.map((item) => item.id);
         for (const failedResult of failedResults) {
-          handleArchiveError({
-            data: { code: failedResult.code },
-            message: failedResult.error,
-          });
+          handleArchiveError(
+            {
+              data: {
+                code: failedResult.code,
+                applicationErrorKind: failedResult.applicationErrorKind,
+              },
+              message: failedResult.error,
+            },
+            [failedResult.id]
+          );
         }
         if (failedWorkspaceIds.length > 0) {
           utils.workspace.listForProject.setData({ projectId }, (old) =>
             restoreWorkspacesToProjectWorkspaceCache(old, previousWorkspaces, failedWorkspaceIds)
           );
         }
-      } catch {
+      } catch (error) {
         utils.workspace.listForProject.setData({ projectId }, (old) =>
           restoreWorkspacesToProjectWorkspaceCache(old, previousWorkspaces, workspaceIdsToArchive)
         );
-        // Error feedback is surfaced by the mutation's onError toast;
-        // callers fire-and-forget, so don't propagate an unhandled rejection.
+        handleArchiveError(error, workspaceIdsToArchive);
         return;
       }
 
@@ -295,6 +307,16 @@ export function KanbanProvider({
         }
         return next;
       });
+    }
+  };
+
+  const dismissArchiveGitLock = () => setArchiveGitLockWorkspaceIds([]);
+
+  const retryGitLockedArchives = async (removeGitIndexLock: boolean) => {
+    const workspaceIds = archiveGitLockWorkspaceIds;
+    setArchiveGitLockWorkspaceIds([]);
+    for (const workspaceId of workspaceIds) {
+      await archiveWorkspace(workspaceId, removeGitIndexLock);
     }
   };
 
@@ -327,6 +349,9 @@ export function KanbanProvider({
         renameWorkspace,
         archiveWorkspace,
         bulkArchiveColumn,
+        archiveGitLockWorkspaceIds,
+        dismissArchiveGitLock,
+        retryGitLockedArchives,
         isBulkArchiving: bulkArchiveMutation.isPending,
         showInlineForm,
         setShowInlineForm,

--- a/src/client/features/workspace/archive-git-lock-dialog.stories.tsx
+++ b/src/client/features/workspace/archive-git-lock-dialog.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import { ArchiveGitLockDialog } from './archive-git-lock-dialog';
+
+const meta = {
+  title: 'Workspace/ArchiveGitLockDialog',
+  component: ArchiveGitLockDialog,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  args: {
+    open: true,
+    onOpenChange: fn(),
+    onRetry: fn(),
+    onRemoveLockAndArchive: fn(),
+  },
+} satisfies Meta<typeof ArchiveGitLockDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const SingleWorkspace: Story = {};
+
+export const MultipleWorkspaces: Story = {
+  args: {
+    workspaceCount: 3,
+  },
+};

--- a/src/client/features/workspace/archive-git-lock-dialog.test.tsx
+++ b/src/client/features/workspace/archive-git-lock-dialog.test.tsx
@@ -8,8 +8,13 @@ import { ArchiveGitLockDialog } from './archive-git-lock-dialog';
 describe('ArchiveGitLockDialog', () => {
   let container: HTMLDivElement;
   let root: Root;
+  let originalActEnvironmentDescriptor: PropertyDescriptor | undefined;
 
   beforeEach(() => {
+    originalActEnvironmentDescriptor = Object.getOwnPropertyDescriptor(
+      globalThis,
+      'IS_REACT_ACT_ENVIRONMENT'
+    );
     Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
       configurable: true,
       writable: true,
@@ -21,8 +26,20 @@ describe('ArchiveGitLockDialog', () => {
   });
 
   afterEach(() => {
-    void act(() => root.unmount());
-    document.body.innerHTML = '';
+    try {
+      void act(() => root.unmount());
+      document.body.innerHTML = '';
+    } finally {
+      if (originalActEnvironmentDescriptor) {
+        Object.defineProperty(
+          globalThis,
+          'IS_REACT_ACT_ENVIRONMENT',
+          originalActEnvironmentDescriptor
+        );
+      } else {
+        Reflect.deleteProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT');
+      }
+    }
   });
 
   it('offers a safe retry and an explicit remove-lock recovery action', () => {

--- a/src/client/features/workspace/archive-git-lock-dialog.test.tsx
+++ b/src/client/features/workspace/archive-git-lock-dialog.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ArchiveGitLockDialog } from './archive-git-lock-dialog';
+
+describe('ArchiveGitLockDialog', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
+      configurable: true,
+      writable: true,
+      value: true,
+    });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    void act(() => root.unmount());
+    document.body.innerHTML = '';
+  });
+
+  it('offers a safe retry and an explicit remove-lock recovery action', () => {
+    const onOpenChange = vi.fn();
+    const onRetry = vi.fn();
+    const onRemoveLockAndArchive = vi.fn();
+    void act(() => {
+      root.render(
+        createElement(ArchiveGitLockDialog, {
+          open: true,
+          onOpenChange,
+          onRetry,
+          onRemoveLockAndArchive,
+        })
+      );
+    });
+
+    expect(document.body.textContent).toContain('Another Git operation may be running');
+
+    const retryButton = [...document.querySelectorAll('button')].find(
+      (button) => button.textContent === 'Retry'
+    );
+    const removeButton = [...document.querySelectorAll('button')].find(
+      (button) => button.textContent === 'Remove Lock and Archive'
+    );
+    expect(retryButton).toBeDefined();
+    expect(removeButton).toBeDefined();
+
+    void act(() => retryButton?.click());
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onRetry).toHaveBeenCalledOnce();
+
+    void act(() => removeButton?.click());
+    expect(onRemoveLockAndArchive).toHaveBeenCalledOnce();
+  });
+});

--- a/src/client/features/workspace/archive-git-lock-dialog.tsx
+++ b/src/client/features/workspace/archive-git-lock-dialog.tsx
@@ -1,0 +1,73 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Button, buttonVariants } from '@/components/ui/button';
+
+export interface ArchiveGitLockDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onRetry: () => void;
+  onRemoveLockAndArchive: () => void;
+  workspaceCount?: number;
+  isPending?: boolean;
+}
+
+export function ArchiveGitLockDialog({
+  open,
+  onOpenChange,
+  onRetry,
+  onRemoveLockAndArchive,
+  workspaceCount = 1,
+  isPending = false,
+}: ArchiveGitLockDialogProps) {
+  const plural = workspaceCount !== 1;
+
+  const runAndClose = (action: () => void) => {
+    onOpenChange(false);
+    action();
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Git is locked</AlertDialogTitle>
+          <AlertDialogDescription>
+            Another Git operation may be running, or an earlier operation may have stopped
+            unexpectedly. Retry without changing the lock, or remove the lock and archive
+            {plural ? ` the ${workspaceCount} affected workspaces` : ' this workspace'}. Remove the
+            lock only if you are sure no other Git operation is running.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={isPending}
+            onClick={() => runAndClose(onRetry)}
+          >
+            Retry
+          </Button>
+          <AlertDialogAction
+            disabled={isPending}
+            className={buttonVariants({ variant: 'destructive' })}
+            onClick={(event) => {
+              event.preventDefault();
+              runAndClose(onRemoveLockAndArchive);
+            }}
+          >
+            Remove Lock and Archive
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/client/features/workspace/archive-workspace-dialog.stories.tsx
+++ b/src/client/features/workspace/archive-workspace-dialog.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import { ArchiveWorkspaceDialog } from './archive-workspace-dialog';
+
+const meta = {
+  title: 'Workspace/ArchiveWorkspaceDialog',
+  component: ArchiveWorkspaceDialog,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  args: {
+    open: true,
+    onOpenChange: fn(),
+    onConfirm: fn(),
+  },
+} satisfies Meta<typeof ArchiveWorkspaceDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithActiveChildren: Story = {
+  args: {
+    activeChildCount: 2,
+  },
+};

--- a/src/client/features/workspace/archive-workspace-dialog.test.tsx
+++ b/src/client/features/workspace/archive-workspace-dialog.test.tsx
@@ -42,26 +42,26 @@ describe('ArchiveWorkspaceDialog', () => {
     }
   });
 
-  it('blocks archive confirmation while Git status is loading', () => {
+  it('always allows archive confirmation and does not expose a commit choice', () => {
     const onConfirm = vi.fn();
     void act(() => {
       root.render(
         createElement(ArchiveWorkspaceDialog, {
           open: true,
           onOpenChange: vi.fn(),
-          hasUncommitted: false,
-          isCheckingGitStatus: true,
           onConfirm,
         })
       );
     });
 
-    const archiveButton = [...document.querySelectorAll('button')].find((button) =>
-      button.textContent?.includes('Checking changes')
+    const archiveButton = [...document.querySelectorAll('button')].find(
+      (button) => button.textContent === 'Archive'
     );
-    expect(archiveButton?.disabled).toBe(true);
+    expect(archiveButton?.disabled).toBe(false);
+    expect(document.querySelector('[role="checkbox"]')).toBeNull();
+    expect(document.body.textContent).toContain('committed before the worktree is removed');
 
     void act(() => archiveButton?.click());
-    expect(onConfirm).not.toHaveBeenCalled();
+    expect(onConfirm).toHaveBeenCalledWith();
   });
 });

--- a/src/client/features/workspace/archive-workspace-dialog.tsx
+++ b/src/client/features/workspace/archive-workspace-dialog.tsx
@@ -1,5 +1,3 @@
-import { useEffect, useState } from 'react';
-
 import {
   AlertDialog,
   AlertDialogAction,
@@ -11,23 +9,15 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
 import { buttonVariants } from '@/components/ui/button';
-import { Checkbox } from '@/components/ui/checkbox';
 
-const defaultDescription = 'Archiving will remove the workspace worktree from disk.';
-const defaultWarning =
-  'Warning: This workspace has uncommitted changes and they will be committed before archiving.';
-const defaultLabel = 'Commit uncommitted changes before archiving';
+const defaultDescription =
+  'Any uncommitted changes will be committed before the worktree is removed.';
 
 export type ArchiveWorkspaceDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  hasUncommitted: boolean;
-  isCheckingGitStatus?: boolean;
-  showCommitOption?: boolean;
-  onConfirm: (commitUncommitted: boolean) => void;
+  onConfirm: () => void;
   description?: string;
-  warningText?: string;
-  checkboxLabel?: string;
   /** Number of active (non-archived) child workspaces */
   activeChildCount?: number;
 };
@@ -35,23 +25,10 @@ export type ArchiveWorkspaceDialogProps = {
 export function ArchiveWorkspaceDialog({
   open,
   onOpenChange,
-  hasUncommitted,
-  isCheckingGitStatus = false,
-  showCommitOption = true,
   onConfirm,
   description = defaultDescription,
-  warningText = defaultWarning,
-  checkboxLabel = defaultLabel,
   activeChildCount = 0,
 }: ArchiveWorkspaceDialogProps) {
-  const [commitChangesChecked, setCommitChangesChecked] = useState(true);
-
-  useEffect(() => {
-    if (open) {
-      setCommitChangesChecked(true);
-    }
-  }, [open]);
-
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
       <AlertDialogContent
@@ -70,20 +47,6 @@ export function ArchiveWorkspaceDialog({
               {activeChildCount !== 1 ? 's' : ''}. Archiving will not automatically archive them.
             </div>
           )}
-          {hasUncommitted && (
-            <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-              {warningText}
-            </div>
-          )}
-          {showCommitOption && (
-            <label className="flex items-center gap-2 text-sm">
-              <Checkbox
-                checked={commitChangesChecked}
-                onCheckedChange={(checked) => setCommitChangesChecked(checked === true)}
-              />
-              {checkboxLabel}
-            </label>
-          )}
         </div>
         <AlertDialogFooter>
           <AlertDialogCancel
@@ -99,15 +62,12 @@ export function ArchiveWorkspaceDialog({
             onClick={(event) => {
               event.preventDefault();
               event.stopPropagation();
-              onConfirm(showCommitOption ? commitChangesChecked : true);
+              onConfirm();
               onOpenChange(false);
             }}
-            disabled={
-              isCheckingGitStatus || (showCommitOption && hasUncommitted && !commitChangesChecked)
-            }
             className={buttonVariants({ variant: 'destructive' })}
           >
-            {isCheckingGitStatus ? 'Checking changes…' : 'Archive'}
+            Archive
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/src/client/features/workspace/index.ts
+++ b/src/client/features/workspace/index.ts
@@ -1,3 +1,4 @@
+export * from './archive-git-lock-dialog';
 export * from './archive-workspace-dialog';
 export * from './auto-iteration-panel';
 export * from './dev-server-setup-panel';

--- a/src/client/lib/workspace-archive.test.ts
+++ b/src/client/lib/workspace-archive.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isWorkspaceDoneOrMerged } from './workspace-archive';
+import { isArchiveGitIndexLockedError, isWorkspaceDoneOrMerged } from './workspace-archive';
 
 describe('isWorkspaceDoneOrMerged', () => {
   it('returns true when PR state is merged', () => {
@@ -43,5 +43,21 @@ describe('isWorkspaceDoneOrMerged', () => {
         kanbanColumn: 'WAITING',
       })
     ).toBe(false);
+  });
+});
+
+describe('isArchiveGitIndexLockedError', () => {
+  it('recognizes only the machine-readable Git index-lock kind', () => {
+    expect(
+      isArchiveGitIndexLockedError({
+        data: { applicationErrorKind: 'GIT_INDEX_LOCKED' },
+      })
+    ).toBe(true);
+    expect(
+      isArchiveGitIndexLockedError({
+        data: { code: 'CONFLICT', applicationErrorKind: null },
+      })
+    ).toBe(false);
+    expect(isArchiveGitIndexLockedError(new Error('Git is locked'))).toBe(false);
   });
 });

--- a/src/client/lib/workspace-archive.ts
+++ b/src/client/lib/workspace-archive.ts
@@ -9,6 +9,19 @@ interface ArchiveWorkspaceStateLike {
   } | null;
 }
 
+interface ArchiveErrorLike {
+  data?: {
+    applicationErrorKind?: string | null;
+  } | null;
+}
+
+export function isArchiveGitIndexLockedError(error: unknown): boolean {
+  if (!(typeof error === 'object' && error !== null && 'data' in error)) {
+    return false;
+  }
+  return (error as ArchiveErrorLike).data?.applicationErrorKind === 'GIT_INDEX_LOCKED';
+}
+
 /**
  * Treat completed PRs and DONE kanban workspaces as safe-to-archive without
  * showing commit-before-archive warnings.

--- a/src/client/routes/projects/workspaces/use-workspace-detail.ts
+++ b/src/client/routes/projects/workspaces/use-workspace-detail.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router';
 import { toast } from 'sonner';
 import { trpc } from '@/client/lib/trpc';
+import { isArchiveGitIndexLockedError } from '@/client/lib/workspace-archive';
 import {
   removeWorkspaceFromProjectWorkspaceCache,
   restoreWorkspacesToProjectWorkspaceCache,
@@ -101,6 +102,7 @@ interface UseSessionManagementOptions {
   selectedModel: string;
   /** Provider selection for newly created sessions */
   selectedProvider: SessionProviderValue;
+  onArchiveGitIndexLocked: () => void;
 }
 
 export type { NewSessionProviderSelection };
@@ -135,7 +137,7 @@ export interface UseSessionManagementReturn {
     { id: string }
   >;
   deleteSession: MutationLike<{ id: string }>;
-  archiveWorkspace: MutationLike<{ id: string; commitUncommitted?: boolean }>;
+  archiveWorkspace: MutationLike<{ id: string; removeGitIndexLock?: true }>;
   openInIde: MutationLike<{ id: string }>;
   availableIdes: AvailableIde[];
   preferredIde: string;
@@ -154,6 +156,7 @@ export function useSessionManagement({
   setSelectedDbSessionId,
   selectedModel,
   selectedProvider,
+  onArchiveGitIndexLocked,
 }: UseSessionManagementOptions): UseSessionManagementReturn {
   const navigate = useNavigate();
   const utils = trpc.useUtils();
@@ -219,16 +222,16 @@ export function useSessionManagement({
       }
     },
     onError: (error, _variables, context) => {
-      if (error.data?.code === 'PRECONDITION_FAILED') {
-        toast.error('Archiving blocked: enable commit before archiving to proceed.');
-      } else {
-        toast.error(error.message || 'Failed to archive workspace');
-      }
-
       if (context?.projectId && context.previousWorkspaces) {
         utils.workspace.listForProject.setData({ projectId: context.projectId }, (old) =>
           restoreWorkspacesToProjectWorkspaceCache(old, context.previousWorkspaces, [_variables.id])
         );
+      }
+
+      if (isArchiveGitIndexLockedError(error)) {
+        onArchiveGitIndexLocked();
+      } else {
+        toast.error(error.message || 'Failed to archive workspace');
       }
     },
     onSettled: (_data, _error, variables, context) => {

--- a/src/client/routes/projects/workspaces/workspace-detail-container.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-container.tsx
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { useChatWebSocket } from '@/client/features/chat';
-import { usePersistentScroll, useWorkspacePanel } from '@/client/features/workspace';
+import {
+  ArchiveGitLockDialog,
+  usePersistentScroll,
+  useWorkspacePanel,
+} from '@/client/features/workspace';
 import { trpc } from '@/client/lib/trpc';
 import { isWorkspaceDoneOrMerged } from '@/client/lib/workspace-archive';
 import { resolveWorkspaceFileLink } from '@/client/lib/workspace-file-links';
@@ -22,7 +26,6 @@ import {
 import type { ChatContentProps } from './workspace-detail-chat-content';
 import {
   buildSessionSummariesById,
-  getArchiveGitStatusQueryOptions,
   getVisibleInitBanner,
   hasUserMessageWithoutAgentMessage,
 } from './workspace-detail-container.utils';
@@ -74,6 +77,7 @@ export function WorkspaceDetailContainer() {
     sessionIds
   );
   const [archiveDialogOpen, setArchiveDialogOpen] = useState(false);
+  const [archiveGitLockDialogOpen, setArchiveGitLockDialogOpen] = useState(false);
   const isParentWorkspace = workspace?.creationSource !== 'CHILD_WORKSPACE';
   const effectiveDefaultProvider = resolveEffectiveSessionProvider(
     workspace?.defaultSessionProvider,
@@ -85,11 +89,6 @@ export function WorkspaceDetailContainer() {
     setSelectedProvider(effectiveDefaultProvider);
   }, [effectiveDefaultProvider]);
 
-  const { data: gitStatus, isFetching: isGitStatusFetching } = trpc.workspace.getGitStatus.useQuery(
-    { workspaceId },
-    getArchiveGitStatusQueryOptions(archiveDialogOpen, workspace?.worktreePath)
-  );
-  const hasUncommitted = gitStatus?.hasUncommitted === true;
   const isDoneOrMergedWorkspace = isWorkspaceDoneOrMerged(workspace);
   const { data: childWorkspaces } = trpc.workspace.listChildren.useQuery(
     { parentWorkspaceId: workspaceId },
@@ -192,19 +191,21 @@ export function WorkspaceDetailContainer() {
     setSelectedDbSessionId,
     selectedModel: chatSettings.selectedModel,
     selectedProvider,
+    onArchiveGitIndexLocked: () => setArchiveGitLockDialogOpen(true),
   });
 
   const handleArchive = useCallback(
-    (commitUncommitted: boolean) => {
-      archiveWorkspace.mutate({ id: workspaceId, commitUncommitted });
+    (removeGitIndexLock = false) => {
+      archiveWorkspace.mutate(
+        removeGitIndexLock ? { id: workspaceId, removeGitIndexLock: true } : { id: workspaceId }
+      );
     },
     [archiveWorkspace, workspaceId]
   );
   const handleArchiveRequest = useCallback(() => {
     // If workspace is done/merged, skip confirmation and archive immediately.
-    // Default commitUncommitted to true so we never lose work if git status hasn't loaded yet.
     if (isDoneOrMergedWorkspace) {
-      handleArchive(true);
+      handleArchive();
       return;
     }
 
@@ -384,11 +385,16 @@ export function WorkspaceDetailContainer() {
         archiveDialog={{
           open: archiveDialogOpen,
           setOpen: setArchiveDialogOpen,
-          hasUncommitted: hasUncommitted && !isDoneOrMergedWorkspace,
-          isCheckingGitStatus: isGitStatusFetching && !isDoneOrMergedWorkspace,
           activeChildCount,
-          onConfirm: handleArchive,
+          onConfirm: () => handleArchive(),
         }}
+      />
+      <ArchiveGitLockDialog
+        open={archiveGitLockDialogOpen}
+        onOpenChange={setArchiveGitLockDialogOpen}
+        onRetry={() => handleArchive()}
+        onRemoveLockAndArchive={() => handleArchive(true)}
+        isPending={archiveWorkspace.isPending}
       />
     </>
   );

--- a/src/client/routes/projects/workspaces/workspace-detail-container.utils.test.ts
+++ b/src/client/routes/projects/workspaces/workspace-detail-container.utils.test.ts
@@ -3,11 +3,9 @@ import type { WorkspaceSessionRuntimeSummary } from '@/client/features/workspace
 import type { SessionRuntimeState } from '@/shared/session-runtime';
 import {
   buildSessionSummariesById,
-  getArchiveGitStatusQueryOptions,
   getVisibleInitBanner,
   hasUserMessageWithoutAgentMessage,
   type SessionForRuntimeOverlay,
-  shouldFetchArchiveGitStatus,
 } from './workspace-detail-container.utils';
 
 describe('getVisibleInitBanner', () => {
@@ -33,21 +31,6 @@ describe('getVisibleInitBanner', () => {
 });
 
 describe('workspace detail container utils', () => {
-  it('fetches archive Git status only while the dialog is visible for a worktree', () => {
-    expect(shouldFetchArchiveGitStatus(false, '/repo/w1')).toBe(false);
-    expect(shouldFetchArchiveGitStatus(true, null)).toBe(false);
-    expect(shouldFetchArchiveGitStatus(true, '/repo/w1')).toBe(true);
-  });
-
-  it('treats archive Git status as stale whenever the dialog reopens', () => {
-    expect(getArchiveGitStatusQueryOptions(true, '/repo/w1')).toEqual({
-      enabled: true,
-      staleTime: 0,
-      refetchOnWindowFocus: false,
-    });
-    expect(getArchiveGitStatusQueryOptions(false, '/repo/w1').enabled).toBe(false);
-  });
-
   it('returns true when the transcript has a user message and no agent message', () => {
     expect(hasUserMessageWithoutAgentMessage([{ source: 'user' }])).toBe(true);
   });

--- a/src/client/routes/projects/workspaces/workspace-detail-container.utils.ts
+++ b/src/client/routes/projects/workspaces/workspace-detail-container.utils.ts
@@ -8,24 +8,6 @@ interface DismissibleInitBanner {
   showDismiss?: boolean;
 }
 
-export function shouldFetchArchiveGitStatus(
-  archiveDialogOpen: boolean,
-  worktreePath: string | null | undefined
-): boolean {
-  return archiveDialogOpen && Boolean(worktreePath);
-}
-
-export function getArchiveGitStatusQueryOptions(
-  archiveDialogOpen: boolean,
-  worktreePath: string | null | undefined
-) {
-  return {
-    enabled: shouldFetchArchiveGitStatus(archiveDialogOpen, worktreePath),
-    staleTime: 0,
-    refetchOnWindowFocus: false,
-  } as const;
-}
-
 export function getVisibleInitBanner<T extends DismissibleInitBanner>(
   banner: T | null | undefined,
   setupWarningDismissed: boolean | null

--- a/src/client/routes/projects/workspaces/workspace-detail-view.test.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-view.test.tsx
@@ -140,8 +140,6 @@ function createViewProps(activeChildCount: number): WorkspaceDetailViewProps {
     archiveDialog: {
       open: true,
       setOpen: vi.fn(),
-      hasUncommitted: false,
-      isCheckingGitStatus: false,
       activeChildCount,
       onConfirm: vi.fn(),
     },

--- a/src/client/routes/projects/workspaces/workspace-detail-view.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-view.tsx
@@ -66,10 +66,8 @@ interface SessionTabsProps {
 interface ArchiveDialogProps {
   open: boolean;
   setOpen: Dispatch<SetStateAction<boolean>>;
-  hasUncommitted: boolean;
-  isCheckingGitStatus: boolean;
   activeChildCount: number;
-  onConfirm: (commitUncommitted: boolean) => void;
+  onConfirm: () => void;
 }
 
 export interface WorkspaceDetailViewProps {
@@ -237,8 +235,6 @@ export function WorkspaceDetailView({
       <ArchiveWorkspaceDialog
         open={archiveDialog.open}
         onOpenChange={archiveDialog.setOpen}
-        hasUncommitted={archiveDialog.hasUncommitted}
-        isCheckingGitStatus={archiveDialog.isCheckingGitStatus}
         activeChildCount={archiveDialog.activeChildCount}
         onConfirm={archiveDialog.onConfirm}
       />


### PR DESCRIPTION
## Summary

- always commit uncommitted workspace changes before removing an archived worktree
- remove the archive-time commit checkbox and Git-status preflight from single and bulk archive flows
- detect worktree-specific Git index locks and offer Cancel, Retry, or explicit lock removal before retrying
- retry only the locked subset after a bulk archive failure
- expose the same explicit recovery option for child-workspace archives

## Root cause

The reported workspace could not be archived because its worktree had a stale, zero-byte `index.lock` in the worktree-specific Git directory. The existing archive flow surfaced that as a generic Git operation failure and gave the user no safe recovery path.

The backend now resolves the exact worktree Git directory, classifies an `index.lock` conflict with a typed application error, and removes that lock only after an explicit user choice. Startup recovery and ordinary archive attempts never delete locks automatically.

## User impact

Archiving no longer requires choosing whether to preserve uncommitted work: those changes are always committed. If Git is locked, the user gets a targeted explanation and can retry normally or explicitly remove the lock and continue.

## Validation

- `pnpm test` — 1,261 suites; 4,496 passed, 3 skipped, 0 failed
- `pnpm typecheck`
- `pnpm check`
- `pnpm build`
- `pnpm build:storybook`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches archive orchestration, Git worktree cleanup, and optimistic UI rollback; lock removal is user-gated but still mutates the filesystem on the server.
> 
> **Overview**
> **Archive always preserves uncommitted work** by removing the `commitUncommitted` flag end-to-end (tRPC, orchestrator, worktree lifecycle, Kanban, workspace detail, child MCP). Dirty worktrees are always staged and committed before removal; the old “disable commit” path and `PRECONDITION_FAILED` guard are gone.
> 
> **Archive confirmation no longer depends on Git status**: the commit checkbox, bulk uncommitted warnings, and workspace-detail `getGitStatus` preflight are removed. Confirm dialogs state that changes will be committed and call **`onConfirm()` with no boolean**.
> 
> **Stale `index.lock` failures are recoverable**: Git ops detect the worktree’s server-resolved lock on failed add/commit and raise `ApplicationError` with kind **`GIT_INDEX_LOCKED`**, surfaced on tRPC as **`applicationErrorKind`**. Callers may pass a one-shot **`removeGitIndexLock: true`** (never a client path); startup recovery does not remove locks automatically.
> 
> **UI**: shared **`ArchiveGitLockDialog`** (Cancel / Retry / Remove Lock and Archive) on workspace detail and Kanban (including bulk failures for the locked subset only), with optimistic cache rollback unchanged for other errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bd1dafdab115c42b422168355208c0c3ab65083. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->