### PR TITLE
Prepare 0.4.6 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to Factory Factory will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.6] - 2026-08-11
+
+### Added
+
+- Add optional BYOK Deepgram voice mode for workspace sessions, with spoken replies and reasoning, voice interruption and barge-in, conversational response shaping, configurable voices, speed and speech sensitivity, and coordinated audio cues (#2126, #2127, #2144)
+- Show session-scoped provider sub-agents alongside child workspaces in the Agents panel, with live status and read-only transcripts that open in persisted workspace tabs (#2145, #2147)
+- Discover available Claude models dynamically, label their resolved family and version in selectors, and update the bundled Claude ACP to expose Opus 5 (#2152, #2153)
+
+### Changed
+
+- Render session lifecycle notices as compact single-line rows with right-aligned timestamps (#2148)
+
+### Fixed
+
+- Harden chat and session lifecycle by rejecting malformed snapshots, clearing ACP state after managed stops, recovering messages interrupted during dispatch, and preventing queued WebSocket messages from replaying into another session (#2137, #2138, #2140, #2143)
+- Prevent chat shortcuts from firing while IME text composition is active (#2141)
+- Clean stale Git worktree registrations when workspace directories are missing and stop reconciliation from starting another workspace during shutdown (#2139, #2142)
+- Hide non-renderable Claude usage telemetry that produced blank transcript rows while preserving usage data and tool pairing (#2149)
+
+### Security
+
+- Upgrade Electron, Mermaid, PostCSS, and transitive dependency overrides to patched releases (#2151)
+
 ## [0.4.5] - 2026-07-30
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "factory-factory",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Workspace-based coding environment for running multiple Claude Code and Codex sessions in parallel",
   "private": false,
   "license": "MIT",


### PR DESCRIPTION
## Summary

- bump the package version from 0.4.5 to 0.4.6
- add the 0.4.6 changelog entry covering all 17 changes merged since 0.4.5
- group the release notes by added, changed, fixed, and security impact, highlighting voice mode, provider sub-agent tabs, dynamic Claude model discovery, Opus 5, and reliability fixes

## Why

Prepare the next patch release with an accurate user-facing record of the voice experience, provider sub-agent visualization, Claude model updates, chat/session hardening, dependency security updates, and workspace reliability changes shipped after 0.4.5.

## Impact

Publishing this release will expose version 0.4.6 and its release notes. There are no runtime code changes in this PR.

## Validation

- `pnpm install --frozen-lockfile`
- `git diff --check`
- `pnpm check`
- `pnpm check:fix`
- `pnpm typecheck`
- `pnpm test` — 396 files passed, 1 skipped; 5,087 tests passed, 4 skipped
- `pnpm build`

Note: the local Codex schema drift sub-check reported the installed CLI as 0.147.0 while the repository pins 0.145.0, so it skipped locally as designed; CI installs the pinned CLI and enforces the check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata only; no runtime or behavioral code changes in the diff.
> 
> **Overview**
> Prepares **0.4.6** as a documentation-only release cut: `package.json` moves from **0.4.5** to **0.4.6**, and `CHANGELOG.md` adds the **[0.4.6] - 2026-08-11** entry.
> 
> The new notes summarize work already merged since 0.4.5—optional BYOK Deepgram voice mode, provider sub-agents in the Agents panel, dynamic Claude model discovery and Opus 5, compact session lifecycle notices, chat/session hardening and related fixes, and security dependency upgrades—without changing application code in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff5551e8957f2cdeaa46e090ba56962a58c1309d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->