### PR TITLE
Fix #2090: Handle empty agent question requests

### DIFF
--- a/src/client/features/chat/question-prompt.test.tsx
+++ b/src/client/features/chat/question-prompt.test.tsx
@@ -13,6 +13,27 @@ afterEach(() => {
 });
 
 describe('QuestionPrompt', () => {
+  it('renders nothing when the questions array is empty', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const onAnswer = vi.fn();
+
+    const question: UserQuestionRequest = {
+      requestId: 'question-empty',
+      timestamp: '2026-04-28T00:00:00.000Z',
+      questions: [],
+    };
+
+    flushSync(() => {
+      root.render(createElement(QuestionPrompt, { question, onAnswer }));
+    });
+
+    expect(container.innerHTML).toBe('');
+
+    root.unmount();
+  });
+
   it('uses compact mobile card padding and wrapping text styles', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);

--- a/src/client/features/chat/question-prompt.tsx
+++ b/src/client/features/chat/question-prompt.tsx
@@ -603,6 +603,10 @@ export function QuestionPrompt({ question, onAnswer }: QuestionPromptProps) {
   }
 
   const totalQuestions = question.questions.length;
+  if (totalQuestions === 0) {
+    return null;
+  }
+
   const requestId = currentRequestId ?? 'unknown';
 
   if (totalQuestions === 1) {


### PR DESCRIPTION
## Summary
- Prevent empty agent question requests from rendering a broken paginated prompt.
- Add a focused DOM regression test for schema-valid requests with no questions.

## Changes
- **QuestionPrompt**: Return `null` when `questions` is empty, after hooks have run and before selecting a layout.
- **Tests**: Verify an empty questions array produces no rendered DOM.

## Testing
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting and lint checks pass (`pnpm check:fix`)
- [x] Build succeeds (`pnpm build`)
- [x] Regression and isolated timing suites pass (14 tests)
- [x] Full suite passed before the final `main` update (4,606 passed, 3 skipped)
- [ ] Final-tree full suite: 4,609 passed and 3 skipped; one unrelated 200 ms shell timing test failed under host load, then passed immediately in isolation
- [ ] Manual testing: Not applicable; the corrected state intentionally renders no UI and is covered by the DOM regression test

Closes #2090

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit d26c60ff2d732a2c1f767261c77b487ade324b11. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

