### PR TITLE
Fix #2082: Reject invalid port finder starts

### DIFF
--- a/docs/superpowers/plans/2026-07-30-valid-port-start.md
+++ b/docs/superpowers/plans/2026-07-30-valid-port-start.md
@@ -79,7 +79,7 @@ Run:
 pnpm vitest run src/cli/runtime-utils.test.ts
 ```
 
-Expected: 2 tests pass.
+Expected: 5 tests pass.
 
 ### Task 2: Backend Port Finder Validation
 

--- a/docs/superpowers/plans/2026-07-30-valid-port-start.md
+++ b/docs/superpowers/plans/2026-07-30-valid-port-start.md
@@ -1,0 +1,197 @@
+# Valid Port Start Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reject invalid starting ports immediately in the CLI and backend port finders so `ff serve --port 0 --dev` cannot wait on an unconnectable port.
+
+**Architecture:** Keep the two existing port-finder boundaries and add identical integer/range validation before either begins probing. Preserve the current scan behavior for valid ports and use focused regression tests to prove invalid inputs never invoke `lsof`.
+
+**Tech Stack:** TypeScript, Node.js networking APIs, Vitest, pnpm
+
+## Global Constraints
+
+- Valid starting ports are integers in the inclusive range `1..65_535`.
+- Invalid input throws `Invalid start port <value>: expected an integer between 1 and 65535`.
+- Invalid input must be rejected before any port probe.
+- Existing behavior for valid start ports, exclusions, maximum attempts, and upper-bound scanning remains unchanged.
+
+---
+
+### Task 1: CLI Port Finder Validation
+
+**Files:**
+- Modify: `src/cli/runtime-utils.test.ts`
+- Modify: `src/cli/runtime-utils.ts`
+
+**Interfaces:**
+- Consumes: `findAvailablePort(startPort: number, options?: FindAvailablePortOptions): Promise<number>`
+- Produces: The same function signature with upfront integer/range validation.
+
+- [ ] **Step 1: Write the failing CLI regression test**
+
+Add this case inside the existing `describe('findAvailablePort')` block:
+
+```typescript
+it.each([0, -1, 65_536, 1.5])(
+  'rejects invalid start port %s before probing',
+  async (startPort) => {
+    mockExec.mockResolvedValue({ stdout: '', stderr: '' });
+
+    await expect(findAvailablePort(startPort)).rejects.toThrow(
+      `Invalid start port ${startPort}: expected an integer between 1 and 65535`
+    );
+
+    expect(mockExec).not.toHaveBeenCalled();
+  }
+);
+```
+
+- [ ] **Step 2: Run the CLI test and verify RED**
+
+Run:
+
+```bash
+pnpm vitest run src/cli/runtime-utils.test.ts
+```
+
+Expected: FAIL because the current helper can return invalid values such as `0` and does not produce the validation error.
+
+- [ ] **Step 3: Implement minimal CLI validation**
+
+Add `MIN_PORT` beside `MAX_PORT`, then validate before reading options or entering the scan:
+
+```typescript
+const MIN_PORT = 1;
+const MAX_PORT = 65_535;
+
+if (!Number.isInteger(startPort) || startPort < MIN_PORT || startPort > MAX_PORT) {
+  throw new Error(
+    `Invalid start port ${startPort}: expected an integer between ${MIN_PORT} and ${MAX_PORT}`
+  );
+}
+```
+
+- [ ] **Step 4: Run the CLI test and verify GREEN**
+
+Run:
+
+```bash
+pnpm vitest run src/cli/runtime-utils.test.ts
+```
+
+Expected: 2 tests pass.
+
+### Task 2: Backend Port Finder Validation
+
+**Files:**
+- Modify: `src/backend/services/port.service.test.ts`
+- Modify: `src/backend/services/port.service.ts`
+
+**Interfaces:**
+- Consumes: `findAvailablePort(startPort: number, maxAttempts?: number): Promise<number>`
+- Produces: The same function signature with validation matching the CLI helper.
+
+- [ ] **Step 1: Write the failing backend regression test**
+
+Add this case inside the backend `describe('findAvailablePort')` block:
+
+```typescript
+it.each([0, -1, 65_536, 1.5])(
+  'should reject invalid start port %s before probing',
+  async (startPort) => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    mockExec.mockResolvedValue({ stdout: '', stderr: '' });
+
+    await expect(findAvailablePort(startPort)).rejects.toThrow(
+      `Invalid start port ${startPort}: expected an integer between 1 and 65535`
+    );
+
+    expect(mockExec).not.toHaveBeenCalled();
+  }
+);
+```
+
+- [ ] **Step 2: Run the backend test and verify RED**
+
+Run:
+
+```bash
+pnpm vitest run src/backend/services/port.service.test.ts
+```
+
+Expected: FAIL because the current helper probes or returns invalid values and does not produce the validation error.
+
+- [ ] **Step 3: Implement minimal backend validation**
+
+Add `MIN_PORT` beside `MAX_PORT` and the same validation block at the start of the backend `findAvailablePort`.
+
+- [ ] **Step 4: Run both focused tests and verify GREEN**
+
+Run:
+
+```bash
+pnpm vitest run src/cli/runtime-utils.test.ts src/backend/services/port.service.test.ts
+```
+
+Expected: Both test files pass with no warnings.
+
+- [ ] **Step 5: Commit the regression fix**
+
+```bash
+git add src/cli/runtime-utils.ts src/cli/runtime-utils.test.ts \
+  src/backend/services/port.service.ts src/backend/services/port.service.test.ts
+git commit -m "Reject invalid port finder starts (#2082)"
+```
+
+### Task 3: Full Verification and Publication
+
+**Files:**
+- Review: all changes relative to `origin/main`
+- Create outside repository: `/tmp/pr-body.md`
+
+**Interfaces:**
+- Consumes: committed port validation and regression tests.
+- Produces: a verified GitHub pull request closing issue `#2082`.
+
+- [ ] **Step 1: Run all required verification**
+
+```bash
+pnpm typecheck && pnpm check:fix && pnpm test && pnpm build
+```
+
+Expected: exit code `0` for every command. Review and explicitly stage any formatter changes before the final commit.
+
+- [ ] **Step 2: Review the complete change**
+
+```bash
+git diff origin/main
+git status -sb
+```
+
+Expected: only the planning artifacts and four intended source/test files differ from `origin/main`; no debug output or unrelated changes are present.
+
+- [ ] **Step 3: Commit any verification-only formatting changes**
+
+If `pnpm check:fix` changed intended files:
+
+```bash
+git add docs/superpowers/specs/2026-07-30-valid-port-start-design.md \
+  docs/superpowers/plans/2026-07-30-valid-port-start.md \
+  src/cli/runtime-utils.ts src/cli/runtime-utils.test.ts \
+  src/backend/services/port.service.ts src/backend/services/port.service.test.ts
+git commit -m "Format port validation changes (#2082)"
+```
+
+If it made no changes, verify `git status --short` is empty.
+
+- [ ] **Step 4: Push and create the pull request**
+
+Push the existing issue branch with tracking, write the required summary, testing checklist, `Closes #2082`, and Factory Factory signature to `/tmp/pr-body.md`, then run:
+
+```bash
+git push -u origin HEAD
+gh pr create --title "Fix #2082: Reject invalid port finder starts" --body-file /tmp/pr-body.md
+gh pr view --web
+```
+
+Expected: `gh` reports the new pull request URL and successfully opens its web view.

