### PR TITLE
Fix #2132: Clean up stale worktree registrations

### DIFF
--- a/src/backend/services/workspace/service/worktree/worktree-lifecycle.service.test.ts
+++ b/src/backend/services/workspace/service/worktree/worktree-lifecycle.service.test.ts
@@ -113,8 +113,9 @@ describe('worktreeLifecycleService cleanup', () => {
     }
   });
 
-  it('evicts Git state when the worktree is already missing', async () => {
+  it('delegates registered worktree cleanup when the directory is already missing', async () => {
     const worktreePath = '/tmp/worktrees/missing-workspace';
+    const project = { repoPath: '/tmp/repo', worktreeBasePath: '/tmp/worktrees' };
     vi.spyOn(gitOpsService, 'commitIfNeeded').mockResolvedValue(undefined);
     vi.spyOn(gitOpsService, 'removeWorktree').mockResolvedValue(undefined);
     const removeStateSpy = vi.spyOn(workspaceGitStateService, 'remove');
@@ -123,14 +124,14 @@ describe('worktreeLifecycleService cleanup', () => {
     >({
       name: 'Missing workspace',
       worktreePath,
-      project: { repoPath: '/tmp/repo', worktreeBasePath: '/tmp/worktrees' },
+      project,
     });
 
     await worktreeLifecycleService.cleanupWorkspaceWorktree(workspace, {});
 
-    expect(removeStateSpy).toHaveBeenCalledWith(worktreePath);
     expect(gitOpsService.commitIfNeeded).not.toHaveBeenCalled();
-    expect(gitOpsService.removeWorktree).not.toHaveBeenCalled();
+    expect(gitOpsService.removeWorktree).toHaveBeenCalledWith(worktreePath, project);
+    expect(removeStateSpy).not.toHaveBeenCalled();
   });
 
   it('does not evict Git state when worktree removal fails', async () => {

--- a/src/backend/services/workspace/service/worktree/worktree-lifecycle.service.ts
+++ b/src/backend/services/workspace/service/worktree/worktree-lifecycle.service.ts
@@ -2,7 +2,6 @@ import { lstat, realpath } from 'node:fs/promises';
 import * as path from 'node:path';
 import { pathExists } from '@/backend/lib/file-helpers';
 import { workspaceAccessor } from '@/backend/services/workspace/resources/workspace.accessor';
-import { workspaceGitStateService } from '@/backend/services/workspace-git-state.service';
 import { gitOpsService } from './git-ops.service';
 
 export class WorktreePathSafetyError extends Error {
@@ -149,17 +148,14 @@ class WorktreeLifecycleService {
     await assertWorktreePathSafe(worktreePath, project.worktreeBasePath);
 
     const worktreeExists = await pathExists(worktreePath);
-    if (!worktreeExists) {
-      workspaceGitStateService.remove(worktreePath);
-      return;
-    }
-
-    if (options.removeGitIndexLock) {
-      await gitOpsService.commitIfNeeded(worktreePath, workspace.name, {
-        removeGitIndexLock: true,
-      });
-    } else {
-      await gitOpsService.commitIfNeeded(worktreePath, workspace.name);
+    if (worktreeExists) {
+      if (options.removeGitIndexLock) {
+        await gitOpsService.commitIfNeeded(worktreePath, workspace.name, {
+          removeGitIndexLock: true,
+        });
+      } else {
+        await gitOpsService.commitIfNeeded(worktreePath, workspace.name);
+      }
     }
     await gitOpsService.removeWorktree(worktreePath, project);
   }


### PR DESCRIPTION
## Summary
- Remove stale Git worktree registrations even when the workspace directory is already missing.
- Prevent stale registrations from permanently blocking `RESUME_BRANCH` workspace creation.

## Changes
- **Workspace cleanup**: Keep commit-on-archive behavior for existing directories, then always delegate worktree removal and Git-state eviction to `GitOpsService`.
- **Regression coverage**: Verify missing directories skip commits while still cleaning registered worktrees through the Git operations boundary.

## Testing
- [x] Tests pass (`pnpm test` — 4,844 passed, 3 skipped)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting passes (`pnpm check:fix`)
- [x] Build succeeds (`pnpm build`)
- [x] Focused regression test passes (`worktree-lifecycle.service.test.ts` — 16 passed)
- [x] Manual testing: Verified `git worktree remove --force` clears a registered, prunable worktree after its directory is removed.

Closes #2132

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
