### PR TITLE
Compact session lifecycle messages

### DIFF
--- a/docs/superpowers/plans/2026-08-10-single-line-session-lifecycle-messages.md
+++ b/docs/superpowers/plans/2026-08-10-single-line-session-lifecycle-messages.md
@@ -1,0 +1,133 @@
+# Single-Line Session Lifecycle Messages Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render session lifecycle messages on one line with an ellipsized message and a fully visible, right-aligned timestamp.
+
+**Architecture:** Keep the existing dedicated `SessionLifecycleMessageRenderer` and flatten its message and timestamp into siblings in the existing flex row. Tailwind utilities define the layout contract: the message owns flexible space and truncates, while the icon and timestamp remain fixed-width.
+
+**Tech Stack:** React 19, TypeScript, Tailwind CSS utilities, Vitest, jsdom
+
+## Global Constraints
+
+- Change only `SessionLifecycleMessageRenderer` and its focused test.
+- Preserve the existing icon, severity styling, lifecycle copy, timestamp format, spacing container, and accessibility attributes.
+- Keep the message and timestamp on one line.
+- At narrow widths, truncate only the message and keep the timestamp fully visible.
+
+---
+
+### Task 1: Compact the session lifecycle row
+
+**Files:**
+- Modify: `src/client/features/chat/agent-activity/message-renderers/session-lifecycle-message-renderer.tsx:23-45`
+- Test: `src/client/features/chat/agent-activity/message-renderers/session-lifecycle-message-renderer.test.tsx:59-75`
+
+**Interfaces:**
+- Consumes: `AgentMessage.lifecycle.message` and `AgentMessage.lifecycle.timestamp`
+- Produces: the existing `SessionLifecycleMessageRenderer(props): React.JSX.Element | null` with a one-line visual layout; no public API changes
+
+- [ ] **Step 1: Write the failing layout test**
+
+Add this test before the decorative-icon test:
+
+```tsx
+it('keeps the timestamp visible while the single-line message truncates', () => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  flushSync(() => {
+    root.render(
+      createElement(SessionLifecycleMessageRenderer, {
+        message: lifecycleMessage(
+          'SYSTEM_STOP',
+          'Session stopped because the available horizontal space is intentionally very narrow.'
+        ),
+      })
+    );
+  });
+
+  const row = container.querySelector('[data-testid="session-lifecycle-message"]');
+  const message = row?.querySelector('p');
+  const time = row?.querySelector('time');
+
+  expect(row?.classList.contains('items-center')).toBe(true);
+  expect(message?.classList.contains('min-w-0')).toBe(true);
+  expect(message?.classList.contains('flex-1')).toBe(true);
+  expect(message?.classList.contains('truncate')).toBe(true);
+  expect(time?.classList.contains('shrink-0')).toBe(true);
+  expect(time?.classList.contains('whitespace-nowrap')).toBe(true);
+  expect(message?.nextElementSibling).toBe(time);
+  root.unmount();
+});
+```
+
+This catches regressions that restore vertical stacking, permit message wrapping, or allow the timestamp to shrink out of view.
+
+- [ ] **Step 2: Run the focused test to verify RED**
+
+Run:
+
+```bash
+pnpm test src/client/features/chat/agent-activity/message-renderers/session-lifecycle-message-renderer.test.tsx
+```
+
+Expected: FAIL because the current row uses `items-start`, the message is nested in a wrapper without `truncate`, and the timestamp lacks `shrink-0 whitespace-nowrap`.
+
+- [ ] **Step 3: Implement the minimal one-line layout**
+
+Replace the renderer's row contents and relevant layout classes with:
+
+```tsx
+<div
+  data-testid="session-lifecycle-message"
+  data-severity={isError ? 'error' : 'warning'}
+  className={cn(
+    'my-2 flex items-center gap-2 rounded-md border px-3 py-2 text-sm',
+    isError
+      ? 'border-destructive/30 bg-destructive/5 text-destructive'
+      : 'border-amber-500/30 bg-amber-500/5 text-muted-foreground',
+    className
+  )}
+>
+  <Icon aria-hidden="true" className="h-4 w-4 shrink-0" />
+  <p className="min-w-0 flex-1 truncate">{message.lifecycle.message}</p>
+  <time
+    className="shrink-0 whitespace-nowrap text-xs opacity-80"
+    dateTime={message.lifecycle.timestamp}
+  >
+    {new Intl.DateTimeFormat(undefined, {
+      hour: 'numeric',
+      minute: '2-digit',
+    }).format(new Date(message.lifecycle.timestamp))}
+  </time>
+</div>
+```
+
+- [ ] **Step 4: Run focused verification to verify GREEN**
+
+Run:
+
+```bash
+pnpm test src/client/features/chat/agent-activity/message-renderers/session-lifecycle-message-renderer.test.tsx
+pnpm typecheck
+pnpm check
+git diff --check
+```
+
+Expected: all commands exit successfully with zero test, type, lint, ownership, or dependency-boundary failures.
+
+- [ ] **Step 5: Review and commit the implementation**
+
+Inspect the exact diff and commit only the renderer, its test, and this plan:
+
+```bash
+git diff -- src/client/features/chat/agent-activity/message-renderers/session-lifecycle-message-renderer.tsx src/client/features/chat/agent-activity/message-renderers/session-lifecycle-message-renderer.test.tsx docs/superpowers/plans/2026-08-10-single-line-session-lifecycle-messages.md
+git add src/client/features/chat/agent-activity/message-renderers/session-lifecycle-message-renderer.tsx src/client/features/chat/agent-activity/message-renderers/session-lifecycle-message-renderer.test.tsx docs/superpowers/plans/2026-08-10-single-line-session-lifecycle-messages.md
+git commit -m "Compact session lifecycle messages"
+```
+
+- [ ] **Step 6: Publish the requested draft PR**
+
+Confirm GitHub CLI availability and authentication, verify the branch scope, push the current branch, and open a draft PR with a body that explains the compact one-line layout and lists the checks from Step 4.

