### PR TITLE
Fix #2129: Clear queued WebSocket messages on session switch

### DIFF
--- a/src/hooks/use-websocket-transport.replay.test.tsx
+++ b/src/hooks/use-websocket-transport.replay.test.tsx
@@ -473,6 +473,50 @@ describe('useWebSocketTransport replay queue', () => {
     harness.cleanup();
   });
 
+  it('starts a fresh reconnect budget when switching directly to a new url', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+
+    const harness = createHarness({
+      initialUrl: 'ws://localhost:3000/chat?sessionId=one',
+    });
+    await flushEffects();
+
+    flushSync(() => {
+      getLastSocket().simulateOpen();
+    });
+
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      flushSync(() => {
+        getLastSocket().close();
+      });
+      await vi.advanceTimersByTimeAsync(40_000);
+      await flushEffects();
+    }
+    flushSync(() => {
+      getLastSocket().close();
+    });
+    expect(harness.transportRef.current?.gaveUp).toBe(true);
+
+    harness.rerenderUrl('ws://localhost:3000/chat?sessionId=two');
+    await vi.advanceTimersByTimeAsync(0);
+    await flushEffects();
+    expect(harness.transportRef.current?.gaveUp).toBe(false);
+
+    // The replacement session's first failure must schedule a retry instead
+    // of inheriting the previous session's exhausted attempt budget.
+    const replacementSocket = getLastSocket();
+    flushSync(() => {
+      replacementSocket.close();
+    });
+    expect(harness.transportRef.current?.gaveUp).toBe(false);
+    await vi.advanceTimersByTimeAsync(40_000);
+    await flushEffects();
+    expect(getLastSocket()).not.toBe(replacementSocket);
+
+    harness.cleanup();
+  });
+
   it('ignores open events from sockets superseded by a URL change', async () => {
     let connectedCount = 0;
     const harness = createHarness({

--- a/src/hooks/use-websocket-transport.replay.test.tsx
+++ b/src/hooks/use-websocket-transport.replay.test.tsx
@@ -298,6 +298,41 @@ describe('useWebSocketTransport replay queue', () => {
     harness.cleanup();
   });
 
+  it('clears queued messages when the WebSocket URL changes', async () => {
+    const harness = createHarness({
+      initialUrl: 'ws://localhost:3000/chat?sessionId=one',
+    });
+    await flushEffects();
+
+    const firstSocket = getLastSocket();
+    flushSync(() => {
+      firstSocket.simulateOpen();
+      firstSocket.close();
+    });
+
+    const firstTransport = harness.transportRef.current;
+    if (!firstTransport) {
+      throw new Error('Transport was not initialized');
+    }
+    expect(firstTransport.send({ id: 'session-one-1' })).toBe(false);
+    expect(firstTransport.send({ id: 'session-one-2' })).toBe(false);
+
+    harness.rerenderUrl('ws://localhost:3000/chat?sessionId=two');
+    await flushEffects();
+
+    const secondSocket = getLastSocket();
+    expect(secondSocket).not.toBe(firstSocket);
+    flushSync(() => {
+      secondSocket.simulateOpen();
+    });
+
+    expect(extractMessageIds(secondSocket)).toEqual([]);
+    expect(harness.transportRef.current?.send({ id: 'session-two' })).toBe(true);
+    expect(extractMessageIds(secondSocket)).toEqual(['session-two']);
+
+    harness.cleanup();
+  });
+
   it('drops messages from sockets superseded by a URL change', async () => {
     const receivedMessages: unknown[] = [];
     const harness = createHarness({

--- a/src/hooks/use-websocket-transport.ts
+++ b/src/hooks/use-websocket-transport.ts
@@ -323,6 +323,7 @@ export function useWebSocketTransport(
 
     if (previousUrl !== null && url !== null && previousUrl !== url) {
       messageQueueRef.current = [];
+      reconnectAttemptsRef.current = 0;
     }
 
     if (url) {

--- a/src/hooks/use-websocket-transport.ts
+++ b/src/hooks/use-websocket-transport.ts
@@ -154,6 +154,7 @@ export function useWebSocketTransport(
   const intentionalCloseRef = useRef(false);
   // Message queue for messages sent while disconnected
   const messageQueueRef = useRef<unknown[]>([]);
+  const previousUrlRef = useRef<string | null>(null);
 
   // Store callbacks in refs to avoid reconnection on callback changes
   const onMessageRef = useRef(onMessage);
@@ -317,6 +318,13 @@ export function useWebSocketTransport(
 
   // Connect when URL becomes available, disconnect when it becomes null
   useEffect(() => {
+    const previousUrl = previousUrlRef.current;
+    previousUrlRef.current = url;
+
+    if (previousUrl !== null && url !== null && previousUrl !== url) {
+      messageQueueRef.current = [];
+    }
+
     if (url) {
       connect();
     } else {


### PR DESCRIPTION
## Summary
- Prevent replay-queued WebSocket messages from crossing session boundaries.
- Preserve offline replay for reconnects to the same WebSocket URL.
- Add full-hook regression coverage for direct session URL changes.

## Changes
- **WebSocket transport**: Track the previous URL and clear queued outbound messages before connecting to a different non-null URL.
- **Tests**: Reproduce a disconnect in session A, switch directly to session B, and verify only fresh session B traffic is delivered.

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Formatting passes (`pnpm check:fix`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: Not applicable; the simulated WebSocket lifecycle regression covers the reported session-switch path.

Closes #2129

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted hook lifecycle change with focused tests; no auth or persistence impact, and same-URL reconnect replay behavior is preserved.
> 
> **Overview**
> Fixes **cross-session leakage** when chat switches to a different `sessionId` WebSocket URL while the transport is disconnected with a **replay** backlog.
> 
> `useWebSocketTransport` now tracks the previous URL and, on a **non-null → different non-null** URL change, **empties the outbound queue** and **resets reconnect attempt count** before opening the new socket. Reconnects to the **same** URL still replay queued messages as before.
> 
> New replay-hook tests cover that session B does not receive session A’s queued sends, and that a direct URL switch clears **`gaveUp`** so the new session gets a **fresh reconnect budget** instead of inheriting an exhausted one.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 682fa44d93e1d2b257f4c872cf83d85b17bc4fa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->