### PR TITLE
Fix #2094: Validate VP8 partition boundaries

### DIFF
--- a/docs/superpowers/plans/2026-07-30-vp8-partition-boundary.md
+++ b/docs/superpowers/plans/2026-07-30-vp8-partition-boundary.md
@@ -1,0 +1,122 @@
+# VP8 Partition Boundary Validation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reject VP8 keyframes whose declared first partition exceeds the bytes available after the full ten-byte keyframe header.
+
+**Architecture:** Preserve the existing attachment-validation and WebP parsing boundaries. Exercise the public `validateAttachment` behavior with a test-local RIFF/VP8 fixture, then correct the private capacity calculation by changing the header allowance from three bytes to ten.
+
+**Tech Stack:** TypeScript, Node.js `Buffer`, Vitest
+
+## Global Constraints
+
+- Keep `inspectSupportedImageFormat` and `validateAttachment` interfaces unchanged.
+- Add no runtime dependencies.
+- Do not change validation for PNG, JPEG, GIF, VP8L, or animated WebP layout.
+- Preserve the existing permanent-error behavior for structurally invalid supported images.
+
+---
+
+### Task 1: Correct the VP8 first-partition boundary
+
+**Files:**
+
+- Modify: `src/backend/services/session/service/chat/chat-message-handlers/image-format-validation.ts:424`
+- Test: `src/backend/services/session/service/chat/chat-message-handlers/attachment-processing.test.ts`
+
+**Interfaces:**
+
+- Consumes: `validateAttachment(attachment: MessageAttachment): void`
+- Produces: unchanged public APIs; malformed VP8 attachments now throw `PermanentAttachmentError`
+
+- [ ] **Step 1: Add a test-local malformed WebP builder**
+
+Add this helper near the existing image fixture helpers:
+
+```typescript
+function createVp8WebpBase64(firstPartitionLength: number, partitionLength: number): string {
+  const vp8Data = Buffer.alloc(10 + partitionLength);
+  vp8Data.writeUIntLE((firstPartitionLength << 5) | 0x10, 0, 3);
+  Buffer.from([0x9d, 0x01, 0x2a]).copy(vp8Data, 3);
+  vp8Data.writeUInt16LE(1, 6);
+  vp8Data.writeUInt16LE(1, 8);
+
+  const webp = Buffer.alloc(20 + vp8Data.length);
+  webp.write('RIFF', 0, 'ascii');
+  webp.writeUInt32LE(webp.length - 8, 4);
+  webp.write('WEBP', 8, 'ascii');
+  webp.write('VP8 ', 12, 'ascii');
+  webp.writeUInt32LE(vp8Data.length, 16);
+  vp8Data.copy(webp, 20);
+  return webp.toString('base64');
+}
+```
+
+- [ ] **Step 2: Write the failing regression test**
+
+Add this case to the `validateAttachment` suite:
+
+```typescript
+it('should reject a VP8 first partition that exceeds the bytes after its keyframe header', () => {
+  const attachment = createImageAttachment({
+    data: createVp8WebpBase64(14, 10),
+  });
+
+  expect(() => validateAttachment(attachment)).toThrow(PermanentAttachmentError);
+});
+```
+
+This test catches the production mutation `dataLength - 10` back to
+`dataLength - 3`.
+
+- [ ] **Step 3: Run the focused test and verify the regression fails**
+
+Run:
+
+```bash
+pnpm test src/backend/services/session/service/chat/chat-message-handlers/attachment-processing.test.ts
+```
+
+Expected: the new test fails because `validateAttachment` does not throw.
+
+- [ ] **Step 4: Apply the minimal production fix**
+
+Change the VP8 keyframe predicate to:
+
+```typescript
+firstPartitionLength <= dataLength - 10 &&
+```
+
+- [ ] **Step 5: Run the focused test and verify it passes**
+
+Run:
+
+```bash
+pnpm test src/backend/services/session/service/chat/chat-message-handlers/attachment-processing.test.ts
+```
+
+Expected: all attachment-processing tests pass.
+
+- [ ] **Step 6: Run complete repository verification**
+
+Run:
+
+```bash
+pnpm typecheck && pnpm check:fix && pnpm test && pnpm build
+```
+
+Expected: every command exits successfully.
+
+- [ ] **Step 7: Review and commit**
+
+Review `git diff origin/main`, stage only the design, plan, validator, and
+test files, then commit with:
+
+```bash
+git commit -m "Fix VP8 partition boundary validation (#2094)"
+```
+
+- [ ] **Step 8: Publish the pull request**
+
+Push the current branch, create the issue-closing PR with the required Factory
+Factory signature, and verify the resulting PR URL.