--- a/docs/superpowers/specs/2026-08-10-single-line-session-lifecycle-messages-design.md
+++ b/docs/superpowers/specs/2026-08-10-single-line-session-lifecycle-messages-design.md
@@ -1,0 +1,35 @@
+# Single-Line Session Lifecycle Messages
+
+## Goal
+
+Render session lifecycle messages as compact single-line rows, with the event time aligned to the far right and kept visible at narrow widths.
+
+## Scope
+
+Change only `SessionLifecycleMessageRenderer`. Preserve the existing icon, severity styling, lifecycle copy, timestamp format, spacing container, and accessibility attributes.
+
+## Layout
+
+The row uses a horizontal flex layout with three items:
+
+1. A non-shrinking severity icon.
+2. A flexible message label that may shrink and truncates with an ellipsis.
+3. A non-shrinking timestamp aligned at the far right.
+
+The message and timestamp remain on one line. When horizontal space is limited, only the message truncates; the timestamp remains fully visible.
+
+## Implementation
+
+Flatten the existing nested message-and-time block into sibling elements in the row. Align the row contents vertically in the center. Apply the minimum-width and overflow utilities needed for ellipsis truncation to the message, and prevent the timestamp from shrinking or wrapping.
+
+No data flow, protocol, formatting, or error-handling behavior changes.
+
+## Testing
+
+Add a focused renderer test that asserts the structural styling contract responsible for the one-line layout:
+
+- The row vertically centers its children.
+- The message is flexible and truncated.
+- The timestamp does not shrink or wrap.
+
+Retain the existing tests for lifecycle copy, severity, and decorative icon behavior. Run the focused renderer test, client type checking, and repository checks appropriate to the changed files.

--- a/src/client/features/chat/agent-activity/message-renderers/session-lifecycle-message-renderer.test.tsx
+++ b/src/client/features/chat/agent-activity/message-renderers/session-lifecycle-message-renderer.test.tsx
@@ -56,7 +56,7 @@ describe('SessionLifecycleMessageRenderer', () => {
     root.unmount();
   });
 
