### PR TITLE
Fix #1900: Await run-script cleanup during shutdown

### DIFF
--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -64,6 +64,7 @@ export function createServer(application: Application, requestedPort?: number): 
     ratchetService,
     rateLimiter,
     reconciliationService,
+    runScriptService,
     runScriptStateMachine,
     schedulerService,
     sessionFileLogger,
@@ -443,6 +444,7 @@ export function createServer(application: Application, requestedPort?: number): 
       await sessionLifecycleService.stopAllClients(SHUTDOWN_TIMEOUT_MS);
 
       terminalService.cleanup();
+      await runScriptService.cleanup();
       sessionFileLogger.cleanup();
       acpTraceLogger.cleanup();
       await rateLimiter.stop();

--- a/src/backend/server.upgrade.test.ts
+++ b/src/backend/server.upgrade.test.ts
@@ -115,6 +115,9 @@ function createTestHarness(options: TestHarnessOptions = {}) {
     runScriptStateMachine: {
       recoverStaleStates: vi.fn(async () => undefined),
     },
+    runScriptService: {
+      cleanup: vi.fn<() => Promise<void>>(() => Promise.resolve()),
+    },
     acpTraceLogger: {
       cleanup: vi.fn(),
       cleanupOldLogs: vi.fn(),
@@ -748,6 +751,30 @@ describe('server websocket upgrade routing', () => {
     expect(harness.lifecycle.database.$disconnect).toHaveBeenCalledOnce();
     expect(transportDisposers.chat).toHaveBeenCalledWith(harness.application);
     expect(transportDisposers.snapshots).toHaveBeenCalledWith(harness.application);
+  });
+
+  it('waits for run-script cleanup before disconnecting the database', async () => {
+    const harness = createTestHarness();
+    let finishRunScriptCleanup!: () => void;
+    const runScriptCleanupCanFinish = new Promise<void>((resolve) => {
+      finishRunScriptCleanup = resolve;
+    });
+    vi.mocked(harness.services.runScriptService.cleanup).mockReturnValueOnce(
+      runScriptCleanupCanFinish
+    );
+    const server = createTestServer(harness.application);
+
+    const stopPromise = server.stop();
+
+    await vi.waitFor(() => {
+      expect(harness.services.runScriptService.cleanup).toHaveBeenCalledOnce();
+    });
+    expect(harness.lifecycle.database.$disconnect).not.toHaveBeenCalled();
+
+    finishRunScriptCleanup();
+    await stopPromise;
+
+    expect(harness.lifecycle.database.$disconnect).toHaveBeenCalledOnce();
   });
 
   it('closes active WebSocket clients before completing server cleanup', async () => {

--- a/src/backend/services/run-script/service/run-script.service.test.ts
+++ b/src/backend/services/run-script/service/run-script.service.test.ts
@@ -2234,6 +2234,39 @@ describe('RunScriptService.cleanup + shutdown handlers', () => {
     expect(mockCleanupTunnels).toHaveBeenCalledTimes(1);
   });
 
+  it('shares in-flight cleanup work between concurrent callers', async () => {
+    const service = new RunScriptService() as unknown as {
+      runningProcesses: Map<string, FakeChildProcess>;
+      stopRunScript: (workspaceId: string) => Promise<{ success: boolean }>;
+      cleanup: () => Promise<void>;
+    };
+    service.runningProcesses.set('ws-1', new FakeChildProcess(1));
+    let finishStop!: () => void;
+    const stopCanFinish = new Promise<void>((resolve) => {
+      finishStop = resolve;
+    });
+    const stopRunScriptSpy = vi.spyOn(service, 'stopRunScript').mockImplementation(async () => {
+      await stopCanFinish;
+      return { success: true };
+    });
+    mockCleanupTunnels.mockResolvedValue(undefined);
+
+    const firstCleanup = service.cleanup();
+    const concurrentCleanup = service.cleanup();
+
+    expect(stopRunScriptSpy).toHaveBeenCalledTimes(1);
+
+    finishStop();
+    await Promise.all([firstCleanup, concurrentCleanup]);
+    expect(mockCleanupTunnels).toHaveBeenCalledTimes(1);
+
+    service.runningProcesses.set('ws-2', new FakeChildProcess(2));
+    await service.cleanup();
+
+    expect(stopRunScriptSpy).toHaveBeenCalledTimes(2);
+    expect(mockCleanupTunnels).toHaveBeenCalledTimes(2);
+  });
+
   it('registers shutdown handlers once and runs cleanup hooks', async () => {
     const handlers = new Map<string, (...args: unknown[]) => unknown>();
     const processOnSpy = vi.spyOn(process, 'on').mockImplementation(((

--- a/src/backend/services/run-script/service/run-script.service.ts
+++ b/src/backend/services/run-script/service/run-script.service.ts
@@ -33,6 +33,7 @@ export class RunScriptService {
   private readonly runOutput = new RunScriptOutputBuffer(MAX_OUTPUT_BUFFER_SIZE);
   private readonly postRunOutput = new RunScriptOutputBuffer(MAX_OUTPUT_BUFFER_SIZE);
 
+  private cleanupPromise: Promise<void> | null = null;
   private isShuttingDown = false;
   private shutdownHandlersRegistered = false;
 
@@ -893,29 +894,39 @@ export class RunScriptService {
   /**
    * Cleanup all running scripts (called on server shutdown)
    */
-  async cleanup() {
-    logger.info('Cleaning up all running scripts', {
-      count: this.runningProcesses.size,
+  cleanup(): Promise<void> {
+    if (this.cleanupPromise !== null) {
+      return this.cleanupPromise;
+    }
+
+    this.cleanupPromise = (async () => {
+      logger.info('Cleaning up all running scripts', {
+        count: this.runningProcesses.size,
+      });
+
+      // Stop all running scripts using the stopRunScript method
+      // This ensures cleanup scripts are run
+      const workspaceIds = Array.from(this.runningProcesses.keys());
+      await Promise.all(
+        workspaceIds.map(async (workspaceId) => {
+          try {
+            await this.stopRunScript(workspaceId);
+          } catch (error) {
+            logger.error('Failed to stop run script during cleanup', toError(error), {
+              workspaceId,
+            });
+          }
+        })
+      );
+
+      this.runningProcesses.clear();
+      this.postRunProcesses.clear();
+      await runScriptProxyService.cleanup();
+    })().finally(() => {
+      this.cleanupPromise = null;
     });
 
-    // Stop all running scripts using the stopRunScript method
-    // This ensures cleanup scripts are run
-    const workspaceIds = Array.from(this.runningProcesses.keys());
-    await Promise.all(
-      workspaceIds.map(async (workspaceId) => {
-        try {
-          await this.stopRunScript(workspaceId);
-        } catch (error) {
-          logger.error('Failed to stop run script during cleanup', toError(error), {
-            workspaceId,
-          });
-        }
-      })
-    );
-
-    this.runningProcesses.clear();
-    this.postRunProcesses.clear();
-    await runScriptProxyService.cleanup();
+    return this.cleanupPromise;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Wait for run-script cleanup to finish as part of the central server shutdown path before the CLI exits.
- Share concurrent signal- and server-triggered cleanup work so user cleanup scripts and process teardown cannot race.

## Changes
- **Run-script service**: Reuse an in-flight cleanup promise while allowing later cleanup cycles after completion.
- **Server lifecycle**: Await run-script cleanup before continuing graceful shutdown and disconnecting the database.
- **Regression coverage**: Verify concurrent callers do not duplicate cleanup and server shutdown remains pending until cleanup completes.

## Testing
- [x] Tests pass (`pnpm test` — 4,572 passed, 3 skipped)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting and lint pass (`pnpm check:fix`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not performed; automated lifecycle tests cover the shutdown ordering and concurrency regression.

Closes #1900

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes graceful shutdown ordering and run-script process teardown; mistakes could exit before cleanup scripts run or race duplicate stops, though behavior is covered by lifecycle tests.
> 
> **Overview**
> **Graceful shutdown** now **`await`s `runScriptService.cleanup()`** in the central server stop path, so workspace dev scripts, user cleanup commands, and proxy teardown can finish **before** the database disconnects and the process exits.
> 
> **`RunScriptService.cleanup()`** reuses a single in-flight promise when shutdown is triggered from multiple places (e.g. SIGTERM and `server.stop()`), avoiding duplicate `stopRunScript` / tunnel cleanup races. After that pass completes, the guard resets so a later cleanup cycle can run if needed.
> 
> Regression tests cover **shutdown ordering** (DB stays connected until run-script cleanup resolves) and **concurrent cleanup** (one shared stop pass, then a fresh pass when new work appears).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 075000e40435924c3288c9d0ddd5ecdf4809085b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->