### PR TITLE
Fix #2130: Prevent chat send during IME composition

### DIFF
--- a/src/client/features/chat/chat-input/hooks/use-chat-input-actions.test.tsx
+++ b/src/client/features/chat/chat-input/hooks/use-chat-input-actions.test.tsx
@@ -118,6 +118,33 @@ afterEach(() => {
 });
 
 describe('useChatInputActions keyboard shortcuts', () => {
+  it('does not send when Enter confirms an IME composition', () => {
+    const onSend = vi.fn();
+    const capabilities = createClaudeChatBarCapabilities('sonnet');
+    const { root, container, textarea } = renderHarness({
+      capabilities,
+      onSend,
+      onSettingsChange: () => undefined,
+    });
+    textarea.value = 'テスト';
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true,
+      cancelable: true,
+      isComposing: true,
+    });
+    flushSync(() => {
+      textarea.dispatchEvent(event);
+    });
+
+    expect(onSend).not.toHaveBeenCalled();
+    expect(textarea.value).toBe('テスト');
+
+    root.unmount();
+    container.remove();
+  });
+
   it('does not dismiss the slash menu when a Mod+Enter send is skipped', () => {
     const onCloseSlashMenu = vi.fn();
     const onSend = vi.fn();

--- a/src/client/features/chat/chat-input/hooks/use-chat-input-actions.ts
+++ b/src/client/features/chat/chat-input/hooks/use-chat-input-actions.ts
@@ -264,6 +264,10 @@ export function useChatInputActions({
   // Handle key press shortcuts before and after slash/file menus.
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (event.nativeEvent.isComposing) {
+        return;
+      }
+
       // Run pre-slash shortcuts first.
       if (runShortcuts(event, preSlashShortcuts)) {
         return;


### PR DESCRIPTION
## Summary
- Prevent chat keyboard shortcuts from firing while an IME composition is active.
- Add a regression test covering CJK text confirmation with Enter.

## Changes
- **Chat input**: Return before shortcut and palette handling when the native keyboard event is composing, allowing the IME to confirm text without sending it.
- **Tests**: Verify composing Enter neither calls `onSend` nor clears the textarea value.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting passes (`pnpm check:fix`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Confirm CJK composition with Enter in the chat input without sending the message.

Closes #2130

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized guard in chat keyboard handling with a unit test; no auth, data, or API changes.
> 
> **Overview**
> Fixes chat input treating **Enter** (and other keys) as send/shortcuts while an IME is still composing text—e.g. confirming Japanese with Enter would accidentally send the message.
> 
> `useChatInputActions` now **returns immediately** from `handleKeyDown` when `event.nativeEvent.isComposing` is true, so slash/file palette delegation and pre/post shortcuts are skipped until composition ends.
> 
> A regression test dispatches Enter with `isComposing: true` on CJK text and asserts **`onSend` is not called** and the textarea value is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb03b0f6851fe74ab8f4aeaa965912cc6bbbd22e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->