### PR TITLE
Fix blank rows in Claude transcripts

### DIFF
--- a/docs/superpowers/plans/2026-08-10-claude-transcript-whitespace.md
+++ b/docs/superpowers/plans/2026-08-10-claude-transcript-whitespace.md
@@ -1,0 +1,149 @@
+# Claude Transcript Whitespace Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove blank padded rows created by Claude usage telemetry while preserving usage statistics, visible string results, and tool-call pairing.
+
+**Architecture:** Keep all ACP usage messages in persisted transcript and reducer state. Filter result messages that have no non-empty string content at the shared `groupAdjacentToolCalls` rendering boundary before they can split tool sequences or become virtual rows.
+
+**Tech Stack:** TypeScript, Vitest, React chat protocol helpers
+
+## Global Constraints
+
+- Apply the behavior to every transcript surface through the existing shared grouping helper.
+- Preserve object-valued usage results in reducer and persisted transcript state.
+- Preserve non-empty string result rendering.
+- Preserve matching tool-use/tool-result pairing when usage telemetry occurs between them.
+- Do not change backend protocols, persistence, database schemas, or provider-specific branches.
+
+---
+
+### Task 1: Filter Non-Renderable Result Rows
+
+**Files:**
+- Modify: `src/lib/chat-protocol.ts:695`
+- Test: `src/lib/chat-protocol.test.ts:232`
+
+**Interfaces:**
+- Consumes: `ChatMessage`, `GroupedMessageItem`, and the existing `groupAdjacentToolCalls(messages: ChatMessage[]): GroupedMessageItem[]` API.
+- Produces: unchanged `groupAdjacentToolCalls` signature with non-renderable result messages omitted from its returned rendering items.
+
+- [x] **Step 1: Add failing regression tests**
+
+Add a local fixture for result messages:
+
+```ts
+function createResultMessage(result: unknown, order: number): ChatMessage {
+  return {
+    id: `msg-${order}`,
+    source: 'agent',
+    message: { type: 'result', result },
+    timestamp: '2026-02-16T00:00:00.000Z',
+    order,
+  };
+}
+```
+
+Add three behaviors under `describe('groupAdjacentToolCalls')`:
+
+```ts
+it.each([
+  ['object-valued usage', { sessionUpdate: 'usage_update', used: 15_000 }],
+  ['empty string', ''],
+  ['whitespace-only string', '   '],
+])('omits %s results from rendering output', (_label, result) => {
+  const assistant = createAssistantTextMessage(2);
+  const grouped = groupAdjacentToolCalls([
+    createAssistantTextMessage(0),
+    createResultMessage(result, 1),
+    assistant,
+  ]);
+
+  expect(grouped).toEqual([createAssistantTextMessage(0), assistant]);
+});
+
+it('keeps non-empty string result messages in rendering output', () => {
+  const result = createResultMessage('Completed successfully', 0);
+  expect(groupAdjacentToolCalls([result])).toEqual([result]);
+});
+
+it('does not let usage results split matching tool calls and results', () => {
+  const grouped = groupAdjacentToolCalls([
+    createToolUseMessage({ id: 'call-1', name: 'Read', input: {}, order: 0 }),
+    createResultMessage({ sessionUpdate: 'usage_update', used: 15_000 }, 1),
+    createToolResultMessage('call-1', 2),
+  ]);
+
+  expect(grouped).toHaveLength(1);
+  expect(isToolSequence(grouped[0]!)).toBe(true);
+  if (isToolSequence(grouped[0]!)) {
+    expect(grouped[0].pairedCalls[0]).toMatchObject({
+      id: 'call-1',
+      status: 'success',
+      result: { content: 'ok', isError: false },
+    });
+  }
+});
+```
+
+- [x] **Step 2: Run the focused test and verify RED**
+
+Run: `pnpm test src/lib/chat-protocol.test.ts`
+
+Expected: the non-renderable result cases fail because each result is returned as a grouped item,
+and the tool-pairing test fails because telemetry splits the adjacent sequence.
+
+- [x] **Step 3: Add the minimal rendering predicate and filter**
+
+Add a private helper near the grouping code:
+
+```ts
+function isRenderableGroupedMessage(message: ChatMessage): boolean {
+  return (
+    message.source !== 'agent' ||
+    message.message?.type !== 'result' ||
+    (typeof message.message.result === 'string' && message.message.result.trim().length > 0)
+  );
+}
+```
+
+At the start of the `groupAdjacentToolCalls` loop, skip these messages before late-tool-result and sequence-boundary processing:
+
+```ts
+for (const message of messages.filter(isRenderableGroupedMessage)) {
+  // existing grouping logic
+}
+```
+
+- [x] **Step 4: Run focused and related tests and verify GREEN**
+
+Run:
+
+```bash
+pnpm test src/lib/chat-protocol.test.ts src/client/features/chat/project-acp-transcript.test.ts src/client/features/chat/agent-activity/message-renderers/assistant-message-renderer.test.tsx
+```
+
+Expected: all selected test files pass with no errors or warnings.
+
+- [x] **Step 5: Run repository verification**
+
+Run:
+
+```bash
+pnpm typecheck
+pnpm check
+pnpm test
+```
+
+Expected: every command exits successfully.
+
+- [ ] **Step 6: Commit the implementation**
+
+```bash
+git add src/lib/chat-protocol.ts src/lib/chat-protocol.test.ts docs/superpowers/plans/2026-08-10-claude-transcript-whitespace.md
+git commit -m "Fix blank rows in Claude transcripts"
+```
+
+- [ ] **Step 7: Publish the requested draft PR**
+
+Confirm the final diff contains only the design, plan, test, and implementation files. Push the current feature branch and open a draft pull request describing the Claude usage-event root cause and verification commands.

