### PR TITLE
Fix #2095: Prevent retry worktree cleanup

### DIFF
--- a/src/backend/orchestration/workspace-init.orchestrator.test.ts
+++ b/src/backend/orchestration/workspace-init.orchestrator.test.ts
@@ -3,6 +3,12 @@ import { SessionStatus } from '@/shared/core';
 import { unsafeCoerce } from '@/test-utils/unsafe-coerce';
 
 const mockWorkspaceUpdate = vi.hoisted(() => vi.fn());
+const mockLogger = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
 
 // --- Module mocks (before imports) ---
 
@@ -92,12 +98,7 @@ vi.mock('@/backend/services/workspace', () => ({
 }));
 
 vi.mock('@/backend/services/logger.service', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  }),
+  createLogger: () => mockLogger,
 }));
 
 vi.mock('@/shared/acp-protocol', () => ({
@@ -122,6 +123,7 @@ import {
 } from '@/backend/services/session';
 import { terminalService, terminalSessionService } from '@/backend/services/terminal';
 import {
+  assertWorktreePathSafe,
   gitOpsService,
   workspaceDataService,
   workspaceRelationshipsService,
@@ -1561,6 +1563,71 @@ describe('initializeWorkspaceWorktree', () => {
       await initializeWorkspaceWorktree(WORKSPACE_ID);
 
       expect(gitOpsService.removeWorktree).not.toHaveBeenCalled();
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'Skipping unregistered worktree cleanup while workspace is provisioning',
+        {
+          workspaceId: WORKSPACE_ID,
+          worktreePath: '/worktrees/workspace-ws-1',
+        }
+      );
+    });
+
+    it('finishes stale cleanup before a retry can recreate the worktree', async () => {
+      const workspace = setupHappyPath();
+      const cleanupSafetyCheck = createDeferredPromise<void>();
+      const sideEffects: string[] = [];
+      let status: 'FAILED' | 'PROVISIONING' = 'PROVISIONING';
+
+      vi.mocked(workspaceStateMachine.startProvisioning).mockImplementation(() => {
+        status = 'PROVISIONING';
+        return Promise.resolve(unsafeCoerce(workspace));
+      });
+      vi.mocked(workspaceStateMachine.markFailed).mockImplementation(() => {
+        status = 'FAILED';
+        return Promise.resolve(unsafeCoerce(workspace));
+      });
+      vi.mocked(workspaceDataService.findById).mockImplementation(() =>
+        Promise.resolve(
+          unsafeCoerce({
+            id: WORKSPACE_ID,
+            status,
+            worktreePath: null,
+          })
+        )
+      );
+      vi.mocked(mockWorkspaceUpdate)
+        .mockRejectedValueOnce(new Error('db update error'))
+        .mockResolvedValueOnce(workspace as never);
+      vi.mocked(gitOpsService.createWorktree).mockImplementation(() => {
+        sideEffects.push('create');
+        return Promise.resolve({
+          worktreePath: '/worktrees/workspace-ws-1',
+          branchName: 'user/test-workspace',
+        });
+      });
+      vi.mocked(gitOpsService.removeWorktree).mockImplementation(() => {
+        sideEffects.push('remove');
+        return Promise.resolve();
+      });
+      vi.mocked(assertWorktreePathSafe).mockImplementationOnce(() => cleanupSafetyCheck.promise);
+
+      const failedInitialization = initializeWorkspaceWorktree(WORKSPACE_ID);
+      await vi.waitFor(() => {
+        expect(sideEffects).toEqual(['create']);
+      });
+      await vi.waitFor(() => {
+        expect(workspaceStateMachine.markFailed).toHaveBeenCalledTimes(1);
+      });
+
+      const retryInitialization = initializeWorkspaceWorktree(WORKSPACE_ID);
+      for (let index = 0; index < 10; index += 1) {
+        await Promise.resolve();
+      }
+
+      cleanupSafetyCheck.resolve();
+      await Promise.all([failedInitialization, retryInitialization]);
+
+      expect(sideEffects).toEqual(['create', 'remove', 'create']);
     });
 
     it('does not remove worktree when failure occurs after persistence succeeds', async () => {

--- a/src/backend/orchestration/workspace-init.orchestrator.test.ts
+++ b/src/backend/orchestration/workspace-init.orchestrator.test.ts
@@ -1547,6 +1547,22 @@ describe('initializeWorkspaceWorktree', () => {
       );
     });
 
+    it('does not remove a retry worktree while the workspace is provisioning', async () => {
+      setupHappyPath();
+      vi.mocked(mockWorkspaceUpdate).mockRejectedValue(new Error('db update error'));
+      vi.mocked(workspaceDataService.findById).mockResolvedValue(
+        unsafeCoerce({
+          id: WORKSPACE_ID,
+          status: 'PROVISIONING',
+          worktreePath: null,
+        })
+      );
+
+      await initializeWorkspaceWorktree(WORKSPACE_ID);
+
+      expect(gitOpsService.removeWorktree).not.toHaveBeenCalled();
+    });
+
     it('does not remove worktree when failure occurs after persistence succeeds', async () => {
       setupHappyPath();
       vi.mocked(workspaceStateMachine.markReady).mockRejectedValue(new Error('ready failed'));

--- a/src/backend/orchestration/workspace-init.orchestrator.ts
+++ b/src/backend/orchestration/workspace-init.orchestrator.ts
@@ -170,6 +170,14 @@ async function cleanupUnregisteredWorktreeAfterInitFailure(
       return;
     }
 
+    if (workspace?.status === 'PROVISIONING') {
+      logger.info('Skipping unregistered worktree cleanup while workspace is provisioning', {
+        workspaceId,
+        worktreePath: worktreeInfo.worktreePath,
+      });
+      return;
+    }
+
     await assertWorktreePathSafe(worktreeInfo.worktreePath, project.worktreeBasePath);
     await gitOpsService.removeWorktree(worktreeInfo.worktreePath, project);
     logger.info('Removed unregistered worktree after init failure', {

--- a/src/backend/orchestration/workspace-init.orchestrator.ts
+++ b/src/backend/orchestration/workspace-init.orchestrator.ts
@@ -50,7 +50,14 @@ type UnregisteredWorktreeCleanupCandidate = {
   worktreeInfo: CreatedWorktreeInfo;
 };
 
+type WorkspaceInitializationOptions = {
+  branchName?: string;
+  useExistingBranch?: boolean;
+  provisioningAlreadyStarted?: boolean;
+};
+
 const gitHubUsernameCache = new GitHubUsernameCache(githubCLIService);
+const workspaceInitializationTails = new Map<string, Promise<void>>();
 
 function getCachedGitHubUsername(): Promise<string | null> {
   return gitHubUsernameCache.getCachedUsername();
@@ -58,6 +65,7 @@ function getCachedGitHubUsername(): Promise<string | null> {
 
 export function clearWorkspaceInitOrchestratorStateForTests(): void {
   gitHubUsernameCache.clear();
+  workspaceInitializationTails.clear();
 }
 
 async function startProvisioningOrLog(workspaceId: string): Promise<boolean> {
@@ -701,13 +709,9 @@ async function handlePostInitSessionStart(
   }
 }
 
-export async function initializeWorkspaceWorktree(
+async function runWorkspaceInitialization(
   workspaceId: string,
-  options?: {
-    branchName?: string;
-    useExistingBranch?: boolean;
-    provisioningAlreadyStarted?: boolean;
-  }
+  options?: WorkspaceInitializationOptions
 ): Promise<void> {
   if (!options?.provisioningAlreadyStarted) {
     const startedProvisioning = await startProvisioningOrLog(workspaceId);
@@ -829,4 +833,22 @@ export async function initializeWorkspaceWorktree(
       await worktreeLifecycleService.clearInitMode(workspaceId);
     }
   }
+}
+
+export function initializeWorkspaceWorktree(
+  workspaceId: string,
+  options?: WorkspaceInitializationOptions
+): Promise<void> {
+  const previousInitialization = workspaceInitializationTails.get(workspaceId) ?? Promise.resolve();
+  const initialization = previousInitialization
+    .catch(() => undefined)
+    .then(() => runWorkspaceInitialization(workspaceId, options));
+
+  workspaceInitializationTails.set(workspaceId, initialization);
+
+  return initialization.finally(() => {
+    if (workspaceInitializationTails.get(workspaceId) === initialization) {
+      workspaceInitializationTails.delete(workspaceId);
+    }
+  });
 }


### PR DESCRIPTION
## Summary
- Prevent stale initialization cleanup from deleting a worktree created by an in-progress retry
- Serialize same-workspace initialization attempts through failure cleanup
- Add regression coverage for both the `PROVISIONING` guard and the destructive interleaving

## Changes
- **Workspace initialization**: Skip unregistered-worktree cleanup when the workspace has re-entered `PROVISIONING`, and log the skip for observability
- **Retry coordination**: Queue initialization attempts per workspace so stale cleanup completes before a retry recreates the deterministic path
- **Tests**: Verify the skip guard and enforce safe `create → remove → create` ordering for an interleaved retry

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Formatting passes (`pnpm check:fix`)
- [x] Manual testing: Not applicable; the backend race is covered by the concurrency regression test

Closes #2095

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes concurrency and git worktree cleanup during provisioning failures; mistakes could leave orphan worktrees or block retries, but scope is limited to workspace init orchestration with new regression tests.
> 
> **Overview**
> Fixes a race where **failed init cleanup** could **`removeWorktree`** on a path a **concurrent retry** had just recreated.
> 
> **Unregistered worktree cleanup** now **bails out** when the workspace is back in **`PROVISIONING`**, with an **info** log instead of deleting the worktree.
> 
> **`initializeWorkspaceWorktree`** **queues** runs per workspace ID so a retry waits for the prior attempt (including stale cleanup) to finish; the real work lives in **`runWorkspaceInitialization`**.
> 
> Tests cover the **`PROVISIONING`** guard and **`create → remove → create`** ordering under overlapping init calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25709339a892ccf2cbc8e3aa3818c84185a3b4a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

