### PR TITLE
Fix #2084: Deduplicate Changes panel folders

### DIFF
--- a/src/client/features/workspace/change-panel-shared.test.tsx
+++ b/src/client/features/workspace/change-panel-shared.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+
+import { createElement } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { type ChangeListEntry, ChangeTreeView } from './change-panel-shared';
+
+const mocks = vi.hoisted(() => ({
+  listFilesUseQuery: vi.fn(() => ({
+    data: {
+      entries: [{ name: 'a.ts', path: 'myfolder/a.ts', type: 'file' as const }],
+    },
+    isError: false,
+    isLoading: false,
+  })),
+}));
+
+vi.mock('@phosphor-icons/react', () => ({
+  CaretDownIcon: () => null,
+  CaretRightIcon: () => null,
+  FileCodeIcon: () => null,
+  FileDashedIcon: () => null,
+  FileMinusIcon: () => null,
+  FilePlusIcon: () => null,
+  FolderIcon: () => null,
+  SpinnerGapIcon: () => null,
+  WarningCircleIcon: () => null,
+}));
+
+vi.mock('@/client/lib/trpc', () => ({
+  trpc: {
+    workspace: {
+      listFiles: {
+        useQuery: mocks.listFilesUseQuery,
+      },
+    },
+  },
+}));
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.clearAllMocks();
+});
+
+describe('ChangeTreeView', () => {
+  it('uses inferred children instead of fetching contents for a git-reported directory', () => {
+    const entries: ChangeListEntry[] = [
+      { path: 'myfolder/', kind: 'untracked', statusCode: '?' },
+      { path: 'myfolder/a.ts', kind: 'modified', statusCode: 'M' },
+    ];
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    flushSync(() => {
+      root.render(
+        createElement(ChangeTreeView, {
+          entries,
+          onFileClick: vi.fn(),
+          workspaceId: 'workspace-1',
+        })
+      );
+    });
+
+    expect(mocks.listFilesUseQuery).not.toHaveBeenCalled();
+    expect(
+      Array.from(container.querySelectorAll('button')).filter((button) =>
+        button.textContent?.includes('a.ts')
+      )
+    ).toHaveLength(1);
+
+    root.unmount();
+  });
+});

