### PR TITLE
Fix #2096: Refresh Create PR button after sessions end

### DIFF
--- a/src/client/routes/projects/workspaces/use-workspace-detail-hooks.test.ts
+++ b/src/client/routes/projects/workspaces/use-workspace-detail-hooks.test.ts
@@ -3,18 +3,28 @@
 import { createElement } from 'react';
 import { flushSync } from 'react-dom';
 import { createRoot } from 'react-dom/client';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { trpc } from '@/client/lib/trpc';
-import { resolveSelectedSessionId, useWorkspaceInitStatus } from './use-workspace-detail-hooks';
+import {
+  resolveSelectedSessionId,
+  useWorkspaceHasChanges,
+  useWorkspaceInitStatus,
+} from './use-workspace-detail-hooks';
 
 const getInitStatusUseQueryMock = vi.hoisted(() => vi.fn());
+const hasChangesUseQueryMock = vi.hoisted(() => vi.fn());
+const workspaceGetInvalidateMock = vi.hoisted(() => vi.fn());
+const workspaceHasChangesInvalidateMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@/client/lib/trpc', () => ({
   trpc: {
     useUtils: () => ({
       workspace: {
         get: {
-          invalidate: vi.fn(),
+          invalidate: workspaceGetInvalidateMock,
+        },
+        hasChanges: {
+          invalidate: workspaceHasChangesInvalidateMock,
         },
       },
     }),
@@ -22,13 +32,103 @@ vi.mock('@/client/lib/trpc', () => ({
       getInitStatus: {
         useQuery: getInitStatusUseQueryMock,
       },
+      hasChanges: {
+        useQuery: hasChangesUseQueryMock,
+      },
     },
   },
 }));
 