--- a/docs/superpowers/specs/2026-07-30-valid-port-start-design.md
+++ b/docs/superpowers/specs/2026-07-30-valid-port-start-design.md
@@ -1,0 +1,29 @@
+# Valid Port Start Design
+
+## Problem
+
+The CLI and backend `findAvailablePort` helpers accept any numeric starting value and only stop once a candidate exceeds `65_535`. A starting value of `0` can therefore be reported as available. In development mode the CLI passes that value to Vite, which treats port `0` as a request for an OS-assigned ephemeral port, while the CLI still waits for a service on port `0`. The resulting timeout falsely reports a frontend startup failure.
+
+## Decision
+
+Both reusable port finders will validate `startPort` before probing. A valid starting port must be an integer in the inclusive TCP user-assignable range `1..65_535`. Invalid input will throw:
+
+```text
+Invalid start port <value>: expected an integer between 1 and 65535
+```
+
+The validation will live at both existing finder boundaries rather than only in the CLI option parser. This keeps CLI and backend behavior consistent and protects all direct callers. Valid inputs will retain the current sequential scan, exclusion handling, maximum-attempt behavior, and upper-bound stop.
+
+## Alternatives Considered
+
+1. Validate only `ff serve` options. This would fix the reported command but leave both general-purpose helpers able to return invalid ports.
+2. Treat port `0` as an intentional request for an ephemeral port. This would require discovering and propagating the actual bound port from Vite and other child processes, which is outside the current finder contract.
+3. Validate both finders before probing. This is the selected approach because it is small, consistent with `PortAllocationService.findFreePort`, and fails immediately with an actionable error.
+
+## Tests
+
+Focused tests in `src/cli/runtime-utils.test.ts` and `src/backend/services/port.service.test.ts` will cover invalid values below, above, and between integer ports. Each test will assert both the clear rejection and that no `lsof` probe occurs. Existing tests continue to cover valid scanning, attempt limits, and stopping at `65_535`.
+
+## Scope
+
+This change does not alter UI behavior, port option defaults, successful port allocation, or the meaning of `maxAttempts`. No screenshots, database changes, or documentation updates outside this design and implementation plan are required.