--- a/docs/superpowers/specs/2026-07-30-vp8-partition-boundary-design.md
+++ b/docs/superpowers/specs/2026-07-30-vp8-partition-boundary-design.md
@@ -1,0 +1,48 @@
+# VP8 Partition Boundary Validation Design
+
+## Context
+
+The WebP validator reads the VP8 keyframe's `first_part_size` from the
+three-byte frame tag, but compares it with `dataLength - 3`. A VP8 keyframe
+places its first partition after the complete ten-byte uncompressed header:
+the frame tag, start code, width, and height. Subtracting only the frame tag
+allows a malformed chunk to claim up to seven bytes more partition data than
+the chunk contains.
+
+## Goal
+
+Reject VP8 keyframes whose declared first partition does not fit after the
+ten-byte keyframe header, while preserving acceptance of existing valid WebP
+images.
+
+## Approach
+
+Keep the image-inspection API and WebP parsing flow unchanged. In
+`isValidVp8Chunk`, compare `firstPartitionLength` with `dataLength - 10`.
+
+Add a regression test through the public `validateAttachment` boundary. The
+test constructs a size-consistent RIFF/WebP container with a 20-byte `VP8 `
+payload, a valid keyframe header, ten payload bytes, and a declared
+`first_part_size` of 14. The container passes RIFF checks but must fail VP8
+validation because only ten bytes remain after the header.
+
+## Error Handling
+
+The malformed payload remains recognizable as WebP, so attachment validation
+rejects it with the existing `PermanentAttachmentError` path for structurally
+invalid supported image data. No new error type or message is required.
+
+## Testing
+
+- Verify the malformed 20-byte VP8 payload is rejected.
+- Keep the existing production-encoded WebP fixture as coverage that valid
+  WebP remains accepted.
+- Run the focused attachment-processing test, type checking, formatting and
+  lint fixes, the full Vitest suite, and the production build.
+
+## Alternatives Considered
+
+Exporting `isValidVp8Chunk` for a direct unit test was rejected because it
+would widen the module API only for tests. Adding a general WebP fixture
+framework was rejected because one small test-local binary builder expresses
+this boundary without introducing unrelated abstraction.

--- a/src/backend/services/session/service/chat/chat-message-handlers/attachment-processing.test.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers/attachment-processing.test.ts
@@ -45,6 +45,23 @@ function createImageAttachment(overrides: Partial<MessageAttachment> = {}): Mess
   };
 }
 
+function createVp8WebpBase64(firstPartitionLength: number, partitionLength: number): string {
+  const vp8Data = Buffer.alloc(10 + partitionLength);
+  vp8Data.writeUIntLE((firstPartitionLength << 5) | 0x10, 0, 3);
+  Buffer.from([0x9d, 0x01, 0x2a]).copy(vp8Data, 3);
+  vp8Data.writeUInt16LE(1, 6);
+  vp8Data.writeUInt16LE(1, 8);
+
+  const webp = Buffer.alloc(20 + vp8Data.length);
+  webp.write('RIFF', 0, 'ascii');
+  webp.writeUInt32LE(webp.length - 8, 4);
+  webp.write('WEBP', 8, 'ascii');
+  webp.write('VP8 ', 12, 'ascii');
+  webp.writeUInt32LE(vp8Data.length, 16);
+  vp8Data.copy(webp, 20);
+  return webp.toString('base64');
+}
+
 function createOversizedPngBase64(): string {
   const bytes = Buffer.alloc(MAX_IMAGE_SIZE + 1);
   Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(bytes);
@@ -208,6 +225,14 @@ describe('validateAttachment', () => {
   it('should reject a PNG whose image data fails its checksum', () => {
     const attachment = createImageAttachment({
       data: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+c9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+    });
+
+    expect(() => validateAttachment(attachment)).toThrow(PermanentAttachmentError);
+  });
+
+  it('should reject a VP8 first partition that exceeds the bytes after its keyframe header', () => {
+    const attachment = createImageAttachment({
+      data: createVp8WebpBase64(14, 10),
     });
 
     expect(() => validateAttachment(attachment)).toThrow(PermanentAttachmentError);

--- a/src/backend/services/session/service/chat/chat-message-handlers/image-format-validation.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers/image-format-validation.ts
@@ -421,7 +421,7 @@ function isValidVp8Chunk(bytes: Buffer, dataStart: number, dataLength: number): 
     bytes.readUInt8(dataStart + 3) === 0x9d &&
     bytes.readUInt8(dataStart + 4) === 0x01 &&
     bytes.readUInt8(dataStart + 5) === 0x2a &&
-    firstPartitionLength <= dataLength - 3 &&
+    firstPartitionLength <= dataLength - 10 &&
     width > 0 &&
     height > 0
   );


### PR DESCRIPTION
## Summary
- Reject malformed VP8 keyframes whose declared first partition exceeds the bytes available after the full 10-byte keyframe header.
- Add a public attachment-validation regression for the malformed WebP boundary case.

## Changes
- **WebP validation**: Compare `first_part_size` with VP8 payload capacity after the complete keyframe header instead of only the frame tag.
- **Regression coverage**: Build a size-consistent RIFF/WebP fixture that declares 14 first-partition bytes while providing only 10, and assert permanent rejection through `validateAttachment`.
- **Documentation**: Record the focused design and implementation plan for the boundary correction.

## Testing
- [x] Focused attachment tests pass (`pnpm test src/backend/services/session/service/chat/chat-message-handlers/attachment-processing.test.ts`: 70 passed)
- [x] Full tests pass (`pnpm test --maxWorkers=2 --testTimeout=30000`: 4,604 passed, 3 skipped)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting passes (`pnpm check:fix`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; the malformed binary boundary is covered deterministically by the regression test.

Closes #2094

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line validation tightening in chat image attachment parsing; no API or auth changes, with regression coverage for the boundary case.
> 
> **Overview**
> Tightens **VP8 WebP** attachment checks so a keyframe’s declared first-partition size must fit in the bytes **after the full 10-byte keyframe header**, not only after the 3-byte frame tag. Malformed payloads that still look like WebP now fail through the existing **`PermanentAttachmentError`** path in **`validateAttachment`**.
> 
> Adds a **`createVp8WebpBase64`** test helper and a regression case (declared 14-byte partition, 10 bytes available after the header). Design and implementation notes are documented under **`docs/superpowers/`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f11ae6c639bde666e77b7d57ec432a95df235b2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

