### PR TITLE
Fix #2099: Prevent cross-PR approval updates

### DIFF
--- a/docs/superpowers/plans/2026-07-30-review-approval-race.md
+++ b/docs/superpowers/plans/2026-07-30-review-approval-race.md
@@ -1,0 +1,124 @@
+# Review Approval Race Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a successful review approval update only the pull request identified by the mutation variables, regardless of navigation during the request.
+
+**Architecture:** Keep the fix inside the existing `useReviewActions` hook. Derive the cache key from the successful mutation's variables, then use a functional `setPrDetails` update so the callback reads the freshest map entry for that key instead of render-time selection state.
+
+**Tech Stack:** React 19, tRPC, TanStack Query, TypeScript, Vitest 4, jsdom
+
+## Global Constraints
+
+- Preserve the existing approval request payload, success toast, error toast, and review-list invalidation.
+- Never use the current selection to identify the PR whose mutation completed.
+- Do not create a details-map entry when the submitted PR has no cached details.
+- Keep the change limited to the reviews route and its focused test.
+
+## File Map
+
+- Modify `src/client/routes/reviews.test.tsx` to reproduce approval of PR A, navigation to PR B, and completion through the latest mutation observer callback.
+- Modify `src/client/routes/reviews.tsx` to target the submitted PR from mutation variables and update its latest cached details.
+
+---
+
+### Task 1: Bind approval completion to mutation variables
+
+**Files:**
+- Modify: `src/client/routes/reviews.test.tsx`
+- Modify: `src/client/routes/reviews.tsx:347-382`
+
+**Interfaces:**
+- Consumes: `submitReview` mutation variables `{ repo: string; number: number; action: 'approve' }` and the current `Map<string, PRWithFullDetails>`.
+- Produces: an approval success callback that updates `${repo}#${number}` only when that key already exists in the details map.
+
+- [ ] **Step 1: Extend the tRPC and component doubles to expose real route behavior**
+
+Update the reviews test doubles so:
+
+- `getPRDetails.useQuery(input)` returns complete details for the requested PR.
+- `submitReview.useMutation(options)` retains the latest observer options while `mutate(input)` retains the submitted variables.
+- `PRInboxItem` renders the PR title and review decision and keeps its real selection callback.
+- `PRDetailPanel` renders the selected PR decision and an approval button wired to `onApprove`.
+
+- [ ] **Step 2: Write the failing race regression**
+
+Add a test that:
+
+1. Renders PR A and PR B with no initial review decision.
+2. Approves PR A.
+3. Selects PR B before the mutation completes.
+4. Completes the pending request by calling the latest observer's `onSuccess` with PR A's saved variables.
+5. Expects PR A to render `APPROVED`, PR B to remain unapproved, and the selected detail panel for PR B to remain unapproved.
+
+- [ ] **Step 3: Run the focused test and verify the current callback fails**
+
+Run:
+
+```bash
+pnpm test -- src/client/routes/reviews.test.tsx
+```
+
+Expected: the new regression fails because the existing callback approves PR B from the latest render closure.
+
+- [ ] **Step 4: Implement the variables-based functional update**
+
+Change the mutation success callback to:
+
+```typescript
+onSuccess: (_data, variables) => {
+  toast.success('PR approved successfully');
+  utils.prReview.listReviewRequests.invalidate();
+
+  const approvedKey = `${variables.repo}#${variables.number}`;
+  setPrDetails((prev) => {
+    const approvedDetails = prev.get(approvedKey);
+    if (!approvedDetails) {
+      return prev;
+    }
+    return new Map(prev).set(approvedKey, {
+      ...approvedDetails,
+      reviewDecision: 'APPROVED',
+    });
+  });
+},
+```
+
+Remove `selectedDetails` from the `useReviewActions` parameter type and call because the action hook no longer needs render-time details for approval completion. Keep `selectedKey` for diff fetching.
+
+- [ ] **Step 5: Run the focused test and verify it passes**
+
+Run:
+
+```bash
+pnpm test -- src/client/routes/reviews.test.tsx
+```
+
+Expected: all reviews route tests pass, including the navigation race regression.
+
+- [ ] **Step 6: Format and commit the focused fix**
+
+Run:
+
+```bash
+pnpm exec biome check --write src/client/routes/reviews.tsx src/client/routes/reviews.test.tsx
+pnpm test -- src/client/routes/reviews.test.tsx
+git add src/client/routes/reviews.tsx src/client/routes/reviews.test.tsx
+git commit -m "Fix review approval navigation race (#2099)"
+```
+
+- [ ] **Step 7: Run full verification and review**
+
+Run:
+
+```bash
+pnpm typecheck && pnpm check:fix && pnpm test && pnpm build
+git diff origin/main
+git status --short
+```
+
+Expected: every command exits with code 0, the diff contains only the approved design, plan, route fix, focused regression, and any applicable screenshot, and the worktree is clean after final commits.
+
+- [ ] **Step 8: Publish the pull request**
+
+Push the current branch, create a pull request titled `Fix #2099: Prevent cross-PR approval updates`, include the required summary, testing checklist, `Closes #2099`, and Factory Factory signature, then verify and report the PR URL.

