### PR TITLE
Fix Codex subagent tool call ordering

### DIFF
--- a/docs/superpowers/plans/2026-08-12-codex-notification-ordering.md
+++ b/docs/superpowers/plans/2026-08-12-codex-notification-ordering.md
@@ -1,0 +1,55 @@
+# Codex Notification Ordering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve Codex app-server notification order so a late-started handler cannot reopen an already completed ACP tool call.
+
+**Architecture:** Add failure-isolated per-item promise chains at the Codex notification entry point. Keep turn/thread notifications, stream projection logic, ACP timeout behavior, and server-request handling unchanged.
+
+**Tech Stack:** TypeScript, Codex app-server JSON-RPC, ACP SDK, Vitest
+
+## Global Constraints
+
+- Use pnpm only.
+- Preserve provider notification order for each thread item.
+- A failed notification must not poison processing of later notifications.
+- Do not block turn completion while a plan item awaits user approval.
+- Do not change tool timeout durations or synthesize provider completion statuses.
+
+---
+
+### Task 1: Serialize Codex notifications
+
+**Files:**
+- Create: `src/backend/services/session/service/acp/codex-app-server-adapter/codex-notification-queue.ts`
+- Create: `src/backend/services/session/service/acp/codex-app-server-adapter/codex-notification-queue.test.ts`
+- Create: `src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.notification-ordering.test.ts`
+- Modify: `src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.ts`
+
+**Interfaces:**
+- Consumes: Codex notifications as `{ method: string; params: unknown }` in callback order.
+- Produces: per-item ordered calls to `CodexStreamEventHandler.handleCodexNotification` and a resolved queue after per-notification failures are reported.
+
+- [x] **Step 1: Write the failing race regression**
+
+Create a deferred first ACP session update, deliver `item/started` and `item/completed` concurrently, release the deferred update, and assert status order is exactly `pending`, `in_progress`, `completed`.
+
+- [x] **Step 2: Run the focused test and verify RED**
+
+Run: `pnpm test src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.notification-ordering.test.ts -t "preserves Codex notification order"`
+
+Expected: FAIL because `completed` is observed before the late `in_progress` update.
+
+- [x] **Step 3: Implement the notification chain**
+
+Add a `Promise<void>` chain per thread-item key to `CodexAppServerAcpAdapter`. Append matching item notification handlers to it, remove settled chains, and absorb each link's failure after best-effort reporting so later notifications continue. Process notifications without an item key immediately. Cover rejected handlers and throwing reporters in the queue's focused test.
+
+- [x] **Step 4: Run the focused tests and verify GREEN**
+
+Run: `pnpm test src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.test.ts src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.test.ts`
+
+Expected: both files pass.
+
+- [x] **Step 5: Run repository verification**
+
+Run, in order: `pnpm check:fix`, `pnpm typecheck`, `pnpm test`, and `pnpm check`.

