### PR TITLE
Fix #1915: Preserve periodic task monthly anchors

### DIFF
--- a/docs/superpowers/plans/2026-07-29-preserve-periodic-task-monthly-anchor.md
+++ b/docs/superpowers/plans/2026-07-29-preserve-periodic-task-monthly-anchor.md
@@ -1,0 +1,110 @@
+# Preserve Periodic Task Monthly Anchor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve a periodic task's stored monthly day-of-month while its active cadence is non-monthly, so returning to `MONTHLY` restores the original schedule.
+
+**Architecture:** Treat `scheduledDayOfMonth` as dormant monthly scheduling metadata rather than a projection of the active cadence. The periodic-task accessor will only derive and persist this field when the effective cadence is `MONTHLY`; non-monthly updates and enable operations will leave the database field untouched while continuing to compute their next run normally.
+
+**Tech Stack:** TypeScript, Prisma, Vitest
+
+## Global Constraints
+
+- Keep `scheduledDayOfMonth` server-owned; do not add it to the tRPC update schema.
+- Preserve the existing current-local-day fallback for tasks that have never stored a monthly anchor.
+- Do not add schema, migration, service, or UI changes.
+- Verify with `pnpm typecheck && pnpm check:fix && pnpm test && pnpm build`.
+
+---
+
+### Task 1: Preserve Dormant Monthly Scheduling Metadata
+
+**Files:**
+- Modify: `src/backend/services/periodic-task/resources/periodic-task.accessor.ts`
+- Test: `src/backend/services/periodic-task/resources/periodic-task.accessor.test.ts`
+
+**Interfaces:**
+- Consumes: `periodicTaskAccessor.update(id, input)` and `periodicTaskAccessor.toggleEnabled(id, enabled)`
+- Produces: Prisma update payloads that write `scheduledDayOfMonth` only for effective `MONTHLY` schedules
+
+- [ ] **Step 1: Add the missing accessor mock and failing round-trip test**
+
+Add `findUniqueOrThrow: vi.fn()` to `prismaMock.periodicTask`. Add an update test that starts with a `MONTHLY` task anchored to day 15, updates it to `DAILY`, verifies the payload omits `scheduledDayOfMonth`, then updates the resulting `DAILY` row back to `MONTHLY` on a later date and verifies both `scheduledDayOfMonth: 15` and a next run on day 15.
+
+- [ ] **Step 2: Run the round-trip test and verify the destructive write**
+
+Run:
+
+```bash
+pnpm test src/backend/services/periodic-task/resources/periodic-task.accessor.test.ts
+```
+
+Expected: the new assertion fails because the `MONTHLY` to `DAILY` payload contains `scheduledDayOfMonth: null`.
+
+- [ ] **Step 3: Add failing edge-case coverage**
+
+Add one test proving `toggleEnabled(id, true)` omits `scheduledDayOfMonth` for a non-monthly row that retains a dormant day 15 anchor. Add one test proving a non-monthly row with no stored anchor still derives the current local day when changed to `MONTHLY`.
+
+- [ ] **Step 4: Implement the minimal accessor fix**
+
+In `update`, retain `existing.scheduledDayOfMonth` for next-run calculation when the effective cadence is non-monthly, but conditionally add the field to the Prisma payload only when the effective cadence is `MONTHLY`. In `toggleEnabled`, resolve and persist the field only for `MONTHLY`; pass an existing dormant anchor through to `computeNextRunAt` for other cadences without writing it.
+
+- [ ] **Step 5: Run focused tests and verify all accessor behaviors**
+
+Run:
+
+```bash
+pnpm test src/backend/services/periodic-task/resources/periodic-task.accessor.test.ts
+```
+
+Expected: all accessor tests pass.
+
+- [ ] **Step 6: Commit the focused bug fix**
+
+```bash
+git add docs/superpowers/plans/2026-07-29-preserve-periodic-task-monthly-anchor.md \
+  src/backend/services/periodic-task/resources/periodic-task.accessor.ts \
+  src/backend/services/periodic-task/resources/periodic-task.accessor.test.ts
+git commit -m "Fix periodic task monthly anchor retention (#1915)"
+```
+
+### Task 2: Verify, Review, and Publish
+
+**Files:**
+- Review: all changes relative to `origin/main`
+- Create: `/tmp/pr-body.md` outside the repository
+
+**Interfaces:**
+- Consumes: the committed Task 1 change
+- Produces: a pushed issue branch and a GitHub pull request that closes #1915
+
+- [ ] **Step 1: Run the required verification chain**
+
+```bash
+pnpm typecheck && pnpm check:fix && pnpm test && pnpm build
+```
+
+Expected: all four commands exit successfully. Review and commit any formatting changes produced by `pnpm check:fix`.
+
+- [ ] **Step 2: Review the complete branch diff**
+
+```bash
+git diff origin/main
+git status --short
+```
+
+Confirm the diff contains only the plan, accessor behavior change, and focused tests, with no debug output or unrelated edits.
+
+- [ ] **Step 3: Request read-only code review and address findings**
+
+Ask a reviewer to compare the branch against #1915, including dormant-anchor preservation, new-monthly fallback behavior, and the non-monthly enable path. Re-run affected tests and commit any required fixes.
+
+- [ ] **Step 4: Push and create the required pull request**
+
+```bash
+git push -u origin HEAD
+gh pr create --title "Fix #1915: Preserve periodic task monthly anchors" --body-file /tmp/pr-body.md
+gh pr view --json url
+```
+
+The PR body must summarize the accessor and test changes, list the required verification commands, include `Closes #1915`, and end with the Factory Factory signature.

