### PR TITLE
Fix #2100: Persist manual workspace provider selection

### DIFF
--- a/src/backend/services/workspace/service/lifecycle/creation.service.test.ts
+++ b/src/backend/services/workspace/service/lifecycle/creation.service.test.ts
@@ -181,6 +181,23 @@ describe('WorkspaceCreationService', () => {
         });
       });
 
+      it('persists selected provider for manual workspaces', async () => {
+        const source: WorkspaceCreationSource = {
+          type: 'MANUAL',
+          projectId: 'proj-1',
+          name: 'My Workspace',
+          provider: 'CODEX',
+        };
+
+        await service.create(source);
+
+        expect(workspaceAccessorModule.workspaceAccessor.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            defaultSessionProvider: 'CODEX',
+          })
+        );
+      });
+
       it('should use explicit ratchetEnabled value', async () => {
         const source: WorkspaceCreationSource = {
           type: 'MANUAL',

--- a/src/backend/services/workspace/service/lifecycle/creation.service.ts
+++ b/src/backend/services/workspace/service/lifecycle/creation.service.ts
@@ -234,6 +234,7 @@ export class WorkspaceCreationService {
         name: source.name,
         description: source.description,
         branchName: source.branchName,
+        defaultSessionProvider: source.provider,
         creationSource: 'MANUAL',
         ...(Object.keys(metadata).length > 0
           ? { creationMetadata: metadata as Prisma.InputJsonValue }


### PR DESCRIPTION
## Summary
- Persist the provider selected during manual workspace creation as the workspace default.
- Keep downstream session creation aligned with the user's workspace-level provider choice.

## Changes
- **Workspace creation**: Forward the MANUAL source provider to `defaultSessionProvider`.
- **Regression coverage**: Verify manual workspaces persist an explicitly selected provider.

## Testing
- [x] Tests pass (`pnpm test --maxWorkers=1 --retry=10`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Create a manual workspace with a provider different from the global default and verify the workspace selector and new sessions use it.

Closes #2100

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
