### PR TITLE
Fix #1914: Guard Linear screenshot URLs

### DIFF
--- a/src/backend/orchestration/workspace-init-issue-prompts.test.ts
+++ b/src/backend/orchestration/workspace-init-issue-prompts.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { unsafeCoerce } from '@/test-utils/unsafe-coerce';
+
+vi.mock('@/backend/services/github', () => ({
+  githubCLIService: {
+    getIssue: vi.fn(),
+  },
+}));
+
+vi.mock('@/backend/services/linear', () => ({
+  linearClientService: {
+    getIssue: vi.fn(),
+  },
+}));
+
+vi.mock('@/backend/services/workspace', () => ({
+  workspaceDataService: {
+    findByIdWithProject: vi.fn(),
+  },
+}));
+
+vi.mock('./linear-config.helper', () => ({
+  getDecryptedLinearConfig: vi.fn(),
+}));
+
+import { linearClientService } from '@/backend/services/linear';
+import { workspaceDataService } from '@/backend/services/workspace';
+import { getDecryptedLinearConfig } from './linear-config.helper';
+import { buildInitialPromptFromLinearIssue } from './workspace-init-issue-prompts';
+
+const logger = unsafeCoerce<Parameters<typeof buildInitialPromptFromLinearIssue>[1]>({
+  info: vi.fn(),
+  warn: vi.fn(),
+});
+
+function mockLinearIssueWorkspace(githubOwner: string | null, githubRepo: string | null) {
+  vi.mocked(workspaceDataService.findByIdWithProject).mockResolvedValue(
+    unsafeCoerce({
+      id: 'workspace-1',
+      linearIssueId: 'linear-issue-1',
+      project: {
+        githubOwner,
+        githubRepo,
+        issueTrackerConfig: {},
+      },
+    })
+  );
+}
+
+describe('buildInitialPromptFromLinearIssue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getDecryptedLinearConfig).mockReturnValue({
+      apiKey: 'linear-api-key',
+      teamId: 'linear-team-1',
+    });
+    vi.mocked(linearClientService.getIssue).mockResolvedValue({
+      id: 'linear-issue-1',
+      identifier: 'ENG-123',
+      title: 'Fix screenshot instructions',
+      description: 'Keep screenshot links usable without GitHub metadata.',
+      url: 'https://linear.app/acme/issue/ENG-123',
+      state: 'Todo',
+      createdAt: '2026-07-30T00:00:00.000Z',
+      creatorName: 'Test User',
+    });
+  });
+
+  it.each([
+    { githubOwner: null, githubRepo: null },
+    { githubOwner: 'purplefish-ai', githubRepo: null },
+    { githubOwner: null, githubRepo: 'factory-factory' },
+  ])('uses a relative screenshot path when GitHub metadata is incomplete', async ({
+    githubOwner,
+    githubRepo,
+  }) => {
+    mockLinearIssueWorkspace(githubOwner, githubRepo);
+
+    const prompt = await buildInitialPromptFromLinearIssue('workspace-1', logger);
+
+    expect(prompt).toContain('# Linear Issue ENG-123');
+    expect(prompt).toContain(
+      `![Description](\${branch}/.factory-factory/screenshots/filename.png)`
+    );
+    expect(prompt).not.toContain('raw.githubusercontent.com');
+  });
+
+  it('uses the configured GitHub repository for screenshot paths', async () => {
+    mockLinearIssueWorkspace('purplefish-ai', 'factory-factory');
+
+    const prompt = await buildInitialPromptFromLinearIssue('workspace-1', logger);
+
+    expect(prompt).toContain(
+      `![Description](https://raw.githubusercontent.com/purplefish-ai/factory-factory/\${branch}/.factory-factory/screenshots/filename.png)`
+    );
+  });
+});

--- a/src/backend/orchestration/workspace-init-issue-prompts.ts
+++ b/src/backend/orchestration/workspace-init-issue-prompts.ts
@@ -100,7 +100,10 @@ export async function buildInitialPromptFromLinearIssue(
       url: issue.url,
       commitReference: issue.identifier,
       closeReference: issue.identifier,
-      rawScreenshotBaseUrl: `https://raw.githubusercontent.com/${project.githubOwner}/${project.githubRepo}/`,
+      rawScreenshotBaseUrl:
+        project.githubOwner && project.githubRepo
+          ? `https://raw.githubusercontent.com/${project.githubOwner}/${project.githubRepo}/`
+          : '',
     });
   } catch (error) {
     logger.warn('Error building initial prompt from Linear issue', {


### PR DESCRIPTION
## Summary
- Prevent Linear issue prompts from embedding malformed raw GitHub screenshot URLs when repository metadata is missing.
- Preserve relative screenshot paths for projects using GitHub Enterprise, GitLab, Bitbucket, or self-hosted Git.

## Changes
- **Workspace initialization**: Build the raw screenshot base URL only when both `githubOwner` and `githubRepo` are available.
- **Regression coverage**: Cover missing, partial, and complete GitHub metadata while confirming Linear prompt generation continues.

## Testing
- [x] Tests pass (`pnpm test`: 358 files, 4,634 tests)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Lint and repository guardrails pass (`pnpm check:fix`, `pnpm check`)
- [x] Manual testing: Not applicable; this backend prompt-generation change is covered by focused regression tests.

Closes #1914

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ab5fcba516fb980ed7aec8097bbe39121c85bbe4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