--- a/src/backend/services/port.service.test.ts
+++ b/src/backend/services/port.service.test.ts
@@ -142,6 +142,19 @@ describe('port.service', () => {
   });
 
   describe('findAvailablePort', () => {
+    it.each([
+      0, -1, 65_536, 1.5,
+    ])('should reject invalid start port %s before probing', async (startPort) => {
+      Object.defineProperty(process, 'platform', { value: 'darwin' });
+      mockExec.mockResolvedValue({ stdout: '', stderr: '' });
+
+      await expect(findAvailablePort(startPort)).rejects.toThrow(
+        `Invalid start port ${startPort}: expected an integer between 1 and 65535`
+      );
+
+      expect(mockExec).not.toHaveBeenCalled();
+    });
+
     it('should return the start port if it is available', async () => {
       Object.defineProperty(process, 'platform', { value: 'darwin' });
 

--- a/src/backend/services/port.service.ts
+++ b/src/backend/services/port.service.ts
@@ -12,6 +12,7 @@ import { createLogger } from './logger.service';
 
 const logger = createLogger('port-service');
 const execAsync = promisify(exec);
+const MIN_PORT = 1;
 const MAX_PORT = 65_535;
 
 /**
@@ -65,6 +66,12 @@ export async function isPortAvailable(port: number): Promise<boolean> {
  * Find an available port starting from the given port.
  */
 export async function findAvailablePort(startPort: number, maxAttempts = 10): Promise<number> {
+  if (!Number.isInteger(startPort) || startPort < MIN_PORT || startPort > MAX_PORT) {
+    throw new Error(
+      `Invalid start port ${startPort}: expected an integer between ${MIN_PORT} and ${MAX_PORT}`
+    );
+  }
+
   for (let i = 0; i < maxAttempts; i++) {
     const port = startPort + i;
     if (port > MAX_PORT) {

--- a/src/cli/runtime-utils.test.ts
+++ b/src/cli/runtime-utils.test.ts
@@ -24,6 +24,18 @@ describe('findAvailablePort', () => {
     Object.defineProperty(process, 'platform', { value: originalPlatform });
   });
 
+  it.each([
+    0, -1, 65_536, 1.5,
+  ])('rejects invalid start port %s before probing', async (startPort) => {
+    mockExec.mockResolvedValue({ stdout: '', stderr: '' });
+
+    await expect(findAvailablePort(startPort)).rejects.toThrow(
+      `Invalid start port ${startPort}: expected an integer between 1 and 65535`
+    );
+
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
   it('does not probe ports above the valid TCP range', async () => {
     mockExec.mockResolvedValue({ stdout: '12345\n', stderr: '' });
 

--- a/src/cli/runtime-utils.ts
+++ b/src/cli/runtime-utils.ts
@@ -6,6 +6,7 @@ import { promisify } from 'node:util';
 import treeKill from 'tree-kill';
 
 const execPromise = promisify(exec);
+const MIN_PORT = 1;
 const MAX_PORT = 65_535;
 
 export function ensureDataDir(databasePath: string): void {
@@ -91,6 +92,12 @@ export async function findAvailablePort(
   startPort: number,
   options: FindAvailablePortOptions = {}
 ): Promise<number> {
+  if (!Number.isInteger(startPort) || startPort < MIN_PORT || startPort > MAX_PORT) {
+    throw new Error(
+      `Invalid start port ${startPort}: expected an integer between ${MIN_PORT} and ${MAX_PORT}`
+    );
+  }
+
   const { maxAttempts = 10, excludePorts = [] } = options;
   for (let i = 0; i < maxAttempts; i += 1) {
     const port = startPort + i;


### PR DESCRIPTION
## Summary
- Reject invalid starting ports before CLI or backend availability probes.
- Prevent `ff serve --port 0 --dev` from waiting on unconnectable port `0`.
- Add regression coverage for lower, upper, and non-integer port boundaries.

## Changes
- **CLI runtime utilities**: Validate that `startPort` is an integer from 1 through 65535 before scanning.
- **Backend port service**: Apply the same validation contract for consistent behavior across callers.
- **Tests**: Assert invalid ports fail with a clear error before invoking `lsof`.

## Testing
- [x] Tests pass (`pnpm test` — 4,649 passed)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting passes (`pnpm check:fix` — no fixes applied)
- [x] Build succeeds (`pnpm build`)
- [x] Manual testing: `ff serve --port 0 --dev` exits immediately with the valid-range error before migrations or child-process startup

Closes #2082

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, symmetric guardrails at existing port-finder entry points; valid-port scanning behavior is unchanged and covered by new boundary tests.
> 
> **Overview**
> **`findAvailablePort`** in the CLI (`runtime-utils.ts`) and backend (`port.service.ts`) now rejects starting ports that are not integers in **1–65535** before any `lsof`/bind probe, with a shared error message. That stops cases like **`ff serve --port 0 --dev`** from treating port `0` as available and then timing out while waiting on an unconnectable port.
> 
> Regression tests in both test files cover `0`, negatives, `65536`, and non-integers and assert **`mockExec` is never called** for invalid inputs. Design and implementation plan docs were added under `docs/superpowers/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c5490c284153a67a6c64eb2986324595196a7bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

