### PR TITLE
Fix #1909: Resolve Windows workspace file links

### DIFF
--- a/src/client/lib/workspace-file-links.test.ts
+++ b/src/client/lib/workspace-file-links.test.ts
@@ -31,6 +31,26 @@ describe('resolveWorkspaceFileLink', () => {
     ).toBe('src/client/App Shell.md');
   });
 
+  it('compares Windows workspace paths case-insensitively', () => {
+    expect(
+      resolveWorkspaceFileLink(
+        'file:///c:/users/MARTIN/factory-factory/workspace-demo/src/client/App%20Shell.md',
+        String.raw`C:\Users\martin\factory-factory\workspace-demo`,
+        ORIGIN
+      )
+    ).toBe('src/client/App Shell.md');
+  });
+
+  it('preserves backslashes as literal characters in POSIX paths', () => {
+    expect(
+      resolveWorkspaceFileLink(
+        'file:///tmp/work/tree/src/client/App%20Shell.md',
+        String.raw`/tmp/work\tree`,
+        ORIGIN
+      )
+    ).toBeNull();
+  });
+
   it('rejects paths outside the workspace', () => {
     expect(
       resolveWorkspaceFileLink('/Users/martin/factory-factory/other/README.md:3', WORKTREE, ORIGIN)

--- a/src/client/lib/workspace-file-links.test.ts
+++ b/src/client/lib/workspace-file-links.test.ts
@@ -21,6 +21,16 @@ describe('resolveWorkspaceFileLink', () => {
     ).toBe('src/client/App Shell.md');
   });
 
+  it('resolves a file URL against a Windows worktree path', () => {
+    expect(
+      resolveWorkspaceFileLink(
+        'file:///C:/Users/martin/factory-factory/workspace-demo/src/client/App%20Shell.md',
+        String.raw`C:\Users\martin\factory-factory\workspace-demo`,
+        ORIGIN
+      )
+    ).toBe('src/client/App Shell.md');
+  });
+
   it('rejects paths outside the workspace', () => {
     expect(
       resolveWorkspaceFileLink('/Users/martin/factory-factory/other/README.md:3', WORKTREE, ORIGIN)

--- a/src/client/lib/workspace-file-links.ts
+++ b/src/client/lib/workspace-file-links.ts
@@ -25,10 +25,11 @@ function appendNormalizedSegment(
 }
 
 function normalizePathForComparison(pathname: string): string {
-  const hasLeadingSlash = pathname.startsWith('/');
+  const normalizedInput = pathname.replace(/\\/g, '/');
+  const hasLeadingSlash = normalizedInput.startsWith('/') || /^[A-Za-z]:\//.test(normalizedInput);
   const segments: string[] = [];
 
-  for (const segment of pathname.split('/')) {
+  for (const segment of normalizedInput.split('/')) {
     appendNormalizedSegment(segments, segment, hasLeadingSlash);
   }
 

--- a/src/client/lib/workspace-file-links.ts
+++ b/src/client/lib/workspace-file-links.ts
@@ -24,9 +24,11 @@ function appendNormalizedSegment(
   segments.push(segment);
 }
 
-function normalizePathForComparison(pathname: string): string {
-  const normalizedInput = pathname.replace(/\\/g, '/');
-  const hasLeadingSlash = normalizedInput.startsWith('/') || /^[A-Za-z]:\//.test(normalizedInput);
+function normalizePathForComparison(pathname: string, usesWindowsPathSemantics: boolean): string {
+  const normalizedInput = usesWindowsPathSemantics ? pathname.replace(/\\/g, '/') : pathname;
+  const hasLeadingSlash =
+    normalizedInput.startsWith('/') ||
+    (usesWindowsPathSemantics && /^[A-Za-z]:\//.test(normalizedInput));
   const segments: string[] = [];
 
   for (const segment of normalizedInput.split('/')) {
@@ -80,9 +82,19 @@ export function resolveWorkspaceFileLink(
     return null;
   }
 
-  const filePath = normalizePathForComparison(stripLineSuffix(pathname));
-  const workspaceRoot = normalizePathForComparison(worktreePath);
-  if (!(filePath === workspaceRoot || filePath.startsWith(`${workspaceRoot}/`))) {
+  const usesWindowsPathSemantics = /^[A-Za-z]:[\\/]/.test(worktreePath);
+  const filePath = normalizePathForComparison(stripLineSuffix(pathname), usesWindowsPathSemantics);
+  const workspaceRoot = normalizePathForComparison(worktreePath, usesWindowsPathSemantics);
+  const comparableFilePath = usesWindowsPathSemantics ? filePath.toLowerCase() : filePath;
+  const comparableWorkspaceRoot = usesWindowsPathSemantics
+    ? workspaceRoot.toLowerCase()
+    : workspaceRoot;
+  if (
+    !(
+      comparableFilePath === comparableWorkspaceRoot ||
+      comparableFilePath.startsWith(`${comparableWorkspaceRoot}/`)
+    )
+  ) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
- Resolve agent `file://` links against native Windows worktree paths.
- Preserve POSIX backslash semantics while comparing Windows paths case-insensitively.
- Add focused regressions for Windows separators, drive-root casing, and POSIX paths.

## Changes
- **Workspace file links**: Select Windows path semantics from drive-absolute worktree roots, normalize native separators, and compare normalized Windows paths without case sensitivity.
- **Cross-platform containment**: Keep backslashes literal for POSIX roots and retain the existing segment-boundary containment check.
- **Tests**: Cover RFC file URLs paired with native Windows roots, mixed-case Windows paths, and POSIX roots containing literal backslashes.

## Testing
- [x] Tests pass (`pnpm test` — 4,633 passed, 3 skipped)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting and lint pass (`pnpm check:fix`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: On Windows, click an agent-generated `file:///C:/...` workspace link and confirm it opens in-app.

Closes #1909

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 284fd3c4b31e35c5053a4aa05cef05faf2cd14b1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