--- a/src/backend/services/periodic-task/resources/periodic-task.accessor.test.ts
+++ b/src/backend/services/periodic-task/resources/periodic-task.accessor.test.ts
@@ -4,6 +4,7 @@ const prismaMock = vi.hoisted(() => ({
   $transaction: vi.fn(),
   periodicTask: {
     findUnique: vi.fn(),
+    findUniqueOrThrow: vi.fn(),
     update: vi.fn(),
     updateMany: vi.fn(),
   },
@@ -210,6 +211,102 @@ describe('periodicTaskAccessor.computeNextRunAt', () => {
     const nextRunAt = periodicTaskAccessor.computeNextRunAt('MONTHLY', from);
 
     expect(nextRunAt.getTime()).toBe(new Date(2026, 1, 28, 9, 5).getTime());
+  });
+});
+
+describe('periodicTaskAccessor.update', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-20T12:00:00.000Z'));
+    prismaMock.periodicTask.findUniqueOrThrow.mockReset();
+    prismaMock.periodicTask.update.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('preserves a monthly anchor across non-monthly cadence changes', async () => {
+    const monthlyTask = {
+      cadence: 'MONTHLY',
+      scheduledTime: '09:00',
+      timezone: 'UTC',
+      scheduledDayOfMonth: 15,
+      createdAt: new Date('2026-01-15T09:00:00.000Z'),
+    };
+    prismaMock.periodicTask.findUniqueOrThrow
+      .mockResolvedValueOnce(monthlyTask)
+      .mockResolvedValueOnce({ ...monthlyTask, cadence: 'DAILY' });
+    prismaMock.periodicTask.update.mockResolvedValue({});
+
+    await periodicTaskAccessor.update('task-1', { cadence: 'DAILY' });
+
+    const dailyUpdate = prismaMock.periodicTask.update.mock.calls[0]?.[0];
+    expect(dailyUpdate?.data).not.toHaveProperty('scheduledDayOfMonth');
+
+    vi.setSystemTime(new Date('2026-01-25T12:00:00.000Z'));
+    await periodicTaskAccessor.update('task-1', { cadence: 'MONTHLY' });
+
+    const monthlyUpdate = prismaMock.periodicTask.update.mock.calls[1]?.[0];
+    expect(monthlyUpdate?.data).toMatchObject({
+      cadence: 'MONTHLY',
+      scheduledDayOfMonth: 15,
+      nextRunAt: new Date('2026-02-15T09:00:00.000Z'),
+    });
+  });
+
+  it('uses the current local day when a task first becomes monthly', async () => {
+    vi.setSystemTime(new Date('2026-01-20T02:00:00.000Z'));
+    prismaMock.periodicTask.findUniqueOrThrow.mockResolvedValue({
+      cadence: 'DAILY',
+      scheduledTime: '09:00',
+      timezone: 'America/New_York',
+      scheduledDayOfMonth: null,
+      createdAt: new Date('2025-12-03T14:00:00.000Z'),
+    });
+    prismaMock.periodicTask.update.mockResolvedValue({});
+
+    await periodicTaskAccessor.update('task-1', { cadence: 'MONTHLY' });
+
+    const update = prismaMock.periodicTask.update.mock.calls[0]?.[0];
+    expect(update?.data).toMatchObject({
+      cadence: 'MONTHLY',
+      scheduledDayOfMonth: 19,
+      nextRunAt: new Date('2026-02-19T14:00:00.000Z'),
+    });
+  });
+});
+
+describe('periodicTaskAccessor.toggleEnabled', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-20T12:00:00.000Z'));
+    prismaMock.periodicTask.findUniqueOrThrow.mockReset();
+    prismaMock.periodicTask.update.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('preserves a dormant monthly anchor when enabling a non-monthly task', async () => {
+    prismaMock.periodicTask.findUniqueOrThrow.mockResolvedValue({
+      cadence: 'DAILY',
+      scheduledTime: '09:00',
+      timezone: 'UTC',
+      scheduledDayOfMonth: 15,
+      createdAt: new Date('2026-01-15T09:00:00.000Z'),
+    });
+    prismaMock.periodicTask.update.mockResolvedValue({});
+
+    await periodicTaskAccessor.toggleEnabled('task-1', true);
+
+    const update = prismaMock.periodicTask.update.mock.calls[0]?.[0];
+    expect(update?.data).not.toHaveProperty('scheduledDayOfMonth');
+    expect(update?.data).toMatchObject({
+      isEnabled: true,
+      nextRunAt: new Date('2026-01-21T09:00:00.000Z'),
+    });
   });
 });
 

