### PR TITLE
Fix #2134: Preserve messages stopped during dispatch

### DIFF
--- a/src/backend/services/session/service/chat/chat-message-handlers.service.test.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers.service.test.ts
@@ -17,6 +17,7 @@ const {
     markRunning: vi.fn(),
     allocateOrder: vi.fn(),
     emitDelta: vi.fn(),
+    emitSessionSnapshot: vi.fn(),
     failMessage: vi.fn(),
     commitSentUserMessageAtOrder: vi.fn(),
     removeTranscriptMessageById: vi.fn(),
@@ -339,6 +340,7 @@ describe('chatMessageHandlerService.tryDispatchNextMessage', () => {
     expect(mockSessionService.sendSessionMessage).not.toHaveBeenCalled();
     expect(mockWorkspaceNotificationService.markDelivered).not.toHaveBeenCalled();
     expect(mockSessionDomainService.failMessage).not.toHaveBeenCalled();
+    expect(mockSessionDomainService.emitSessionSnapshot).toHaveBeenCalledWith('s1');
   });
 
   it('fails a message once when ACP reports an internal error', async () => {

--- a/src/backend/services/session/service/chat/chat-message-handlers.service.test.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers.service.test.ts
@@ -88,6 +88,20 @@ describe('chatMessageHandlerService.tryDispatchNextMessage', () => {
       planModeEnabled: false,
     },
   };
+  const queuedMessageWithAttachment: QueuedMessage = {
+    ...queuedMessage,
+    text: 'preserve this draft',
+    attachments: [
+      {
+        id: 'attachment-1',
+        name: 'notes.txt',
+        type: 'text/plain',
+        size: 11,
+        data: 'draft notes',
+        contentType: 'text',
+      },
+    ],
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -206,11 +220,13 @@ describe('chatMessageHandlerService.tryDispatchNextMessage', () => {
     expect(mockSessionDomainService.emitDelta).not.toHaveBeenCalled();
   });
 
-  it('does not send or commit a dequeued message when stop begins during dispatch configuration', async () => {
+  it('fails a dequeued message for recovery when stop begins during dispatch configuration', async () => {
     let resolveModelUpdate!: () => void;
     const modelUpdate = new Promise<void>((resolve) => {
       resolveModelUpdate = resolve;
     });
+    mockSessionDomainService.peekNextMessage.mockReturnValue(queuedMessageWithAttachment);
+    mockSessionDomainService.dequeueNext.mockReturnValue(queuedMessageWithAttachment);
     mockSessionService.getSessionClient.mockReturnValue({});
     mockSessionService.setSessionModel.mockReturnValue(modelUpdate);
 
@@ -227,9 +243,43 @@ describe('chatMessageHandlerService.tryDispatchNextMessage', () => {
     expect(mockSessionDomainService.markRunning).not.toHaveBeenCalled();
     expect(mockSessionDomainService.commitSentUserMessageAtOrder).not.toHaveBeenCalled();
     expect(mockSessionDomainService.requeueFront).not.toHaveBeenCalled();
+    expect(mockSessionDomainService.failMessage).toHaveBeenCalledWith(
+      's1',
+      queuedMessageWithAttachment,
+      'Message was not sent because the session stopped during dispatch.'
+    );
   });
 
-  it('does not send or requeue a dequeued message when stop completes during configuration', async () => {
+  it('fails a dequeued message for recovery when configuration rejects after stop begins', async () => {
+    let rejectModelUpdate!: (error: Error) => void;
+    const modelUpdate = new Promise<void>((_resolve, reject) => {
+      rejectModelUpdate = reject;
+    });
+    mockSessionDomainService.peekNextMessage.mockReturnValue(queuedMessageWithAttachment);
+    mockSessionDomainService.dequeueNext.mockReturnValue(queuedMessageWithAttachment);
+    mockSessionService.getSessionClient.mockReturnValue({});
+    mockSessionService.setSessionModel.mockReturnValue(modelUpdate);
+
+    const dispatchPromise = chatMessageHandlerService.tryDispatchNextMessage('s1');
+    await vi.waitFor(() => {
+      expect(mockSessionService.setSessionModel).toHaveBeenCalledWith('s1', undefined);
+    });
+
+    mockSessionService.isSessionStopping.mockReturnValue(true);
+    rejectModelUpdate(new Error('session stopped'));
+    await dispatchPromise;
+
+    expect(mockSessionService.sendSessionMessage).not.toHaveBeenCalled();
+    expect(mockSessionDomainService.commitSentUserMessageAtOrder).not.toHaveBeenCalled();
+    expect(mockSessionDomainService.requeueFront).not.toHaveBeenCalled();
+    expect(mockSessionDomainService.failMessage).toHaveBeenCalledWith(
+      's1',
+      queuedMessageWithAttachment,
+      'Message was not sent because the session stopped during dispatch.'
+    );
+  });
+
+  it('fails a dequeued message for recovery when stop completes during configuration', async () => {
     let resolveModelUpdate!: () => void;
     const modelUpdate = new Promise<void>((resolve) => {
       resolveModelUpdate = resolve;
@@ -256,6 +306,39 @@ describe('chatMessageHandlerService.tryDispatchNextMessage', () => {
     expect(mockSessionDomainService.markRunning).not.toHaveBeenCalled();
     expect(mockSessionDomainService.commitSentUserMessageAtOrder).not.toHaveBeenCalled();
     expect(mockSessionDomainService.requeueFront).not.toHaveBeenCalled();
+    expect(mockSessionDomainService.failMessage).toHaveBeenCalledWith(
+      's1',
+      queuedMessage,
+      'Message was not sent because the session stopped during dispatch.'
+    );
+  });
+
+  it('does not expose a stopped workspace notification as a recoverable user message', async () => {
+    const notificationMessage: QueuedMessage = {
+      ...queuedMessage,
+      id: 'workspace-notification-notif-parent',
+    };
+    let resolveModelUpdate!: () => void;
+    const modelUpdate = new Promise<void>((resolve) => {
+      resolveModelUpdate = resolve;
+    });
+    mockSessionDomainService.peekNextMessage.mockReturnValue(notificationMessage);
+    mockSessionDomainService.dequeueNext.mockReturnValue(notificationMessage);
+    mockSessionService.getSessionClient.mockReturnValue({});
+    mockSessionService.setSessionModel.mockReturnValue(modelUpdate);
+
+    const dispatchPromise = chatMessageHandlerService.tryDispatchNextMessage('s1');
+    await vi.waitFor(() => {
+      expect(mockSessionService.setSessionModel).toHaveBeenCalledWith('s1', undefined);
+    });
+
+    mockSessionService.isSessionStopping.mockReturnValue(true);
+    resolveModelUpdate();
+    await dispatchPromise;
+
+    expect(mockSessionService.sendSessionMessage).not.toHaveBeenCalled();
+    expect(mockWorkspaceNotificationService.markDelivered).not.toHaveBeenCalled();
+    expect(mockSessionDomainService.failMessage).not.toHaveBeenCalled();
   });
 
   it('fails a message once when ACP reports an internal error', async () => {

--- a/src/backend/services/session/service/chat/chat-message-handlers.service.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers.service.ts
@@ -582,28 +582,7 @@ class ChatMessageHandlerService {
     const isCompactCommand = this.isCompactCommand(msg.text);
     const compactionClient = isClaudeCompactionClient(client) ? client : null;
 
-    if (msg.settings.planModeEnabled) {
-      await sessionConfigService.setSessionCollaborationMode(dbSessionId, 'plan');
-    }
-
-    // Only clients that expose thinking-budget controls support this feature.
-    // Keep this before state mutation so provider errors can be safely requeued.
-    if (isThinkingBudgetClient(client)) {
-      const thinkingTokens = msg.settings.thinkingEnabled ? DEFAULT_THINKING_BUDGET : null;
-      await sessionConfigService.setSessionThinkingBudget(dbSessionId, thinkingTokens);
-    }
-    await sessionConfigService.setSessionModel(
-      dbSessionId,
-      msg.settings.selectedModel ?? undefined
-    );
-    await sessionConfigService.setSessionReasoningEffort(
-      dbSessionId,
-      msg.settings.reasoningEffort ?? null
-    );
-
-    // Configuration calls above yield. Re-check the lifecycle barrier before any
-    // dispatch state mutation so a stop cannot be crossed by this dequeued turn.
-    if (!this.isDispatchGenerationCurrent(dbSessionId, stopGeneration)) {
+    if (!(await this.configureMessageForDispatch(dbSessionId, msg, client, stopGeneration))) {
       return;
     }
 
@@ -662,6 +641,59 @@ class ChatMessageHandlerService {
         remainingInQueue: sessionDomainService.getQueueLength(dbSessionId),
       });
     }
+  }
+
+  private async configureMessageForDispatch(
+    dbSessionId: string,
+    msg: QueuedMessage,
+    client: unknown,
+    stopGeneration: number
+  ): Promise<boolean> {
+    try {
+      if (msg.settings.planModeEnabled) {
+        await sessionConfigService.setSessionCollaborationMode(dbSessionId, 'plan');
+      }
+
+      // Only clients that expose thinking-budget controls support this feature.
+      // Keep this before state mutation so provider errors can be safely recovered.
+      if (isThinkingBudgetClient(client)) {
+        const thinkingTokens = msg.settings.thinkingEnabled ? DEFAULT_THINKING_BUDGET : null;
+        await sessionConfigService.setSessionThinkingBudget(dbSessionId, thinkingTokens);
+      }
+      await sessionConfigService.setSessionModel(
+        dbSessionId,
+        msg.settings.selectedModel ?? undefined
+      );
+      await sessionConfigService.setSessionReasoningEffort(
+        dbSessionId,
+        msg.settings.reasoningEffort ?? null
+      );
+    } catch (error) {
+      if (this.isDispatchGenerationCurrent(dbSessionId, stopGeneration)) {
+        throw error;
+      }
+      this.failStoppedUserMessage(dbSessionId, msg);
+      return false;
+    }
+
+    // Configuration calls above yield. Re-check the lifecycle barrier before any
+    // dispatch state mutation so a stop cannot be crossed by this dequeued turn.
+    if (!this.isDispatchGenerationCurrent(dbSessionId, stopGeneration)) {
+      this.failStoppedUserMessage(dbSessionId, msg);
+      return false;
+    }
+    return true;
+  }
+
+  private failStoppedUserMessage(dbSessionId: string, msg: QueuedMessage): void {
+    if (this.getWorkspaceNotificationId(msg.id)) {
+      return;
+    }
+    sessionDomainService.failMessage(
+      dbSessionId,
+      msg,
+      'Message was not sent because the session stopped during dispatch.'
+    );
   }
 
   private getWorkspaceNotificationId(messageId: string): string | null {

--- a/src/backend/services/session/service/chat/chat-message-handlers.service.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers.service.ts
@@ -687,6 +687,7 @@ class ChatMessageHandlerService {
 
   private failStoppedUserMessage(dbSessionId: string, msg: QueuedMessage): void {
     if (this.getWorkspaceNotificationId(msg.id)) {
+      sessionDomainService.emitSessionSnapshot(dbSessionId);
       return;
     }
     sessionDomainService.failMessage(

--- a/src/backend/services/session/service/chat/chat-message-handlers/handlers/queue-message.handler.test.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers/handlers/queue-message.handler.test.ts
@@ -63,6 +63,37 @@ describe('createQueueMessageHandler', () => {
     expect(mocks.enqueue).not.toHaveBeenCalled();
   });
 
+  it('rejects client messages that use the workspace notification id namespace', async () => {
+    mocks.enqueue.mockReturnValue({ position: 0 });
+    const ws = { send: vi.fn() };
+    const tryDispatchNextMessage = vi.fn();
+    const handler = createQueueMessageHandler({
+      getClientCreator: () => null,
+      tryDispatchNextMessage,
+      setManualDispatchResume: vi.fn(),
+    });
+
+    await handler({
+      ws: ws as never,
+      sessionId: 'session-1',
+      workingDir: '/tmp/work',
+      message: {
+        type: 'queue_message',
+        id: 'workspace-notification-user-controlled',
+        text: 'hello',
+      } as never,
+    });
+
+    expect(ws.send).not.toHaveBeenCalled();
+    expect(mocks.rejectMessage).toHaveBeenCalledWith(
+      'session-1',
+      'workspace-notification-user-controlled',
+      'Reserved message id'
+    );
+    expect(mocks.enqueue).not.toHaveBeenCalled();
+    expect(tryDispatchNextMessage).not.toHaveBeenCalled();
+  });
+
   it('emits rejected state for queue messages with invalid attachments', async () => {
     const ws = { send: vi.fn() };
     const tryDispatchNextMessage = vi.fn();

--- a/src/backend/services/session/service/chat/chat-message-handlers/handlers/queue-message.handler.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers/handlers/queue-message.handler.ts
@@ -9,6 +9,7 @@ import {
 } from '@/backend/services/session/service/chat/chat-message-handlers/utils';
 import { sessionDomainService } from '@/backend/services/session/service/session-domain.service';
 import type { QueueMessageInput } from '@/shared/websocket';
+import { WORKSPACE_NOTIFICATION_MESSAGE_ID_PREFIX } from '@/shared/workspace-notifications';
 
 function validateAttachments(attachments: QueueMessageInput['attachments']): string | null {
   if (!attachments?.length) {
@@ -36,6 +37,10 @@ function validateQueueMessageInput(
 
   if (!message.id) {
     return 'Missing message id';
+  }
+
+  if (message.id.startsWith(WORKSPACE_NOTIFICATION_MESSAGE_ID_PREFIX)) {
+    return 'Reserved message id';
   }
 
   return validateAttachments(message.attachments);


### PR DESCRIPTION
## Summary
- Preserve dequeued user messages when session stop races async dispatch configuration
- Keep full text and attachments recoverable live and after reconnect
- Avoid exposing persist-first workspace notifications in the user composer

## Changes
- **Chat dispatch**: Route stale configuration completion and rejection through durable failed-message recovery before any ACP send
- **Workspace notifications**: Leave system notification recovery to the persisted notification row instead of treating it as a user draft
- **Tests**: Cover stop-in-progress, completed-stop generation changes, rejected configuration calls, attachments, and notification exclusion

## Testing
- [x] Tests pass (`pnpm test` — 4,846 passed)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting and lint pass (`pnpm check:fix`)
- [x] Build succeeds (`pnpm build`)
- [x] Targeted race tests pass (`chat-message-handlers.service.test.ts` — 34 passed)
- [ ] Manual testing: Not applicable; the timing window is covered deterministically with deferred promises

Closes #2134

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes chat dispatch lifecycle and message durability on stop races, but behavior is scoped to session chat with strong unit coverage and no auth or persistence schema changes.
> 
> **Overview**
> Fixes a race where a user message could be **dequeued** during async session configuration (model, thinking, plan mode) and then **silently dropped** if stop completed before send—losing text and attachments.
> 
> Dispatch configuration is moved into **`configureMessageForDispatch`**, which re-checks the stop generation after awaits. If the session is no longer current, **`failMessage`** records the dequeued message with a fixed recovery reason (including attachments) instead of requeueing or sending. Config errors after stop follow the same path; errors while still current still propagate.
> 
> **Workspace notification** queue entries use the reserved id prefix: on that stop path the service **`emitSessionSnapshot`** only (no user-draft recovery), and the **`queue_message`** handler now **rejects** client-supplied ids in that namespace so notifications cannot be spoofed via the composer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da9e15c678ea144e15f7ae34a7366025cdc155b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->