### PR TITLE
Fix #2093: Persist ExitPlanMode approval

### DIFF
--- a/docs/superpowers/plans/2026-07-30-exit-plan-mode-settings-persistence.md
+++ b/docs/superpowers/plans/2026-07-30-exit-plan-mode-settings-persistence.md
@@ -1,0 +1,118 @@
+# ExitPlanMode Settings Persistence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep plan mode disabled across refresh after an approved `ExitPlanMode` request.
+
+**Architecture:** Persist the capability-clamped disabled setting at the shared
+plan-approval action boundary. Keep the reducer pure and preserve the existing
+Codex and non-Codex completion behavior.
+
+**Tech Stack:** React hooks, TypeScript, Vitest, jsdom sessionStorage
+
+## Global Constraints
+
+- Do not change permission-response wire messages or provider-specific completion behavior.
+- Do not add persistence side effects to reducers.
+- Preserve the `answerQuestion` ExitPlanMode path's in-memory update.
+
+---
+
+### Task 1: Add the regression test and persistence fix
+
+**Files:**
+- Modify: `src/client/features/chat/use-chat-state.integration.test.tsx`
+- Modify: `src/client/features/chat/use-chat-actions.ts`
+
+**Interfaces:**
+- Consumes: `UseChatStateReturn.approvePermission(requestId, allow, optionId?)`
+- Produces: session-scoped persisted `ChatSettings` with `planModeEnabled: false`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Add a test that renders `useChatState` for `session-A`, dispatches Codex
+capabilities with plan mode enabled, calls `updateSettings` to persist
+`planModeEnabled: true`, installs a pending `ExitPlanMode` permission request,
+approves it, and asserts:
+
+```typescript
+expect(harness.chatRef.current?.chatSettings.planModeEnabled).toBe(false);
+expect(loadSettings('session-A')?.planModeEnabled).toBe(false);
+```
+
+- [ ] **Step 2: Run the test to verify RED**
+
+Run:
+
+```bash
+pnpm test src/client/features/chat/use-chat-state.integration.test.tsx
+```
+
+Expected: the new test fails because `loadSettings('session-A')` returns
+`planModeEnabled: true`.
+
+- [ ] **Step 3: Implement the minimal persistence change**
+
+In `completeCodexPlanApproval`, after dispatching the existing settings update,
+construct and persist capability-aware settings:
+
+```typescript
+const syncedSettings = clampChatSettingsForCapabilities(
+  { ...state.chatSettings, planModeEnabled: false },
+  state.chatCapabilities
+);
+persistSettings(dbSessionIdRef.current, syncedSettings);
+```
+
+Include `dbSessionIdRef` in the callback dependencies.
+
+- [ ] **Step 4: Run the focused test to verify GREEN**
+
+Run:
+
+```bash
+pnpm test src/client/features/chat/use-chat-state.integration.test.tsx
+```
+
+Expected: all tests in the file pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/client/features/chat/use-chat-actions.ts \
+  src/client/features/chat/use-chat-state.integration.test.tsx
+git commit -m "Persist plan mode exit approval (#2093)"
+```
+
+### Task 2: Verify, review, and publish
+
+**Files:**
+- Review: all changes relative to `origin/main`
+
+**Interfaces:**
+- Consumes: the completed regression fix
+- Produces: a clean branch and pull request closing issue #2093
+
+- [ ] **Step 1: Run required verification**
+
+```bash
+pnpm typecheck && pnpm check:fix && pnpm test && pnpm build
+```
+
+- [ ] **Step 2: Review the complete diff and status**
+
+```bash
+git diff origin/main
+git status -sb
+```
+
+- [ ] **Step 3: Commit any formatting-only follow-up if needed**
+
+Stage only files changed by the required formatting check and use a terse,
+descriptive commit.
+
+- [ ] **Step 4: Push and create the pull request**
+
+Push the current issue branch, create the requested PR body with verification
+results and `Closes #2093`, append the Factory Factory signature, create the PR,
+and verify its URL.

--- a/docs/superpowers/specs/2026-07-30-exit-plan-mode-settings-persistence-design.md
+++ b/docs/superpowers/specs/2026-07-30-exit-plan-mode-settings-persistence-design.md
@@ -1,0 +1,45 @@
+# ExitPlanMode Settings Persistence Design
+
+## Problem
+
+Approving `ExitPlanMode` clears `chatSettings.planModeEnabled` in memory, but the
+action flow does not update the session-scoped settings in `sessionStorage`.
+Reloading can therefore restore the stale enabled value.
+
+## Approaches considered
+
+1. Persist only inside `approvePermission`. This follows the permission reducer
+   closely, but misses the existing `answerQuestion` path that also completes an
+   `ExitPlanMode` approval.
+2. Synchronize plan mode from ACP config updates. This may eventually reinforce
+   the state, but it does not cover Codex and would put persistence concerns too
+   far from the user action that changes the setting.
+3. Persist in the shared plan-approval completion helper. This keeps both
+   approval entry paths consistent and mirrors the existing capability-clamped
+   persistence pattern used by settings and model changes.
+
+Approach 3 is selected.
+
+## Design
+
+`completeCodexPlanApproval` will continue to perform the shared local
+`planModeEnabled: false` update needed by the question-response path. It will
+also build a complete settings object from the state captured before approval,
+override plan mode to `false`, clamp it against the current provider
+capabilities, and persist it using the current database session id.
+
+Provider-specific behavior remains unchanged: non-Codex providers may receive a
+post-plan ACP mode update, while Codex receives the automatic `Approved`
+message.
+
+## Testing
+
+An integration test will exercise the real `useChatState` action callback and
+browser `sessionStorage`: enable and persist plan mode, approve an
+`ExitPlanMode` permission request, then assert both current state and persisted
+settings are disabled. The test will fail before the production change because
+the stored value remains `true`.
+
+Existing reducer tests continue to cover denial and unrelated-tool behavior.
+The implementation conditions remain unchanged, so those paths do not invoke
+the completion helper and cannot overwrite persisted plan mode.

