### PR TITLE
Fix #2091: Respect dismissed slash palette

### DIFF
--- a/src/client/features/chat/chat-input/hooks/use-chat-input-actions.test.tsx
+++ b/src/client/features/chat/chat-input/hooks/use-chat-input-actions.test.tsx
@@ -17,30 +17,36 @@ import { useChatInputActions } from './use-chat-input-actions';
 
 interface ShortcutHarnessProps {
   capabilities: ChatBarCapabilities;
+  disabled?: boolean;
   running?: boolean;
   settingsPlanEnabled?: boolean;
   settingsThinkingEnabled?: boolean;
+  onCloseSlashMenu?: () => void;
+  onSend?: (text: string) => void;
   onSettingsChange: (settings: Partial<ChatSettings>) => void;
 }
 
 function ShortcutHarness({
   capabilities,
+  disabled = false,
   running = false,
   settingsPlanEnabled = false,
   settingsThinkingEnabled = false,
+  onCloseSlashMenu = () => undefined,
+  onSend = () => undefined,
   onSettingsChange,
 }: ShortcutHarnessProps) {
   const [attachments, setAttachments] = useState<MessageAttachment[]>([]);
   const actions = useChatInputActions({
-    onSend: () => undefined,
+    onSend,
     onStop: () => undefined,
     onOpenQuickActions: () => undefined,
-    onCloseSlashMenu: () => undefined,
+    onCloseSlashMenu,
     onCloseFileMentionMenu: () => undefined,
     onChange: () => undefined,
     onSettingsChange,
     capabilities,
-    disabled: false,
+    disabled,
     running,
     settings: {
       ...DEFAULT_CHAT_SETTINGS,
@@ -94,11 +100,68 @@ function dispatchModShiftShortcut(textarea: HTMLTextAreaElement, key: string): K
   return event;
 }
 
+function dispatchModShortcut(textarea: HTMLTextAreaElement, key: string): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', {
+    key,
+    ctrlKey: true,
+    bubbles: true,
+    cancelable: true,
+  });
+  flushSync(() => {
+    textarea.dispatchEvent(event);
+  });
+  return event;
+}
+
 afterEach(() => {
   document.body.innerHTML = '';
 });
 
 describe('useChatInputActions keyboard shortcuts', () => {
+  it('does not dismiss the slash menu when a Mod+Enter send is skipped', () => {
+    const onCloseSlashMenu = vi.fn();
+    const onSend = vi.fn();
+    const capabilities = createClaudeChatBarCapabilities('sonnet');
+    const { root, container, textarea } = renderHarness({
+      capabilities,
+      disabled: true,
+      onCloseSlashMenu,
+      onSend,
+      onSettingsChange: () => undefined,
+    });
+    textarea.value = '/help';
+
+    dispatchModShortcut(textarea, 'Enter');
+
+    expect(onSend).not.toHaveBeenCalled();
+    expect(onCloseSlashMenu).not.toHaveBeenCalled();
+
+    root.unmount();
+    container.remove();
+  });
+
+  it('closes the slash menu after a successful Mod+Enter send', () => {
+    const onCloseSlashMenu = vi.fn();
+    const onSend = vi.fn();
+    const capabilities = createClaudeChatBarCapabilities('sonnet');
+    const { root, container, textarea } = renderHarness({
+      capabilities,
+      onCloseSlashMenu,
+      onSend,
+      onSettingsChange: () => undefined,
+    });
+    textarea.value = '/help';
+
+    dispatchModShortcut(textarea, 'Enter');
+
+    expect(onSend).toHaveBeenCalledWith('/help');
+    expect(onCloseSlashMenu).toHaveBeenCalledOnce();
+    expect(textarea.value).toBe('');
+
+    root.unmount();
+    container.remove();
+  });
+
   it('toggles plan mode with Mod+Shift+P when plan mode is enabled', () => {
     const onSettingsChange = vi.fn();
     const capabilities = createClaudeChatBarCapabilities('sonnet');

--- a/src/client/features/chat/chat-input/hooks/use-chat-input-actions.ts
+++ b/src/client/features/chat/chat-input/hooks/use-chat-input-actions.ts
@@ -143,7 +143,7 @@ export function useChatInputActions({
   const sendFromInput = useCallback(
     (inputElement: HTMLTextAreaElement | null) => {
       if (!inputElement) {
-        return;
+        return false;
       }
       const text = inputElement.value.trim();
       if ((text || attachments.length > 0) && !disabled) {
@@ -151,7 +151,9 @@ export function useChatInputActions({
         inputElement.value = '';
         onChange?.('');
         setAttachments([]);
+        return true;
       }
+      return false;
     },
     [attachments.length, disabled, onChange, onSend, setAttachments]
   );
@@ -164,9 +166,10 @@ export function useChatInputActions({
         shift: false,
         alt: false,
         action: (event) => {
-          onCloseSlashMenu?.();
-          onCloseFileMentionMenu?.();
-          sendFromInput(event.currentTarget);
+          if (sendFromInput(event.currentTarget)) {
+            onCloseSlashMenu?.();
+            onCloseFileMentionMenu?.();
+          }
         },
       },
       {

--- a/src/client/features/composer/hooks/use-slash-commands.test.ts
+++ b/src/client/features/composer/hooks/use-slash-commands.test.ts
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+
+import { act, type ChangeEvent, createElement, createRef, type RefObject } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { CommandInfo } from '@/lib/chat-protocol';
+import { useSlashCommands } from './use-slash-commands';
+
+type SlashCommandsResult = ReturnType<typeof useSlashCommands>;
+
+interface HarnessProps {
+  inputRef: RefObject<HTMLTextAreaElement | null>;
+  slashCommands: CommandInfo[];
+  onResult: (result: SlashCommandsResult) => void;
+}
+
+function Harness({ inputRef, slashCommands, onResult }: HarnessProps) {
+  const result = useSlashCommands({
+    inputRef,
+    slashCommands,
+  });
+  onResult(result);
+  return createElement('textarea', { ref: inputRef });
+}
+
+interface RenderedHook {
+  getResult: () => SlashCommandsResult;
+  rerender: (slashCommands: CommandInfo[]) => void;
+  textarea: HTMLTextAreaElement;
+}
+
+const mountedRoots: Array<{ container: HTMLDivElement; root: Root }> = [];
+
+Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
+  configurable: true,
+  writable: true,
+  value: true,
+});
+
+function renderHook(initialSlashCommands: CommandInfo[]): RenderedHook {
+  const container = document.createElement('div');
+  const root = createRoot(container);
+  const inputRef = createRef<HTMLTextAreaElement>();
+  let result: SlashCommandsResult | undefined;
+
+  const render = (slashCommands: CommandInfo[]) => {
+    root.render(
+      createElement(Harness, {
+        inputRef,
+        slashCommands,
+        onResult: (nextResult) => {
+          result = nextResult;
+        },
+      })
+    );
+  };
+
+  document.body.appendChild(container);
+  mountedRoots.push({ container, root });
+  void act(() => render(initialSlashCommands));
+
+  const textarea = inputRef.current;
+  if (!textarea) {
+    throw new Error('Expected the hook harness to render a textarea');
+  }
+
+  return {
+    getResult: () => {
+      if (!result) {
+        throw new Error('Expected the hook harness to expose a result');
+      }
+      return result;
+    },
+    rerender: (slashCommands) => {
+      void act(() => render(slashCommands));
+    },
+    textarea,
+  };
+}
+
+function changeInput(rendered: RenderedHook, value: string) {
+  rendered.textarea.value = value;
+  void act(() => {
+    rendered
+      .getResult()
+      .handleInputChange({ target: rendered.textarea } as ChangeEvent<HTMLTextAreaElement>);
+  });
+}
+
+const helpCommand: CommandInfo = {
+  name: 'help',
+  description: 'Show available commands',
+};
+
+afterEach(() => {
+  for (const { container, root } of mountedRoots.splice(0)) {
+    void act(() => root.unmount());
+    container.remove();
+  }
+});
+
+describe('useSlashCommands async loading', () => {
+  it('keeps the palette closed when commands arrive after the user dismisses it', () => {
+    const rendered = renderHook([]);
+    changeInput(rendered, '/');
+
+    expect(rendered.getResult().slashMenuOpen).toBe(true);
+    void act(() => rendered.getResult().handleSlashMenuClose());
+    expect(rendered.getResult().slashMenuOpen).toBe(false);
+
+    rendered.rerender([helpCommand]);
+
+    expect(rendered.getResult().slashMenuOpen).toBe(false);
+  });
+
+  it('treats close-and-passthrough keyboard handling as a dismissal', () => {
+    const rendered = renderHook([helpCommand]);
+    changeInput(rendered, '/missing');
+    rendered.getResult().paletteRef.current = {
+      handleKeyDown: () => 'close-and-passthrough',
+    };
+
+    void act(() => {
+      expect(rendered.getResult().delegateToSlashMenu('Enter')).toBe('close-and-passthrough');
+    });
+    expect(rendered.getResult().slashMenuOpen).toBe(false);
+
+    rendered.rerender([helpCommand, { name: 'status', description: 'Show current status' }]);
+
+    expect(rendered.getResult().slashMenuOpen).toBe(false);
+  });
+
+  it('opens the palette again when the user resumes typing after dismissal', () => {
+    const rendered = renderHook([]);
+    changeInput(rendered, '/');
+    void act(() => rendered.getResult().handleSlashMenuClose());
+
+    changeInput(rendered, '/h');
+
+    expect(rendered.getResult().slashMenuOpen).toBe(true);
+    expect(rendered.getResult().slashFilter).toBe('h');
+  });
+
+  it('opens the palette when commands arrive without an explicit dismissal', () => {
+    const rendered = renderHook([]);
+    rendered.textarea.value = '/he';
+
+    rendered.rerender([helpCommand]);
+
+    expect(rendered.getResult().slashMenuOpen).toBe(true);
+    expect(rendered.getResult().slashFilter).toBe('he');
+  });
+});

--- a/src/client/features/composer/hooks/use-slash-commands.ts
+++ b/src/client/features/composer/hooks/use-slash-commands.ts
@@ -39,6 +39,7 @@ export function useSlashCommands({
   const [slashMenuOpen, setSlashMenuOpen] = useState(false);
   const [slashFilter, setSlashFilter] = useState('');
   const paletteRef = useRef<SlashCommandPaletteHandle>(null);
+  const userDismissedRef = useRef(false);
   const commandsReady = !enabled || commandsLoaded || slashCommands.length > 0;
 
   useEffect(() => {
@@ -51,7 +52,7 @@ export function useSlashCommands({
 
   // Re-evaluate slash menu when commands arrive (handles typing "/" before commands load)
   useEffect(() => {
-    if (!enabled || slashCommands.length === 0 || !inputRef?.current) {
+    if (!enabled || slashCommands.length === 0 || !inputRef?.current || userDismissedRef.current) {
       return;
     }
     const currentValue = inputRef.current.value;
@@ -87,6 +88,7 @@ export function useSlashCommands({
 
         // Only show menu if no space yet (still completing command name)
         if (spaceIndex === -1) {
+          userDismissedRef.current = false;
           setSlashFilter(filter);
           setSlashMenuOpen(true);
         } else {
@@ -121,6 +123,7 @@ export function useSlashCommands({
   );
 
   const handleSlashMenuClose = useCallback(() => {
+    userDismissedRef.current = true;
     setSlashMenuOpen(false);
     setSlashFilter('');
   }, []);
@@ -132,6 +135,7 @@ export function useSlashCommands({
       }
       const result = paletteRef.current.handleKeyDown(key);
       if (result === 'close-and-passthrough') {
+        userDismissedRef.current = true;
         setSlashMenuOpen(false);
       }
       return result;


### PR DESCRIPTION
## Summary
- Respect explicit slash-command palette dismissal while commands load asynchronously
- Preserve automatic opening for undismissed slash drafts and allow typing to reopen the palette

## Changes
- **Composer hook**: Track user dismissal across command updates, including the direct close-and-passthrough keyboard path
- **Regression coverage**: Add hook tests for dismissal, keyboard passthrough, reset-on-typing, and undismissed command arrival

## Testing
- [x] Tests pass (`pnpm test` — 4,599 passed)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting passes (`pnpm check:fix`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not performed; the timing-only interaction is covered by focused hook tests

Closes #2091

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized chat input and slash-menu UX with regression tests; no auth, data, or API changes.
> 
> **Overview**
> Fixes slash-command palette **reopening after the user dismissed it** while commands were still loading, and stops **Mod+Enter** from closing the palette when send is skipped (e.g. input disabled).
> 
> `useSlashCommands` now tracks explicit dismissal (close UI or palette `close-and-passthrough` keyboard path) and skips the “commands just arrived” effect when that flag is set; continuing to type in an active `/…` draft clears dismissal so the palette can open again. Undismissed `/` drafts still auto-open when commands load.
> 
> `sendFromInput` returns whether a send actually ran; **Mod+Enter** only invokes slash/file menu close handlers after a successful send. New hook and keyboard shortcut tests cover dismissal, async command arrival, and send vs. no-send paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14a1d061ca6d9d3a4b8791e5b2e1a357470ac195. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