--- a/src/backend/services/periodic-task/resources/periodic-task.accessor.ts
+++ b/src/backend/services/periodic-task/resources/periodic-task.accessor.ts
@@ -178,7 +178,7 @@ function resolveScheduledDayOfMonth(
   anchorDate: Date
 ): number | null {
   if (cadence !== 'MONTHLY') {
-    return null;
+    return existingDay ?? null;
   }
 
   return existingDay ?? getDayOfMonth(anchorDate, timezone);
@@ -367,7 +367,7 @@ export const periodicTaskAccessor = {
         ...(input.cadence !== undefined && { cadence: input.cadence }),
         ...(input.scheduledTime !== undefined && { scheduledTime: input.scheduledTime }),
         ...(input.timezone !== undefined && { timezone: input.timezone }),
-        scheduledDayOfMonth,
+        ...(cadence === 'MONTHLY' && { scheduledDayOfMonth }),
         nextRunAt: computeNextRunAt(cadence, now, scheduledTime, timezone, scheduledDayOfMonth),
       });
     }
@@ -383,15 +383,18 @@ export const periodicTaskAccessor = {
     const data: Record<string, unknown> = { isEnabled: enabled };
     if (enabled) {
       const task = await prisma.periodicTask.findUniqueOrThrow({ where: { id } });
+      const cadence = task.cadence as PeriodicTaskCadence;
       const scheduledDayOfMonth = resolveScheduledDayOfMonth(
-        task.cadence as PeriodicTaskCadence,
+        cadence,
         task.scheduledDayOfMonth,
         task.timezone,
         task.createdAt
       );
-      data.scheduledDayOfMonth = scheduledDayOfMonth;
+      if (cadence === 'MONTHLY') {
+        data.scheduledDayOfMonth = scheduledDayOfMonth;
+      }
       data.nextRunAt = computeNextRunAt(
-        task.cadence as PeriodicTaskCadence,
+        cadence,
         new Date(),
         task.scheduledTime,
         task.timezone,


### PR DESCRIPTION
## Summary
- Preserve a periodic task's original monthly day-of-month anchor across temporary cadence changes.
- Prevent non-monthly enable operations from clearing dormant monthly scheduling metadata.
- Keep first-time monthly scheduling anchored to the current day in the configured timezone.

## Changes
- **Periodic task accessor**: Retain stored `scheduledDayOfMonth` values for non-monthly cadences while only persisting the field for effective `MONTHLY` schedules.
- **Regression coverage**: Test the `MONTHLY` → `DAILY` → `MONTHLY` round trip, the non-monthly enable path, and first-time timezone-aware monthly anchoring.

## Testing
- [x] Tests pass (`pnpm test` — 4,573 passed, 3 skipped)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting and lint pass (`pnpm check:fix`)
- [x] Build succeeds (`pnpm build`)
- [x] Manual verification: Focused accessor regression suite passes with 19 tests

Closes #1915

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
