### PR TITLE
Fix #2158: Ignore terminal creation while disconnected

### DIFF
--- a/docs/superpowers/plans/2026-08-13-disconnected-terminal-tab-creation.md
+++ b/docs/superpowers/plans/2026-08-13-disconnected-terminal-tab-creation.md
@@ -38,7 +38,7 @@ it('ignores disconnected create requests without blocking terminal restoration',
   document.body.appendChild(container);
   const root = createRoot(container);
   const panelRef = createRef<TerminalPanelRef>();
-  let terminalState: TerminalTabState | null = null;
+  const terminalStates: TerminalTabState[] = [];
 
   flushSync(() => {
     root.render(
@@ -46,7 +46,7 @@ it('ignores disconnected create requests without blocking terminal restoration',
         workspaceId: 'workspace-1',
         ref: panelRef,
         onStateChange: (state) => {
-          terminalState = state;
+          terminalStates.push(state);
         },
       })
     );
@@ -57,7 +57,7 @@ it('ignores disconnected create requests without blocking terminal restoration',
   });
 
   expect(mocks.create).not.toHaveBeenCalled();
-  expect(terminalState?.tabs).toEqual([]);
+  expect(terminalStates.at(-1)?.tabs).toEqual([]);
 
   flushSync(() => {
     mocks.options?.onTerminalList?.([
@@ -65,7 +65,7 @@ it('ignores disconnected create requests without blocking terminal restoration',
     ]);
   });
 
-  expect(terminalState?.tabs).toEqual([
+  expect(terminalStates.at(-1)?.tabs).toEqual([
     { id: 'tab-terminal-existing', label: 'Terminal 1' },
   ]);
 

--- a/docs/superpowers/plans/2026-08-13-disconnected-terminal-tab-creation.md
+++ b/docs/superpowers/plans/2026-08-13-disconnected-terminal-tab-creation.md
@@ -1,0 +1,181 @@
+# Disconnected Terminal Tab Creation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent disconnected terminal creation attempts from producing an orphaned pending tab that hides existing terminals after reconnection.
+
+**Architecture:** Keep terminal creation and restoration at their existing `TerminalPanel` boundaries. Reject creation in the shared `handleNewTab` callback whenever the terminal WebSocket is disconnected, leaving the existing no-duplicate restoration guard unchanged.
+
+**Tech Stack:** React, TypeScript, Vitest, jsdom, pnpm
+
+## Global Constraints
+
+- A disconnected new-tab request must not add a local tab, record pending correlation state, change the active tab, or call the WebSocket create function.
+- Existing server terminals must remain restorable after a disconnected new-tab request.
+- Connected creation, request correlation, terminal-list deduplication, and reconnect controls must retain their current behavior.
+- The fix must apply to both the imperative `TerminalPanelRef.createNewTerminal` API and the parent-provided `TerminalTabState.onNewTab` callback through their shared handler.
+
+---
+
+### Task 1: Reject Disconnected Terminal Creation
+
+**Files:**
+- Modify: `src/client/features/workspace/terminal-panel.test.tsx`
+- Modify: `src/client/features/workspace/terminal-panel.tsx:277-293`
+
+**Interfaces:**
+- Consumes: `connected: boolean` from `useTerminalWebSocket` and `TerminalPanelRef.createNewTerminal(): void`.
+- Produces: `handleNewTab(): void`, which is a no-op while disconnected and otherwise preserves the existing pending-tab/create flow.
+
+- [ ] **Step 1: Write the failing regression test**
+
+Import `TerminalTabState`, capture the latest state through `onStateChange`, invoke terminal creation while disconnected, and then deliver a server list:
+
+```typescript
+it('ignores disconnected create requests without blocking terminal restoration', () => {
+  mocks.connected = false;
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const panelRef = createRef<TerminalPanelRef>();
+  let terminalState: TerminalTabState | null = null;
+
+  flushSync(() => {
+    root.render(
+      createElement(TerminalPanel, {
+        workspaceId: 'workspace-1',
+        ref: panelRef,
+        onStateChange: (state) => {
+          terminalState = state;
+        },
+      })
+    );
+  });
+
+  flushSync(() => {
+    panelRef.current?.createNewTerminal();
+  });
+
+  expect(mocks.create).not.toHaveBeenCalled();
+  expect(terminalState?.tabs).toEqual([]);
+
+  flushSync(() => {
+    mocks.options?.onTerminalList?.([
+      { id: 'terminal-existing', createdAt: '2026-08-13T00:00:00.000Z' },
+    ]);
+  });
+
+  expect(terminalState?.tabs).toEqual([
+    { id: 'tab-terminal-existing', label: 'Terminal 1' },
+  ]);
+
+  root.unmount();
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+pnpm test src/client/features/workspace/terminal-panel.test.tsx -t "ignores disconnected create requests"
+```
+
+Expected: FAIL because the current callback calls `create`, appends a pending tab, and prevents the terminal list from replacing it.
+
+- [ ] **Step 3: Update reconnect notice setup so it does not rely on the bug**
+
+In `shows a disconnected notice while the transport is reconnecting`, render and create the terminal while `mocks.connected` is true, associate it through `onCreated`, then set `mocks.connected = false` and rerender the same panel before checking the notice. In `offers a manual reconnect once the transport gives up`, remove the unnecessary disconnected `createNewTerminal` call because the empty state already renders the reconnect control.
+
+- [ ] **Step 4: Implement the minimal connected-state guard**
+
+Add the guard before request ID creation and include `connected` in the callback dependencies:
+
+```typescript
+const handleNewTab = useCallback(() => {
+  if (!connected) {
+    return;
+  }
+
+  const requestId = createTerminalRequestId();
+  const id = `tab-${requestId}`;
+
+  pendingTabIdsByRequestRef.current.set(requestId, id);
+  updateTabs((prev) => [
+    ...prev,
+    {
+      id,
+      label: `Terminal ${prev.length + 1}`,
+      terminalId: null,
+      output: '',
+    },
+  ]);
+  setActiveTabId(id);
+  create(requestId);
+}, [connected, create, setActiveTabId, updateTabs]);
+```
+
+- [ ] **Step 5: Run the panel tests and verify GREEN**
+
+Run:
+
+```bash
+pnpm test src/client/features/workspace/terminal-panel.test.tsx
+```
+
+Expected: all `TerminalPanel` tests pass without warnings.
+
+- [ ] **Step 6: Commit the regression fix**
+
+```bash
+git add src/client/features/workspace/terminal-panel.tsx \
+  src/client/features/workspace/terminal-panel.test.tsx
+git commit -m "Ignore disconnected terminal creation (#2158)"
+```
+
+### Task 2: Full Verification and Publication
+
+**Files:**
+- Review: all changes relative to `origin/main`
+- Create outside repository: `/tmp/pr-body.md`
+
+**Interfaces:**
+- Consumes: the committed terminal creation guard, regression tests, design, and plan.
+- Produces: a verified GitHub pull request that closes issue `#2158`.
+
+- [ ] **Step 1: Run repository verification**
+
+Run the user-requested chain and the repository's full guardrail check:
+
+```bash
+pnpm typecheck && pnpm check:fix && pnpm test && pnpm build
+pnpm check
+```
+
+Expected: every command exits `0`. Review and stage any intended formatter changes before the final commit.
+
+- [ ] **Step 2: Review the complete change**
+
+```bash
+git diff origin/main
+git diff --check origin/main
+git status -sb
+```
+
+Expected: only the two planning artifacts and the intended terminal panel source/test files differ from `origin/main`; no debug output, unrelated refactoring, or uncommitted changes remain. No screenshot is required because the fix adds no visual state.
+
+- [ ] **Step 3: Commit any verification-only formatting changes**
+
+If `pnpm check:fix` changed intended files, stage only those files and commit them with an imperative subject under 72 characters. If it made no changes, verify `git status --short` is empty.
+
+- [ ] **Step 4: Push and create the pull request**
+
+Confirm `gh --version` and `gh auth status`, push the existing issue branch, write `/tmp/pr-body.md` with the required summary, changes, testing checklist, `Closes #2158`, and Factory Factory signature, then run:
+
+```bash
+git push -u origin HEAD
+gh pr create --title "Fix #2158: Ignore terminal creation while disconnected" --body-file /tmp/pr-body.md
+gh pr view --web
+```
+
+Expected: GitHub reports the new pull request URL and successfully opens its web view.

--- a/docs/superpowers/specs/2026-08-13-disconnected-terminal-tab-creation-design.md
+++ b/docs/superpowers/specs/2026-08-13-disconnected-terminal-tab-creation-design.md
@@ -1,0 +1,27 @@
+# Disconnected Terminal Tab Creation Design
+
+## Problem
+
+`TerminalPanel` creates a pending local tab before asking the terminal WebSocket to create its PTY. The terminal channel uses the `drop` queue policy, so a create request sent while disconnected is discarded and can never correlate a server terminal ID back to that tab. When the connection returns, the pending tab also makes terminal-list restoration return early, hiding every existing server terminal until the user closes the orphaned tab.
+
+## Decision
+
+`TerminalPanel.handleNewTab` will return immediately when `connected` is false. The guard will run before generating a request ID, recording pending correlation state, updating tabs, changing the active tab, or sending the create request. Both creation entry points—the imperative panel ref and the inline new-tab callback—already use this handler, so one boundary protects all callers.
+
+The existing terminal-list rule will remain unchanged. It still prevents duplicate tabs during ordinary reconnects, while the creation guard ensures a disconnected click cannot introduce the invalid pending state that defeats restoration.
+
+## Alternatives Considered
+
+1. Queue create requests until reconnection. This conflicts with the terminal channel's deliberate `drop` policy and would require cancellation and duplicate-delivery semantics for stale UI actions.
+2. Merge server terminals into any local pending tabs during restoration. This treats the orphaned state after it has already been created and cannot safely determine whether an uncorrelated pending tab represents a live request.
+3. Ignore new-tab requests while disconnected. This is selected because it prevents the invalid state at its source and preserves the existing reconnect behavior.
+
+## Tests
+
+A focused `TerminalPanel` regression test will render the panel disconnected, invoke the public `createNewTerminal` API, and verify that no local tab or create request is produced. It will then deliver a server terminal list and verify that the existing terminal is restored, covering the user-visible failure described by issue #2158.
+
+The existing reconnecting-banner test currently creates its initial tab while already disconnected, which relies on the bug. It will instead create a valid terminal while connected, rerender after disconnection, and continue asserting that the warning is shown for an existing terminal.
+
+## Scope
+
+This change does not alter WebSocket queueing, terminal-list reconciliation, reconnect controls, tab styling, or backend behavior. It adds no new visual state, so a UI screenshot would not materially demonstrate the fix.

--- a/src/client/features/workspace/terminal-panel.test.tsx
+++ b/src/client/features/workspace/terminal-panel.test.tsx
@@ -5,7 +5,11 @@ import { flushSync } from 'react-dom';
 import { createRoot } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TERMINAL_OUTPUT_MAX_CHARS, TERMINAL_TRUNCATION_MARKER } from '@/client/lib/rolling-output';
-import { TerminalPanel, type TerminalPanelRef } from './terminal-panel';
+import {
+  TerminalPanel,
+  type TerminalPanelRef,
+  type TerminalTabState,
+} from './terminal-panel';
 
 const mocks = vi.hoisted(() => ({
   create: vi.fn(),
@@ -76,6 +80,46 @@ describe('TerminalPanel', () => {
     document.body.innerHTML = '';
   });
 
+  it('ignores disconnected create requests without blocking terminal restoration', () => {
+    mocks.connected = false;
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const panelRef = createRef<TerminalPanelRef>();
+    let terminalState: TerminalTabState | null = null;
+
+    flushSync(() => {
+      root.render(
+        createElement(TerminalPanel, {
+          workspaceId: 'workspace-1',
+          ref: panelRef,
+          onStateChange: (state) => {
+            terminalState = state;
+          },
+        })
+      );
+    });
+
+    flushSync(() => {
+      panelRef.current?.createNewTerminal();
+    });
+
+    expect(mocks.create).not.toHaveBeenCalled();
+    expect(terminalState?.tabs).toEqual([]);
+
+    flushSync(() => {
+      mocks.options?.onTerminalList?.([
+        { id: 'terminal-existing', createdAt: '2026-08-13T00:00:00.000Z' },
+      ]);
+    });
+
+    expect(terminalState?.tabs).toEqual([
+      { id: 'tab-terminal-existing', label: 'Terminal 1' },
+    ]);
+
+    root.unmount();
+  });
+
   it('keeps the server active terminal aligned with the selected pending tab', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
@@ -139,7 +183,6 @@ describe('TerminalPanel', () => {
   });
 
   it('shows a disconnected notice while the transport is reconnecting', async () => {
-    mocks.connected = false;
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);
@@ -150,6 +193,15 @@ describe('TerminalPanel', () => {
     });
     flushSync(() => {
       panelRef.current?.createNewTerminal();
+    });
+    const requestId = mocks.create.mock.calls[0]?.[0] as string;
+    flushSync(() => {
+      mocks.options?.onCreated?.('terminal-a', requestId);
+    });
+
+    mocks.connected = false;
+    flushSync(() => {
+      root.render(createElement(TerminalPanel, { workspaceId: 'workspace-1', ref: panelRef }));
     });
     await vi.dynamicImportSettled();
 
@@ -166,13 +218,9 @@ describe('TerminalPanel', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);
-    const panelRef = createRef<TerminalPanelRef>();
 
     flushSync(() => {
-      root.render(createElement(TerminalPanel, { workspaceId: 'workspace-1', ref: panelRef }));
-    });
-    flushSync(() => {
-      panelRef.current?.createNewTerminal();
+      root.render(createElement(TerminalPanel, { workspaceId: 'workspace-1' }));
     });
     await vi.dynamicImportSettled();
 

--- a/src/client/features/workspace/terminal-panel.test.tsx
+++ b/src/client/features/workspace/terminal-panel.test.tsx
@@ -5,11 +5,7 @@ import { flushSync } from 'react-dom';
 import { createRoot } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TERMINAL_OUTPUT_MAX_CHARS, TERMINAL_TRUNCATION_MARKER } from '@/client/lib/rolling-output';
-import {
-  TerminalPanel,
-  type TerminalPanelRef,
-  type TerminalTabState,
-} from './terminal-panel';
+import { TerminalPanel, type TerminalPanelRef, type TerminalTabState } from './terminal-panel';
 
 const mocks = vi.hoisted(() => ({
   create: vi.fn(),

--- a/src/client/features/workspace/terminal-panel.test.tsx
+++ b/src/client/features/workspace/terminal-panel.test.tsx
@@ -86,7 +86,7 @@ describe('TerminalPanel', () => {
     document.body.appendChild(container);
     const root = createRoot(container);
     const panelRef = createRef<TerminalPanelRef>();
-    let terminalState: TerminalTabState | null = null;
+    const terminalStates: TerminalTabState[] = [];
 
     flushSync(() => {
       root.render(
@@ -94,7 +94,7 @@ describe('TerminalPanel', () => {
           workspaceId: 'workspace-1',
           ref: panelRef,
           onStateChange: (state) => {
-            terminalState = state;
+            terminalStates.push(state);
           },
         })
       );
@@ -105,7 +105,7 @@ describe('TerminalPanel', () => {
     });
 
     expect(mocks.create).not.toHaveBeenCalled();
-    expect(terminalState?.tabs).toEqual([]);
+    expect(terminalStates.at(-1)?.tabs).toEqual([]);
 
     flushSync(() => {
       mocks.options?.onTerminalList?.([
@@ -113,7 +113,7 @@ describe('TerminalPanel', () => {
       ]);
     });
 
-    expect(terminalState?.tabs).toEqual([
+    expect(terminalStates.at(-1)?.tabs).toEqual([
       { id: 'tab-terminal-existing', label: 'Terminal 1' },
     ]);
 

--- a/src/client/features/workspace/terminal-panel.tsx
+++ b/src/client/features/workspace/terminal-panel.tsx
@@ -275,6 +275,10 @@ export const TerminalPanel = forwardRef<TerminalPanelRef, TerminalPanelProps>(
 
     // Create new terminal tab - extracted so it can be exposed via ref
     const handleNewTab = useCallback(() => {
+      if (!connected) {
+        return;
+      }
+
       const requestId = createTerminalRequestId();
       const id = `tab-${requestId}`;
 
@@ -290,7 +294,7 @@ export const TerminalPanel = forwardRef<TerminalPanelRef, TerminalPanelProps>(
       ]);
       setActiveTabId(id);
       create(requestId);
-    }, [create, setActiveTabId, updateTabs]);
+    }, [connected, create, setActiveTabId, updateTabs]);
 
     // Expose createNewTerminal to parent via ref
     useImperativeHandle(


### PR DESCRIPTION
## Summary
- Prevent terminal creation attempts while the terminal WebSocket is disconnected.
- Preserve restoration of existing server terminals after reconnecting.
- Add regression coverage for the dropped-create/orphaned-tab sequence.

## Changes
- **Terminal panel**: Return before creating pending client state or sending a create request when the terminal channel is disconnected.
- **Tests**: Verify a disconnected create attempt is ignored and a later terminal list still restores existing terminals; update reconnect notice setup to use a valid connected terminal.
- **Documentation**: Record the scoped design and test-first implementation plan.

## Testing
- [x] Tests pass (`pnpm test`: 5,140 passed, 4 skipped)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Repository guardrails pass (`pnpm check`; local Codex schema drift enforcement was skipped because the installed CLI differs from the pinned version)
- [ ] Manual testing: Not applicable; this guard adds no distinct visual state, and the disconnect/reconnect sequence is covered by the component regression test.

Closes #2158

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit c94e5a3534df89628ba4c64961ef07473b32d92f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

