### PR TITLE
Fix #2085: timezone-aware monthly task advancement

### DIFF
--- a/src/backend/services/periodic-task/resources/periodic-task.accessor.test.ts
+++ b/src/backend/services/periodic-task/resources/periodic-task.accessor.test.ts
@@ -205,6 +205,16 @@ describe('periodicTaskAccessor.computeNextRunAt', () => {
     });
   });
 
+  it('advances from the timezone month when no scheduled time is configured', () => {
+    const timezone = 'Asia/Tokyo';
+    const from = new Date('2024-01-31T15:00:27.123Z'); // Feb 1 in Tokyo
+
+    const nextRunAt = periodicTaskAccessor.computeNextRunAt('MONTHLY', from, null, timezone, 1);
+
+    expect(calendarDate(nextRunAt, timezone)).toBe('2024-03-01');
+    expect(nextRunAt.toISOString()).toBe('2024-02-29T15:00:27.123Z');
+  });
+
   it('preserves local Date monthly clamping when no timezone is configured', () => {
     const from = new Date(2026, 0, 31, 9, 5);
 

--- a/src/backend/services/periodic-task/resources/periodic-task.accessor.ts
+++ b/src/backend/services/periodic-task/resources/periodic-task.accessor.ts
@@ -62,6 +62,24 @@ function parseScheduledTime(scheduledTime: string): ScheduledTimeParts {
   };
 }
 
+function getTimeZoneTimeParts(date: Date, timezone: string): ScheduledTimeParts {
+  const parts = Object.fromEntries(
+    new Intl.DateTimeFormat('en-CA', {
+      timeZone: timezone,
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    })
+      .formatToParts(date)
+      .map(({ type, value }) => [type, value])
+  );
+
+  return {
+    hours: Number(parts.hour) % 24,
+    minutes: Number(parts.minute),
+  };
+}
+
 function daysInMonth(year: number, month: number): number {
   return new Date(year, month, 0).getDate();
 }
@@ -136,6 +154,32 @@ function dateFromTimeZoneDateTime(
   return new Date(utcProbeMs);
 }
 
+function computeNextMonthlyRunAtInTimeZone(
+  from: Date,
+  scheduledTime: string | null | undefined,
+  timezone: string,
+  scheduledDayOfMonth: number | null | undefined
+): Date {
+  const fromParts = getTimeZoneDateParts(from, timezone);
+  const targetYear = fromParts.month === 12 ? fromParts.year + 1 : fromParts.year;
+  const targetMonth = fromParts.month === 12 ? 1 : fromParts.month + 1;
+  const targetDay = Math.min(
+    scheduledDayOfMonth ?? fromParts.day,
+    daysInMonth(targetYear, targetMonth)
+  );
+  const target = dateFromTimeZoneDateTime(
+    { year: targetYear, month: targetMonth, day: targetDay },
+    scheduledTime ? parseScheduledTime(scheduledTime) : getTimeZoneTimeParts(from, timezone),
+    timezone
+  );
+
+  if (!scheduledTime) {
+    target.setUTCSeconds(from.getUTCSeconds(), from.getUTCMilliseconds());
+  }
+
+  return target;
+}
+
 /**
  * When a task has a scheduledTime + timezone, snap the computed next date to
  * that clock time in the user's timezone.
@@ -206,19 +250,12 @@ function computeNextRunAt(
       next.setDate(next.getDate() + 7);
       break;
     case 'MONTHLY': {
-      if (scheduledTime && timezone) {
-        const fromParts = getTimeZoneDateParts(from, timezone);
-        const targetYear = fromParts.month === 12 ? fromParts.year + 1 : fromParts.year;
-        const targetMonth = fromParts.month === 12 ? 1 : fromParts.month + 1;
-        const targetDay = Math.min(
-          scheduledDayOfMonth ?? fromParts.day,
-          daysInMonth(targetYear, targetMonth)
-        );
-
-        return dateFromTimeZoneDateTime(
-          { year: targetYear, month: targetMonth, day: targetDay },
-          parseScheduledTime(scheduledTime),
-          timezone
+      if (timezone) {
+        return computeNextMonthlyRunAtInTimeZone(
+          from,
+          scheduledTime,
+          timezone,
+          scheduledDayOfMonth
         );
       }
 


### PR DESCRIPTION
## Summary
- Fix monthly periodic-task advancement when a timezone is configured without a scheduled time
- Keep month, year, and day calculations in the task timezone near UTC month boundaries
- Preserve unscheduled wall-clock precision and existing no-timezone behavior

## Changes
- **Periodic task scheduling**: Route timezone-aware monthly calculations through a single helper that advances from the task's local calendar month and clamps the anchored day
- **Regression coverage**: Add the Tokyo boundary case that previously produced February 2 instead of March 1

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Formatting and lint pass (`pnpm check:fix`)
- [x] Manual testing: Reproduced the failing Tokyo boundary case and verified the next local date is March 1 with time precision preserved

Closes #2085

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1d83331593eecba99b6787db4e444a183bf837e3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