--- a/docs/superpowers/specs/2026-08-10-claude-transcript-whitespace-design.md
+++ b/docs/superpowers/specs/2026-08-10-claude-transcript-whitespace-design.md
@@ -1,0 +1,51 @@
+# Claude Transcript Whitespace Design
+
+## Problem
+
+Claude ACP sessions emit `usage_update` events that Factory Factory translates into agent
+`result` messages with object-valued `result` payloads. These messages must remain in transcript
+state because the reducer uses them to maintain usage statistics, including after hydration.
+
+The result renderer intentionally displays only string-valued results. Object-valued usage results
+therefore render no content, but each still reaches the message list and receives virtual-row and
+message-wrapper padding. The reported workspace contains 16 such events, producing a large amount
+of blank vertical space. Codex transcripts do not currently emit these result events, which is why
+their rendering looks correct.
+
+## Design
+
+Filter non-renderable result messages in the shared `groupAdjacentToolCalls` rendering-preparation
+function. A result message is renderable only when its `result` is a non-empty string. All other
+message types continue through the existing grouping logic unchanged.
+
+This boundary is shared by live workspace chat, quick chat, closed-session transcripts, and
+sub-agent transcripts, so one change fixes every transcript surface without duplicating filtering
+rules in individual React components.
+
+The filter runs before tool-sequence boundary handling. As a result, usage telemetry arriving
+between a tool-use event and its tool-result event will not split the pair. The existing late-result
+pairing behavior remains supported.
+
+## Data and Behavior
+
+- Object-valued usage results remain in reducer and persisted transcript state.
+- Token and cost statistics continue to update and hydrate from those messages.
+- Telemetry-only and empty result messages produce no grouped rendering item and therefore no
+  padded or virtualized row.
+- Non-empty string result messages remain visible through the existing result renderer.
+- Tool-use and tool-result messages separated only by usage telemetry remain one paired tool
+  sequence.
+
+No backend protocol, persistence, database, or provider-specific branching changes are required.
+
+## Testing
+
+Add focused unit coverage around `groupAdjacentToolCalls`:
+
+1. An object-valued usage result is excluded from grouped rendering output.
+2. A non-empty string result remains in grouped rendering output.
+3. A usage result between matching tool-use and tool-result messages does not split the sequence,
+   and the paired call retains its completed status and result.
+
+Run the focused test file, then the relevant client/protocol tests, TypeScript checks, and standard
+repository guardrails.

--- a/src/lib/chat-protocol.test.ts
+++ b/src/lib/chat-protocol.test.ts
@@ -229,7 +229,56 @@ function createAssistantTextMessage(order: number): ChatMessage {
   };
 }
 
