### PR TITLE
Fix #2086: Apply plan mode before first prompt

### DIFF
--- a/src/backend/services/session/service/chat/chat-message-handlers.service.test.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers.service.test.ts
@@ -33,6 +33,7 @@ const {
     setSessionModel: vi.fn(),
     setSessionReasoningEffort: vi.fn(),
     setSessionThinkingBudget: vi.fn(),
+    setSessionCollaborationMode: vi.fn(),
     sendSessionMessage: vi.fn(),
   },
   mockSessionDataService: {
@@ -101,6 +102,7 @@ describe('chatMessageHandlerService.tryDispatchNextMessage', () => {
     mockSessionService.setSessionThinkingBudget.mockResolvedValue(undefined);
     mockSessionService.setSessionModel.mockResolvedValue(undefined);
     mockSessionService.setSessionReasoningEffort.mockResolvedValue(undefined);
+    mockSessionService.setSessionCollaborationMode.mockResolvedValue(undefined);
     mockSessionService.sendSessionMessage.mockResolvedValue(undefined);
     mockWorkspaceNotificationService.markDelivered.mockResolvedValue(undefined);
     mockWorkspaceNotificationService.findForDelivery.mockResolvedValue(null);
@@ -826,6 +828,34 @@ describe('chatMessageHandlerService.tryDispatchNextMessage', () => {
     );
   });
 
+  it('applies queued plan mode before dispatching the prompt', async () => {
+    const planMessage: QueuedMessage = {
+      ...queuedMessage,
+      settings: {
+        ...queuedMessage.settings,
+        planModeEnabled: true,
+      },
+    };
+    mockSessionDomainService.peekNextMessage.mockReturnValue(planMessage);
+    mockSessionDomainService.dequeueNext.mockReturnValue(planMessage);
+    mockSessionService.getSessionClient.mockReturnValue({ sessionId: 's1', threadId: 't1' });
+
+    await chatMessageHandlerService.tryDispatchNextMessage('s1');
+
+    expect(mockSessionService.setSessionCollaborationMode).toHaveBeenCalledWith('s1', 'plan');
+    expect(mockSessionService.setSessionCollaborationMode.mock.invocationCallOrder[0]).toBeLessThan(
+      mockSessionService.sendSessionMessage.mock.invocationCallOrder[0] ?? 0
+    );
+  });
+
+  it('does not change collaboration mode for a non-plan queued message', async () => {
+    mockSessionService.getSessionClient.mockReturnValue({ sessionId: 's1', threadId: 't1' });
+
+    await chatMessageHandlerService.tryDispatchNextMessage('s1');
+
+    expect(mockSessionService.setSessionCollaborationMode).not.toHaveBeenCalled();
+  });
+
   it('persists dispatched user message before turn completion', async () => {
     const client = {
       isCompactingActive: vi.fn().mockReturnValue(false),
@@ -992,5 +1022,36 @@ describe('chatMessageHandlerService.tryDispatchNextMessage', () => {
 
     resolveFirstSend?.();
     await firstDispatch;
+  });
+
+  it('applies plan mode before the first prompt after auto-start', async () => {
+    const planMessage: QueuedMessage = {
+      ...queuedMessage,
+      settings: {
+        ...queuedMessage.settings,
+        planModeEnabled: true,
+      },
+    };
+    const client = { sessionId: 's1', threadId: 't1' };
+    const getOrCreate = vi.fn(async () => client);
+    chatMessageHandlerService.setClientCreator({ getOrCreate });
+    mockSessionDomainService.peekNextMessage.mockReturnValue(planMessage);
+    mockSessionDomainService.dequeueNext.mockReturnValue(planMessage);
+    mockSessionService.getSessionClient.mockReturnValueOnce(undefined).mockReturnValue(client);
+
+    await chatMessageHandlerService.tryDispatchNextMessage('s1');
+
+    expect(getOrCreate).toHaveBeenCalledWith('s1', {
+      thinkingEnabled: false,
+      planModeEnabled: true,
+      model: undefined,
+      reasoningEffort: undefined,
+    });
+    expect(getOrCreate.mock.invocationCallOrder[0]).toBeLessThan(
+      mockSessionService.setSessionCollaborationMode.mock.invocationCallOrder[0] ?? 0
+    );
+    expect(mockSessionService.setSessionCollaborationMode.mock.invocationCallOrder[0]).toBeLessThan(
+      mockSessionService.sendSessionMessage.mock.invocationCallOrder[0] ?? 0
+    );
   });
 });

--- a/src/backend/services/session/service/chat/chat-message-handlers.service.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers.service.ts
@@ -581,6 +581,10 @@ class ChatMessageHandlerService {
     const isCompactCommand = this.isCompactCommand(msg.text);
     const compactionClient = isClaudeCompactionClient(client) ? client : null;
 
+    if (msg.settings.planModeEnabled) {
+      await sessionConfigService.setSessionCollaborationMode(dbSessionId, 'plan');
+    }
+
     // Only clients that expose thinking-budget controls support this feature.
     // Keep this before state mutation so provider errors can be safely requeued.
     if (isThinkingBudgetClient(client)) {

--- a/src/backend/services/session/service/lifecycle/session.config.service.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.config.service.test.ts
@@ -666,6 +666,58 @@ describe('SessionConfigService', () => {
     expect(runtimeManager.setConfigOption).not.toHaveBeenCalled();
   });
 
+  it('resolves and applies the advertised plan collaboration mode', async () => {
+    const modeConfig = {
+      id: 'collaboration_mode',
+      name: 'Collaboration Mode',
+      type: 'select',
+      category: 'mode',
+      currentValue: 'default',
+      options: [
+        { value: 'default', name: 'Default' },
+        { value: 'PLAN', name: 'Plan' },
+      ],
+    };
+    runtimeManager.getClient.mockReturnValue(
+      unsafeCoerce({
+        provider: 'CODEX',
+        providerSessionId: 'provider-session-1',
+        configOptions: [modeConfig],
+      })
+    );
+    runtimeManager.setSessionMode.mockResolvedValue([{ ...modeConfig, currentValue: 'PLAN' }]);
+
+    await service.setSessionCollaborationMode('session-1', 'plan');
+
+    expect(runtimeManager.setSessionMode).toHaveBeenCalledWith('session-1', 'PLAN');
+  });
+
+  it('skips plan collaboration mode when the session does not advertise it', async () => {
+    runtimeManager.getClient.mockReturnValue(
+      unsafeCoerce({
+        provider: 'CLAUDE',
+        providerSessionId: 'provider-session-1',
+        configOptions: [
+          {
+            id: 'mode',
+            name: 'Mode',
+            type: 'select',
+            category: 'mode',
+            currentValue: 'default',
+            options: [
+              { value: 'default', name: 'Default' },
+              { value: 'acceptEdits', name: 'Accept Edits' },
+            ],
+          },
+        ],
+      })
+    );
+
+    await service.setSessionCollaborationMode('session-1', 'plan');
+
+    expect(runtimeManager.setSessionMode).not.toHaveBeenCalled();
+  });
+
   it('tracks whitespace-only reasoning effort fallback as settings sourced', async () => {
     vi.mocked(userSettingsService.get).mockResolvedValue(
       unsafeCoerce({

--- a/src/backend/services/session/service/lifecycle/session.config.service.ts
+++ b/src/backend/services/session/service/lifecycle/session.config.service.ts
@@ -278,6 +278,31 @@ export class SessionConfigService {
     logger.debug('No ACP handle for setSessionModel', { sessionId, model });
   }
 
+  async setSessionCollaborationMode(sessionId: string, mode: 'plan'): Promise<void> {
+    const acpHandle = this.runtimeManager.getClient(sessionId);
+    if (!acpHandle) {
+      logger.debug('No ACP handle for setSessionCollaborationMode', { sessionId, mode });
+      return;
+    }
+
+    const modeOption = acpHandle.configOptions.find((option) => option.category === 'mode');
+    if (!modeOption) {
+      return;
+    }
+
+    const availableModeValues = getConfigOptionValues(modeOption);
+    const targetMode = this.resolveStartupModeTarget(
+      acpHandle.provider as SessionProvider,
+      mode,
+      availableModeValues
+    );
+    if (!targetMode || modeOption.currentValue === targetMode) {
+      return;
+    }
+
+    await this.setSessionConfigOption(sessionId, modeOption.id, targetMode);
+  }
+
   async setSessionThinkingBudget(sessionId: string, maxTokens: number | null): Promise<void> {
     const acpHandle = this.runtimeManager.getClient(sessionId);
     if (acpHandle) {


### PR DESCRIPTION
## Summary
- Apply queued plan mode before prompt dispatch, including the auto-started first message.
- Resolve the provider-advertised ACP plan mode value instead of restoring the legacy permission flag.
- Add regression coverage for dispatch ordering, auto-start, disabled plan mode, and unsupported mode options.

## Changes
- **Chat dispatch**: Await the plan collaboration-mode update before queued prompt state mutation and send.
- **Session configuration**: Add a resolver-backed collaboration-mode helper that uses the current ACP mode API and safely no-ops when plan mode is unavailable.
- **Tests**: Verify creator → plan mode → first prompt ordering and provider-advertised mode resolution.

## Testing
- [x] Tests pass (4,615 passed, 3 skipped across the load-safe full-suite partition)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting passes (`pnpm check:fix`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Backend-only dispatch behavior is covered by the auto-start ordering regression; no UI screenshot is applicable.

Closes #2086

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