--- a/docs/superpowers/specs/2026-07-30-review-approval-race-design.md
+++ b/docs/superpowers/specs/2026-07-30-review-approval-race-design.md
@@ -1,0 +1,43 @@
+# Review Approval Race Design
+
+## Goal
+
+Ensure a completed approval updates only the pull request submitted to the approval mutation, even when the user navigates to another review while the request is in flight.
+
+## Root Cause
+
+`useReviewActions` submits the selected pull request's repository and number as mutation variables, but its `onSuccess` callback reads `selectedKey` and `selectedDetails` from render state. TanStack Query updates mutation observer options on later renders, so navigating from PR A to PR B while A is pending can make A's completion run a callback whose closure points at B.
+
+The callback then writes an approved copy of B into the component's `prDetails` map. Both the list and detail panel prefer that map, and the details query is disabled when an entry exists, so the incorrect state remains for the component's lifetime.
+
+## Design
+
+Use the successful mutation's `variables.repo` and `variables.number` to derive the approved PR key. Update `prDetails` with a functional state setter and look up the matching details from the setter's `prev` map. If the matching PR has no cached details, leave the map unchanged and allow the list invalidation to refresh server data.
+
+This keeps mutation completion independent of whichever PR is currently selected and avoids relying on a potentially stale `prDetails` closure. The success toast and review-request list invalidation remain unchanged.
+
+## Alternatives Considered
+
+1. **Mutation variables plus functional state update (selected).** Uses the identity already carried by the request, reads the freshest local map, and requires no additional lifecycle state.
+2. **Capture details in `onMutate` context.** Also preserves call-time identity, but duplicates data that is already in mutation variables and can overwrite fresher cached details with an older snapshot.
+3. **Pass a per-call `onSuccess` to `mutate`.** Can capture the selected PR at invocation time, but spreads mutation behavior across the callback configuration and call site without improving the data contract.
+
+## Scope
+
+- Modify `src/client/routes/reviews.tsx`.
+- Extend `src/client/routes/reviews.test.tsx` with a race regression.
+- Do not change backend review submission, list invalidation, keyboard shortcuts, or general details caching.
+
+## Edge Cases
+
+- Navigating to another PR before approval resolves must not approve the newly selected PR locally.
+- The originally submitted PR must be updated even when it is no longer selected.
+- If the originally submitted PR has no cached details when approval resolves, the callback must not create an incomplete entry or alter another PR.
+- The review-request list must still be invalidated after success.
+
+## Verification
+
+- Run the focused reviews route test and observe the new regression fail before implementation.
+- Run the focused test after implementation and verify the submitted PR alone becomes approved.
+- Run `pnpm typecheck && pnpm check:fix && pnpm test && pnpm build`.
+- Review the complete diff against `origin/main`.