--- a/src/client/features/chat/use-chat-actions.ts
+++ b/src/client/features/chat/use-chat-actions.ts
@@ -363,11 +363,16 @@ export function useChatActions(options: UseChatActionsOptions): UseChatActionsRe
       }
 
       dispatch({ type: 'UPDATE_SETTINGS', payload: { planModeEnabled: false } });
+      const syncedSettings = clampChatSettingsForCapabilities(
+        { ...state.chatSettings, planModeEnabled: false },
+        state.chatCapabilities
+      );
+      persistSettings(dbSessionIdRef.current, syncedSettings);
       if (isCodexProvider) {
         queueAutomaticMessage('Approved');
       }
     },
-    [send, dispatch, queueAutomaticMessage]
+    [send, dispatch, dbSessionIdRef, queueAutomaticMessage]
   );
 
   const stopChat = useCallback(() => {

--- a/src/client/features/chat/use-chat-state.integration.test.tsx
+++ b/src/client/features/chat/use-chat-state.integration.test.tsx
@@ -7,6 +7,8 @@ import { toast } from 'sonner';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MessageAttachment } from '@/lib/chat-protocol';
 import { MessageState } from '@/lib/chat-protocol';
+import { createCodexChatBarCapabilities } from '@/shared/chat-capabilities';
+import { loadSettings } from './chat-persistence';
 import { type UseChatStateReturn, useChatState } from './use-chat-state';
 
 vi.mock('sonner', () => ({
@@ -278,6 +280,56 @@ describe('useChatState rejected message recovery', () => {
     expect(harness.chatRef.current?.inputAttachments).toEqual([]);
     expect(sessionStorage.getItem('chat-draft-null')).toBeNull();
     expect(sessionStorage.getItem('chat-attachments-null')).toBeNull();
+
+    harness.cleanup();
+  });
+});
+
+describe('useChatState plan mode persistence', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it('persists disabled plan mode after approving ExitPlanMode', async () => {
+    const harness = renderChatState('session-A');
+    await flushEffects();
+
+    flushSync(() => {
+      harness.chatRef.current?.dispatch({
+        type: 'WS_CHAT_CAPABILITIES',
+        payload: { capabilities: createCodexChatBarCapabilities() },
+      });
+    });
+    flushSync(() => {
+      harness.chatRef.current?.updateSettings({ planModeEnabled: true });
+    });
+
+    expect(loadSettings('session-A')?.planModeEnabled).toBe(true);
+
+    flushSync(() => {
+      harness.chatRef.current?.dispatch({
+        type: 'WS_PERMISSION_REQUEST',
+        payload: {
+          requestId: 'exit-plan',
+          toolName: 'ExitPlanMode',
+          toolInput: {},
+          timestamp: '2026-07-30T00:00:00.000Z',
+        },
+      });
+    });
+    flushSync(() => {
+      harness.chatRef.current?.approvePermission('exit-plan', true);
+    });
+
+    expect(harness.chatRef.current?.chatSettings.planModeEnabled).toBe(false);
+    expect(loadSettings('session-A')?.planModeEnabled).toBe(false);
 
     harness.cleanup();
   });


### PR DESCRIPTION
## Summary
- Persist plan mode as disabled when an `ExitPlanMode` approval completes
- Prevent stale session settings from re-enabling plan mode after refresh
- Add a real hook and `sessionStorage` regression test

## Changes
- **Chat actions**: Persist capability-clamped settings at the shared plan-approval completion boundary so permission and question approval paths stay consistent
- **Tests**: Verify an approved `ExitPlanMode` request updates both in-memory state and session-scoped persisted settings
- **Design**: Document the action-boundary persistence decision and implementation plan

## Testing
- [x] Tests pass (`pnpm test` — 4,596 passed, 3 skipped)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Formatting passes (`pnpm check:fix` — no fixes applied)
- [x] Manual testing: Not applicable; the persistence flow is covered by the jsdom integration regression test

Closes #2093

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized chat-settings persistence at an existing approval helper; no wire protocol or reducer changes.
> 
> **Overview**
> Fixes **#2093** by writing **disabled plan mode** to session-scoped settings when an **`ExitPlanMode`** approval finishes, so a refresh no longer restores a stale `planModeEnabled: true`.
> 
> In **`completeCodexPlanApproval`**, after the in-memory `UPDATE_SETTINGS`, the flow now builds capability-clamped settings and calls **`persistSettings`** for the current session—the same boundary used by permission and question approval paths. Provider-specific behavior (Codex auto-approve message, non-Codex mode config) is unchanged.
> 
> A **jsdom integration test** covers enabling plan mode, approving **`ExitPlanMode`**, and asserting both live state and **`loadSettings`** show plan mode off. Design and implementation notes were added under **`docs/superpowers/`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffaa3eaae150b55d320ca75bc64ea9d193c667ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

