### PR TITLE
Fix #2163: Validate permission request ACP options

### DIFF
--- a/src/client/features/chat/reducer/index.ts
+++ b/src/client/features/chat/reducer/index.ts
@@ -10,7 +10,7 @@
  * The state is designed to be used with useReducer for predictable updates.
  */
 
-import type { ChatMessage, PermissionRequest, WebSocketMessage } from '@/lib/chat-protocol';
+import type { ChatMessage, WebSocketMessage } from '@/lib/chat-protocol';
 import { isWebSocketMessage, isWsAgentMessage } from '@/lib/chat-protocol';
 import { generateMessageId } from './helpers';
 import { reduceMessageCompactSlice } from './slices/messages/compact';
@@ -221,9 +221,7 @@ function handlePermissionRequestMessage(data: WebSocketMessage): ChatAction | nu
         // Include plan content for ExitPlanMode requests
         planContent: data.planContent ?? null,
         // Include ACP permission options for multi-option UI
-        acpOptions: (data as Record<string, unknown>).acpOptions as
-          | PermissionRequest['acpOptions']
-          | undefined,
+        ...(Array.isArray(data.acpOptions) ? { acpOptions: data.acpOptions } : {}),
       },
     };
   }

--- a/src/client/features/chat/reducer/permission-request-message.test.ts
+++ b/src/client/features/chat/reducer/permission-request-message.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import type { PermissionRequest, WebSocketMessage } from '@/lib/chat-protocol';
+import { unsafeCoerce } from '@/test-utils/unsafe-coerce';
+import { createActionFromWebSocketMessage } from './index';
+
+describe('permission request WebSocket messages', () => {
+  it('preserves array acpOptions', () => {
+    const acpOptions = [
+      { optionId: 'allow', name: 'Allow', kind: 'allow_once' as const },
+      { optionId: 'reject', name: 'Reject', kind: 'reject_once' as const },
+    ];
+    const action = createActionFromWebSocketMessage({
+      type: 'permission_request',
+      requestId: 'req-123',
+      toolName: 'Bash',
+      acpOptions,
+    });
+
+    expect((action as { payload: PermissionRequest }).payload.acpOptions).toEqual(acpOptions);
+  });
+
+  it('omits non-array acpOptions', () => {
+    const action = createActionFromWebSocketMessage(
+      unsafeCoerce<WebSocketMessage>({
+        type: 'permission_request',
+        requestId: 'req-123',
+        toolName: 'Bash',
+        acpOptions: {
+          0: { optionId: 'allow', name: 'Allow', kind: 'allow_once' },
+          length: 1,
+        },
+      })
+    );
+
+    expect((action as { payload: PermissionRequest }).payload).not.toHaveProperty('acpOptions');
+  });
+});


### PR DESCRIPTION
## Summary
- Validate permission request `acpOptions` before storing them in chat state.
- Preserve valid ACP option arrays while omitting malformed values that would crash permission UI consumers.

## Changes
- **Chat reducer**: Match the existing user-question and pending-request normalization pattern with an `Array.isArray` guard.
- **Regression coverage**: Verify valid arrays are preserved and array-like objects are omitted.

## Testing
- [x] Tests pass (`pnpm test` — 5,141 passed, 4 skipped)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Repository guardrails pass (`pnpm check`)
- [ ] Manual testing: Not applicable; this inbound normalization boundary is covered by reducer tests.

Closes #2163

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)
