### PR TITLE
Prepare 0.4.4 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to Factory Factory will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.4] - 2026-07-29
+
+### Changed
+
+- Normalize Kanban card status chips and tighten their metadata layout (#2073)
+- Show issue creators consistently across GitHub and Linear Todo cards, and clarify the provider-specific column heading (#2066)
+
+### Fixed
+
+- Preserve failed dispatch drafts after runtime crashes (#2072)
+- Await run-script cleanup during server shutdown (#2071)
+- Keep monthly periodic tasks anchored to their configured day (#2070)
+- Guard Ratchet observations against pull-request URL changes and clean up completed fixer sessions correctly (#2068, #2069)
+
+### Documentation
+
+- Correct the documented Ratchet observation guard to reflect pull-request URL keying (#2074)
+
 ## [0.4.3] - 2026-07-29
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "factory-factory",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Workspace-based coding environment for running multiple Claude Code and Codex sessions in parallel",
   "private": false,
   "license": "MIT",


### PR DESCRIPTION
## Summary

- bump the package version from 0.4.3 to 0.4.4
- add the 0.4.4 changelog entry covering all eight changes merged since 0.4.3
- group the release notes by changed, fixed, and documentation impact

## Why

Prepare the next patch release with an accurate user-facing record of the Kanban presentation updates and reliability fixes shipped after 0.4.3.

## Impact

Publishing this release will expose version 0.4.4 and its release notes. There are no runtime code changes in this PR.

## Validation

- `pnpm check`
- `pnpm typecheck`
- `pnpm test` — 355 files passed, 2 skipped; 4,595 tests passed, 3 skipped
- `pnpm build`

Note: the local Codex schema drift sub-check reported the installed CLI as 0.146.0 while the repository pins 0.145.0, so it skipped locally as designed; CI installs the pinned CLI and enforces the check.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata only (version and changelog); publishing exposes the new version and notes but this PR does not change runtime behavior.
> 
> **Overview**
> Prepares **0.4.4** as a patch release with no application code changes in this PR.
> 
> Bumps `package.json` from **0.4.3** to **0.4.4** and adds a **CHANGELOG** section dated 2026-07-29 that records eight merged items since 0.4.3: Kanban status-chip normalization and issue-creator/column-heading UI (#2073, #2066); reliability fixes for dispatch drafts after crashes, run-script shutdown cleanup, monthly periodic task anchoring, and Ratchet observation/session cleanup (#2072, #2071, #2070, #2068, #2069); plus a documentation correction for Ratchet PR URL keying (#2074).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fdd253ef505c590614f1f625fa913ffb18a3da3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->