### PR TITLE
Fix #2092: Clean orphaned provisioning worktrees

### DIFF
--- a/src/backend/app-context.ts
+++ b/src/backend/app-context.ts
@@ -28,6 +28,7 @@ import {
 } from './orchestration/workspace-children.orchestrator';
 import {
   initializeWorkspaceWorktree,
+  recoverStaleProvisioningWorkspace,
   retryQueuedDispatchAfterWorkspaceReady,
 } from './orchestration/workspace-init.orchestrator';
 import { executeStartupScriptPipeline } from './orchestration/workspace-init-script-pipeline';
@@ -232,6 +233,7 @@ export function createDefaultApplicationDependencies(): ApplicationDependencies 
     prSnapshotService,
     ratchetService,
     rateLimiter,
+    recoverStaleProvisioningWorkspace,
     runScriptConfigPersistenceService,
     reconciliationService,
     runScriptService: defaultRunScriptService,

--- a/src/backend/orchestration/domain-bridges.orchestrator.test.ts
+++ b/src/backend/orchestration/domain-bridges.orchestrator.test.ts
@@ -74,9 +74,6 @@ vi.mock('@/backend/services/workspace', () => ({
     on: vi.fn(),
   },
   workspaceStateMachine: { markFailed: vi.fn(), markReady: vi.fn() },
-  worktreeLifecycleService: {
-    cleanupUnregisteredProvisioningWorktree: vi.fn(),
-  },
   getWorkspaceInitPolicy: vi.fn(),
 }));
 
