### PR TITLE
Fix #2097: Clear stale quick chat sessions

### DIFF
--- a/src/client/features/kanban/use-quick-chat.test.tsx
+++ b/src/client/features/kanban/use-quick-chat.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+
+import { createElement } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useQuickChat } from './use-quick-chat';
+
+const sessionsByWorkspace = vi.hoisted(() => new Map<string, Array<{ id: string }> | undefined>());
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/client/features/chat', () => ({
+  useChatWebSocket: vi.fn(() => ({})),
+}));
+
+vi.mock('@/client/lib/trpc', () => ({
+  trpc: {
+    useUtils: () => ({
+      session: {
+        listSessions: {
+          cancel: vi.fn(),
+          getData: vi.fn(),
+          setData: vi.fn(),
+          invalidate: vi.fn(),
+        },
+      },
+    }),
+    session: {
+      listSessions: {
+        useQuery: ({ workspaceId }: { workspaceId: string }) => ({
+          data: sessionsByWorkspace.get(workspaceId),
+        }),
+      },
+      createAndStartSession: {
+        useMutation: () => ({
+          mutate: vi.fn(),
+          isPending: false,
+        }),
+      },
+      deleteSession: {
+        useMutation: () => ({
+          mutate: vi.fn(),
+        }),
+      },
+    },
+  },
+}));
+
+vi.mock('@/hooks/use-auto-scroll', () => ({
+  useAutoScroll: () => ({
+    onScroll: vi.fn(),
+    isNearBottom: true,
+    scrollToBottom: vi.fn(),
+  }),
+}));
+
+type QuickChatResult = ReturnType<typeof useQuickChat>;
+
+interface HarnessProps {
+  workspaceId: string | null;
+  revision: number;
+  onResult: (result: QuickChatResult) => void;
+}
+
+function Harness({ workspaceId, revision, onResult }: HarnessProps) {
+  void revision;
+  onResult(useQuickChat(workspaceId));
+  return null;
+}
+
+interface RenderedHook {
+  getResult: () => QuickChatResult;
+  rerender: (workspaceId: string | null) => void;
+}
+
+const mountedRoots: Array<{ container: HTMLDivElement; root: Root }> = [];
+
+function renderHook(workspaceId: string | null): RenderedHook {
+  const container = document.createElement('div');
+  const root = createRoot(container);
+  let result: QuickChatResult | undefined;
+  let revision = 0;
+
+  document.body.appendChild(container);
+  mountedRoots.push({ container, root });
+
+  const render = (nextWorkspaceId: string | null) => {
+    revision += 1;
+    flushSync(() => {
+      root.render(
+        createElement(Harness, {
+          workspaceId: nextWorkspaceId,
+          revision,
+          onResult: (nextResult) => {
+            result = nextResult;
+          },
+        })
+      );
+    });
+  };
+
+  render(workspaceId);
+
+  return {
+    getResult: () => {
+      if (!result) {
+        throw new Error('Expected the hook harness to expose a result');
+      }
+      return result;
+    },
+    rerender: render,
+  };
+}
+
+beforeEach(() => {
+  sessionsByWorkspace.clear();
+});
+
+afterEach(() => {
+  for (const { container, root } of mountedRoots.splice(0)) {
+    flushSync(() => root.unmount());
+    container.remove();
+  }
+  vi.clearAllMocks();
+});
+
+describe('useQuickChat session selection', () => {
+  it('clears a stale session after the new workspace confirms it has no sessions', async () => {
+    sessionsByWorkspace.set('workspace-a', [{ id: 'session-a' }]);
+    const rendered = renderHook('workspace-a');
+
+    await vi.waitFor(() => {
+      expect(rendered.getResult().selectedSessionId).toBe('session-a');
+    });
+
+    rendered.rerender('workspace-b');
+    expect(rendered.getResult().selectedSessionId).toBe('session-a');
+
+    sessionsByWorkspace.set('workspace-b', []);
+    rendered.rerender('workspace-b');
+
+    await vi.waitFor(() => {
+      expect(rendered.getResult().selectedSessionId).toBeNull();
+    });
+  });
+});

