### PR TITLE
Release 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to Factory Factory will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3] - 2026-07-29
+
+### Added
+
+- Show linked GitHub and Linear issues on Kanban task cards (#2055)
+
+### Changed
+
+- Serve Kanban Git statistics from the workspace cache and project columns from the shared status reason (#2053, #2063)
+- Commit workspace changes before archiving and enforce foreign-key index coverage (#2051, #2059)
+- Update the bundled Codex CLI schemas to 0.145.0 (#2064)
+
+### Fixed
+
+- Preserve macOS screenshot media types when pasting images into task and chat inputs (#2042, #2052)
+- Correct dark-mode status banner colors and center modal animations (#2054, #2058)
+- Stop Ratchet sessions after pull requests merge and prevent ACP dispatch errors from retrying indefinitely (#2056, #2057)
+- Publish auto-iteration status changes immediately to the workspace snapshot stream (#2065)
+
+### Documentation
+
+- Correct the project structure documented in the contributor guide (#2041)
+
 ## [0.4.2] - 2026-07-27
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "factory-factory",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Workspace-based coding environment for running multiple Claude Code and Codex sessions in parallel",
   "private": false,
   "license": "MIT",


### PR DESCRIPTION
## Summary

- bump the package patch version from `0.4.2` to `0.4.3`
- add the `0.4.3` changelog entry covering all changes merged since `v0.4.2`

## Impact

Prepares the next patch release with current package metadata and user-facing release notes.

## Validation

- `git diff --check`
- `pnpm check`
- commit hooks: `pnpm typecheck`, Prisma generated drift check, dependency boundary check, and `knip`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only version metadata and release notes change; no runtime or application code in the diff.
> 
> **Overview**
> Prepares patch release **0.4.3** by bumping `package.json` from `0.4.2` to `0.4.3` and adding the matching **Keep a Changelog** section dated 2026-07-29.
> 
> The new notes summarize work already merged since `0.4.2`: Kanban cards show linked GitHub/Linear issues; Kanban Git stats and column sourcing changes; archive/commit and FK index work; Codex CLI schemas 0.145.0; fixes for macOS paste media types, dark-mode UI, Ratchet/ACP session behavior, and auto-iteration snapshot streaming; plus a contributor-guide doc fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0827c918318ab76993474ac7f6b2fd5aff587539. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->