### PR TITLE
Fix #2087: Cover viewed session generation cleanup

### DIFF
--- a/src/backend/services/session/service/lifecycle/session.lifecycle.service.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.lifecycle.service.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SessionDomainService } from '@/backend/services/session/service/session-domain.service';
+import { sessionEventBus } from '@/backend/services/session/service/session-event-bus';
 import { userSettingsService } from '@/backend/services/settings';
 import { workspaceNotificationService } from '@/backend/services/workspace';
 import type { ChatMessage } from '@/shared/acp-protocol';
@@ -864,6 +865,7 @@ function createStartableLifecycleService(options?: {
     tryDispatchNextMessage,
     sessionConfigService,
     runtimeManager,
+    sessionDomainService,
   };
 }
 
@@ -1069,6 +1071,20 @@ describe('SessionLifecycleService startSession pending workspace notifications',
 
     await service.stopSession('session-1');
 
+    expect(getStopGenerations(service).has('session-1')).toBe(false);
+  });
+
+  it('releases the stop generation when viewers retain inactive session state', async () => {
+    const { service, sessionDomainService } = createStartableLifecycleService();
+    sessionEventBus.registerViewerCountProvider((sessionId) => (sessionId === 'session-1' ? 1 : 0));
+
+    try {
+      await service.stopSession('session-1');
+    } finally {
+      sessionEventBus.registerViewerCountProvider(null);
+    }
+
+    expect(sessionDomainService.clearSession).not.toHaveBeenCalled();
     expect(getStopGenerations(service).has('session-1')).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

- Backfill issue-specific regression coverage for stop-generation cleanup already shipped in #2105
- Verify connected viewers can retain inactive session-domain state without retaining lifecycle generation state

## Changes

- **Session lifecycle tests**: Stop a session with an active viewer, assert the domain store remains available, and assert `stopGenerations` releases the session entry independently

## Testing

- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Formatting and lint checks pass (`pnpm check:fix`)
- [x] Mutation check: removing manual-stop generation cleanup makes the new regression fail
- [ ] Manual testing: Not applicable; this is backend lifecycle regression coverage

Closes #2087

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
