### PR TITLE
Fix #2081: Trim repository paths during project creation

### DIFF
--- a/docs/superpowers/plans/2026-07-30-project-repo-path-whitespace.md
+++ b/docs/superpowers/plans/2026-07-30-project-repo-path-whitespace.md
@@ -1,0 +1,179 @@
+# Project Repository Path Whitespace Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ensure local project creation and live factory-config detection consistently use repository paths without accidental surrounding whitespace.
+
+**Architecture:** Normalize at the two client boundaries that emit the path, then normalize again in the trusted project-creation schema for defense in depth. Keep the existing form, router, and service interfaces unchanged.
+
+**Tech Stack:** React, TypeScript, tRPC, Zod, Vitest
+
+## Global Constraints
+
+- Preserve internal path whitespace while removing only leading and trailing whitespace.
+- Keep the existing `Repository path is required` error for whitespace-only create input.
+- Do not change unrelated project update or validation routes.
+- Follow red-green-refactor and keep each production change covered by a test that failed first.
+
+---
+
+### Task 1: Client path normalization
+
+**Files:**
+- Modify: `src/client/routes/projects/new.test.tsx`
+- Modify: `src/client/routes/projects/new.tsx`
+
+**Interfaces:**
+- Consumes: `ProjectRepoFormProps` callbacks and `trpc.project` hooks already used by `NewProjectPage`.
+- Produces: `create.mutate({ repoPath: string, ... })` and
+  `checkFactoryConfig.useQuery({ repoPath: string }, ...)` calls with trimmed paths.
+
+- [ ] **Step 1: Write failing component tests**
+
+Add a rendered local-path form test double that forwards `repoPath`, `setRepoPath`, and
+`onSubmit`, plus hoisted spies for the create mutation and config query. Add one test that
+enters `"  /repos/example  "`, submits the form, and expects the mutation payload's
+`repoPath` to equal `"/repos/example"`. Add a second fake-timer test that enters the same
+value, advances 500 ms, and expects the latest config-query input to equal
+`{ repoPath: "/repos/example" }`.
+
+- [ ] **Step 2: Run client tests to verify RED**
+
+Run:
+
+```bash
+pnpm vitest run src/client/routes/projects/new.test.tsx
+```
+
+Expected: both new tests fail because the mutation and debounced query receive
+`"  /repos/example  "`.
+
+- [ ] **Step 3: Implement minimal client normalization**
+
+In the debounce effect, call:
+
+```typescript
+setDebouncedRepoPath(repoPath.trim());
+```
+
+In `handleLocalSubmit`, compute and reuse:
+
+```typescript
+const trimmedRepoPath = repoPath.trim();
+if (!trimmedRepoPath) {
+  setError('Repository path is required');
+  return;
+}
+```
+
+Then send `repoPath: trimmedRepoPath` in the create mutation.
+
+- [ ] **Step 4: Run client tests to verify GREEN**
+
+Run:
+
+```bash
+pnpm vitest run src/client/routes/projects/new.test.tsx
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit the client fix**
+
+```bash
+git add src/client/routes/projects/new.tsx src/client/routes/projects/new.test.tsx
+git commit -m "Trim project paths in creation UI (#2081)"
+```
+
+### Task 2: Project creation schema normalization
+
+**Files:**
+- Modify: `src/backend/trpc/project.router.test.ts`
+- Modify: `src/backend/trpc/project.trpc.ts`
+
+**Interfaces:**
+- Consumes: `projectRouter.create({ repoPath: string, ... })`.
+- Produces: service calls whose `repoPath` is trimmed and a Zod rejection for
+  whitespace-only paths.
+
+- [ ] **Step 1: Write failing router tests**
+
+Add a test that calls create with `"  /good/path  "`, stubs validation and creation as
+successful, and expects both `validateRepoPath` and `create` to receive `"/good/path"`.
+Add a test that calls create with `"   "`, expects the existing
+`Repository path is required` error, and verifies neither validation nor creation runs.
+
+- [ ] **Step 2: Run router tests to verify RED**
+
+Run:
+
+```bash
+pnpm vitest run src/backend/trpc/project.router.test.ts
+```
+
+Expected: the padded path test observes whitespace at the service boundary and the
+whitespace-only call reaches repository validation instead of failing schema validation.
+
+- [ ] **Step 3: Implement minimal schema normalization**
+
+Change the create input field to:
+
+```typescript
+repoPath: z.string().trim().min(1, 'Repository path is required'),
+```
+
+- [ ] **Step 4: Run router tests to verify GREEN**
+
+Run:
+
+```bash
+pnpm vitest run src/backend/trpc/project.router.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit the backend fix**
+
+```bash
+git add src/backend/trpc/project.trpc.ts src/backend/trpc/project.router.test.ts
+git commit -m "Normalize project paths at create boundary (#2081)"
+```
+
+### Task 3: Verification and pull request
+
+**Files:**
+- Review: all files changed from `origin/main`
+- Create temporarily: `/tmp/pr-body.md`
+
+**Interfaces:**
+- Consumes: the two focused commits from Tasks 1 and 2.
+- Produces: a clean, pushed branch and a GitHub pull request closing issue #2081.
+
+- [ ] **Step 1: Run full verification**
+
+Run:
+
+```bash
+pnpm typecheck && pnpm check:fix && pnpm test && pnpm build
+```
+
+Expected: every command exits successfully.
+
+- [ ] **Step 2: Review and commit formatting changes**
+
+Run `git diff origin/main` and `git status --short`. Remove debug artifacts, confirm only
+the planned files changed, and commit any intentional formatter edits.
+
+- [ ] **Step 3: Push and create the PR**
+
+Push with `git push -u origin HEAD`, write the required summary, testing checklist,
+`Closes #2081`, and Factory Factory signature to `/tmp/pr-body.md`, then run:
+
+```bash
+gh pr create --title "Fix #2081: Trim repository paths during project creation" --body-file /tmp/pr-body.md
+```
+
+- [ ] **Step 4: Verify the PR**
+
+Run `gh pr view --json url,title,state` and confirm the returned URL, title, and open
+state.

