### PR TITLE
Fix #2060: Stop completed Ratchet sessions after abort

### DIFF
--- a/src/backend/services/ratchet/service/ratchet-active-session.helpers.ts
+++ b/src/backend/services/ratchet/service/ratchet-active-session.helpers.ts
@@ -164,12 +164,21 @@ export async function checkActiveFixerSession(params: {
   // Ratchet session has completed its current unit of work: settle first so
   // the stop's exit hook no-ops, then close it to avoid lingering idle agents.
   if (!sessionBridge.isSessionWorking(session.id)) {
-    const result = await settle('COMPLETED', 'session finished its unit of work');
-    await stopCompletedRatchetSession({
-      workspaceId: workspace.id,
-      sessionId: session.id,
-      sessionBridge,
-    });
+    const stopCompletedSession = () =>
+      stopCompletedRatchetSession({
+        workspaceId: workspace.id,
+        sessionId: session.id,
+        sessionBridge,
+      });
+    let result: ActiveFixerCheckResult;
+    try {
+      result = await settle('COMPLETED', 'session finished its unit of work');
+    } catch (error) {
+      // Preserve prompt cancellation while still starting best-effort cleanup.
+      void stopCompletedSession();
+      throw error;
+    }
+    await stopCompletedSession();
     return result;
   }
 

--- a/src/backend/services/ratchet/service/ratchet.service.test.ts
+++ b/src/backend/services/ratchet/service/ratchet.service.test.ts
@@ -3716,6 +3716,38 @@ describe('ratchet service (state-change + idle dispatch)', () => {
       await pendingStop;
     });
 
+    it('stops completed session even when abort fires after settlement', async () => {
+      const controller = new AbortController();
+      const timeoutError = new Error('Workspace check timed out');
+      vi.mocked(mockSessionBridge.findSessionById).mockResolvedValue({
+        id: 'completed-session',
+        provider: 'CLAUDE',
+        status: SessionStatus.RUNNING,
+      } as never);
+      vi.mocked(mockSessionBridge.isSessionRunning).mockReturnValue(true);
+      vi.mocked(mockSessionBridge.isSessionWorking).mockReturnValue(false);
+      vi.mocked(mockSessionBridge.stopSession).mockResolvedValue();
+      vi.mocked(mockWorkspaceBridge.recordSessionEnd).mockImplementation(() => {
+        controller.abort(timeoutError);
+        return Promise.resolve(true);
+      });
+
+      const check = unsafeCoerce<{
+        checkActiveFixerSession: (w: unknown, signal: AbortSignal) => Promise<unknown>;
+      }>(ratchetService).checkActiveFixerSession(
+        {
+          id: 'ws-completed-aborted-after-settlement',
+          ratchetActiveSessionId: 'completed-session',
+          defaultSessionProvider: 'CLAUDE',
+          ratchetSessionProvider: 'CLAUDE',
+        },
+        controller.signal
+      );
+
+      await expect(check).rejects.toBe(timeoutError);
+      expect(mockSessionBridge.stopSession).toHaveBeenCalledWith('completed-session');
+    });
+
     it('returns the active fixer when the session is working', async () => {
       vi.mocked(mockSessionBridge.findSessionById).mockResolvedValue({
         id: 'working-session',


### PR DESCRIPTION
## Summary
- Stop completed Ratchet fixer sessions even when cancellation is observed immediately after dispatch settlement commits.
- Preserve the original cancellation error while starting best-effort ACP process cleanup.

## Changes
- **Ratchet active-session cleanup**: Mirror the provider-mismatch settlement guard for completed sessions so cleanup starts if settlement throws after its database write.
- **Regression coverage**: Reproduce an abort during `recordSessionEnd` and verify the completed ACP session is stopped without replacing the timeout error.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting and repository checks pass (`pnpm check:fix`, `pnpm check`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; this backend lifecycle race is covered by the focused regression test.

Closes #2060

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