-  it('keeps the timestamp visible while the single-line message truncates', () => {
+  it('keeps the timestamp visible and exposes the full copy while the message truncates', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);
@@ -80,6 +80,9 @@ describe('SessionLifecycleMessageRenderer', () => {
     expect(message?.classList.contains('min-w-0')).toBe(true);
     expect(message?.classList.contains('flex-1')).toBe(true);
     expect(message?.classList.contains('truncate')).toBe(true);
+    expect(message?.getAttribute('title')).toBe(
+      'Session stopped because the available horizontal space is intentionally very narrow.'
+    );
     expect(time?.classList.contains('shrink-0')).toBe(true);
     expect(time?.classList.contains('whitespace-nowrap')).toBe(true);
     expect(message?.nextElementSibling).toBe(time);

--- a/src/client/features/chat/agent-activity/message-renderers/session-lifecycle-message-renderer.test.tsx
+++ b/src/client/features/chat/agent-activity/message-renderers/session-lifecycle-message-renderer.test.tsx
@@ -56,6 +56,36 @@ describe('SessionLifecycleMessageRenderer', () => {
     root.unmount();
   });
 
+  it('keeps the timestamp visible while the single-line message truncates', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    flushSync(() => {
+      root.render(
+        createElement(SessionLifecycleMessageRenderer, {
+          message: lifecycleMessage(
+            'SYSTEM_STOP',
+            'Session stopped because the available horizontal space is intentionally very narrow.'
+          ),
+        })
+      );
+    });
+
+    const row = container.querySelector('[data-testid="session-lifecycle-message"]');
+    const message = row?.querySelector('p');
+    const time = row?.querySelector('time');
+
+    expect(row?.classList.contains('items-center')).toBe(true);
+    expect(message?.classList.contains('min-w-0')).toBe(true);
+    expect(message?.classList.contains('flex-1')).toBe(true);
+    expect(message?.classList.contains('truncate')).toBe(true);
+    expect(time?.classList.contains('shrink-0')).toBe(true);
+    expect(time?.classList.contains('whitespace-nowrap')).toBe(true);
+    expect(message?.nextElementSibling).toBe(time);
+    root.unmount();
+  });
+
   it('marks the severity icon as decorative', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);

--- a/src/client/features/chat/agent-activity/message-renderers/session-lifecycle-message-renderer.tsx
+++ b/src/client/features/chat/agent-activity/message-renderers/session-lifecycle-message-renderer.tsx
@@ -25,23 +25,24 @@ export function SessionLifecycleMessageRenderer({
       data-testid="session-lifecycle-message"
       data-severity={isError ? 'error' : 'warning'}
       className={cn(
-        'my-2 flex items-start gap-2 rounded-md border px-3 py-2 text-sm',
+        'my-2 flex items-center gap-2 rounded-md border px-3 py-2 text-sm',
         isError
           ? 'border-destructive/30 bg-destructive/5 text-destructive'
           : 'border-amber-500/30 bg-amber-500/5 text-muted-foreground',
         className
       )}
     >
-      <Icon aria-hidden="true" className="mt-0.5 h-4 w-4 shrink-0" />
-      <div className="min-w-0 flex-1">
-        <p className="break-words">{message.lifecycle.message}</p>
-        <time className="mt-0.5 block text-xs opacity-80" dateTime={message.lifecycle.timestamp}>
-          {new Intl.DateTimeFormat(undefined, {
-            hour: 'numeric',
-            minute: '2-digit',
-          }).format(new Date(message.lifecycle.timestamp))}
-        </time>
-      </div>
+      <Icon aria-hidden="true" className="h-4 w-4 shrink-0" />
+      <p className="min-w-0 flex-1 truncate">{message.lifecycle.message}</p>
+      <time
+        className="shrink-0 whitespace-nowrap text-xs opacity-80"
+        dateTime={message.lifecycle.timestamp}
+      >
+        {new Intl.DateTimeFormat(undefined, {
+          hour: 'numeric',
+          minute: '2-digit',
+        }).format(new Date(message.lifecycle.timestamp))}
+      </time>
     </div>
   );
 }

--- a/src/client/features/chat/agent-activity/message-renderers/session-lifecycle-message-renderer.tsx
+++ b/src/client/features/chat/agent-activity/message-renderers/session-lifecycle-message-renderer.tsx
@@ -33,7 +33,9 @@ export function SessionLifecycleMessageRenderer({
       )}
     >
       <Icon aria-hidden="true" className="h-4 w-4 shrink-0" />
-      <p className="min-w-0 flex-1 truncate">{message.lifecycle.message}</p>
+      <p className="min-w-0 flex-1 truncate" title={message.lifecycle.message}>
+        {message.lifecycle.message}
+      </p>
       <time
         className="shrink-0 whitespace-nowrap text-xs opacity-80"
         dateTime={message.lifecycle.timestamp}


### PR DESCRIPTION
## Summary

- render session lifecycle messages as a compact single-line row
- keep timestamps visible and aligned at the far right
- truncate long lifecycle copy with an ellipsis in narrow panels
- preserve existing severity styling, timestamp formatting, and accessibility behavior

## Why

Session lifecycle notices used two lines because the timestamp was stacked beneath the message. Keeping both values on one line makes the transcript denser while retaining the time at a consistent right edge.

## Validation

- `pnpm test` — 5,057 passed, 4 skipped
- `pnpm typecheck`
- `pnpm check`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout and Tailwind class changes in one chat renderer with no protocol or data-flow impact.
> 
> **Overview**
> **Session lifecycle notices** in the agent activity transcript now render as a **single horizontal row** (icon, message, timestamp) instead of stacking the time under the copy.
> 
> `SessionLifecycleMessageRenderer` flattens the nested message/time block into flex siblings: the row uses **`items-center`**, the message gets **`min-w-0 flex-1 truncate`** with a **`title`** for full text on hover, and the **`time`** element is **`shrink-0 whitespace-nowrap`** so it stays visible at the right edge when panels are narrow. Severity styling, timestamp formatting, and decorative icon behavior are unchanged.
> 
> A focused Vitest case locks in that layout contract; design/plan docs under `docs/superpowers/` describe the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fc3d6bb11c7b6df7ed04e06ef6b2f2bfe531755. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->