@@ -150,6 +147,7 @@ vi.mock('@/backend/services/terminal', () => ({
 
 vi.mock('./workspace-init.orchestrator', () => ({
   initializeWorkspaceWorktree: vi.fn(),
+  recoverStaleProvisioningWorkspace: vi.fn(),
 }));
 
 // --- Import mocked modules to get references ---
@@ -182,11 +180,13 @@ import {
   workspaceRunScriptService,
   workspaceSnapshotStore,
   workspaceStateMachine,
-  worktreeLifecycleService,
 } from '@/backend/services/workspace';
 import { type BridgeServices, configureDomainBridges } from './domain-bridges.orchestrator';
 import { reconciliationService } from './reconciliation.service';
-import { initializeWorkspaceWorktree } from './workspace-init.orchestrator';
+import {
+  initializeWorkspaceWorktree,
+  recoverStaleProvisioningWorkspace,
+} from './workspace-init.orchestrator';
 
 // Helper to extract bridge argument from a mocked configure call.
 function getBridge<T>(mockFn: (arg: T) => void): T {
@@ -220,6 +220,7 @@ function createBridgeServices(overrides: Partial<BridgeServices> = {}): BridgeSe
     prFetchCoordinator,
     prSnapshotService,
     ratchetService,
+    recoverStaleProvisioningWorkspace,
     reconciliationService,
     sessionDataService,
     sessionDomainService,
@@ -240,7 +241,6 @@ function createBridgeServices(overrides: Partial<BridgeServices> = {}): BridgeSe
     workspaceRunScriptService,
     workspaceSnapshotStore,
     workspaceStateMachine,
-    worktreeLifecycleService,
     initializeWorkspaceWorktree,
     ...overrides,
   };
@@ -442,22 +442,12 @@ describe('configureDomainBridges', () => {
   });
 
   describe('reconciliation bridge delegation', () => {
-    it('workspace bridge cleanup delegates to worktreeLifecycleService', async () => {
+    it('workspace bridge recovery delegates to recoverStaleProvisioningWorkspace', async () => {
       configureDomainBridges(createBridgeServices());
       const bridge = getBridge(reconciliationService.configure);
 
-      await bridge.workspace.cleanupUnregisteredProvisioningWorktree('ws1');
-      expect(worktreeLifecycleService.cleanupUnregisteredProvisioningWorktree).toHaveBeenCalledWith(
-        'ws1'
-      );
-    });
-
-    it('workspace bridge markFailed delegates to workspaceStateMachine', async () => {
-      configureDomainBridges(createBridgeServices());
-      const bridge = getBridge(reconciliationService.configure);
-
-      await bridge.workspace.markFailed('ws1', 'broken');
-      expect(workspaceStateMachine.markFailed).toHaveBeenCalledWith('ws1', 'broken');
+      await bridge.workspace.recoverStaleProvisioningWorkspace('ws1', 'timed out');
+      expect(recoverStaleProvisioningWorkspace).toHaveBeenCalledWith('ws1', 'timed out');
     });
 
     it('workspace bridge initializeWorktree delegates to initializeWorkspaceWorktree', async () => {

--- a/src/backend/orchestration/domain-bridges.orchestrator.test.ts
+++ b/src/backend/orchestration/domain-bridges.orchestrator.test.ts
@@ -74,6 +74,9 @@ vi.mock('@/backend/services/workspace', () => ({
     on: vi.fn(),
   },
   workspaceStateMachine: { markFailed: vi.fn(), markReady: vi.fn() },
+  worktreeLifecycleService: {
+    cleanupUnregisteredProvisioningWorktree: vi.fn(),
+  },
   getWorkspaceInitPolicy: vi.fn(),
 }));
 
@@ -179,6 +182,7 @@ import {
   workspaceRunScriptService,
   workspaceSnapshotStore,
   workspaceStateMachine,
+  worktreeLifecycleService,
 } from '@/backend/services/workspace';
 import { type BridgeServices, configureDomainBridges } from './domain-bridges.orchestrator';
 import { reconciliationService } from './reconciliation.service';
@@ -236,6 +240,7 @@ function createBridgeServices(overrides: Partial<BridgeServices> = {}): BridgeSe
     workspaceRunScriptService,
     workspaceSnapshotStore,
     workspaceStateMachine,
+    worktreeLifecycleService,
     initializeWorkspaceWorktree,
     ...overrides,
   };
@@ -437,6 +442,16 @@ describe('configureDomainBridges', () => {
   });
 
   describe('reconciliation bridge delegation', () => {
+    it('workspace bridge cleanup delegates to worktreeLifecycleService', async () => {
+      configureDomainBridges(createBridgeServices());
+      const bridge = getBridge(reconciliationService.configure);
+
+      await bridge.workspace.cleanupUnregisteredProvisioningWorktree('ws1');
+      expect(worktreeLifecycleService.cleanupUnregisteredProvisioningWorktree).toHaveBeenCalledWith(
+        'ws1'
+      );
+    });
+
     it('workspace bridge markFailed delegates to workspaceStateMachine', async () => {
       configureDomainBridges(createBridgeServices());
       const bridge = getBridge(reconciliationService.configure);

--- a/src/backend/orchestration/domain-bridges.orchestrator.ts
+++ b/src/backend/orchestration/domain-bridges.orchestrator.ts
@@ -57,6 +57,7 @@ import {
   type workspaceRunScriptService,
   type workspaceSnapshotStore,
   type workspaceStateMachine,
+  type worktreeLifecycleService,
 } from '@/backend/services/workspace';
 import { AutoIterationStatus, SessionStatus } from '@/shared/core';
 import { deriveWorkspaceSidebarStatus } from '@/shared/workspace-sidebar-status';
@@ -105,6 +106,7 @@ export type BridgeServices = {
   workspaceRunScriptService: typeof workspaceRunScriptService;
   workspaceSnapshotStore: typeof workspaceSnapshotStore;
   workspaceStateMachine: typeof workspaceStateMachine;
+  worktreeLifecycleService: typeof worktreeLifecycleService;
 };
 
 async function stopSessionBestEffort(
@@ -291,6 +293,7 @@ export function configureDomainBridges(services: BridgeServices): void {
     workspaceRunScriptService,
     workspaceSnapshotStore,
     workspaceStateMachine,
+    worktreeLifecycleService,
   } = services;
   const logger = createLogger('domain-bridges');
 
@@ -377,6 +380,8 @@ export function configureDomainBridges(services: BridgeServices): void {
   });
   reconciliationService.configure({
     workspace: {
+      cleanupUnregisteredProvisioningWorktree: (id) =>
+        worktreeLifecycleService.cleanupUnregisteredProvisioningWorktree(id),
       markFailed: async (id, reason) => {
         await workspaceStateMachine.markFailed(id, reason);
       },

--- a/src/backend/orchestration/domain-bridges.orchestrator.ts
+++ b/src/backend/orchestration/domain-bridges.orchestrator.ts
@@ -57,12 +57,14 @@ import {
   type workspaceRunScriptService,
   type workspaceSnapshotStore,
   type workspaceStateMachine,
-  type worktreeLifecycleService,
 } from '@/backend/services/workspace';
 import { AutoIterationStatus, SessionStatus } from '@/shared/core';
 import { deriveWorkspaceSidebarStatus } from '@/shared/workspace-sidebar-status';
 import type { reconciliationService } from './reconciliation.service';
-import type { initializeWorkspaceWorktree } from './workspace-init.orchestrator';
+import type {
+  initializeWorkspaceWorktree,
+  recoverStaleProvisioningWorkspace,
+} from './workspace-init.orchestrator';
 
 type SessionDataService = typeof sessionDataService;
 type SessionDomainService = typeof sessionDomainService;
@@ -86,6 +88,7 @@ export type BridgeServices = {
   prFetchCoordinator: typeof prFetchCoordinator;
   prSnapshotService: typeof prSnapshotService;
   ratchetService: typeof ratchetService;
+  recoverStaleProvisioningWorkspace: typeof recoverStaleProvisioningWorkspace;
   reconciliationService: typeof reconciliationService;
   acpRuntimeManager: typeof acpRuntimeManager;
   sessionDataService: typeof sessionDataService;
@@ -106,7 +109,6 @@ export type BridgeServices = {
   workspaceRunScriptService: typeof workspaceRunScriptService;
   workspaceSnapshotStore: typeof workspaceSnapshotStore;
   workspaceStateMachine: typeof workspaceStateMachine;
-  worktreeLifecycleService: typeof worktreeLifecycleService;
 };
 
 async function stopSessionBestEffort(
@@ -274,6 +276,7 @@ export function configureDomainBridges(services: BridgeServices): void {
     prFetchCoordinator,
     prSnapshotService,
     ratchetService,
+    recoverStaleProvisioningWorkspace,
     reconciliationService,
     sessionDataService,
     sessionDomainService,
@@ -293,7 +296,6 @@ export function configureDomainBridges(services: BridgeServices): void {
     workspaceRunScriptService,
     workspaceSnapshotStore,
     workspaceStateMachine,
-    worktreeLifecycleService,
   } = services;
   const logger = createLogger('domain-bridges');
 
@@ -380,13 +382,10 @@ export function configureDomainBridges(services: BridgeServices): void {
   });
   reconciliationService.configure({
     workspace: {
-      cleanupUnregisteredProvisioningWorktree: (id) =>
-        worktreeLifecycleService.cleanupUnregisteredProvisioningWorktree(id),
-      markFailed: async (id, reason) => {
-        await workspaceStateMachine.markFailed(id, reason);
-      },
       initializeWorktree: (id, options) => initializeWorkspaceWorktree(id, options),
       findNeedingWorktree: () => workspaceMaintenanceService.findNeedingWorktree(),
+      recoverStaleProvisioningWorkspace: (id, reason) =>
+        recoverStaleProvisioningWorkspace(id, reason),
     },
     terminal: {
       recoverOrphanedSessions: () => terminalSessionService.recoverOrphanedSessions(),

--- a/src/backend/orchestration/reconciliation.service.test.ts
+++ b/src/backend/orchestration/reconciliation.service.test.ts
@@ -2,15 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock Prisma
 const mockFindMany = vi.fn();
-const mockFindUnique = vi.fn();
-const mockUpdate = vi.fn();
 
 vi.mock('@/backend/db', () => ({
   prisma: {
     workspace: {
       findMany: (...args: unknown[]) => mockFindMany(...args),
-      findUnique: (...args: unknown[]) => mockFindUnique(...args),
-      update: (...args: unknown[]) => mockUpdate(...args),
     },
   },
 }));
@@ -31,7 +27,7 @@ vi.mock('@/backend/services/terminal', () => ({
 }));
 
 const mockInitializeWorktree = vi.fn();
-const mockCleanupUnregisteredProvisioningWorktree = vi.fn();
+const mockRecoverStaleProvisioningWorkspace = vi.fn();
 
 import { terminalSessionService } from '@/backend/services/terminal';
 // Import after mocks are set up
@@ -42,23 +38,13 @@ describe('ReconciliationService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
-    mockCleanupUnregisteredProvisioningWorktree.mockReset().mockResolvedValue(undefined);
+    mockRecoverStaleProvisioningWorkspace.mockReset().mockResolvedValue(true);
     reconciliationService.configure({
       workspace: {
-        cleanupUnregisteredProvisioningWorktree: (workspaceId: string) =>
-          mockCleanupUnregisteredProvisioningWorktree(workspaceId),
-        markFailed: async (workspaceId: string, reason: string) => {
-          const current = await mockFindUnique({ where: { id: workspaceId } });
-          if (!current) {
-            throw new Error('Not found');
-          }
-          await mockUpdate({
-            where: { id: workspaceId },
-            data: { status: 'FAILED', initErrorMessage: reason },
-          });
-        },
         initializeWorktree: (...args: unknown[]) => mockInitializeWorktree(...args),
         findNeedingWorktree: () => workspaceMaintenanceService.findNeedingWorktree(),
+        recoverStaleProvisioningWorkspace: (workspaceId: string, reason: string) =>
+          mockRecoverStaleProvisioningWorkspace(workspaceId, reason),
       },
       terminal: {
         recoverOrphanedSessions: () => terminalSessionService.recoverOrphanedSessions(),
@@ -91,7 +77,7 @@ describe('ReconciliationService', () => {
       });
     });
 
-    it('should mark stale PROVISIONING workspaces as FAILED', async () => {
+    it('should recover stale PROVISIONING workspaces', async () => {
       const now = new Date('2024-01-15T12:00:00Z');
       vi.setSystemTime(now);
 
@@ -106,33 +92,14 @@ describe('ReconciliationService', () => {
       };
 
       mockFindMany.mockResolvedValue([staleWorkspace]);
-      mockFindUnique.mockResolvedValue(staleWorkspace);
-      mockUpdate.mockResolvedValue({ ...staleWorkspace, status: 'FAILED' });
-      const recoverySteps: string[] = [];
-      mockCleanupUnregisteredProvisioningWorktree.mockImplementation(() => {
-        recoverySteps.push('cleanup');
-        return Promise.resolve();
-      });
-      mockUpdate.mockImplementation(() => {
-        recoverySteps.push('mark-failed');
-        return Promise.resolve({ ...staleWorkspace, status: 'FAILED' });
-      });
-
       await reconciliationService.reconcile();
 
       // Should NOT call initializeWorktree for stale PROVISIONING
       expect(mockInitializeWorktree).not.toHaveBeenCalled();
-      expect(mockCleanupUnregisteredProvisioningWorktree).toHaveBeenCalledWith('ws-2');
-      expect(recoverySteps).toEqual(['cleanup', 'mark-failed']);
-
-      // Should transition to FAILED via state machine
-      expect(mockUpdate).toHaveBeenCalledWith({
-        where: { id: 'ws-2' },
-        data: expect.objectContaining({
-          status: 'FAILED',
-          initErrorMessage: expect.stringContaining('timed out'),
-        }),
-      });
+      expect(mockRecoverStaleProvisioningWorkspace).toHaveBeenCalledWith(
+        'ws-2',
+        expect.stringContaining('timed out')
+      );
     });
 
     it('should not fail stale PROVISIONING workspaces while init script PID is running', async () => {
@@ -152,8 +119,7 @@ describe('ReconciliationService', () => {
 
       expect(killSpy).toHaveBeenCalledWith(12_345, 0);
       expect(mockInitializeWorktree).not.toHaveBeenCalled();
-      expect(mockUpdate).not.toHaveBeenCalled();
-      expect(mockCleanupUnregisteredProvisioningWorktree).not.toHaveBeenCalled();
+      expect(mockRecoverStaleProvisioningWorkspace).not.toHaveBeenCalled();
     });
 
     it('should fail stale PROVISIONING workspaces when init script PID is not running', async () => {
@@ -167,8 +133,6 @@ describe('ReconciliationService', () => {
       };
 
       mockFindMany.mockResolvedValue([staleWorkspace]);
-      mockFindUnique.mockResolvedValue(staleWorkspace);
-      mockUpdate.mockResolvedValue({ ...staleWorkspace, status: 'FAILED' });
       vi.spyOn(process, 'kill').mockImplementation(() => {
         const error = new Error('No such process') as NodeJS.ErrnoException;
         error.code = 'ESRCH';
@@ -177,33 +141,10 @@ describe('ReconciliationService', () => {
 
       await reconciliationService.reconcile();
 
-      expect(mockUpdate).toHaveBeenCalledWith({
-        where: { id: 'ws-dead' },
-        data: expect.objectContaining({
-          status: 'FAILED',
-        }),
-      });
-    });
-
-    it('leaves stale PROVISIONING workspaces unchanged when orphan cleanup fails', async () => {
-      const staleWorkspace = {
-        id: 'ws-cleanup-failed',
-        status: 'PROVISIONING',
-        branchName: 'feature/stale',
-        initStartedAt: new Date('2024-01-15T11:40:00Z'),
-        initScriptPid: null,
-        project: { id: 'proj-1' },
-      };
-
-      mockFindMany.mockResolvedValue([staleWorkspace]);
-      mockCleanupUnregisteredProvisioningWorktree.mockRejectedValue(
-        new Error('worktree removal failed')
+      expect(mockRecoverStaleProvisioningWorkspace).toHaveBeenCalledWith(
+        'ws-dead',
+        expect.stringContaining('timed out')
       );
-
-      await expect(reconciliationService.reconcile()).resolves.not.toThrow();
-
-      expect(mockCleanupUnregisteredProvisioningWorktree).toHaveBeenCalledWith('ws-cleanup-failed');
-      expect(mockUpdate).not.toHaveBeenCalled();
     });
 
     it('should handle mixed NEW and stale PROVISIONING workspaces', async () => {
@@ -227,8 +168,6 @@ describe('ReconciliationService', () => {
       };
 
       mockFindMany.mockResolvedValue([newWorkspace, staleWorkspace]);
-      mockFindUnique.mockResolvedValue(staleWorkspace);
-      mockUpdate.mockResolvedValue({ ...staleWorkspace, status: 'FAILED' });
       mockInitializeWorktree.mockResolvedValue(undefined);
 
       await reconciliationService.reconcile();
@@ -238,13 +177,10 @@ describe('ReconciliationService', () => {
         branchName: 'feature/new',
       });
 
-      // Stale PROVISIONING should be marked as FAILED
-      expect(mockUpdate).toHaveBeenCalledWith({
-        where: { id: 'ws-2' },
-        data: expect.objectContaining({
-          status: 'FAILED',
-        }),
-      });
+      expect(mockRecoverStaleProvisioningWorkspace).toHaveBeenCalledWith(
+        'ws-2',
+        expect.stringContaining('timed out')
+      );
     });
 
     it('should handle errors gracefully when initializing NEW workspaces', async () => {
@@ -276,7 +212,7 @@ describe('ReconciliationService', () => {
       };
 
       mockFindMany.mockResolvedValue([staleWorkspace]);
-      mockFindUnique.mockRejectedValue(new Error('Database error'));
+      mockRecoverStaleProvisioningWorkspace.mockRejectedValue(new Error('Database error'));
 
       // Should not throw
       await expect(reconciliationService.reconcile()).resolves.not.toThrow();

--- a/src/backend/orchestration/reconciliation.service.test.ts
+++ b/src/backend/orchestration/reconciliation.service.test.ts
@@ -31,6 +31,7 @@ vi.mock('@/backend/services/terminal', () => ({
 }));
 
 const mockInitializeWorktree = vi.fn();
+const mockCleanupUnregisteredProvisioningWorktree = vi.fn();
 
 import { terminalSessionService } from '@/backend/services/terminal';
 // Import after mocks are set up
@@ -41,8 +42,11 @@ describe('ReconciliationService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
+    mockCleanupUnregisteredProvisioningWorktree.mockReset().mockResolvedValue(undefined);
     reconciliationService.configure({
       workspace: {
+        cleanupUnregisteredProvisioningWorktree: (workspaceId: string) =>
+          mockCleanupUnregisteredProvisioningWorktree(workspaceId),
         markFailed: async (workspaceId: string, reason: string) => {
           const current = await mockFindUnique({ where: { id: workspaceId } });
           if (!current) {
@@ -104,11 +108,22 @@ describe('ReconciliationService', () => {
       mockFindMany.mockResolvedValue([staleWorkspace]);
       mockFindUnique.mockResolvedValue(staleWorkspace);
       mockUpdate.mockResolvedValue({ ...staleWorkspace, status: 'FAILED' });
+      const recoverySteps: string[] = [];
+      mockCleanupUnregisteredProvisioningWorktree.mockImplementation(() => {
+        recoverySteps.push('cleanup');
+        return Promise.resolve();
+      });
+      mockUpdate.mockImplementation(() => {
+        recoverySteps.push('mark-failed');
+        return Promise.resolve({ ...staleWorkspace, status: 'FAILED' });
+      });
 
       await reconciliationService.reconcile();
 
       // Should NOT call initializeWorktree for stale PROVISIONING
       expect(mockInitializeWorktree).not.toHaveBeenCalled();
+      expect(mockCleanupUnregisteredProvisioningWorktree).toHaveBeenCalledWith('ws-2');
+      expect(recoverySteps).toEqual(['cleanup', 'mark-failed']);
 
       // Should transition to FAILED via state machine
       expect(mockUpdate).toHaveBeenCalledWith({
@@ -138,6 +153,7 @@ describe('ReconciliationService', () => {
       expect(killSpy).toHaveBeenCalledWith(12_345, 0);
       expect(mockInitializeWorktree).not.toHaveBeenCalled();
       expect(mockUpdate).not.toHaveBeenCalled();
+      expect(mockCleanupUnregisteredProvisioningWorktree).not.toHaveBeenCalled();
     });
 
     it('should fail stale PROVISIONING workspaces when init script PID is not running', async () => {
@@ -167,6 +183,27 @@ describe('ReconciliationService', () => {
           status: 'FAILED',
         }),
       });
+    });
+
+    it('leaves stale PROVISIONING workspaces unchanged when orphan cleanup fails', async () => {
+      const staleWorkspace = {
+        id: 'ws-cleanup-failed',
+        status: 'PROVISIONING',
+        branchName: 'feature/stale',
+        initStartedAt: new Date('2024-01-15T11:40:00Z'),
+        initScriptPid: null,
+        project: { id: 'proj-1' },
+      };
+
+      mockFindMany.mockResolvedValue([staleWorkspace]);
+      mockCleanupUnregisteredProvisioningWorktree.mockRejectedValue(
+        new Error('worktree removal failed')
+      );
+
+      await expect(reconciliationService.reconcile()).resolves.not.toThrow();
+
+      expect(mockCleanupUnregisteredProvisioningWorktree).toHaveBeenCalledWith('ws-cleanup-failed');
+      expect(mockUpdate).not.toHaveBeenCalled();
     });
 
     it('should handle mixed NEW and stale PROVISIONING workspaces', async () => {

--- a/src/backend/orchestration/reconciliation.service.ts
+++ b/src/backend/orchestration/reconciliation.service.ts
@@ -9,6 +9,7 @@ const logger = createLogger('reconciliation');
 /** Workspace capabilities needed for reconciliation, injected at startup. */
 export interface ReconciliationWorkspaceBridge {
   markFailed(workspaceId: string, reason: string): Promise<void>;
+  cleanupUnregisteredProvisioningWorktree(workspaceId: string): Promise<void>;
   initializeWorktree(
     workspaceId: string,
     options?: { branchName?: string; useExistingBranch?: boolean }
@@ -164,8 +165,9 @@ class ReconciliationService {
           continue;
         }
 
-        // Stale provisioning - mark as failed so user can retry
+        // Remove any crash-left worktree before exposing FAILED for a user retry.
         try {
+          await this.workspace.cleanupUnregisteredProvisioningWorktree(workspace.id);
           await this.workspace.markFailed(
             workspace.id,
             'Provisioning timed out. This may indicate a server restart during initialization. Please retry.'
@@ -175,7 +177,7 @@ class ReconciliationService {
             initStartedAt: workspace.initStartedAt,
           });
         } catch (error) {
-          logger.error('Failed to mark stale workspace as failed', toError(error), {
+          logger.error('Failed to recover stale provisioning workspace', toError(error), {
             workspaceId: workspace.id,
           });
         }

--- a/src/backend/orchestration/reconciliation.service.ts
+++ b/src/backend/orchestration/reconciliation.service.ts
@@ -6,23 +6,22 @@ import { createLogger } from '@/backend/services/logger.service';
 
 const logger = createLogger('reconciliation');
 
+interface WorkspaceNeedingWorktree {
+  id: string;
+  status: string;
+  branchName: string | null;
+  initStartedAt: Date | null;
+  initScriptPid: number | null;
+}
+
 /** Workspace capabilities needed for reconciliation, injected at startup. */
 export interface ReconciliationWorkspaceBridge {
-  markFailed(workspaceId: string, reason: string): Promise<void>;
-  cleanupUnregisteredProvisioningWorktree(workspaceId: string): Promise<void>;
+  recoverStaleProvisioningWorkspace(workspaceId: string, reason: string): Promise<boolean>;
   initializeWorktree(
     workspaceId: string,
     options?: { branchName?: string; useExistingBranch?: boolean }
   ): Promise<void>;
-  findNeedingWorktree(): Promise<
-    Array<{
-      id: string;
-      status: string;
-      branchName: string | null;
-      initStartedAt: Date | null;
-      initScriptPid: number | null;
-    }>
-  >;
+  findNeedingWorktree(): Promise<WorkspaceNeedingWorktree[]>;
 }
 
 export interface ReconciliationTerminalBridge {
@@ -156,46 +155,55 @@ class ReconciliationService {
 
     for (const workspace of workspacesNeedingWorktree) {
       if (workspace.status === 'PROVISIONING') {
-        if (workspace.initScriptPid && isProcessRunning(workspace.initScriptPid)) {
-          logger.info('Skipping stale provisioning workspace with running init script', {
-            workspaceId: workspace.id,
-            initStartedAt: workspace.initStartedAt,
-            initScriptPid: workspace.initScriptPid,
-          });
-          continue;
-        }
-
-        // Remove any crash-left worktree before exposing FAILED for a user retry.
-        try {
-          await this.workspace.cleanupUnregisteredProvisioningWorktree(workspace.id);
-          await this.workspace.markFailed(
-            workspace.id,
-            'Provisioning timed out. This may indicate a server restart during initialization. Please retry.'
-          );
-          logger.warn('Marked stale provisioning workspace as failed', {
-            workspaceId: workspace.id,
-            initStartedAt: workspace.initStartedAt,
-          });
-        } catch (error) {
-          logger.error('Failed to recover stale provisioning workspace', toError(error), {
-            workspaceId: workspace.id,
-          });
-        }
+        await this.recoverStaleProvisioningWorkspace(workspace);
       } else {
-        // NEW workspace - initialize normally
-        try {
-          await this.workspace.initializeWorktree(workspace.id, {
-            branchName: workspace.branchName ?? undefined,
-          });
-          logger.info('Initialized workspace via reconciliation', {
-            workspaceId: workspace.id,
-          });
-        } catch (error) {
-          logger.error('Failed to initialize workspace', toError(error), {
-            workspaceId: workspace.id,
-          });
-        }
+        await this.initializeNewWorkspace(workspace);
       }
+    }
+  }
+
+  private async recoverStaleProvisioningWorkspace(
+    workspace: WorkspaceNeedingWorktree
+  ): Promise<void> {
+    if (workspace.initScriptPid && isProcessRunning(workspace.initScriptPid)) {
+      logger.info('Skipping stale provisioning workspace with running init script', {
+        workspaceId: workspace.id,
+        initStartedAt: workspace.initStartedAt,
+        initScriptPid: workspace.initScriptPid,
+      });
+      return;
+    }
+
+    try {
+      const recovered = await this.workspace.recoverStaleProvisioningWorkspace(
+        workspace.id,
+        'Provisioning timed out. This may indicate a server restart during initialization. Please retry.'
+      );
+      if (recovered) {
+        logger.warn('Marked stale provisioning workspace as failed', {
+          workspaceId: workspace.id,
+          initStartedAt: workspace.initStartedAt,
+        });
+      }
+    } catch (error) {
+      logger.error('Failed to recover stale provisioning workspace', toError(error), {
+        workspaceId: workspace.id,
+      });
+    }
+  }
+
+  private async initializeNewWorkspace(workspace: WorkspaceNeedingWorktree): Promise<void> {
+    try {
+      await this.workspace.initializeWorktree(workspace.id, {
+        branchName: workspace.branchName ?? undefined,
+      });
+      logger.info('Initialized workspace via reconciliation', {
+        workspaceId: workspace.id,
+      });
+    } catch (error) {
+      logger.error('Failed to initialize workspace', toError(error), {
+        workspaceId: workspace.id,
+      });
     }
   }
 

--- a/src/backend/orchestration/workspace-init.orchestrator.test.ts
+++ b/src/backend/orchestration/workspace-init.orchestrator.test.ts
@@ -75,6 +75,7 @@ vi.mock('@/backend/services/workspace', () => ({
     markReadyWithWarning: vi.fn(),
   },
   worktreeLifecycleService: {
+    prepareStaleProvisioningRecovery: vi.fn(),
     getInitMode: vi.fn(),
     clearInitMode: vi.fn(),
   },
@@ -133,6 +134,7 @@ import {
 import {
   clearWorkspaceInitOrchestratorStateForTests,
   initializeWorkspaceWorktree,
+  recoverStaleProvisioningWorkspace,
 } from './workspace-init.orchestrator';
 
 // --- Test Helpers ---
@@ -227,6 +229,82 @@ describe('initializeWorkspaceWorktree', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     clearWorkspaceInitOrchestratorStateForTests();
+  });
+
+  describe('stale provisioning recovery', () => {
+    it('does not mark failed when the workspace no longer qualifies for recovery', async () => {
+      vi.mocked(worktreeLifecycleService.prepareStaleProvisioningRecovery).mockResolvedValue(false);
+
+      await expect(
+        recoverStaleProvisioningWorkspace(WORKSPACE_ID, 'Provisioning timed out')
+      ).resolves.toBe(false);
+
+      expect(workspaceStateMachine.markFailed).not.toHaveBeenCalled();
+    });
+
+    it('does not mark failed when orphan preparation fails', async () => {
+      vi.mocked(worktreeLifecycleService.prepareStaleProvisioningRecovery).mockRejectedValue(
+        new Error('worktree removal failed')
+      );
+
+      await expect(
+        recoverStaleProvisioningWorkspace(WORKSPACE_ID, 'Provisioning timed out')
+      ).rejects.toThrow('worktree removal failed');
+
+      expect(workspaceStateMachine.markFailed).not.toHaveBeenCalled();
+    });
+
+    it('skips stale recovery while initialization is active', async () => {
+      setupHappyPath();
+      const factoryConfig = createDeferredPromise<null>();
+      vi.mocked(FactoryConfigService.readConfig).mockReturnValue(factoryConfig.promise);
+
+      const initialization = initializeWorkspaceWorktree(WORKSPACE_ID);
+      await vi.waitFor(() => {
+        expect(gitOpsService.createWorktree).toHaveBeenCalledTimes(1);
+      });
+
+      const recovery = recoverStaleProvisioningWorkspace(WORKSPACE_ID, 'Provisioning timed out');
+      await expect(recovery).resolves.toBe(false);
+      expect(worktreeLifecycleService.prepareStaleProvisioningRecovery).not.toHaveBeenCalled();
+
+      factoryConfig.resolve(null);
+      await initialization;
+
+      expect(worktreeLifecycleService.prepareStaleProvisioningRecovery).not.toHaveBeenCalled();
+      expect(workspaceStateMachine.markFailed).not.toHaveBeenCalled();
+    });
+
+    it('finishes stale cleanup and failure transition before a retry can start', async () => {
+      setupHappyPath();
+      const cleanup = createDeferredPromise<boolean>();
+      vi.mocked(worktreeLifecycleService.prepareStaleProvisioningRecovery).mockReturnValue(
+        cleanup.promise
+      );
+
+      const recovery = recoverStaleProvisioningWorkspace(WORKSPACE_ID, 'Provisioning timed out');
+      await vi.waitFor(() => {
+        expect(worktreeLifecycleService.prepareStaleProvisioningRecovery).toHaveBeenCalledWith(
+          WORKSPACE_ID
+        );
+      });
+
+      const retry = initializeWorkspaceWorktree(WORKSPACE_ID);
+      await Promise.resolve();
+
+      expect(workspaceStateMachine.startProvisioning).not.toHaveBeenCalled();
+
+      cleanup.resolve(true);
+      await Promise.all([recovery, retry]);
+
+      expect(workspaceStateMachine.markFailed).toHaveBeenCalledWith(
+        WORKSPACE_ID,
+        'Provisioning timed out'
+      );
+      expect(vi.mocked(workspaceStateMachine.markFailed).mock.invocationCallOrder[0]).toBeLessThan(
+        vi.mocked(workspaceStateMachine.startProvisioning).mock.invocationCallOrder[0]!
+      );
+    });
   });
 
   describe('provisioning gate', () => {

--- a/src/backend/orchestration/workspace-init.orchestrator.ts
+++ b/src/backend/orchestration/workspace-init.orchestrator.ts
@@ -57,7 +57,7 @@ type WorkspaceInitializationOptions = {
 };
 
 const gitHubUsernameCache = new GitHubUsernameCache(githubCLIService);
-const workspaceInitializationTails = new Map<string, Promise<void>>();
+const workspaceInitializationTails = new Map<string, Promise<unknown>>();
 
 function getCachedGitHubUsername(): Promise<string | null> {
   return gitHubUsernameCache.getCachedUsername();
@@ -835,14 +835,12 @@ async function runWorkspaceInitialization(
   }
 }
 
-export function initializeWorkspaceWorktree(
+function enqueueWorkspaceInitializationTask<T>(
   workspaceId: string,
-  options?: WorkspaceInitializationOptions
-): Promise<void> {
+  task: () => Promise<T>
+): Promise<T> {
   const previousInitialization = workspaceInitializationTails.get(workspaceId) ?? Promise.resolve();
-  const initialization = previousInitialization
-    .catch(() => undefined)
-    .then(() => runWorkspaceInitialization(workspaceId, options));
+  const initialization = previousInitialization.catch(() => undefined).then(task);
 
   workspaceInitializationTails.set(workspaceId, initialization);
 
@@ -851,4 +849,34 @@ export function initializeWorkspaceWorktree(
       workspaceInitializationTails.delete(workspaceId);
     }
   });
+}
+
+export function recoverStaleProvisioningWorkspace(
+  workspaceId: string,
+  reason: string
+): Promise<boolean> {
+  // A live initializer owns the path until it settles; the next poll can re-check it.
+  if (workspaceInitializationTails.has(workspaceId)) {
+    return Promise.resolve(false);
+  }
+
+  return enqueueWorkspaceInitializationTask(workspaceId, async () => {
+    const shouldRecover =
+      await worktreeLifecycleService.prepareStaleProvisioningRecovery(workspaceId);
+    if (!shouldRecover) {
+      return false;
+    }
+
+    await workspaceStateMachine.markFailed(workspaceId, reason);
+    return true;
+  });
+}
+
+export function initializeWorkspaceWorktree(
+  workspaceId: string,
+  options?: WorkspaceInitializationOptions
+): Promise<void> {
+  return enqueueWorkspaceInitializationTask(workspaceId, () =>
+    runWorkspaceInitialization(workspaceId, options)
+  );
 }

--- a/src/backend/services/workspace/service/worktree/worktree-lifecycle.service.test.ts
+++ b/src/backend/services/workspace/service/worktree/worktree-lifecycle.service.test.ts
@@ -186,6 +186,67 @@ describe('worktreeLifecycleService cleanup', () => {
       await rm(tempRoot, { recursive: true, force: true });
     }
   });
+
+  it('removes the deterministic worktree left by interrupted provisioning', async () => {
+    const tempRoot = await mkdtemp(path.join(tmpdir(), 'ff-worktree-cleanup-'));
+    const worktreeBasePath = path.join(tempRoot, 'worktrees');
+    const worktreePath = path.join(worktreeBasePath, 'workspace-workspace-1');
+    const project = {
+      repoPath: path.join(tempRoot, 'repo'),
+      worktreeBasePath,
+    };
+    await mkdir(worktreePath, { recursive: true });
+    vi.spyOn(workspaceAccessor, 'findByIdWithProject').mockResolvedValue(
+      unsafeCoerce({
+        id: 'workspace-1',
+        status: 'PROVISIONING',
+        worktreePath: null,
+        project,
+      })
+    );
+    const removeSpy = vi.spyOn(gitOpsService, 'removeWorktree').mockResolvedValue(undefined);
+
+    try {
+      await worktreeLifecycleService.cleanupUnregisteredProvisioningWorktree('workspace-1');
+
+      expect(removeSpy).toHaveBeenCalledWith(worktreePath, project);
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    {
+      name: 'the worktree path has been persisted',
+      workspace: {
+        status: 'PROVISIONING',
+        worktreePath: '/tmp/worktrees/workspace-workspace-1',
+      },
+    },
+    {
+      name: 'the workspace is no longer provisioning',
+      workspace: {
+        status: 'FAILED',
+        worktreePath: null,
+      },
+    },
+  ])('does not remove a worktree when $name', async ({ workspace }) => {
+    vi.spyOn(workspaceAccessor, 'findByIdWithProject').mockResolvedValue(
+      unsafeCoerce({
+        id: 'workspace-1',
+        ...workspace,
+        project: {
+          repoPath: '/tmp/repo',
+          worktreeBasePath: '/tmp/worktrees',
+        },
+      })
+    );
+    const removeSpy = vi.spyOn(gitOpsService, 'removeWorktree').mockResolvedValue(undefined);
+
+    await worktreeLifecycleService.cleanupUnregisteredProvisioningWorktree('workspace-1');
+
+    expect(removeSpy).not.toHaveBeenCalled();
+  });
 });
 
 describe('worktreeLifecycleService init mode', () => {

--- a/src/backend/services/workspace/service/worktree/worktree-lifecycle.service.test.ts
+++ b/src/backend/services/workspace/service/worktree/worktree-lifecycle.service.test.ts
@@ -207,7 +207,9 @@ describe('worktreeLifecycleService cleanup', () => {
     const removeSpy = vi.spyOn(gitOpsService, 'removeWorktree').mockResolvedValue(undefined);
 
     try {
-      await worktreeLifecycleService.cleanupUnregisteredProvisioningWorktree('workspace-1');
+      await expect(
+        worktreeLifecycleService.prepareStaleProvisioningRecovery('workspace-1')
+      ).resolves.toBe(true);
 
       expect(removeSpy).toHaveBeenCalledWith(worktreePath, project);
     } finally {
@@ -218,6 +220,7 @@ describe('worktreeLifecycleService cleanup', () => {
   it.each([
     {
       name: 'the worktree path has been persisted',
+      shouldRecover: true,
       workspace: {
         status: 'PROVISIONING',
         worktreePath: '/tmp/worktrees/workspace-workspace-1',
@@ -225,12 +228,13 @@ describe('worktreeLifecycleService cleanup', () => {
     },
     {
       name: 'the workspace is no longer provisioning',
+      shouldRecover: false,
       workspace: {
         status: 'FAILED',
         worktreePath: null,
       },
     },
-  ])('does not remove a worktree when $name', async ({ workspace }) => {
+  ])('does not remove a worktree when $name', async ({ shouldRecover, workspace }) => {
     vi.spyOn(workspaceAccessor, 'findByIdWithProject').mockResolvedValue(
       unsafeCoerce({
         id: 'workspace-1',
@@ -243,7 +247,9 @@ describe('worktreeLifecycleService cleanup', () => {
     );
     const removeSpy = vi.spyOn(gitOpsService, 'removeWorktree').mockResolvedValue(undefined);
 
-    await worktreeLifecycleService.cleanupUnregisteredProvisioningWorktree('workspace-1');
+    await expect(
+      worktreeLifecycleService.prepareStaleProvisioningRecovery('workspace-1')
+    ).resolves.toBe(shouldRecover);
 
     expect(removeSpy).not.toHaveBeenCalled();
   });

--- a/src/backend/services/workspace/service/worktree/worktree-lifecycle.service.ts
+++ b/src/backend/services/workspace/service/worktree/worktree-lifecycle.service.ts
@@ -119,16 +119,21 @@ class WorktreeLifecycleService {
     return Promise.resolve();
   }
 
-  async cleanupUnregisteredProvisioningWorktree(workspaceId: string): Promise<void> {
+  /** Returns whether the freshly read workspace should be transitioned to FAILED. */
+  async prepareStaleProvisioningRecovery(workspaceId: string): Promise<boolean> {
     const workspace = await workspaceAccessor.findByIdWithProject(workspaceId);
-    if (!workspace || workspace.status !== 'PROVISIONING' || workspace.worktreePath) {
-      return;
+    if (!workspace || workspace.status !== 'PROVISIONING') {
+      return false;
+    }
+    if (workspace.worktreePath) {
+      return true;
     }
 
     const project = getProjectOrThrow(workspace);
     const worktreePath = path.join(project.worktreeBasePath, `workspace-${workspaceId}`);
     await assertWorktreePathSafe(worktreePath, project.worktreeBasePath);
     await gitOpsService.removeWorktree(worktreePath, project);
+    return true;
   }
 
   async cleanupWorkspaceWorktree(

--- a/src/backend/services/workspace/service/worktree/worktree-lifecycle.service.ts
+++ b/src/backend/services/workspace/service/worktree/worktree-lifecycle.service.ts
@@ -119,6 +119,18 @@ class WorktreeLifecycleService {
     return Promise.resolve();
   }
 
+  async cleanupUnregisteredProvisioningWorktree(workspaceId: string): Promise<void> {
+    const workspace = await workspaceAccessor.findByIdWithProject(workspaceId);
+    if (!workspace || workspace.status !== 'PROVISIONING' || workspace.worktreePath) {
+      return;
+    }
+
+    const project = getProjectOrThrow(workspace);
+    const worktreePath = path.join(project.worktreeBasePath, `workspace-${workspaceId}`);
+    await assertWorktreePathSafe(worktreePath, project.worktreeBasePath);
+    await gitOpsService.removeWorktree(worktreePath, project);
+  }
+
   async cleanupWorkspaceWorktree(
     workspace: WorkspaceWithProject,
     options: WorktreeArchiveOptions

--- a/src/test-utils/application-graph.ts
+++ b/src/test-utils/application-graph.ts
@@ -58,6 +58,7 @@ vi.mock('@/backend/orchestration/workspace-notification-delivery.orchestrator', 
 }));
 vi.mock('@/backend/orchestration/workspace-init.orchestrator', () => ({
   initializeWorkspaceWorktree: vi.fn(),
+  recoverStaleProvisioningWorkspace: vi.fn(),
   retryQueuedDispatchAfterWorkspaceReady: vi.fn(),
 }));
 vi.mock('@/backend/orchestration/workspace-init-script-pipeline', () => ({
@@ -190,6 +191,7 @@ import {
 } from '@/backend/orchestration/workspace-children.orchestrator';
 import {
   initializeWorkspaceWorktree,
+  recoverStaleProvisioningWorkspace,
   retryQueuedDispatchAfterWorkspaceReady,
 } from '@/backend/orchestration/workspace-init.orchestrator';
 import { executeStartupScriptPipeline } from '@/backend/orchestration/workspace-init-script-pipeline';
@@ -376,6 +378,7 @@ export function createFakeApplicationGraph(label = 'test'): FakeApplicationGraph
     rateLimiter,
     ratchetService,
     reconciliationService,
+    recoverStaleProvisioningWorkspace,
     retryQueuedDispatchAfterWorkspaceReady,
     runScriptConfigPersistenceService,
     runScriptService: createRunScriptService({ registerShutdownHandlers: false }),


### PR DESCRIPTION
## Summary

- Clean crash-left unregistered worktrees before stale provisioning workspaces become retryable.
- Serialize stale recovery with initialization and retries to avoid deleting a live worktree.
- Leave cleanup failures in `PROVISIONING` so reconciliation can safely try again.

## Changes

- **Workspace lifecycle**: Re-read stale candidates, preserve persisted worktrees, and safely remove deterministic orphan paths through the existing Git cleanup service.
- **Initialization orchestration**: Coordinate recovery with the per-workspace queue and transition to `FAILED` only after cleanup succeeds.
- **Tests**: Cover orphan removal, status/path guards, live initialization, retry ordering, fail-closed cleanup, and bridge wiring.

## Testing

- [x] Tests pass (`pnpm test` — 4,648 passed, 3 skipped)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting passes (`pnpm check:fix`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Reproduce a server crash between worktree creation and persistence, restart, and retry the workspace.

Closes #2092

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workspace provisioning recovery and git worktree deletion ordering; mistakes could remove the wrong worktree or leave stuck PROVISIONING states, though serialization and re-read guards mitigate that.
> 
> **Overview**
> Stale **PROVISIONING** workspaces are no longer failed directly from reconciliation via `markFailed`. Reconciliation now calls **`recoverStaleProvisioningWorkspace`**, which runs through the same per-workspace init queue as **`initializeWorkspaceWorktree`** so recovery cannot delete a live worktree or race a retry.
> 
> **`prepareStaleProvisioningRecovery`** re-reads the workspace: if still provisioning with no persisted `worktreePath`, it removes the deterministic orphan path (`workspace-{id}`) via git cleanup; if cleanup fails, the workspace stays **PROVISIONING** for a later poll. **`markFailed`** runs only after that step succeeds (or when a persisted path means no removal is needed).
> 
> Wiring updates pass **`recoverStaleProvisioningWorkspace`** through app context and domain bridges; tests cover orphan removal, guards, live init skip, and ordering vs retry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af43dfdc2eb7a3a4d0b2197056d022327c025a70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->