--- a/src/client/features/workspace/change-panel-shared.tsx
+++ b/src/client/features/workspace/change-panel-shared.tsx
@@ -245,21 +245,21 @@ export interface ChangeTreeNode {
  */
 export function buildChangeTree(entries: ChangeListEntry[]): ChangeTreeNode[] {
   const root: ChangeTreeNode[] = [];
-  // Maps a directory path to its children array (for virtual dirs only)
-  const dirChildrenMap = new Map<string, ChangeTreeNode[]>();
+  const directoryNodeMap = new Map<string, ChangeTreeNode>();
 
-  function ensureVirtualDirChain(dirPath: string): ChangeTreeNode[] {
-    const existing = dirChildrenMap.get(dirPath);
+  function ensureDirectoryNode(dirPath: string): ChangeTreeNode {
+    const existing = directoryNodeMap.get(dirPath);
     if (existing) {
       return existing;
     }
     const lastSlash = dirPath.lastIndexOf('/');
-    const parentList = lastSlash === -1 ? root : ensureVirtualDirChain(dirPath.slice(0, lastSlash));
+    const parentList =
+      lastSlash === -1 ? root : ensureDirectoryNode(dirPath.slice(0, lastSlash)).children;
     const name = lastSlash === -1 ? dirPath : dirPath.slice(lastSlash + 1);
     const node: ChangeTreeNode = { name, path: dirPath, type: 'directory', children: [] };
-    dirChildrenMap.set(dirPath, node.children);
+    directoryNodeMap.set(dirPath, node);
     parentList.push(node);
-    return node.children;
+    return node;
   }
 
   for (const entry of entries) {
@@ -267,15 +267,21 @@ export function buildChangeTree(entries: ChangeListEntry[]): ChangeTreeNode[] {
     // Git reports untracked directories with a trailing slash (e.g. "newfolder/")
     const isGitDir = path.endsWith('/');
     const normalPath = isGitDir ? path.slice(0, -1) : path;
+
+    if (isGitDir) {
+      ensureDirectoryNode(normalPath).entry = entry;
+      continue;
+    }
+
     const lastSlash = normalPath.lastIndexOf('/');
     const name = lastSlash === -1 ? normalPath : normalPath.slice(lastSlash + 1);
     const parentList =
-      lastSlash === -1 ? root : ensureVirtualDirChain(normalPath.slice(0, lastSlash));
+      lastSlash === -1 ? root : ensureDirectoryNode(normalPath.slice(0, lastSlash)).children;
 
     parentList.push({
       name,
       path: normalPath,
-      type: isGitDir ? 'directory' : 'file',
+      type: 'file',
       entry,
       children: [],
     });

--- a/src/client/features/workspace/change-panel-shared.tsx
+++ b/src/client/features/workspace/change-panel-shared.tsx
@@ -537,9 +537,10 @@ const ChangeTreeItemRow = memo(function ChangeTreeItemRow({
     );
   }
 
-  // Git-reported untracked directory: delegate to self-contained component that fetches children
+  // Git-reported directories without inferred children fetch their contents on demand.
+  // When inferred children exist, the flattened tree is the single source of child rows.
   const isGitReported = !!node.entry;
-  if (isGitReported && workspaceId) {
+  if (isGitReported && node.children.length === 0 && workspaceId) {
     return (
       <GitReportedDirRow
         node={node}
@@ -561,15 +562,22 @@ const ChangeTreeItemRow = memo(function ChangeTreeItemRow({
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
       )}
       style={{ paddingLeft: `${depth * 12 + 4}px` }}
-      title={node.path}
+      title={isGitReported ? `Untracked: ${node.path}` : node.path}
     >
       {isExpanded ? (
         <CaretDownIcon className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
       ) : (
         <CaretRightIcon className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
       )}
-      <FolderIcon className="h-4 w-4 shrink-0 text-brand" />
+      <FolderIcon
+        className={cn('h-4 w-4 shrink-0', isGitReported ? 'text-muted-foreground' : 'text-brand')}
+      />
       <span className="flex-1 truncate font-medium">{node.name}</span>
+      {node.entry && (
+        <span className="text-xs font-mono uppercase text-muted-foreground">
+          {node.entry.statusCode ?? '?'}
+        </span>
+      )}
     </button>
   );
 });

--- a/src/client/features/workspace/combined-changes-panel.test.ts
+++ b/src/client/features/workspace/combined-changes-panel.test.ts
@@ -1,9 +1,84 @@
 import { describe, expect, it } from 'vitest';
+import { buildChangeTree, type ChangeListEntry } from './change-panel-shared';
 import {
   buildCombinedEntries,
   getIndicatorLabel,
   getPartialDataWarning,
 } from './combined-changes-panel';
+
+const gitDirectoryEntry: ChangeListEntry = {
+  path: 'myfolder/',
+  kind: 'untracked',
+  statusCode: '?',
+};
+const childFileEntry: ChangeListEntry = {
+  path: 'myfolder/a.ts',
+  kind: 'modified',
+  statusCode: 'M',
+};
+
+describe('buildChangeTree', () => {
+  it.each([
+    ['before', [gitDirectoryEntry, childFileEntry]],
+    ['after', [childFileEntry, gitDirectoryEntry]],
+  ])('unifies a git-reported directory with its child when the directory appears %s the child', (_order, entries) => {
+    expect(buildChangeTree(entries)).toEqual([
+      {
+        name: 'myfolder',
+        path: 'myfolder',
+        type: 'directory',
+        entry: gitDirectoryEntry,
+        children: [
+          {
+            name: 'a.ts',
+            path: 'myfolder/a.ts',
+            type: 'file',
+            entry: childFileEntry,
+            children: [],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('unifies a nested git-reported directory with its child file', () => {
+    const nestedDirectoryEntry: ChangeListEntry = {
+      path: 'outer/inner/',
+      kind: 'untracked',
+      statusCode: '?',
+    };
+    const nestedFileEntry: ChangeListEntry = {
+      path: 'outer/inner/a.ts',
+      kind: 'modified',
+      statusCode: 'M',
+    };
+
+    expect(buildChangeTree([nestedDirectoryEntry, nestedFileEntry])).toEqual([
+      {
+        name: 'outer',
+        path: 'outer',
+        type: 'directory',
+        children: [
+          {
+            name: 'inner',
+            path: 'outer/inner',
+            type: 'directory',
+            entry: nestedDirectoryEntry,
+            children: [
+              {
+                name: 'a.ts',
+                path: 'outer/inner/a.ts',
+                type: 'file',
+                entry: nestedFileEntry,
+                children: [],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+});
 
 describe('buildCombinedEntries', () => {
   it('does not mark main-relative files as not pushed when upstream is in sync', () => {


### PR DESCRIPTION
## Summary
- Reuse one normalized tree node when Git reports a directory and another change entry references a file beneath it
- Preserve both the Git-reported directory metadata and inferred child files regardless of input order

## Changes
- **Changes tree**: Track directory nodes by normalized path and attach Git directory entries to the shared node
- **Regression coverage**: Test directory-first, child-first, and nested overlap scenarios

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Repository checks pass (`pnpm check`)
- [ ] Manual testing: The development server started successfully, but the prescribed in-app browser control was unavailable for screenshot capture; the tree behavior is covered by focused regression tests

Closes #2084

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Changes panel tree building and rendering; behavior is covered by new unit and component tests with no auth or data-layer changes.
> 
> **Overview**
> Fixes duplicate folder rows when Git reports an untracked directory (e.g. `myfolder/`) and the change list also includes files under that path.
> 
> **`buildChangeTree`** now keeps one directory node per normalized path: git-reported directories attach their metadata to the shared node instead of creating a separate folder, and child files nest under it regardless of entry order.
> 
> **`ChangeTreeItemRow`** only uses on-demand `listFiles` via `GitReportedDirRow` when a git-reported folder has **no** inferred children; if the tree already has children from change entries, those rows are shown and the fetch is skipped. Unified git-reported folders also get untracked styling (muted folder icon, status code, tooltip).
> 
> Regression tests cover tree unification (order-independent and nested) and a jsdom test that `listFiles` is not called when children are inferred.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d92d8f37964c6e5792bef072bdebf2c09d6f3102. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->