### PR TITLE
Fix #2089: Remove unreachable remote branch normalization

### DIFF
--- a/src/backend/interceptors/branch-naming.interceptor.test.ts
+++ b/src/backend/interceptors/branch-naming.interceptor.test.ts
@@ -913,6 +913,46 @@ describe('PR completion handling', () => {
     );
   });
 
+  it('keeps a generated branch prefix that matches the remote name', async () => {
+    const interceptor = createBranchNamingInterceptor();
+    mocks.findProjectById.mockResolvedValue({
+      id: 'project-1',
+      githubOwner: 'origin',
+    });
+    const event = createEvent({
+      toolUseId: 'matching-prefix-cleanup',
+      input: { command: 'gh pr create --fill' },
+    });
+    mocks.gitCommand
+      .mockResolvedValueOnce({ code: 0, stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ code: 0, stdout: 'abc123\n', stderr: '' })
+      .mockResolvedValueOnce({
+        code: 0,
+        stdout: 'origin/origin/fix-authentication-bug\n',
+        stderr: '',
+      })
+      .mockResolvedValueOnce({ code: 0, stdout: 'abc123\n', stderr: '' })
+      .mockResolvedValueOnce({ code: 0, stdout: 'abc123\n', stderr: '' })
+      .mockResolvedValueOnce({ code: 0, stdout: '', stderr: '' });
+
+    await interceptor.onToolStart!(event, context);
+    await interceptor.onToolComplete!(
+      { ...event, output: { content: 'created', isError: false } },
+      context
+    );
+
+    expect(mocks.gitCommand).toHaveBeenNthCalledWith(
+      5,
+      ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/origin/fix-authentication-bug'],
+      '/tmp/workspace'
+    );
+    expect(mocks.gitCommand).toHaveBeenNthCalledWith(
+      6,
+      ['push', 'origin', '--delete', 'owner/automatic-1'],
+      '/tmp/workspace'
+    );
+  });
+
   it.each([
     {
       reason: 'HEAD cannot be resolved',

--- a/src/backend/interceptors/branch-naming.interceptor.ts
+++ b/src/backend/interceptors/branch-naming.interceptor.ts
@@ -179,11 +179,6 @@ function parseRemoteName(upstreamRef: string): string | undefined {
 }
 
 function normalizeRemoteBranchName(branchName: string, remoteName: string): string {
-  const remotePrefix = `${remoteName}/`;
-  if (branchName.startsWith(remotePrefix)) {
-    return branchName.slice(remotePrefix.length);
-  }
-
   const fullRefPrefix = `refs/remotes/${remoteName}/`;
   if (branchName.startsWith(fullRefPrefix)) {
     return branchName.slice(fullRefPrefix.length);


### PR DESCRIPTION
## Summary

- Remove unreachable short remote-prefix normalization from PR branch cleanup
- Preserve normalization for canonical `refs/remotes/<remote>/...` values
- Protect valid local branches whose first path component matches the remote name

## Changes

- **Branch cleanup**: Stop stripping ambiguous `<remote>/` prefixes from stored and generated local branch names
- **Regression coverage**: Verify a generated `origin/fix-authentication-bug` branch remains intact when the upstream remote is also named `origin`

## Testing

- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Formatting and lint checks pass (`pnpm check:fix`)
- [x] Mutation check: restoring short-prefix normalization makes the regression fail
- [ ] Manual testing: Not applicable; this is backend branch-cleanup logic

Closes #2089

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