--- a/docs/superpowers/specs/2026-07-30-project-repo-path-whitespace-design.md
+++ b/docs/superpowers/specs/2026-07-30-project-repo-path-whitespace-design.md
@@ -1,0 +1,42 @@
+# Project Repository Path Whitespace Design
+
+## Problem
+
+The new-project page treats a whitespace-padded local repository path inconsistently. It
+uses `repoPath.trim()` to reject blank input, but sends the original value to both the
+project creation mutation and the debounced factory-config query. The project creation
+router also accepts and forwards the untrimmed value. Filesystem consumers therefore
+look up a different path from the one the user intended, and derived project metadata can
+inherit trailing whitespace.
+
+## Design
+
+Normalize the local repository path at every boundary introduced by this flow:
+
+- The client debounce stores `repoPath.trim()` so live factory-config detection receives
+  the intended path and disables itself for whitespace-only input.
+- The local submit handler computes the trimmed path once, uses it for required-field
+  validation, and submits it to the create mutation.
+- The project creation input schema applies Zod's `.trim()` before `.min(1)` so direct
+  callers cannot bypass normalization and whitespace-only input receives the existing
+  required-path error.
+
+The update and standalone validation routes are outside this issue because they are not
+part of project creation or its live config check.
+
+## Error Handling and Edge Cases
+
+- Leading and trailing whitespace is removed; internal whitespace remains unchanged.
+- Whitespace-only input is treated as missing on both client and server.
+- Existing startup-script trimming and selection behavior remains unchanged.
+- Electron directory-picker values pass through unchanged unless they contain accidental
+  surrounding whitespace.
+
+## Testing
+
+Add component-level regression tests proving that the page sends a trimmed path to the
+create mutation and, after the debounce, to `checkFactoryConfig`. Add router coverage
+proving that create validation and persistence both receive the trimmed value and that a
+whitespace-only value is rejected before any service call.
+
+No screenshot is required because the rendered UI and copy do not change.

--- a/src/backend/trpc/project.router.test.ts
+++ b/src/backend/trpc/project.router.test.ts
@@ -336,6 +336,35 @@ describe('projectRouter', () => {
     );
   });
 