+function createResultMessage(result: unknown, order: number): ChatMessage {
+  return {
+    id: `msg-${order}`,
+    source: 'agent',
+    message: { type: 'result', result },
+    timestamp: '2026-02-16T00:00:00.000Z',
+    order,
+  };
+}
+
 describe('groupAdjacentToolCalls', () => {
+  it.each([
+    ['object-valued usage', { sessionUpdate: 'usage_update', used: 15_000 }],
+    ['empty string', ''],
+    ['whitespace-only string', '   '],
+  ])('omits %s results from rendering output', (_label, result) => {
+    const assistant = createAssistantTextMessage(2);
+    const grouped = groupAdjacentToolCalls([
+      createAssistantTextMessage(0),
+      createResultMessage(result, 1),
+      assistant,
+    ]);
+
+    expect(grouped).toEqual([createAssistantTextMessage(0), assistant]);
+  });
+
+  it('keeps non-empty string result messages in rendering output', () => {
+    const result = createResultMessage('Completed successfully', 0);
+
+    expect(groupAdjacentToolCalls([result])).toEqual([result]);
+  });
+
+  it('does not let usage results split matching tool calls and results', () => {
+    const grouped = groupAdjacentToolCalls([
+      createToolUseMessage({ id: 'call-1', name: 'Read', input: {}, order: 0 }),
+      createResultMessage({ sessionUpdate: 'usage_update', used: 15_000 }, 1),
+      createToolResultMessage('call-1', 2),
+    ]);
+
+    expect(grouped).toHaveLength(1);
+    expect(isToolSequence(grouped[0]!)).toBe(true);
+    if (isToolSequence(grouped[0]!)) {
+      expect(grouped[0].pairedCalls[0]).toMatchObject({
+        id: 'call-1',
+        status: 'success',
+        result: { content: 'ok', isError: false },
+      });
+    }
+  });
+
   it('filters reasoning tool calls from grouped tool sequences', () => {
     const grouped = groupAdjacentToolCalls([
       createToolUseMessage({

--- a/src/lib/chat-protocol.ts
+++ b/src/lib/chat-protocol.ts
@@ -687,6 +687,14 @@ export function filterDuplicateResultMessages(messages: ChatMessage[]): ChatMess
   });
 }
 
+function isRenderableGroupedMessage(message: ChatMessage): boolean {
+  return (
+    message.source !== 'agent' ||
+    message.message?.type !== 'result' ||
+    (typeof message.message.result === 'string' && message.message.result.trim().length > 0)
+  );
+}
+
 /**
  * Groups adjacent tool_use and tool_result messages together.
  * Returns a mixed array of regular messages and tool sequences.
@@ -727,7 +735,7 @@ export function groupAdjacentToolCalls(messages: ChatMessage[]): GroupedMessageI
     currentToolSequence = [];
   };
 
-  for (const message of messages) {
+  for (const message of messages.filter(isRenderableGroupedMessage)) {
     const lateToolResultInfo =
       message.message && isToolResultMessage(message.message)
         ? extractToolResultInfo(message.message)


### PR DESCRIPTION
## Summary

- hide non-renderable Claude result telemetry at the shared transcript rendering boundary
- preserve persisted usage data, token/cost hydration, and visible textual results
- keep matching tool-use and tool-result events paired when usage telemetry appears between them
- apply the fix consistently to live chat, quick chat, closed sessions, and sub-agent transcripts

## Root cause

Claude ACP emits `usage_update` events as object-valued agent `result` messages. The result renderer intentionally produces no content for those objects, but the virtualized message list still allocated padded rows for them. The reported workspace contained 16 such events; Codex sessions do not currently emit them.

## Validation

- `pnpm test` — 5,023 passed, 4 skipped
- `pnpm typecheck`
- `pnpm check`
- `pnpm check:fix`
- focused red/green coverage for object, empty, whitespace-only, textual, and tool-pairing cases

`pnpm check` skipped only the local Codex schema drift sub-check because local codex-cli is 0.147.0 while the repository pins 0.145.0; CI installs the pinned version and enforces it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Rendering-only change in a shared grouping helper with targeted tests; no protocol, persistence, or backend changes.
> 
> **Overview**
> **Claude transcripts** were showing large blank gaps because object-valued agent `result` messages (usage telemetry) still became virtual list rows even though the result renderer only shows non-empty strings.
> 
> This PR drops those rows at the shared **`groupAdjacentToolCalls`** boundary via **`isRenderableGroupedMessage`**: agent `result` messages are omitted from grouped output unless `result` is a trimmed non-empty string. Persisted transcript and reducer state are unchanged, so usage stats and hydration still see object results.
> 
> Filtering runs **before** tool-sequence grouping, so usage events between a tool use and its tool result no longer split the pair. Unit tests cover object, empty, and whitespace-only results, visible string results, and tool pairing. Design and implementation plan docs were added under `docs/superpowers/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cef7ab4413cd0d251212504146fbea0f3671956. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->