### PR TITLE
Reject empty Codex subagent receiver IDs (#2159)

### DIFF
--- a/src/backend/services/session/service/acp/codex-app-server-adapter/codex-subagent-mapper.test.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/codex-subagent-mapper.test.ts
@@ -103,6 +103,22 @@ describe('mapCodexSubagentToolItem', () => {
     expect(mapping?.meta).toBeUndefined();
   });
 
+  it('ignores collab calls with empty receiver thread IDs', () => {
+    expect(
+      mapCodexSubagentToolItem(
+        {
+          type: 'collabAgentToolCall',
+          id: 'item-collab-empty-receiver',
+          tool: 'spawnAgent',
+          senderThreadId: 'parent-thread-1',
+          receiverThreadIds: [''],
+          status: 'inProgress',
+        },
+        'parent-1'
+      )
+    ).toBeNull();
+  });
+
   it('ignores non-subagent items', () => {
     expect(
       mapCodexSubagentToolItem(

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/codex-zod.test.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/codex-zod.test.ts
@@ -285,6 +285,22 @@ describe('codex-zod', () => {
     expect(parsed.futureField).toBe('retained');
   });
 
+  it.each([
+    [['']],
+    [['child_1', '']],
+  ])('rejects collaboration tool calls with empty receiver thread IDs: %j', (receiverThreadIds) => {
+    const parsed = collabAgentToolCallItemSchema.safeParse({
+      type: 'collabAgentToolCall',
+      id: 'item_collab_1',
+      tool: 'spawnAgent',
+      senderThreadId: 'parent_thread_1',
+      receiverThreadIds,
+      status: 'inProgress',
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
   it('parses configRequirements/read responses', () => {
     const parsed = configRequirementsReadResponseSchema.parse({
       requirements: {

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/codex-zod.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/codex-zod.ts
@@ -94,7 +94,7 @@ export const collabAgentToolCallItemSchema = threadItemSchema
     type: z.literal('collabAgentToolCall'),
     tool: z.string(),
     senderThreadId: z.string(),
-    receiverThreadIds: z.array(z.string()),
+    receiverThreadIds: z.array(z.string().min(1)),
     status: z.string(),
   })
   .passthrough();


### PR DESCRIPTION
## Summary

- Reject empty Codex subagent receiver thread IDs at the provider schema boundary.
- Prevent malformed collaboration tool calls from entering subagent activity and notification tracking.
- Add regression coverage for singular and mixed empty receiver IDs and mapper behavior.

## Changes

- **Codex app-server schema**: Require every `receiverThreadIds` element to contain at least one character, matching the ACP subagent ID convention.
- **Regression tests**: Cover empty IDs in singular and multi-receiver payloads and verify malformed collaboration calls are ignored by the mapper.

## Testing

- [x] Tests pass (`pnpm test` — 5,142 passed, 4 skipped)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Repository guardrails pass (`pnpm check`; local Codex schema drift check deferred to CI because the installed CLI is newer than the pinned version)
- [x] Manual testing: Verified the regression tests fail before the schema change and pass after it.

Closes #2159

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

