### PR TITLE
Reject dangling file length symlinks

### DIFF
--- a/scripts/check-file-length.test.ts
+++ b/scripts/check-file-length.test.ts
@@ -304,6 +304,16 @@ describe('repository discovery and CLI', () => {
     );
   });
 
+  test('refuses a Git-listed dangling symlink instead of treating it as deleted', () => {
+    const repositoryRoot = createTemporaryRepository();
+    symlinkSync('missing.ts', join(repositoryRoot, 'src/dangling.ts'));
+    execFileSync('git', ['add', 'src/dangling.ts'], { cwd: repositoryRoot });
+
+    expect(() => readFileLengths(repositoryRoot, discoverCandidatePaths(repositoryRoot))).toThrow(
+      'dangling symbolic link'
+    );
+  });
+
   test.each([
     ['cross-drive', 'D:\\outside.ts'],
     ['UNC', '\\\\server\\share\\outside.ts'],

--- a/scripts/check-file-length.ts
+++ b/scripts/check-file-length.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import {
+  lstatSync,
   readFileSync,
   realpathSync,
   renameSync,
@@ -179,6 +180,30 @@ function isMissingPathError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && 'code' in error && error.code === 'ENOENT';
 }
 
+function resolveCandidateRealPath(absolutePath: string, relativePath: string): string | null {
+  let candidateStats: ReturnType<typeof lstatSync>;
+  try {
+    candidateStats = lstatSync(absolutePath);
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return null;
+    }
+    throw error;
+  }
+
+  try {
+    return realpathSync(absolutePath);
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      if (candidateStats.isSymbolicLink()) {
+        throw new Error(`File length candidate path is a dangling symbolic link: ${relativePath}`);
+      }
+      return null;
+    }
+    throw error;
+  }
+}
+
 export function readFileLengths(repositoryRoot: string, paths: readonly string[]): FileLength[] {
   const resolvedRepositoryRoot = resolve(repositoryRoot);
   const realRepositoryRoot = realpathSync(resolvedRepositoryRoot);
@@ -189,14 +214,9 @@ export function readFileLengths(repositoryRoot: string, paths: readonly string[]
     }
 
     const absolutePath = resolve(resolvedRepositoryRoot, relativePath);
-    let realPath: string;
-    try {
-      realPath = realpathSync(absolutePath);
-    } catch (error) {
-      if (isMissingPathError(error)) {
-        return [];
-      }
-      throw error;
+    const realPath = resolveCandidateRealPath(absolutePath, relativePath);
+    if (realPath === null) {
+      return [];
     }
     const pathFromRepositoryRoot = relative(realRepositoryRoot, realPath);
     if (


### PR DESCRIPTION
## Summary

- distinguish a genuinely deleted tracked candidate from an existing dangling symlink before calling `realpathSync`
- reject dangling symlinks explicitly instead of silently omitting them from file-length evaluation
- preserve existing behavior for deleted files, valid in-repository symlinks, containment checks, and non-regular files

## Why

Follow-up to [#2155](https://github.com/purplefish-ai/factory-factory/pull/2155), addressing [this review thread](https://github.com/purplefish-ai/factory-factory/pull/2155#discussion_r3769286762).

Both deleted files and dangling symlinks cause `realpathSync` to throw `ENOENT`. The original reader treated every such error as a deleted candidate, so a Git-listed dangling symlink bypassed the fail-closed path checks. The reader now uses `lstatSync` first: a missing directory entry is omitted as before, while an existing symlink whose target cannot be resolved is rejected.

## Validation

- TDD regression: the dangling-symlink test failed before the fix because no error was thrown
- `pnpm test scripts/check-file-length.test.ts` — 52 passed
- `pnpm typecheck`
- `pnpm test` — 5,139 passed, 4 skipped
- `pnpm check:fix`
- `pnpm check`

The local Codex schema drift step was skipped by the existing version guard because the installed CLI is `0.147.0` while the repository pins `0.145.0`; CI installs the pinned version and enforces that check.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the `check-file-length` guardrail script with stricter fail-closed behavior and no production runtime impact.
> 
> **Overview**
> **File-length candidate resolution** now uses `lstatSync` before `realpathSync` so Git-listed paths that still exist on disk are not lumped in with truly missing files.
> 
> **Dangling symlinks** (tracked symlink whose target is missing) **throw** with an explicit `dangling symbolic link` error instead of being skipped like a deleted file, closing a hole where they could bypass root-containment checks. **Deleted candidates** still resolve to `null` and are omitted from line counts; valid symlinks, escape detection, and non-regular-file handling are unchanged.
> 
> A regression test asserts that a Git-added dangling symlink under `src/` fails the check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b87be3e6d27d1ec89e687ba3a13d2093ea210a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->