+  it('trims a repository path before validating and creating a project', async () => {
+    mockProjectManagementService.validateRepoPath.mockResolvedValue({ valid: true });
+    mockProjectManagementService.create.mockResolvedValue({ id: 'created' });
+
+    await expect(createCaller().create({ repoPath: '  /good/path  ' })).resolves.toEqual({
+      id: 'created',
+    });
+
+    expect(mockProjectManagementService.validateRepoPath).toHaveBeenCalledWith('/good/path');
+    expect(mockProjectManagementService.create).toHaveBeenCalledWith(
+      {
+        repoPath: '/good/path',
+        startupScriptCommand: undefined,
+        startupScriptPath: undefined,
+        startupScriptTimeout: undefined,
+      },
+      { worktreeBaseDir: '/tmp/worktrees' }
+    );
+  });
+
+  it('rejects a whitespace-only repository path before validating or creating a project', async () => {
+    await expect(createCaller().create({ repoPath: '   ' })).rejects.toThrow(
+      'Repository path is required'
+    );
+
+    expect(mockProjectManagementService.validateRepoPath).not.toHaveBeenCalled();
+    expect(mockProjectManagementService.create).not.toHaveBeenCalled();
+  });
+
   it('rejects privileged project mutations from untrusted requests', async () => {
     const caller = createCaller({
       remoteAddress: '203.0.113.10',

--- a/src/backend/trpc/project.trpc.ts
+++ b/src/backend/trpc/project.trpc.ts
@@ -281,7 +281,7 @@ export const projectRouter = router({
   create: trustedLocalProcedure
     .input(
       z.object({
-        repoPath: z.string().min(1, 'Repository path is required'),
+        repoPath: z.string().trim().min(1, 'Repository path is required'),
         // Startup script configuration (optional at creation time)
         startupScriptCommand: z.string().optional(),
         startupScriptPath: z.string().optional(),

--- a/src/client/routes/projects/new.test.tsx
+++ b/src/client/routes/projects/new.test.tsx
@@ -212,6 +212,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   document.body.innerHTML = '';
   localStorage.clear();
 });
@@ -283,6 +284,5 @@ describe('NewProjectPage local path submission', () => {
       repoPath: '/repos/example',
     });
     root.unmount();
-    vi.useRealTimers();
   });
 });

--- a/src/client/routes/projects/new.test.tsx
+++ b/src/client/routes/projects/new.test.tsx
@@ -14,6 +14,10 @@ import NewProjectPage from './new';
 const navigateMock = vi.fn();
 const useAppHeaderMock = vi.fn();
 const selectProjectSlugMock = vi.fn();
+const { createMutateMock, checkFactoryConfigUseQueryMock } = vi.hoisted(() => ({
+  createMutateMock: vi.fn(),
+  checkFactoryConfigUseQueryMock: vi.fn(),
+}));
 const projects = [
   { id: 'project-1', slug: 'alpha', name: 'Alpha' },
   { id: 'project-2', slug: 'beta', name: 'Beta' },
@@ -70,8 +74,28 @@ vi.mock('@/client/features/project/onboarding-cli-health', () => ({
 }));
 
 vi.mock('@/client/features/project/project-repo-form', () => ({
-  ProjectRepoForm: ({ footerActions }: { footerActions?: ReactNode }) =>
-    createElement('div', null, 'Project Repo Form', footerActions),
+  ProjectRepoForm: ({
+    footerActions,
+    onSubmit,
+    repoPath,
+    setRepoPath,
+  }: {
+    footerActions?: ReactNode;
+    onSubmit: (event: React.FormEvent) => void;
+    repoPath: string;
+    setRepoPath: (repoPath: string) => void;
+  }) =>
+    createElement(
+      'form',
+      { onSubmit },
+      createElement('input', {
+        'aria-label': 'Repository path',
+        onChange: (event: React.ChangeEvent<HTMLInputElement>) => setRepoPath(event.target.value),
+        value: repoPath,
+      }),
+      createElement('button', { type: 'submit' }, 'Add local repository'),
+      footerActions
+    ),
 }));
 
 vi.mock('@/client/features/project/setup-terminal-modal', () => ({
@@ -106,9 +130,14 @@ vi.mock('@/client/lib/trpc', () => ({
     }),
     project: {
       list: { useQuery: () => ({ data: projects }) },
-      checkFactoryConfig: { useQuery: () => ({ data: { exists: false } }) },
+      checkFactoryConfig: {
+        useQuery: (...args: unknown[]) => {
+          checkFactoryConfigUseQueryMock(...args);
+          return { data: { exists: false } };
+        },
+      },
       checkGithubAuth: { useQuery: () => ({ data: null, isLoading: false, refetch: vi.fn() }) },
-      create: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      create: { useMutation: () => ({ mutate: createMutateMock, isPending: false }) },
       createFromGithub: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
     },
   },
@@ -178,6 +207,8 @@ beforeEach(() => {
   navigateMock.mockClear();
   useAppHeaderMock.mockClear();
   selectProjectSlugMock.mockClear();
+  createMutateMock.mockClear();
+  checkFactoryConfigUseQueryMock.mockClear();
 });
 
 afterEach(() => {
@@ -210,5 +241,48 @@ describe('NewProjectPage navigation', () => {
     );
 
     root.unmount();
+  });
+});
+
+describe('NewProjectPage local path submission', () => {
+  it('submits a trimmed repository path', () => {
+    const { container, root } = renderPage();
+    const input = container.querySelector<HTMLInputElement>('input[aria-label="Repository path"]');
+    const form = input?.closest('form');
+
+    flushSync(() => {
+      const valueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+      valueSetter?.call(input, '  /repos/example  ');
+      input?.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    flushSync(() => {
+      form?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    });
+
+    expect(createMutateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ repoPath: '/repos/example' })
+    );
+    root.unmount();
+  });
+
+  it('queries factory config with a trimmed repository path after debouncing', () => {
+    vi.useFakeTimers();
+    const { container, root } = renderPage();
+    const input = container.querySelector<HTMLInputElement>('input[aria-label="Repository path"]');
+
+    flushSync(() => {
+      const valueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+      valueSetter?.call(input, '  /repos/example  ');
+      input?.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    flushSync(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(checkFactoryConfigUseQueryMock.mock.calls.at(-1)?.[0]).toEqual({
+      repoPath: '/repos/example',
+    });
+    root.unmount();
+    vi.useRealTimers();
   });
 });

--- a/src/client/routes/projects/new.tsx
+++ b/src/client/routes/projects/new.tsx
@@ -83,7 +83,7 @@ export default function NewProjectPage() {
   // Debounce repo path changes for API calls
   useEffect(() => {
     const timer = setTimeout(() => {
-      setDebouncedRepoPath(repoPath);
+      setDebouncedRepoPath(repoPath.trim());
     }, 500);
     return () => clearTimeout(timer);
   }, [repoPath]);
@@ -136,13 +136,14 @@ export default function NewProjectPage() {
   const handleLocalSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
-    if (!repoPath.trim()) {
+    const trimmedRepoPath = repoPath.trim();
+    if (!trimmedRepoPath) {
       setError('Repository path is required');
       return;
     }
     const trimmedScript = startupScript.trim();
     createProject.mutate({
-      repoPath,
+      repoPath: trimmedRepoPath,
       startupScriptCommand: scriptType === 'command' && trimmedScript ? trimmedScript : undefined,
       startupScriptPath: scriptType === 'path' && trimmedScript ? trimmedScript : undefined,
     });


### PR DESCRIPTION
## Summary

- Trim local repository paths before project creation and live factory-config checks.
- Normalize project creation input at the tRPC schema boundary so direct callers cannot persist whitespace-padded paths.
- Add client and backend regressions for padded and whitespace-only paths.

## Changes

- **Project creation UI**: Reuse the trimmed repository path for required validation and the create mutation.
- **Factory config detection**: Debounce the trimmed path so valid repositories are detected despite accidental surrounding whitespace.
- **Project router**: Apply Zod trimming before required-field validation as defense in depth.
- **Tests**: Cover both client emissions, downstream backend service arguments, and whitespace-only rejection.

## Testing

- [x] Tests pass (`pnpm test` — 4,645 passed, 3 skipped)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting passes (`pnpm check:fix`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; the UI and copy are unchanged, and both affected data-flow boundaries are covered by regression tests.

Closes #2081

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
