### PR TITLE
Fix #2062: Guard ratchet observations by PR URL

### DIFF
--- a/src/backend/orchestration/domain-bridges.orchestrator.ts
+++ b/src/backend/orchestration/domain-bridges.orchestrator.ts
@@ -340,6 +340,7 @@ export function configureDomainBridges(services: BridgeServices): void {
   const ratchetSnapshotBridge: RatchetPRSnapshotBridge = {
     recordPrObservation: ({
       workspaceId,
+      prUrl,
       prNumber,
       ciStatus,
       prState,
@@ -349,6 +350,7 @@ export function configureDomainBridges(services: BridgeServices): void {
       observedAt,
     }) =>
       prSnapshotService.recordPrObservation(workspaceId, {
+        prUrl,
         prNumber,
         ciStatus,
         prState,

--- a/src/backend/services/github/service/bridges.ts
+++ b/src/backend/services/github/service/bridges.ts
@@ -51,6 +51,7 @@ export interface GitHubPRSnapshotPersistenceInput extends GitHubSnapshotFields {
  */
 export interface GitHubPrObservationPersistenceInput {
   /** The PR the observation was fetched for. Guarded, not written. */
+  expectedPrUrl: string;
   expectedPrNumber: number;
   prCiStatus: CIStatus;
   prState: PRState;

--- a/src/backend/services/github/service/pr-snapshot.service.test.ts
+++ b/src/backend/services/github/service/pr-snapshot.service.test.ts
@@ -395,6 +395,7 @@ describe('PRSnapshotService', () => {
       const refresh = prSnapshotService.refreshWorkspace('w-ordered');
       await vi.waitFor(() => expect(mockFetchAndComputePRState).toHaveBeenCalledTimes(1));
       const directObservation = prSnapshotService.recordPrObservation('w-ordered', {
+        prUrl: 'https://github.com/org/repo/pull/1',
         prNumber: 1,
         ciStatus: 'FAILURE',
         prState: 'OPEN',
@@ -425,6 +426,7 @@ describe('PRSnapshotService', () => {
       const observedAt = new Date('2026-02-11T00:00:00Z');
 
       await prSnapshotService.recordPrObservation('w-ci-1', {
+        prUrl: 'https://github.com/org/repo/pull/1',
         prNumber: 1,
         ciStatus: 'SUCCESS',
         prState: 'OPEN',
@@ -434,6 +436,7 @@ describe('PRSnapshotService', () => {
       });
 
       expect(mockApplyPrObservationWithDispatchReset).toHaveBeenCalledWith('w-ci-1', {
+        expectedPrUrl: 'https://github.com/org/repo/pull/1',
         expectedPrNumber: 1,
         prCiStatus: 'SUCCESS',
         prState: 'OPEN',
@@ -447,6 +450,7 @@ describe('PRSnapshotService', () => {
       const observedAt = new Date('2026-02-11T01:00:00Z');
 
       await prSnapshotService.recordPrObservation('w-ci-2', {
+        prUrl: 'https://github.com/org/repo/pull/1',
         prNumber: 1,
         ciStatus: 'SUCCESS',
         prState: 'OPEN',
@@ -457,6 +461,7 @@ describe('PRSnapshotService', () => {
       });
 
       expect(mockApplyPrObservationWithDispatchReset).toHaveBeenCalledWith('w-ci-2', {
+        expectedPrUrl: 'https://github.com/org/repo/pull/1',
         expectedPrNumber: 1,
         prCiStatus: 'SUCCESS',
         prState: 'OPEN',
@@ -470,6 +475,7 @@ describe('PRSnapshotService', () => {
       const observedAt = new Date('2026-02-11T02:00:00Z');
 
       await prSnapshotService.recordPrObservation('w-ci-3', {
+        prUrl: 'https://github.com/org/repo/pull/1',
         prNumber: 1,
         ciStatus: 'SUCCESS',
         prState: 'OPEN',
@@ -480,6 +486,7 @@ describe('PRSnapshotService', () => {
       });
 
       expect(mockApplyPrObservationWithDispatchReset).toHaveBeenCalledWith('w-ci-3', {
+        expectedPrUrl: 'https://github.com/org/repo/pull/1',
         expectedPrNumber: 1,
         prCiStatus: 'SUCCESS',
         prState: 'OPEN',
@@ -505,6 +512,7 @@ describe('PRSnapshotService', () => {
       prSnapshotService.on(PR_SNAPSHOT_UPDATED, (event) => events.push(event));
 
       await prSnapshotService.recordPrObservation('ws-exhausted', {
+        prUrl: 'https://github.com/org/repo/pull/1',
         prNumber: 1,
         ciStatus: 'PENDING',
         prState: 'OPEN',
@@ -538,6 +546,7 @@ describe('PRSnapshotService', () => {
       prSnapshotService.on(PR_SNAPSHOT_UPDATED, (event) => events.push(event));
 
       await prSnapshotService.recordPrObservation('ws-merged', {
+        prUrl: 'https://github.com/org/repo/pull/2',
         prNumber: 2,
         ciStatus: 'SUCCESS',
         prState: 'MERGED',
@@ -566,6 +575,7 @@ describe('PRSnapshotService', () => {
       prSnapshotService.on(PR_SNAPSHOT_UPDATED, (event) => events.push(event));
 
       await prSnapshotService.recordPrObservation('ws-same-pr', {
+        prUrl: 'https://github.com/org/repo/pull/3',
         prNumber: 3,
         ciStatus: 'SUCCESS',
         prState: 'OPEN',
@@ -585,6 +595,7 @@ describe('PRSnapshotService', () => {
       prSnapshotService.on(PR_SNAPSHOT_UPDATED, (event) => events.push(event));
 
       await prSnapshotService.recordPrObservation('ws-stale-ci', {
+        prUrl: 'https://github.com/org/repo/pull/1',
         prNumber: 1,
         ciStatus: 'SUCCESS',
         prState: 'OPEN',

--- a/src/backend/services/github/service/pr-snapshot.service.ts
+++ b/src/backend/services/github/service/pr-snapshot.service.ts
@@ -61,6 +61,7 @@ export interface PRUrlAttachedEvent {
 
 /** One ratchet check's observation of a PR: every input `deriveRatchetState` reads. */
 interface PrObservationInput {
+  prUrl: string;
   prNumber: number;
   ciStatus: SnapshotData['prCiStatus'];
   prState: SnapshotData['prState'];
@@ -128,6 +129,7 @@ class PRSnapshotService extends EventEmitter {
   async recordPrObservation(workspaceId: string, input: PrObservationInput): Promise<void> {
     await this.runWorkspaceOperation(workspaceId, async () => {
       const result = await this.workspace.applyPrObservationWithDispatchReset(workspaceId, {
+        expectedPrUrl: input.prUrl,
         expectedPrNumber: input.prNumber,
         prCiStatus: input.ciStatus,
         prState: input.prState,

--- a/src/backend/services/ratchet/service/bridges.ts
+++ b/src/backend/services/ratchet/service/bridges.ts
@@ -142,6 +142,7 @@ export interface RatchetPRSnapshotBridge {
    */
   recordPrObservation(input: {
     workspaceId: string;
+    prUrl: string;
     prNumber: number;
     ciStatus: CIStatus;
     prState: PRState;

--- a/src/backend/services/ratchet/service/ratchet.service.test.ts
+++ b/src/backend/services/ratchet/service/ratchet.service.test.ts
@@ -1421,6 +1421,7 @@ describe('ratchet service (state-change + idle dispatch)', () => {
     expect(mockSnapshotBridge.recordPrObservation).toHaveBeenCalledWith(
       expect.objectContaining({
         workspaceId: 'ws-observation',
+        prUrl: 'https://github.com/example/repo/pull/44',
         prState: 'CHANGES_REQUESTED',
         reviewState: 'CHANGES_REQUESTED',
         ciStatus: CIStatus.SUCCESS,
@@ -1501,7 +1502,11 @@ describe('ratchet service (state-change + idle dispatch)', () => {
     expect(mockSessionBridge.stopSession).toHaveBeenNthCalledWith(1, 'ratchet-running');
     expect(mockSessionBridge.stopSession).toHaveBeenNthCalledWith(2, 'ratchet-idle');
     expect(mockSnapshotBridge.recordPrObservation).toHaveBeenCalledWith(
-      expect.objectContaining({ workspaceId: 'ws-merged', prState: 'MERGED' })
+      expect.objectContaining({
+        workspaceId: 'ws-merged',
+        prUrl: 'https://github.com/example/repo/pull/45',
+        prState: 'MERGED',
+      })
     );
     expect(vi.mocked(mockSessionBridge.stopSession).mock.invocationCallOrder.at(-1)).toBeLessThan(
       vi.mocked(mockSnapshotBridge.recordPrObservation).mock.invocationCallOrder[0] ?? 0
@@ -1620,6 +1625,7 @@ describe('ratchet service (state-change + idle dispatch)', () => {
     expect(mockSnapshotBridge.recordPrObservation).toHaveBeenCalledWith(
       expect.objectContaining({
         workspaceId: 'ws-conflict',
+        prUrl: 'https://github.com/example/repo/pull/43',
         ciStatus: CIStatus.SUCCESS,
         hasMergeConflict: true,
       })

--- a/src/backend/services/ratchet/service/ratchet.service.ts
+++ b/src/backend/services/ratchet/service/ratchet.service.ts
@@ -894,6 +894,7 @@ class RatchetService extends EventEmitter {
       signal.throwIfAborted();
       await this.snapshot.recordPrObservation({
         workspaceId: workspace.id,
+        prUrl: workspace.prUrl,
         prNumber: prStateInfo.prNumber,
         ciStatus: prStateInfo.ciStatus,
         prState: prStateInfo.cachedPrState,

--- a/src/backend/services/workspace/resources/workspace.accessor.test.ts
+++ b/src/backend/services/workspace/resources/workspace.accessor.test.ts
@@ -442,6 +442,49 @@ describe('workspaceAccessor', () => {
 
       await expect(
         workspaceAccessor.applyPrObservationWithDispatchReset('ws-1', {
+          expectedPrUrl: 'https://github.com/org/repo/pull/42',
+          expectedPrNumber: 42,
+          prCiStatus: 'SUCCESS',
+          prState: 'MERGED',
+          prReviewState: null,
+          prHasMergeConflict: false,
+          prUpdatedAt,
+        })
+      ).resolves.toEqual({ applied: false, dispatchReset: false });
+
+      expect(mockPrUpdateMany).not.toHaveBeenCalled();
+      expect(mockRatchetUpdateMany).not.toHaveBeenCalled();
+    });
+
+    it('refuses a stale observation after the PR URL changes while its number is unknown', async () => {
+      mockPrFindUnique.mockResolvedValue(
+        currentColumns({ url: 'https://github.com/org/repo/pull/99', number: null })
+      );
+
+      await expect(
+        workspaceAccessor.applyPrObservationWithDispatchReset('ws-1', {
+          expectedPrUrl: 'https://github.com/org/repo/pull/42',
+          expectedPrNumber: 42,
+          prCiStatus: 'SUCCESS',
+          prState: 'MERGED',
+          prReviewState: null,
+          prHasMergeConflict: false,
+          prUpdatedAt,
+        })
+      ).resolves.toEqual({ applied: false, dispatchReset: false });
+
+      expect(mockPrUpdateMany).not.toHaveBeenCalled();
+      expect(mockRatchetUpdateMany).not.toHaveBeenCalled();
+    });
+
+    it('refuses a stale observation when a failed re-point leaves the old PR number cached', async () => {
+      mockPrFindUnique.mockResolvedValue(
+        currentColumns({ url: 'https://github.com/org/repo/pull/99', number: 42 })
+      );
+
+      await expect(
+        workspaceAccessor.applyPrObservationWithDispatchReset('ws-1', {
+          expectedPrUrl: 'https://github.com/org/repo/pull/42',
           expectedPrNumber: 42,
           prCiStatus: 'SUCCESS',
           prState: 'MERGED',
@@ -467,6 +510,7 @@ describe('workspaceAccessor', () => {
 
       await expect(
         workspaceAccessor.applyPrObservationWithDispatchReset('ws-1', {
+          expectedPrUrl: 'https://github.com/org/repo/pull/42',
           expectedPrNumber: 42,
           prCiStatus: 'SUCCESS',
           prState: 'OPEN',
@@ -486,6 +530,7 @@ describe('workspaceAccessor', () => {
 
       await expect(
         workspaceAccessor.applyPrObservationWithDispatchReset('ws-1', {
+          expectedPrUrl: 'https://github.com/org/repo/pull/42',
           expectedPrNumber: 42,
           prCiStatus: 'PENDING',
           prState: 'OPEN',

--- a/src/backend/services/workspace/resources/workspace.accessor.ts
+++ b/src/backend/services/workspace/resources/workspace.accessor.ts
@@ -156,6 +156,7 @@ export interface PrObservationPersistenceInput {
    * stamp it onto the new one, and a workspace deriving `MERGED` leaves the ratchet
    * poll set altogether.
    */
+  expectedPrUrl: string;
   expectedPrNumber: number;
   prCiStatus: CIStatus;
   prState: PRState;
@@ -168,6 +169,11 @@ export interface PrObservationPersistenceInput {
 export interface PrAggregatePersistenceResult {
   applied: boolean;
   dispatchReset: boolean;
+}
+
+interface PrObservationIdentityGuard {
+  prUrl: string;
+  prNumber: number;
 }
 
 type PrAggregatePersistenceInput = Partial<{
@@ -213,6 +219,19 @@ function prAggregateChanged(
   return compared.some(
     (field) => observation[field] !== undefined && current[field] !== observation[field]
   );
+}
+
+function prIdentityChanged(
+  current: PRAggregateGuard,
+  expected?: PrObservationIdentityGuard
+): boolean {
+  if (!expected) {
+    return false;
+  }
+  if (current.prNumber !== null && current.prNumber !== expected.prNumber) {
+    return true;
+  }
+  return current.prUrl !== expected.prUrl;
 }
 
 /**
@@ -801,8 +820,11 @@ class WorkspaceAccessor {
     workspaceId: string,
     observation: PrObservationPersistenceInput
   ): Promise<PrAggregatePersistenceResult> {
-    const { expectedPrNumber, ...fields } = observation;
-    return this.applyPrAggregateUpdateWithDispatchReset(workspaceId, fields, expectedPrNumber);
+    const { expectedPrUrl, expectedPrNumber, ...fields } = observation;
+    return this.applyPrAggregateUpdateWithDispatchReset(workspaceId, fields, {
+      prUrl: expectedPrUrl,
+      prNumber: expectedPrNumber,
+    });
   }
 
   /**
@@ -844,12 +866,8 @@ class WorkspaceAccessor {
   private async applyPrAggregateUpdateWithDispatchReset(
     workspaceId: string,
     observation: PrAggregatePersistenceInput,
-    /**
-     * When given, the PR number the observation was fetched for. A row now naming
-     * a different PR means the workspace was re-pointed mid-fetch, so this
-     * observation describes a PR that is no longer the workspace's.
-     */
-    expectedPrNumber?: number
+    /** The exact PR identity the observation was fetched from. */
+    expectedPr?: PrObservationIdentityGuard
   ): Promise<PrAggregatePersistenceResult> {
     const { branchName, ...prFields } = observation;
     return await prisma.$transaction(async (transaction) => {
@@ -857,14 +875,7 @@ class WorkspaceAccessor {
       if (!current) {
         return { applied: false, dispatchReset: false };
       }
-      // A null cached number is "not known yet" rather than a different PR:
-      // discovery attaches a url without a number, and the check's own number came
-      // from parsing that url. Only a populated mismatch is a re-point.
-      if (
-        expectedPrNumber !== undefined &&
-        current.prNumber !== null &&
-        current.prNumber !== expectedPrNumber
-      ) {
+      if (prIdentityChanged(current, expectedPr)) {
         return { applied: false, dispatchReset: false };
       }
       const dispatch = await workspaceRatchetAccessor.readDispatchGuard(transaction, workspaceId);

--- a/src/backend/services/workspace/service/lifecycle/workspace-pr-snapshot.service.test.ts
+++ b/src/backend/services/workspace/service/lifecycle/workspace-pr-snapshot.service.test.ts
@@ -113,6 +113,7 @@ describe('workspacePrSnapshotService', () => {
 
   it('owns atomic CI observation dispatch reset persistence', async () => {
     const observation = {
+      expectedPrUrl: 'https://github.com/org/repo/pull/7',
       expectedPrNumber: 7,
       prCiStatus: 'FAILURE' as const,
       prState: 'OPEN' as const,


### PR DESCRIPTION
## Summary
- Prevent stale ratchet observations from overwriting a workspace after its attached PR URL changes
- Preserve first observations when the attached URL matches but the cached PR number is still unknown
- Cover failed re-point and bridge propagation edge cases

## Changes
- **Ratchet observation pipeline**: Carry the exact PR URL captured before the GitHub fetch through the ratchet, orchestration, and snapshot bridges
- **Workspace persistence**: Guard the transactional PR aggregate update against both URL changes and populated PR-number mismatches
- **Tests**: Add regression coverage for null and stale cached PR numbers, valid same-URL observations, and URL forwarding

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting and guardrails pass (`pnpm check:fix`)
- [x] Build succeeds (`pnpm build`)
- [x] Manual testing: Verified the focused regression fails before the guard and passes after it

Closes #2062

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