--- a/docs/superpowers/specs/2026-08-12-codex-notification-ordering-design.md
+++ b/docs/superpowers/specs/2026-08-12-codex-notification-ordering-design.md
@@ -1,0 +1,23 @@
+# Codex Notification Ordering Design
+
+## Problem
+
+The Codex app-server RPC client reports notifications in wire order, but the ACP adapter launches each asynchronous notification handler independently. An `item/completed` handler can therefore overtake an earlier `item/started` handler while the latter awaits subagent bookkeeping or an ACP session update. The completed handler emits a terminal tool status, then the started handler resumes and emits `pending` or `in_progress` last. Factory Factory correctly treats that late non-terminal status as a newly open tool call and eventually synthesizes a timeout failure.
+
+## Design
+
+Serialize Codex app-server item notifications at their entry point in `CodexAppServerAcpAdapter`. Notifications for the same thread item are appended to a promise chain and processed only after the preceding notification for that item finishes. A failed handler is reported as adapter shape drift and absorbed at the chain boundary—even if reporting itself fails—so one malformed notification cannot permanently block later notifications.
+
+Turn and thread notifications remain independent. This preserves the existing plan-approval flow, where `turn/completed` must be observed and deferred while the plan item handler awaits user permission. Server requests also remain on their existing path because they require independent responses. Tool timeout values and ACP terminalization rules remain unchanged.
+
+## Alternatives Considered
+
+- Mark `subAgentActivity` complete on `item/started`: hides the observed symptom but reports completion before the provider does and does not fix reasoning or collaboration-tool races.
+- Terminalize open tools at `turn/completed`: useful only after a turn ends, so it cannot protect hour-long multi-agent turns.
+- Increase the timeout: delays the false failure without correcting event order.
+
+## Testing
+
+Add an adapter regression that deliberately blocks the first subagent session update, delivers `item/started` and `item/completed` without awaiting the first handler, then releases the block. The observable ACP statuses must remain `pending`, `in_progress`, `completed`; the old implementation produces `pending`, `completed`, `in_progress`. Add queue tests proving a rejected handler and a throwing error reporter cannot poison later notifications for the same item.
+
+Run the focused adapter tests, then the repository-required formatting, type, test, and guardrail commands.

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.notification-ordering.test.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.notification-ordering.test.ts
@@ -1,0 +1,134 @@
+import type { AgentSideConnection, RequestPermissionResponse } from '@agentclientprotocol/sdk';
+import { describe, expect, it, vi } from 'vitest';
+import { CodexAppServerAcpAdapter } from './codex-app-server-acp-adapter';
+
+type MockConnection = Pick<
+  AgentSideConnection,
+  'closed' | 'sessionUpdate' | 'requestPermission' | 'extNotification'
+>;
+type InjectedCodexClient = NonNullable<ConstructorParameters<typeof CodexAppServerAcpAdapter>[1]>;
+
+function createMockConnection(): MockConnection {
+  return {
+    closed: new Promise<void>(() => undefined),
+    sessionUpdate: vi.fn(async () => undefined),
+    extNotification: vi.fn(async () => undefined),
+    requestPermission: vi.fn(() =>
+      Promise.resolve({
+        outcome: { outcome: 'selected', optionId: 'allow_once' },
+      } as RequestPermissionResponse)
+    ),
+  };
+}
+
+function createMockCodexClient(): {
+  client: InjectedCodexClient;
+  request: ReturnType<typeof vi.fn>;
+} {
+  const request = vi.fn();
+  const client = {
+    start: vi.fn(),
+    stop: vi.fn(async () => undefined),
+    request,
+    notify: vi.fn(),
+    respondSuccess: vi.fn(),
+    respondError: vi.fn(),
+  } as unknown as InjectedCodexClient;
+  return { client, request };
+}
+
+async function initializeAdapter(
+  adapter: CodexAppServerAcpAdapter,
+  request: ReturnType<typeof vi.fn>
+): Promise<void> {
+  request.mockResolvedValueOnce({});
+  request.mockResolvedValueOnce({
+    requirements: {
+      allowedApprovalPolicies: ['on-failure'],
+      allowedSandboxModes: ['workspace-write'],
+    },
+  });
+  request.mockResolvedValueOnce({
+    data: [{ name: 'Default', mode: 'default' }],
+    nextCursor: null,
+  });
+  request.mockResolvedValueOnce({
+    data: [
+      {
+        id: 'gpt-5',
+        displayName: 'GPT-5',
+        description: 'Default model',
+        defaultReasoningEffort: 'medium',
+        supportedReasoningEfforts: [],
+        inputModalities: ['text'],
+        isDefault: true,
+      },
+    ],
+    nextCursor: null,
+  });
+  await adapter.initialize({
+    protocolVersion: 1,
+    clientCapabilities: {},
+    clientInfo: { name: 'test-client', version: '0.0.1' },
+  });
+}
+
+describe('CodexAppServerAcpAdapter notification ordering', () => {
+  it('preserves Codex notification order across asynchronous ACP updates', async () => {
+    const connection = createMockConnection();
+    const { client, request } = createMockCodexClient();
+    const adapter = new CodexAppServerAcpAdapter(connection as AgentSideConnection, client);
+    await initializeAdapter(adapter, request);
+
+    request.mockResolvedValueOnce({
+      thread: { id: 'thread_notification_order', cwd: '/tmp/workspace' },
+      approvalPolicy: 'on-failure',
+      reasoningEffort: 'medium',
+    });
+    await adapter.newSession({ cwd: '/tmp/workspace', mcpServers: [] });
+
+    const sessionUpdate = connection.sessionUpdate as ReturnType<typeof vi.fn>;
+    sessionUpdate.mockClear();
+    let releaseFirstUpdate: () => void = () => undefined;
+    const firstUpdateBlocked = new Promise<void>((resolve) => {
+      releaseFirstUpdate = resolve;
+    });
+    sessionUpdate
+      .mockImplementationOnce(async () => await firstUpdateBlocked)
+      .mockResolvedValue(undefined);
+
+    const handleCodexNotification = (
+      adapter as unknown as {
+        handleCodexNotification: (method: string, params: unknown) => Promise<void>;
+      }
+    ).handleCodexNotification.bind(adapter);
+    const item = {
+      type: 'subAgentActivity',
+      id: 'item_notification_order',
+      callId: 'call_notification_order',
+      agentThreadId: 'child_notification_order',
+      agentPath: 'review/notification_order',
+      kind: 'started',
+    };
+    const started = handleCodexNotification('item/started', {
+      threadId: 'thread_notification_order',
+      turnId: 'turn_notification_order',
+      item: { ...item, status: 'inProgress' },
+    });
+    await vi.waitFor(() => expect(sessionUpdate).toHaveBeenCalledTimes(1));
+
+    const completed = handleCodexNotification('item/completed', {
+      threadId: 'thread_notification_order',
+      turnId: 'turn_notification_order',
+      item: { ...item, status: 'completed' },
+    });
+    releaseFirstUpdate();
+    await Promise.all([started, completed]);
+
+    expect(sessionUpdate.mock.calls.map((call) => call[0].update.status).filter(Boolean)).toEqual([
+      'pending',
+      'in_progress',
+      'completed',
+    ]);
+  });
+});

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.ts
@@ -52,6 +52,7 @@ import {
   parseTextFromPromptBlock,
   toCodexMcpConfigMap,
 } from './codex-adapter-parsing';
