### PR TITLE
Fix #2135: Stop reconciliation between workspaces on shutdown

### DIFF
--- a/src/backend/orchestration/reconciliation.service.test.ts
+++ b/src/backend/orchestration/reconciliation.service.test.ts
@@ -59,6 +59,10 @@ describe('ReconciliationService', () => {
   });
 
   describe('reconcile', () => {
+    beforeEach(() => {
+      reconciliationService.startPeriodicCleanup();
+    });
+
     it('should initialize NEW workspaces', async () => {
       const newWorkspace = {
         id: 'ws-1',
@@ -328,6 +332,51 @@ describe('ReconciliationService', () => {
       await stopPromise;
       expect(stopped).toBe(true);
       expect(reconciliationSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not initialize another workspace after shutdown starts', async () => {
+      const releaseInitialization: { current: (() => void) | null } = { current: null };
+      mockFindMany.mockResolvedValue([
+        {
+          id: 'ws-1',
+          status: 'NEW',
+          branchName: 'feature/first',
+          project: { id: 'proj-1' },
+        },
+        {
+          id: 'ws-2',
+          status: 'NEW',
+          branchName: 'feature/second',
+          project: { id: 'proj-1' },
+        },
+      ]);
+      mockInitializeWorktree
+        .mockImplementationOnce(
+          () =>
+            new Promise<void>((resolve) => {
+              releaseInitialization.current = resolve;
+            })
+        )
+        .mockResolvedValue(undefined);
+      vi.spyOn(reconciliationService, 'cleanupOrphans').mockResolvedValue();
+
+      reconciliationService.startPeriodicCleanup();
+      await vi.advanceTimersToNextTimerAsync();
+
+      expect(mockInitializeWorktree).toHaveBeenCalledTimes(1);
+      expect(mockInitializeWorktree).toHaveBeenCalledWith('ws-1', {
+        branchName: 'feature/first',
+      });
+
+      const stopPromise = reconciliationService.stopPeriodicCleanup();
+      await Promise.resolve();
+
+      if (releaseInitialization.current) {
+        releaseInitialization.current();
+      }
+      await stopPromise;
+
+      expect(mockInitializeWorktree).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/backend/orchestration/reconciliation.service.ts
+++ b/src/backend/orchestration/reconciliation.service.ts
@@ -154,6 +154,11 @@ class ReconciliationService {
     const workspacesNeedingWorktree = await this.workspace.findNeedingWorktree();
 
     for (const workspace of workspacesNeedingWorktree) {
+      if (this.isShuttingDown) {
+        logger.debug('Stopping reconciliation - shutdown in progress');
+        return;
+      }
+
       if (workspace.status === 'PROVISIONING') {
         await this.recoverStaleProvisioningWorkspace(workspace);
       } else {


### PR DESCRIPTION
## Summary
- Stop periodic workspace reconciliation before starting another workspace after shutdown begins.
- Add regression coverage for shutdown requested during an in-flight workspace initialization.

## Changes
- **Reconciliation**: Check the existing shutdown state before every workspace initialization or stale-provisioning recovery step.
- **Tests**: Exercise the real periodic-cleanup lifecycle and verify the current initialization may finish while the next one never starts.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting passes (`pnpm check:fix`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; backend shutdown behavior is covered by the automated lifecycle regression test.

Closes #2135

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow shutdown guard on an existing orchestration loop; in-flight initialization can still finish, with behavior covered by a new lifecycle test.
> 
> **Overview**
> During shutdown, workspace reconciliation **stops before starting the next workspace** instead of walking the full `findNeedingWorktree` list. Each loop iteration in `reconcileWorkspaces` now checks `isShuttingDown` and returns immediately (with a debug log), so stale-provisioning recovery and new worktree initialization do not run after stop has begun.
> 
> **Tests** start periodic cleanup in the `reconcile` suite and add a regression case: two `NEW` workspaces with the first `initializeWorktree` held in flight while `stopPeriodicCleanup` runs—only the first workspace is initialized; the second never starts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bf7237e07fcac9219ca2dbed14427c5633db545. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

