### PR TITLE
Fix #2088: Recover screenshot capture loading

### DIFF
--- a/src/client/features/workspace/right-panel.tsx
+++ b/src/client/features/workspace/right-panel.tsx
@@ -111,7 +111,8 @@ interface RightPanelProps {
   workspaceId: string;
   className?: string;
   messages?: ChatMessage[];
-  onTakeScreenshots?: () => void;
+  isTakingScreenshots?: boolean;
+  onTakeScreenshots?: () => Promise<void>;
 }
 
 interface TopPanelAreaProps {
@@ -119,7 +120,8 @@ interface TopPanelAreaProps {
   messages: ChatMessage[];
   activeTopTab: TopPanelTab;
   onTopTabChange: (tab: TopPanelTab) => void;
-  onTakeScreenshots: () => void;
+  isTakingScreenshots: boolean;
+  onTakeScreenshots?: () => void;
   isAutoIteration: boolean;
   periodicTaskId: string | null;
   isParentWorkspace: boolean;
@@ -130,6 +132,7 @@ function TopPanelArea({
   messages,
   activeTopTab,
   onTopTabChange,
+  isTakingScreenshots,
   onTakeScreenshots,
   isAutoIteration,
   periodicTaskId,
@@ -224,7 +227,11 @@ function TopPanelArea({
         {showFiles && <FileBrowserPanel workspaceId={workspaceId} />}
         {showTasks && <TodoPanelContainer messages={messages} />}
         {showScreenshots && (
-          <ScreenshotsPanel workspaceId={workspaceId} onTakeScreenshots={onTakeScreenshots} />
+          <ScreenshotsPanel
+            workspaceId={workspaceId}
+            isTakingScreenshots={isTakingScreenshots}
+            onTakeScreenshots={onTakeScreenshots}
+          />
         )}
         {showAutoIteration && <AutoIterationPanel workspaceId={workspaceId} />}
         {showPeriodicTask && periodicTaskId && (
@@ -240,6 +247,7 @@ export function RightPanel({
   workspaceId,
   className,
   messages = [],
+  isTakingScreenshots = false,
   onTakeScreenshots,
 }: RightPanelProps) {
   // Track which workspaceId has been loaded to handle workspace changes
@@ -325,7 +333,7 @@ export function RightPanel({
 
   const handleTakeScreenshots = useCallback(() => {
     handleTopTabChange('screenshots');
-    onTakeScreenshots?.();
+    void onTakeScreenshots?.();
   }, [handleTopTabChange, onTakeScreenshots]);
 
   // Auto-select the auto-iteration or periodic-task tab on first load,
@@ -426,7 +434,8 @@ export function RightPanel({
           messages={messages}
           activeTopTab={activeTopTab}
           onTopTabChange={handleTopTabChange}
-          onTakeScreenshots={handleTakeScreenshots}
+          isTakingScreenshots={isTakingScreenshots}
+          onTakeScreenshots={onTakeScreenshots ? handleTakeScreenshots : undefined}
           isAutoIteration={isAutoIteration}
           periodicTaskId={periodicTaskId}
           isParentWorkspace={isParentWorkspace}

--- a/src/client/features/workspace/screenshots-panel.test.tsx
+++ b/src/client/features/workspace/screenshots-panel.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+
+import { createElement, type ReactNode } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ScreenshotsPanel } from './screenshots-panel';
+
+const mocks = vi.hoisted(() => ({
+  openTab: vi.fn(),
+  onTakeScreenshots: vi.fn(),
+}));
+
+vi.mock('@phosphor-icons/react', () => ({
+  CameraIcon: () => null,
+  SpinnerGapIcon: () => null,
+  XIcon: () => null,
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, onClick }: { children: ReactNode; onClick?: () => void }) =>
+    createElement('button', { onClick, type: 'button' }, children),
+}));
+
+vi.mock('@/components/ui/scroll-area', () => ({
+  ScrollArea: ({ children }: { children: ReactNode }) => createElement('div', null, children),
+}));
+
+vi.mock('@/client/lib/trpc', () => ({
+  trpc: {
+    useUtils: () => ({
+      workspace: {
+        listScreenshots: {
+          invalidate: vi.fn(),
+        },
+      },
+    }),
+    workspace: {
+      deleteScreenshot: {
+        useMutation: () => ({ mutate: vi.fn() }),
+      },
+      listScreenshots: {
+        useQuery: () => ({
+          data: { screenshots: [] },
+          isLoading: false,
+        }),
+      },
+      readScreenshot: {
+        useQuery: () => ({ data: undefined, isLoading: false }),
+      },
+    },
+  },
+}));
+
+vi.mock('./workspace-panel-context', () => ({
+  useWorkspacePanel: () => ({ openTab: mocks.openTab }),
+}));
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.clearAllMocks();
+});
+
+describe('ScreenshotsPanel', () => {
+  it('shows the retry action again when its controlled loading state clears', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    flushSync(() => {
+      root.render(
+        createElement(ScreenshotsPanel, {
+          workspaceId: 'workspace-1',
+          isTakingScreenshots: true,
+          onTakeScreenshots: mocks.onTakeScreenshots,
+        })
+      );
+    });
+
+    expect(container.textContent).toContain('Taking Screenshots...');
+    expect(container.querySelector('button')).toBeNull();
+
+    flushSync(() => {
+      root.render(
+        createElement(ScreenshotsPanel, {
+          workspaceId: 'workspace-1',
+          isTakingScreenshots: false,
+          onTakeScreenshots: mocks.onTakeScreenshots,
+        })
+      );
+    });
+
+    const retryButton = container.querySelector('button');
+    expect(retryButton?.textContent).toContain('Take Screenshots');
+
+    retryButton?.click();
+    expect(mocks.onTakeScreenshots).toHaveBeenCalledOnce();
+
+    root.unmount();
+  });
+});

--- a/src/client/features/workspace/screenshots-panel.tsx
+++ b/src/client/features/workspace/screenshots-panel.tsx
@@ -1,5 +1,5 @@
 import { CameraIcon, SpinnerGapIcon, XIcon } from '@phosphor-icons/react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback } from 'react';
 import { trpc } from '@/client/lib/trpc';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -12,6 +12,7 @@ import { useWorkspacePanel } from './workspace-panel-context';
 
 interface ScreenshotsPanelProps {
   workspaceId: string;
+  isTakingScreenshots: boolean;
   onTakeScreenshots?: () => void;
 }
 
@@ -19,11 +20,13 @@ interface ScreenshotsPanelProps {
 // Main Component
 // =============================================================================
 
-export function ScreenshotsPanel({ workspaceId, onTakeScreenshots }: ScreenshotsPanelProps) {
+export function ScreenshotsPanel({
+  workspaceId,
+  isTakingScreenshots,
+  onTakeScreenshots,
+}: ScreenshotsPanelProps) {
   const { openTab } = useWorkspacePanel();
   const utils = trpc.useUtils();
-  const [isTaking, setIsTaking] = useState(false);
-  const prevCountRef = useRef(0);
 
   const deleteMutation = trpc.workspace.deleteScreenshot.useMutation({
     onSuccess: () => {
@@ -33,21 +36,15 @@ export function ScreenshotsPanel({ workspaceId, onTakeScreenshots }: Screenshots
 
   const { data, isLoading } = trpc.workspace.listScreenshots.useQuery(
     { workspaceId },
-    { refetchInterval: isTaking ? 3000 : 10_000, staleTime: isTaking ? 1000 : 5000 }
+    {
+      refetchInterval: isTakingScreenshots ? 3000 : 10_000,
+      staleTime: isTakingScreenshots ? 1000 : 5000,
+    }
   );
 
   const screenshots = data?.screenshots ?? [];
 
-  // Clear isTaking when new screenshots appear
-  useEffect(() => {
-    if (isTaking && screenshots.length > prevCountRef.current) {
-      setIsTaking(false);
-    }
-    prevCountRef.current = screenshots.length;
-  }, [screenshots.length, isTaking]);
-
   const handleTakeScreenshots = useCallback(() => {
-    setIsTaking(true);
     onTakeScreenshots?.();
   }, [onTakeScreenshots]);
 
@@ -64,7 +61,7 @@ export function ScreenshotsPanel({ workspaceId, onTakeScreenshots }: Screenshots
       <div className="flex flex-col items-center justify-center h-full text-center p-4 gap-3">
         <CameraIcon className="h-8 w-8 text-muted-foreground" />
         <div>
-          {isTaking ? (
+          {isTakingScreenshots ? (
             <>
               <p className="text-sm font-medium text-muted-foreground">Taking Screenshots...</p>
               <p className="text-xs text-muted-foreground/70 mt-1">
@@ -80,7 +77,7 @@ export function ScreenshotsPanel({ workspaceId, onTakeScreenshots }: Screenshots
             </>
           )}
         </div>
-        {isTaking ? (
+        {isTakingScreenshots ? (
           <SpinnerGapIcon className="h-5 w-5 animate-spin text-muted-foreground" />
         ) : (
           onTakeScreenshots && (

--- a/src/client/routes/projects/workspaces/use-workspace-detail.ts
+++ b/src/client/routes/projects/workspaces/use-workspace-detail.ts
@@ -144,7 +144,7 @@ export interface UseSessionManagementReturn {
   handleSelectSession: (dbSessionId: string) => void;
   handleCloseSession: (dbSessionId: string) => void;
   handleNewChat: () => void;
-  handleQuickAction: (name: string, prompt: string) => void;
+  handleQuickAction: (name: string, prompt: string) => Promise<void>;
 }
 
 export function useSessionManagement({
@@ -336,11 +336,11 @@ export function useSessionManagement({
   ]);
 
   const handleQuickAction = useCallback(
-    (name: string, prompt: string) => {
+    async (name: string, prompt: string) => {
       const provider = selectedProvider;
       const model = provider === 'CODEX' ? undefined : selectedModel || undefined;
-      createSession.mutate(
-        {
+      try {
+        const session = await createSession.mutateAsync({
           workspaceId,
           workflow: 'followup',
           name,
@@ -348,14 +348,12 @@ export function useSessionManagement({
           provider,
           initialMessage: prompt,
           initialPrompt: '',
-        },
-        {
-          onSuccess: (session) => {
-            // Setting the new session ID triggers WebSocket reconnection automatically
-            setSelectedDbSessionId(session.id);
-          },
-        }
-      );
+        });
+        // Setting the new session ID triggers WebSocket reconnection automatically
+        setSelectedDbSessionId(session.id);
+      } catch {
+        // The mutation's onError handler reports the failure.
+      }
     },
     [createSession, workspaceId, setSelectedDbSessionId, selectedModel, selectedProvider]
   );

--- a/src/client/routes/projects/workspaces/workspace-detail-view.test.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-view.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { createElement, type ReactNode } from 'react';
+import { act, createElement, type ReactNode } from 'react';
 import { flushSync } from 'react-dom';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -13,6 +13,23 @@ const archiveDialogMock = vi.hoisted(() =>
       'data-testid': 'archive-dialog',
       'data-active-child-count': props.activeChildCount,
     })
+  )
+);
+
+const rightPanelMock = vi.hoisted(() =>
+  vi.fn((props: { isTakingScreenshots: boolean; onTakeScreenshots: () => Promise<void> }) =>
+    createElement(
+      'button',
+      {
+        'data-testid': 'take-screenshots',
+        'data-loading': String(Boolean(props.isTakingScreenshots)),
+        onClick: () => {
+          void props.onTakeScreenshots();
+        },
+        type: 'button',
+      },
+      'Take screenshots'
+    )
   )
 );
 
@@ -46,7 +63,7 @@ vi.mock('@/components/ui/sheet', () => ({
 
 vi.mock('@/client/features/workspace', () => ({
   ArchiveWorkspaceDialog: archiveDialogMock,
-  RightPanel: () => createElement('aside', null, 'Right panel'),
+  RightPanel: rightPanelMock,
   WorkspaceContentView: ({ children }: { children: ReactNode }) =>
     createElement('main', null, children),
 }));
@@ -209,6 +226,38 @@ describe('WorkspaceDetailView', () => {
     const { container, root } = renderView(props);
 
     expect(container.textContent).toContain('Script failed');
+
+    root.unmount();
+  });
+
+  it('clears screenshot loading when session creation fails', async () => {
+    let rejectSessionCreation: ((error: Error) => void) | undefined;
+    const props = createViewProps(0);
+    props.rightPanelVisible = true;
+    props.header.handleQuickAction = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectSessionCreation = reject;
+        })
+    );
+
+    const { container, root } = renderView(props);
+    const takeScreenshotsButton = container.querySelector<HTMLButtonElement>(
+      '[data-testid="take-screenshots"]'
+    );
+
+    expect(takeScreenshotsButton?.dataset.loading).toBe('false');
+
+    await act(() => {
+      takeScreenshotsButton?.click();
+    });
+    expect(takeScreenshotsButton?.dataset.loading).toBe('true');
+
+    await act(() => {
+      rejectSessionCreation?.(new Error('Session creation failed'));
+    });
+
+    expect(takeScreenshotsButton?.dataset.loading).toBe('false');
 
     root.unmount();
   });

--- a/src/client/routes/projects/workspaces/workspace-detail-view.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-view.tsx
@@ -1,4 +1,4 @@
-import type { Dispatch, SetStateAction } from 'react';
+import { type Dispatch, type SetStateAction, useCallback, useState } from 'react';
 import { Loading } from '@/client/components/loading';
 import {
   ArchiveWorkspaceDialog,
@@ -23,6 +23,9 @@ import type { useWorkspaceInitStatus } from './use-workspace-detail-hooks';
 import { ChatContent, type ChatContentProps } from './workspace-detail-chat-content';
 import { getVisibleInitBanner } from './workspace-detail-container.utils';
 import { ArchivingOverlay, ScriptFailedBanner } from './workspace-overlays';
+
+const TAKE_SCREENSHOTS_PROMPT =
+  'Take a screenshot of the workspace dev app using Playwright MCP tools. Read factory-factory.json for the scripts.run command, pick a free port, replace {port}, and start the dev server in the background. Once ready, determine the most relevant screen and save a screenshot to .factory-factory/screenshots/ with a descriptive filename.';
 
 interface WorkspaceStateProps {
   workspaceLoading: boolean;
@@ -122,6 +125,18 @@ export function WorkspaceDetailView({
   archiveDialog,
 }: WorkspaceDetailViewProps) {
   const isMobile = useIsMobile();
+  const [isTakingScreenshots, setIsTakingScreenshots] = useState(false);
+
+  const handleTakeScreenshots = useCallback(async () => {
+    setIsTakingScreenshots(true);
+    try {
+      await header.handleQuickAction('Take Screenshots', TAKE_SCREENSHOTS_PROMPT);
+    } catch {
+      // The session mutation reports the error to the user.
+    } finally {
+      setIsTakingScreenshots(false);
+    }
+  }, [header.handleQuickAction]);
 
   if (workspaceState.workspaceLoading) {
     return <Loading message="Loading workspace..." />;
@@ -166,12 +181,8 @@ export function WorkspaceDetailView({
     <RightPanel
       workspaceId={workspaceState.workspaceId}
       messages={chat.messages}
-      onTakeScreenshots={() =>
-        header.handleQuickAction(
-          'Take Screenshots',
-          'Take a screenshot of the workspace dev app using Playwright MCP tools. Read factory-factory.json for the scripts.run command, pick a free port, replace {port}, and start the dev server in the background. Once ready, determine the most relevant screen and save a screenshot to .factory-factory/screenshots/ with a descriptive filename.'
-        )
-      }
+      isTakingScreenshots={isTakingScreenshots}
+      onTakeScreenshots={handleTakeScreenshots}
     />
   );
 


### PR DESCRIPTION
## Summary
- Move screenshot capture loading ownership to the workspace detail view
- Clear the capture state when session creation settles, including failures
- Restore the retry action through a controlled `ScreenshotsPanel` state

## Changes
- **Session management**: Make quick-action session creation awaitable while preserving mutation error toasts and successful session selection
- **Workspace detail**: Track screenshot-specific loading around the async quick action with `try`/`finally`
- **Screenshots panel**: Remove the success-count-only local state and consume controlled loading state from its owner
- **Tests**: Cover rejected session creation and retry-button reappearance

## Testing
- [x] Tests pass (`pnpm test` — 4,632 passed)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting passes (`pnpm check:fix`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Force screenshot session creation to fail and verify the Take Screenshots retry action returns (browser automation unavailable in this session)

Closes #2088

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