--- a/src/client/routes/reviews.test.tsx
+++ b/src/client/routes/reviews.test.tsx
@@ -1,13 +1,32 @@
 // @vitest-environment jsdom
 
-import { createElement, forwardRef, type ReactNode } from 'react';
+import { act, createElement, forwardRef, type ReactNode } from 'react';
 import { flushSync } from 'react-dom';
 import { createRoot } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PRWithFullDetails } from '@/shared/github-types';
 import ReviewsPage from './reviews';
 
 const listProjectsMock = vi.fn();
 const listReviewRequestsMock = vi.fn();
+
+type SubmitReviewVariables = {
+  repo: string;
+  number: number;
+  action: 'approve';
+};
+
+const reviewMocks = vi.hoisted(() => ({
+  detailsByKey: new Map<string, PRWithFullDetails>(),
+  invalidateReviewRequests: vi.fn(),
+  submitReviewMutate: vi.fn(),
+  submitReviewMutationOptions: undefined as
+    | {
+        onSuccess: (data: { success: boolean }, variables: SubmitReviewVariables) => void;
+      }
+    | undefined,
+  submittedReviewVariables: undefined as SubmitReviewVariables | undefined,
+}));
 
 vi.mock('react-router', () => ({
   Link: ({ children, to }: { children: ReactNode; to: string }) =>
@@ -30,16 +49,34 @@ vi.mock('@/client/components/app-header-context', () => ({
 }));
 
 vi.mock('@/client/components/pr-detail-panel', () => ({
-  PRDetailPanel: () => createElement('div', null, 'PR Detail Panel'),
+  PRDetailPanel: ({ pr, onApprove }: { pr: PRWithFullDetails | null; onApprove: () => void }) =>
+    createElement(
+      'div',
+      null,
+      createElement(
+        'span',
+        { 'data-testid': 'detail-decision' },
+        pr ? `${pr.number}:${pr.reviewDecision ?? 'NONE'}` : 'No PR'
+      ),
+      createElement('button', { onClick: onApprove, type: 'button' }, 'Approve')
+    ),
 }));
 
 vi.mock('@/client/components/pr-inbox-item', () => {
-  const InboxItem = forwardRef<HTMLButtonElement, { onSelect: () => void }>(function InboxItem(
-    { onSelect },
-    ref
-  ) {
-    return createElement('button', { ref, onClick: onSelect, type: 'button' }, 'PR item');
-  });
+  const InboxItem = forwardRef<HTMLButtonElement, { onSelect: () => void; pr: PRWithFullDetails }>(
+    function InboxItem({ onSelect, pr }, ref) {
+      return createElement(
+        'button',
+        {
+          ref,
+          'data-testid': `pr-${pr.number}`,
+          onClick: onSelect,
+          type: 'button',
+        },
+        `${pr.number}:${pr.reviewDecision ?? 'NONE'}`
+      );
+    }
+  );
 
   return {
     PRInboxItem: InboxItem,
@@ -70,7 +107,9 @@ vi.mock('@/client/features/workspace', () => ({
 vi.mock('@/client/lib/trpc', () => ({
   trpc: {
     useUtils: () => ({
-      prReview: { listReviewRequests: { invalidate: vi.fn() } },
+      prReview: {
+        listReviewRequests: { invalidate: reviewMocks.invalidateReviewRequests },
+      },
       client: { prReview: { getDiff: { query: vi.fn() } } },
     }),
     project: {
@@ -83,10 +122,20 @@ vi.mock('@/client/lib/trpc', () => ({
         useQuery: () => listReviewRequestsMock(),
       },
       getPRDetails: {
-        useQuery: () => ({ data: undefined }),
+        useQuery: ({ repo, number }: { repo: string; number: number }) => ({
+          data: reviewMocks.detailsByKey.get(`${repo}#${number}`),
+        }),
       },
       submitReview: {
-        useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+        useMutation: (options: {
+          onSuccess: (data: { success: boolean }, variables: SubmitReviewVariables) => void;
+        }) => {
+          reviewMocks.submitReviewMutationOptions = options;
+          return {
+            mutate: reviewMocks.submitReviewMutate,
+            isPending: false,
+          };
+        },
       },
     },
   },
@@ -98,6 +147,17 @@ afterEach(() => {
 });
 
 beforeEach(() => {
+  Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
+    configurable: true,
+    writable: true,
+    value: true,
+  });
+  reviewMocks.detailsByKey.clear();
+  reviewMocks.submitReviewMutationOptions = undefined;
+  reviewMocks.submittedReviewVariables = undefined;
+  reviewMocks.submitReviewMutate.mockImplementation((variables: SubmitReviewVariables) => {
+    reviewMocks.submittedReviewVariables = variables;
+  });
   Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
     value: vi.fn(),
     configurable: true,
@@ -123,6 +183,34 @@ beforeEach(() => {
     isLoading: false,
   });
 });
+
+function makeDetails(number: number, title: string): PRWithFullDetails {
+  return {
+    number,
+    title,
+    url: `https://example.com/pr/${number}`,
+    author: { login: 'alice' },
+    repository: {
+      name: 'repo',
+      nameWithOwner: 'org/repo',
+    },
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    isDraft: false,
+    state: 'OPEN',
+    reviewDecision: null,
+    statusCheckRollup: null,
+    reviews: [],
+    comments: [],
+    labels: [],
+    additions: 1,
+    deletions: 1,
+    changedFiles: 1,
+    headRefName: 'feature',
+    baseRefName: 'main',
+    mergeStateStatus: 'UNKNOWN',
+  };
+}
 
 describe('ReviewsPage header', () => {
   it('renders workspaces back link in header when a project exists', () => {
@@ -175,5 +263,95 @@ describe('ReviewsPage header', () => {
     expect(link).not.toBeNull();
 
     root.unmount();
+  });
+});
+
+describe('ReviewsPage approval', () => {
+  it('updates the submitted PR when selection changes before approval completes', () => {
+    listProjectsMock.mockReturnValue({ data: [] });
+    listReviewRequestsMock.mockReturnValue({
+      data: {
+        prs: [
+          {
+            number: 1,
+            title: 'PR A',
+            url: 'https://example.com/pr/1',
+            author: { login: 'alice' },
+            repository: { nameWithOwner: 'org/repo' },
+            createdAt: '2024-01-01T00:00:00Z',
+            isDraft: false,
+            reviewDecision: null,
+            additions: 1,
+            deletions: 1,
+            changedFiles: 1,
+          },
+          {
+            number: 2,
+            title: 'PR B',
+            url: 'https://example.com/pr/2',
+            author: { login: 'bob' },
+            repository: { nameWithOwner: 'org/repo' },
+            createdAt: '2024-01-02T00:00:00Z',
+            isDraft: false,
+            reviewDecision: null,
+            additions: 2,
+            deletions: 2,
+            changedFiles: 2,
+          },
+        ],
+      },
+      isLoading: false,
+    });
+    reviewMocks.detailsByKey.set('org/repo#1', makeDetails(1, 'PR A'));
+    reviewMocks.detailsByKey.set('org/repo#2', makeDetails(2, 'PR B'));
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    void act(() => {
+      root.render(createElement(ReviewsPage));
+    });
+
+    const approveButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Approve'
+    );
+    expect(approveButton).toBeDefined();
+
+    void act(() => {
+      approveButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(reviewMocks.submittedReviewVariables).toEqual({
+      repo: 'org/repo',
+      number: 1,
+      action: 'approve',
+    });
+
+    const prB = container.querySelector<HTMLButtonElement>('[data-testid="pr-2"]');
+    expect(prB).not.toBeNull();
+    void act(() => {
+      prB?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const mutationOptions = reviewMocks.submitReviewMutationOptions;
+    const submittedVariables = reviewMocks.submittedReviewVariables;
+    expect(mutationOptions).toBeDefined();
+    expect(submittedVariables).toBeDefined();
+
+    void act(() => {
+      if (mutationOptions && submittedVariables) {
+        mutationOptions.onSuccess({ success: true }, submittedVariables);
+      }
+    });
+
+    expect(container.querySelector('[data-testid="pr-1"]')?.textContent).toBe('1:APPROVED');
+    expect(container.querySelector('[data-testid="pr-2"]')?.textContent).toBe('2:NONE');
+    expect(container.querySelector('[data-testid="detail-decision"]')?.textContent).toBe('2:NONE');
+    expect(reviewMocks.invalidateReviewRequests).toHaveBeenCalledTimes(1);
+
+    void act(() => {
+      root.unmount();
+    });
   });
 });

--- a/src/client/routes/reviews.tsx
+++ b/src/client/routes/reviews.tsx
@@ -352,7 +352,6 @@ function ReviewsDesktopLayout({
 function useReviewActions({
   selectedPR,
   selectedKey,
-  selectedDetails,
   diffs,
   setPrDetails,
   setDiffs,
@@ -360,7 +359,6 @@ function useReviewActions({
 }: {
   selectedPR: ReviewRequest | undefined;
   selectedKey: string | null;
-  selectedDetails: PRWithFullDetails | null;
   diffs: Map<string, string>;
   setPrDetails: React.Dispatch<React.SetStateAction<Map<string, PRWithFullDetails>>>;
   setDiffs: React.Dispatch<React.SetStateAction<Map<string, string>>>;
@@ -369,14 +367,21 @@ function useReviewActions({
   const utils = trpc.useUtils();
 
   const approveMutation = trpc.prReview.submitReview.useMutation({
-    onSuccess: () => {
+    onSuccess: (_data, variables) => {
       toast.success('PR approved successfully');
       utils.prReview.listReviewRequests.invalidate();
-      if (!(selectedKey && selectedDetails)) {
-        return;
-      }
-      const updated = { ...selectedDetails, reviewDecision: 'APPROVED' as const };
-      setPrDetails((prev) => new Map(prev).set(selectedKey, updated));
+
+      const approvedKey = `${variables.repo}#${variables.number}`;
+      setPrDetails((prev) => {
+        const approvedDetails = prev.get(approvedKey);
+        if (!approvedDetails) {
+          return prev;
+        }
+        return new Map(prev).set(approvedKey, {
+          ...approvedDetails,
+          reviewDecision: 'APPROVED',
+        });
+      });
     },
     onError: (err) => {
       toast.error(`Failed to approve PR: ${err.message}`);
@@ -492,7 +497,6 @@ function ReviewsPageContent() {
   const { fetchDiff, handleApprove, handleOpenGitHub, approving } = useReviewActions({
     selectedPR,
     selectedKey,
-    selectedDetails,
     diffs,
     setPrDetails,
     setDiffs,


### PR DESCRIPTION
## Summary
- Bind review approval completion to the pull request submitted in the mutation variables.
- Prevent fast navigation from marking a different pull request as approved in the reviews list or detail panel.
- Add a route-level regression covering approval of PR A, navigation to PR B, and delayed mutation completion.

## Changes
- **Reviews approval state**: Derive the approved cache key from `repo` and `number` mutation variables, then update the freshest matching details through a functional state setter.
- **Regression coverage**: Exercise the real reviews route selection and details-cache flow while simulating TanStack Query's latest mutation observer callback.
- **Documentation**: Record the race's root cause, selected design, edge cases, and implementation plan.

## Testing
- [x] Tests pass (`pnpm test`: 4,606 passed)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting passes (`pnpm check:fix`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not performed because reproducing the completion path would approve a real external PR; the deterministic route regression covers the race safely.

Closes #2099

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 560290d4703a299ede94aad151274c828c5b28fd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