+beforeEach(() => {
+  hasChangesUseQueryMock.mockReturnValue({ data: false });
+  workspaceHasChangesInvalidateMock.mockResolvedValue(undefined);
+});
+
 afterEach(() => {
   document.body.innerHTML = '';
   vi.clearAllMocks();
+});
+
+describe('useWorkspaceHasChanges', () => {
+  function Probe({
+    workspaceId = 'workspace-1',
+    running,
+    prState = 'NONE',
+  }: {
+    workspaceId?: string;
+    running: boolean;
+    prState?: 'NONE' | 'OPEN';
+  }) {
+    const utils = trpc.useUtils();
+    useWorkspaceHasChanges(workspaceId, { hasHadSessions: true, prState }, running, utils);
+    return null;
+  }
+
+  it('invalidates hasChanges when a running session stops', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    flushSync(() => {
+      root.render(createElement(Probe, { running: true }));
+    });
+    expect(workspaceHasChangesInvalidateMock).not.toHaveBeenCalled();
+
+    flushSync(() => {
+      root.render(createElement(Probe, { running: false }));
+    });
+    expect(workspaceHasChangesInvalidateMock).toHaveBeenCalledOnce();
+    expect(workspaceHasChangesInvalidateMock).toHaveBeenCalledWith({
+      workspaceId: 'workspace-1',
+    });
+
+    root.unmount();
+  });
+
+  it('does not invalidate for an initially stopped workspace', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    flushSync(() => {
+      root.render(createElement(Probe, { running: false }));
+    });
+
+    expect(workspaceHasChangesInvalidateMock).not.toHaveBeenCalled();
+    root.unmount();
+  });
+
+  it('does not treat navigation to a stopped workspace as a session completion', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    flushSync(() => {
+      root.render(createElement(Probe, { workspaceId: 'workspace-1', running: true }));
+    });
+    flushSync(() => {
+      root.render(createElement(Probe, { workspaceId: 'workspace-2', running: false }));
+    });
+
+    expect(workspaceHasChangesInvalidateMock).not.toHaveBeenCalled();
+    root.unmount();
+  });
+
+  it('does not invalidate when the workspace already has a pull request', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    flushSync(() => {
+      root.render(createElement(Probe, { running: true, prState: 'OPEN' }));
+    });
+    flushSync(() => {
+      root.render(createElement(Probe, { running: false, prState: 'OPEN' }));
+    });
+
+    expect(workspaceHasChangesInvalidateMock).not.toHaveBeenCalled();
+    root.unmount();
+  });
 });
 
 describe('useWorkspaceInitStatus', () => {

--- a/src/client/routes/projects/workspaces/use-workspace-detail-hooks.ts
+++ b/src/client/routes/projects/workspaces/use-workspace-detail-hooks.ts
@@ -9,6 +9,40 @@ import {
 } from './setup-warning-storage';
 import type { useWorkspaceData } from './use-workspace-detail';
 
+type WorkspaceHasChangesSource = Pick<
+  NonNullable<ReturnType<typeof useWorkspaceData>['workspace']>,
+  'hasHadSessions' | 'prState'
+>;
+
+export function useWorkspaceHasChanges(
+  workspaceId: string,
+  workspace: WorkspaceHasChangesSource | undefined,
+  running: boolean,
+  utils: ReturnType<typeof trpc.useUtils>
+): boolean | undefined {
+  const shouldCheckForChanges = workspace?.hasHadSessions === true && workspace.prState === 'NONE';
+  const { data: hasChanges } = trpc.workspace.hasChanges.useQuery(
+    { workspaceId },
+    { enabled: shouldCheckForChanges }
+  );
+  const previousStateRef = useRef({ workspaceId, running });
+
+  useEffect(() => {
+    const previousState = previousStateRef.current;
+    if (
+      shouldCheckForChanges &&
+      previousState.workspaceId === workspaceId &&
+      previousState.running &&
+      !running
+    ) {
+      void utils.workspace.hasChanges.invalidate({ workspaceId });
+    }
+    previousStateRef.current = { workspaceId, running };
+  }, [running, shouldCheckForChanges, utils, workspaceId]);
+
+  return hasChanges;
+}
+
 export function useWorkspaceInitStatus(
   workspaceId: string,
   workspace: ReturnType<typeof useWorkspaceData>['workspace'],

--- a/src/client/routes/projects/workspaces/workspace-detail-container.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-container.tsx
@@ -21,6 +21,7 @@ import { useSessionManagement, useWorkspaceData } from './use-workspace-detail';
 import {
   useAutoFocusChatInput,
   useSelectedSessionId,
+  useWorkspaceHasChanges,
   useWorkspaceInitStatus,
 } from './use-workspace-detail-hooks';
 import type { ChatContentProps } from './workspace-detail-chat-content';
@@ -55,11 +56,6 @@ export function WorkspaceDetailContainer() {
   const { rightPanelVisible, setRightPanelVisible, activeTabId, clearScrollState, openTab } =
     useWorkspacePanel();
   const { data: userSettings } = trpc.userSettings.get.useQuery();
-
-  const { data: hasChanges } = trpc.workspace.hasChanges.useQuery(
-    { workspaceId },
-    { enabled: workspace?.hasHadSessions === true && workspace?.prState === 'NONE' }
-  );
 
   const { workspaceInitStatus, isScriptFailed, setupWarningDismissed, dismissSetupWarning } =
     useWorkspaceInitStatus(workspaceId, workspace, utils);
@@ -170,6 +166,7 @@ export function WorkspaceDetailContainer() {
       Array.from(sessionSummariesById.values()).some((summary) => isSessionSummaryWorking(summary)),
     [sessionSummariesById]
   );
+  const hasChanges = useWorkspaceHasChanges(workspaceId, workspace, workspaceRunning, utils);
 
   const {
     createSession,


### PR DESCRIPTION
## Summary
- Refresh the workspace's `hasChanges` query when an agent session finishes.
- Surface the existing Create PR action immediately after committed changes become available.

## Changes
- **Workspace detail state**: Colocate the `hasChanges` query with transition-aware invalidation that detects running-to-stopped session changes for the same workspace.
- **Edge-case handling**: Avoid unnecessary invalidations on initial idle renders, workspace navigation, and workspaces that already have a pull request.
- **Regression coverage**: Exercise the session completion transition and its non-triggering edge cases in the detail hook tests.

## Testing
- [x] Tests pass (`pnpm test`: 4,609 passed, 3 skipped)
- [x] Types pass (`pnpm typecheck`)
- [x] Lint and formatting pass (`pnpm check:fix`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: UI screenshot capture was unavailable in this session; verify by ending an agent session that committed changes in a workspace without a PR and confirming Create PR appears without reloading.

Closes #2096

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 51512554dfc1771ce6cf858e4b7ed83684bbe2c0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

