### PR TITLE
Fix #2136: Reject malformed chat snapshot messages

### DIFF
--- a/src/lib/chat-protocol.test.ts
+++ b/src/lib/chat-protocol.test.ts
@@ -108,6 +108,15 @@ describe('session lifecycle websocket validation', () => {
       })
     ).toBe(false);
   });
+
+  it.each([
+    ['null', null],
+    ['string', 'invalid'],
+    ['number', 42],
+    ['boolean', true],
+  ])('rejects %s entries in authoritative session snapshots', (_label, message) => {
+    expect(isWebSocketMessage({ type: 'session_snapshot', messages: [message] })).toBe(false);
+  });
 });
 
 function createToolUseMessage(params: {

--- a/src/lib/chat-protocol.ts
+++ b/src/lib/chat-protocol.ts
@@ -108,7 +108,7 @@ function hasValidSnapshotLifecycleMessages(data: object): boolean {
   }
   return messages.every((message) => {
     if (typeof message !== 'object' || message === null) {
-      return true;
+      return false;
     }
     const agentMessage = (message as { message?: unknown }).message;
     if (


### PR DESCRIPTION
## Summary
- Reject malformed chat session snapshots before they reach the reducer
- Add regression coverage for null, string, number, and boolean message entries

## Changes
- **Chat WebSocket protocol**: Reject non-object entries in `session_snapshot.messages` at the runtime type guard boundary
- **Tests**: Cover every JSON primitive category that previously passed snapshot validation

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Repository checks pass (`pnpm check` and `pnpm check:fix`)
- [ ] Manual testing: Not applicable; this protocol-only guard behavior is covered by automated tests

Closes #2136

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