--- a/src/client/features/kanban/use-quick-chat.test.tsx
+++ b/src/client/features/kanban/use-quick-chat.test.tsx
@@ -38,7 +38,14 @@ vi.mock('@/client/lib/trpc', () => ({
       },
       createAndStartSession: {
         useMutation: () => ({
-          mutate: vi.fn(),
+          mutate: vi.fn(
+            (
+              { workspaceId }: { workspaceId: string },
+              options?: { onSuccess?: (session: { id: string }) => void }
+            ) => {
+              options?.onSuccess?.({ id: `created-for-${workspaceId}` });
+            }
+          ),
           isPending: false,
         }),
       },
@@ -130,6 +137,21 @@ afterEach(() => {
 });
 
 describe('useQuickChat session selection', () => {
+  it.each([
+    ['new chat', (result: QuickChatResult) => result.handleNewChat()],
+    ['quick action', (result: QuickChatResult) => result.handleQuickAction('Review', 'Review it')],
+  ])('keeps a session selected after a %s while the session list is stale', (_label, create) => {
+    sessionsByWorkspace.set('workspace-a', []);
+    const rendered = renderHook('workspace-a');
+
+    flushSync(() => {
+      create(rendered.getResult());
+    });
+
+    rendered.rerender('workspace-a');
+    expect(rendered.getResult().selectedSessionId).toBe('created-for-workspace-a');
+  });
+
   it('clears a stale session after the new workspace confirms it has no sessions', async () => {
     sessionsByWorkspace.set('workspace-a', [{ id: 'session-a' }]);
     const rendered = renderHook('workspace-a');

--- a/src/client/features/kanban/use-quick-chat.ts
+++ b/src/client/features/kanban/use-quick-chat.ts
@@ -4,6 +4,14 @@ import { useChatWebSocket } from '@/client/features/chat';
 import { trpc } from '@/client/lib/trpc';
 import { useAutoScroll } from '@/hooks/use-auto-scroll';
 
+function isPendingCreatedSelection(
+  pendingSession: { id: string; workspaceId: string } | null,
+  workspaceId: string,
+  selectedSessionId: string | null
+) {
+  return pendingSession?.workspaceId === workspaceId && pendingSession.id === selectedSessionId;
+}
+
 export function useQuickChat(workspaceId: string | null) {
   const utils = trpc.useUtils();
   const viewportRef = useRef<HTMLDivElement>(null);
@@ -15,26 +23,44 @@ export function useQuickChat(workspaceId: string | null) {
   );
 
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
+  const pendingCreatedSessionRef = useRef<{ id: string; workspaceId: string } | null>(null);
 
   // Auto-select first session; reset when workspace changes
   useEffect(() => {
     if (!workspaceId) {
+      pendingCreatedSessionRef.current = null;
       setSelectedSessionId(null);
       return;
     }
-    if (sessions?.length === 0) {
+    if (!sessions) {
+      return;
+    }
+
+    const currentValid = sessions.some((session) => session.id === selectedSessionId);
+    const pendingCreatedSession = pendingCreatedSessionRef.current;
+    const currentIsPending = isPendingCreatedSelection(
+      pendingCreatedSession,
+      workspaceId,
+      selectedSessionId
+    );
+
+    if (currentValid && currentIsPending) {
+      pendingCreatedSessionRef.current = null;
+    }
+    if (currentValid) {
+      return;
+    }
+    if (currentIsPending) {
+      return;
+    }
+    if (sessions.length === 0) {
       setSelectedSessionId(null);
       return;
     }
-    if (sessions && sessions.length > 0) {
-      // Keep current selection if it's still valid
-      const currentValid = sessions.some((s) => s.id === selectedSessionId);
-      if (!currentValid) {
-        const firstSession = sessions[0];
-        if (firstSession) {
-          setSelectedSessionId(firstSession.id);
-        }
-      }
+
+    const firstSession = sessions[0];
+    if (firstSession) {
+      setSelectedSessionId(firstSession.id);
     }
   }, [workspaceId, sessions, selectedSessionId]);
 
@@ -121,6 +147,7 @@ export function useQuickChat(workspaceId: string | null) {
       { workspaceId, workflow: 'followup', model: '', name, initialPrompt: '' },
       {
         onSuccess: (session) => {
+          pendingCreatedSessionRef.current = { id: session.id, workspaceId };
           setSelectedSessionId(session.id);
         },
       }
@@ -143,6 +170,7 @@ export function useQuickChat(workspaceId: string | null) {
         },
         {
           onSuccess: (session) => {
+            pendingCreatedSessionRef.current = { id: session.id, workspaceId };
             setSelectedSessionId(session.id);
           },
         }

--- a/src/client/features/kanban/use-quick-chat.ts
+++ b/src/client/features/kanban/use-quick-chat.ts
@@ -22,6 +22,10 @@ export function useQuickChat(workspaceId: string | null) {
       setSelectedSessionId(null);
       return;
     }
+    if (sessions?.length === 0) {
+      setSelectedSessionId(null);
+      return;
+    }
     if (sessions && sessions.length > 0) {
       // Keep current selection if it's still valid
       const currentValid = sessions.some((s) => s.id === selectedSessionId);


### PR DESCRIPTION
## Summary
- Clear Quick Chat's selected session when the active workspace confirms it has no sessions
- Prevent a stale session from another workspace from remaining connected and rendered
- Add a hook-level regression test for the workspace-switch loading and empty states

## Changes
- **Quick Chat session selection**: Reset `selectedSessionId` for a resolved empty sessions array while preserving it during the transient loading state
- **Regression coverage**: Reproduce switching from a populated workspace to a loading, then empty, workspace

## Testing
- [x] Tests pass (`pnpm test`) — 4,596 tests
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting passes (`pnpm check:fix`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: switch from a workspace with chat sessions to one with no sessions and confirm the prior chat is not rendered

Closes #2097

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Kanban quick-chat selection logic with targeted tests; no auth, API, or data-model changes.
> 
> **Overview**
> Fixes Quick Chat keeping a **selected session from another workspace** (or wiping a just-created session) when `listSessions` is loading or briefly stale.
> 
> **`useQuickChat`** now waits for a resolved session list before changing selection, **clears `selectedSessionId` when the workspace’s list is confirmed empty**, and tracks **pending created sessions** so new chat / quick actions stay selected until the list catches up.
> 
> Adds **`use-quick-chat.test.tsx`** hook tests for stale-list creation and workspace-switch → empty workspace behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 578176d54d7b4902bb5cacbad1b086a4d253b394. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