+import { CodexNotificationQueue } from './codex-notification-queue';
 import { CodexRequestError, CodexRpcClient, type CodexRpcExitEvent } from './codex-rpc-client';
 import { CodexSubagentController } from './codex-subagent-controller';
 import { mapCodexSubagentToolItem } from './codex-subagent-mapper';
@@ -105,6 +106,7 @@ export class CodexAppServerAcpAdapter implements Agent {
   private readonly shapeDriftReporter: ShapeDriftReporter;
   private readonly streamEventHandler: CodexStreamEventHandler;
   private readonly subagentController: CodexSubagentController;
+  private readonly codexNotificationQueue = new CodexNotificationQueue();
 
   private get sessions(): Map<string, AdapterSession> {
     return this.stateContainer.sessions;
@@ -746,8 +748,17 @@ export class CodexAppServerAcpAdapter implements Agent {
     await this.streamEventHandler.replayThreadHistory(sessionId, threadId);
   }
 
-  private async handleCodexNotification(method: string, params: unknown): Promise<void> {
-    await this.streamEventHandler.handleCodexNotification({ method, params });
+  private handleCodexNotification(method: string, params: unknown): Promise<void> {
+    return this.codexNotificationQueue.enqueue(
+      params,
+      () => this.streamEventHandler.handleCodexNotification({ method, params }),
+      (error) => {
+        this.reportShapeDrift('notification_handler_error', {
+          method,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    );
   }
 
   private async emitReasoningThoughtChunkFromItem(

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/codex-notification-queue.test.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/codex-notification-queue.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+import { CodexNotificationQueue } from './codex-notification-queue';
+
+const ITEM_PARAMS = {
+  threadId: 'thread-1',
+  itemId: 'item-1',
+};
+
+describe('CodexNotificationQueue', () => {
+  it('continues processing an item after an earlier notification rejects', async () => {
+    const queue = new CodexNotificationQueue();
+    const onError = vi.fn();
+    const processed: string[] = [];
+
+    const rejected = queue.enqueue(
+      ITEM_PARAMS,
+      () => Promise.reject(new Error('malformed notification')),
+      onError
+    );
+    const continued = queue.enqueue(
+      ITEM_PARAMS,
+      () => {
+        processed.push('continued');
+        return Promise.resolve();
+      },
+      onError
+    );
+
+    await expect(Promise.all([rejected, continued])).resolves.toEqual([undefined, undefined]);
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'malformed notification' })
+    );
+    expect(processed).toEqual(['continued']);
+  });
+
+  it('does not let error reporting poison an item queue', async () => {
+    const queue = new CodexNotificationQueue();
+    const processed: string[] = [];
+
+    await queue.enqueue(
+      ITEM_PARAMS,
+      () => Promise.reject(new Error('malformed notification')),
+      () => {
+        throw new Error('reporting unavailable');
+      }
+    );
+    await queue.enqueue(ITEM_PARAMS, () => {
+      processed.push('continued');
+      return Promise.resolve();
+    });
+
+    expect(processed).toEqual(['continued']);
+  });
+});

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/codex-notification-queue.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/codex-notification-queue.ts
@@ -1,0 +1,52 @@
+import { isRecord } from './acp-adapter-utils';
+
+function getNotificationItemKey(params: unknown): string | null {
+  if (!isRecord(params) || typeof params.threadId !== 'string') {
+    return null;
+  }
+  const itemId =
+    typeof params.itemId === 'string'
+      ? params.itemId
+      : isRecord(params.item) && typeof params.item.id === 'string'
+        ? params.item.id
+        : null;
+  return itemId ? `${params.threadId}:${itemId}` : null;
+}
+
+export class CodexNotificationQueue {
+  private readonly chainsByItemKey = new Map<string, Promise<void>>();
+
+  enqueue(
+    params: unknown,
+    processNotification: () => Promise<void>,
+    onError?: (error: unknown) => void
+  ): Promise<void> {
+    const processSafely = async (): Promise<void> => {
+      try {
+        await processNotification();
+      } catch (error) {
+        try {
+          onError?.(error);
+        } catch {
+          // Notification failures are isolated so later provider events can continue.
+        }
+      }
+    };
+    const itemKey = getNotificationItemKey(params);
+    if (!itemKey) {
+      return processSafely();
+    }
+
+    const previousNotification = this.chainsByItemKey.get(itemKey);
+    const notificationChain = previousNotification
+      ? previousNotification.then(processSafely)
+      : processSafely();
+    this.chainsByItemKey.set(itemKey, notificationChain);
+    void notificationChain.then(() => {
+      if (this.chainsByItemKey.get(itemKey) === notificationChain) {
+        this.chainsByItemKey.delete(itemKey);
+      }
+    });
+    return notificationChain;
+  }
+}


### PR DESCRIPTION
## Summary

- serialize Codex app-server notifications per thread item before projecting them into ACP
- keep turn and thread notifications independent so plan approval can still defer turn completion
- isolate notification and reporting failures so one malformed event cannot poison later events
- add deterministic regressions for the subagent ordering race and rejection recovery

## Why

Codex app-server notifications arrived in wire order, but Factory Factory handled them concurrently. A delayed `item/started` handler could resume after `item/completed`, emit a non-terminal ACP status last, and reopen the local tool watchdog. After one hour, Factory Factory would synthesize false subagent failures and cancel the parent prompt even though the child agents had completed successfully.

## Impact

Subagent, reasoning, and collaboration tool rows now retain provider order and no longer produce false one-hour ACP timeout failures from this race. Tool timeout durations and provider completion semantics are unchanged.

## Validation

- `pnpm check:fix`
- `pnpm typecheck`
- focused adapter tests: 65 passed
- `pnpm test`
- `pnpm check`
- pre-commit: lint-staged, typecheck, Prisma drift, dependency checks, and knip
- independent code review: no remaining Critical or Important findings

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit fedf1ce4f02db917f87180e347165ecf54e2719c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->