### PR TITLE
Fix #2164: Prevent stale voice worklet callbacks

### DIFF
--- a/docs/superpowers/plans/2026-08-13-voice-worklet-cleanup.md
+++ b/docs/superpowers/plans/2026-08-13-voice-worklet-cleanup.md
@@ -1,0 +1,108 @@
+# Voice Worklet Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent queued AudioWorklet messages from invoking speech callbacks after voice capture cleanup.
+
+**Architecture:** Keep resource disposal centralized in `disposeCaptureResources`. Detach the worklet port handler before closing and disconnecting, mirroring the existing WebSocket lifecycle boundary, and protect it with a focused unit regression test.
+
+**Tech Stack:** TypeScript, React voice feature, Web Audio API, Vitest, pnpm.
+
+## Global Constraints
+
+- Use pnpm, never npm or yarn.
+- Keep the change scoped to AudioWorklet cleanup and its co-located regression test.
+- Follow test-driven development: observe the regression test fail before changing production code.
+- Run `pnpm check:fix`, `pnpm typecheck`, `pnpm test`, `pnpm check`, and `pnpm build` before handoff.
+- Close GitHub issue #2164 from the pull request body.
+
+---
+
+### Task 1: Detach the AudioWorklet message handler during cleanup
+
+**Files:**
+- Modify: `src/client/features/voice/use-mic-capture.ts`
+- Test: `src/client/features/voice/use-mic-capture.test.ts`
+
+**Interfaces:**
+- Consumes: `CaptureResources` and the existing `AudioWorkletNode.port.onmessage` lifecycle.
+- Produces: exported `disposeCaptureResources(resources: CaptureResources): void`, which clears `port.onmessage` before closing and disconnecting a present worklet node.
+
+- [ ] **Step 1: Write the failing regression test**
+
+```typescript
+it('detaches queued worklet messages before closing capture resources', () => {
+  const onSpeechDetected = vi.fn();
+  const port = { onmessage: onSpeechDetected, close: vi.fn() };
+  const workletNode = {
+    port,
+    disconnect: vi.fn(),
+  } as unknown as AudioWorkletNode;
+
+  disposeCaptureResources({
+    workletNode,
+    silentGain: null,
+    audioContext: null,
+    mediaStream: null,
+    socket: null,
+  });
+  port.onmessage?.({ data: new ArrayBuffer(0) } as MessageEvent<ArrayBuffer>);
+
+  expect(onSpeechDetected).not.toHaveBeenCalled();
+  expect(port.close).toHaveBeenCalledOnce();
+  expect(workletNode.disconnect).toHaveBeenCalledOnce();
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify the new test fails because the handler remains installed**
+
+Run: `pnpm test src/client/features/voice/use-mic-capture.test.ts`
+
+Expected: FAIL because `onSpeechDetected` is called after disposal.
+
+- [ ] **Step 3: Implement the minimal cleanup fix**
+
+```typescript
+export function disposeCaptureResources(resources: CaptureResources): void {
+  const { workletNode } = resources;
+  if (workletNode) {
+    workletNode.port.onmessage = null;
+    workletNode.port.close();
+    workletNode.disconnect();
+  }
+  // Preserve the remainder of the existing cleanup behavior.
+}
+```
+
+- [ ] **Step 4: Re-run the focused test and verify it passes**
+
+Run: `pnpm test src/client/features/voice/use-mic-capture.test.ts`
+
+Expected: PASS with all tests in the file green.
+
+- [ ] **Step 5: Run repository verification**
+
+Run in order:
+
+```bash
+pnpm check:fix
+pnpm typecheck
+pnpm test
+pnpm check
+pnpm build
+```
+
+Expected: every command exits successfully.
+
+- [ ] **Step 6: Commit the focused fix**
+
+```bash
+git add src/client/features/voice/use-mic-capture.ts src/client/features/voice/use-mic-capture.test.ts
+git commit -m "Fix queued voice worklet callbacks (#2164)"
+```
+
+- [ ] **Step 7: Review, publish, and open the pull request**
+
+Review `git diff origin/main`, push the current issue branch, and create a pull
+request whose body summarizes the cleanup race, lists verification evidence,
+includes `Closes #2164`, and ends with the required Factory Factory signature.

--- a/docs/superpowers/specs/2026-08-13-voice-worklet-cleanup-design.md
+++ b/docs/superpowers/specs/2026-08-13-voice-worklet-cleanup-design.md
@@ -1,0 +1,39 @@
+# Voice Worklet Cleanup Design
+
+## Problem
+
+Voice capture installs an `AudioWorkletNode.port.onmessage` callback that can
+invoke the barge-in speech callbacks. Cleanup closes the port and disconnects
+the worklet, but a message task queued before shutdown can still reach the
+installed handler. Because the handler captures a detector reference that is
+separate from the hook-owned ref cleared during cleanup, a stale callback can
+suppress playback in a later voice session.
+
+## Design
+
+`disposeCaptureResources` will detach the worklet port's `onmessage` handler
+before closing the port and disconnecting the node. This matches the existing
+WebSocket teardown pattern in the same function and prevents queued worklet
+messages from crossing the capture lifecycle boundary.
+
+No hook state, detector behavior, or audio graph setup changes are required.
+The cleanup helper will be exported for a focused co-located unit test, as the
+same module already exports an internal message-handler helper for testing.
+
+## Testing
+
+The regression test will create a fake worklet whose message handler represents
+a speech callback, dispose its resources, and then simulate delivery of a
+queued message through the port's current `onmessage` property. The callback
+must not run, while port closure and node disconnection must still occur. The
+test must fail against the current implementation and pass after detachment is
+added.
+
+## Edge Cases
+
+- Cleanup with no worklet remains a no-op through the existing nullable
+  resource contract.
+- Detachment happens before `close()` so synchronous or queued delivery cannot
+  observe the stale handler during shutdown.
+- Existing cleanup of the silent gain, audio context, media tracks, and socket
+  remains unchanged.

--- a/src/client/features/voice/use-mic-capture.test.ts
+++ b/src/client/features/voice/use-mic-capture.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
-import { attachTranscriptHandler, matchesStopPhrase } from './use-mic-capture';
+import {
+  attachTranscriptHandler,
+  disposeCaptureResources,
+  matchesStopPhrase,
+} from './use-mic-capture';
 
 describe('matchesStopPhrase', () => {
   it('matches common stop phrases regardless of case', () => {
@@ -173,5 +177,29 @@ describe('attachTranscriptHandler', () => {
 
     expect(onSoftStop).not.toHaveBeenCalled();
     expect(onFinalTranscript).toHaveBeenCalledWith('please stop');
+  });
+});
+
+describe('disposeCaptureResources', () => {
+  it('detaches queued worklet messages before closing capture resources', () => {
+    const onSpeechDetected = vi.fn();
+    const port = { onmessage: onSpeechDetected, close: vi.fn() };
+    const workletNode = {
+      port,
+      disconnect: vi.fn(),
+    } as unknown as AudioWorkletNode;
+
+    disposeCaptureResources({
+      workletNode,
+      silentGain: null,
+      audioContext: null,
+      mediaStream: null,
+      socket: null,
+    });
+    port.onmessage?.({ data: new ArrayBuffer(0) } as MessageEvent<ArrayBuffer>);
+
+    expect(onSpeechDetected).not.toHaveBeenCalled();
+    expect(port.close).toHaveBeenCalledOnce();
+    expect(workletNode.disconnect).toHaveBeenCalledOnce();
   });
 });

--- a/src/client/features/voice/use-mic-capture.test.ts
+++ b/src/client/features/voice/use-mic-capture.test.ts
@@ -183,10 +183,16 @@ describe('attachTranscriptHandler', () => {
 describe('disposeCaptureResources', () => {
   it('detaches queued worklet messages before closing capture resources', () => {
     const onSpeechDetected = vi.fn();
-    const port = { onmessage: onSpeechDetected, close: vi.fn() };
+    const queuedMessage = { data: new ArrayBuffer(0) } as MessageEvent<ArrayBuffer>;
+    const port = {
+      onmessage: onSpeechDetected as ((event: MessageEvent<ArrayBuffer>) => void) | null,
+      close: vi.fn(),
+    };
+    port.close.mockImplementation(() => port.onmessage?.(queuedMessage));
+    const disconnect = vi.fn(() => port.onmessage?.(queuedMessage));
     const workletNode = {
       port,
-      disconnect: vi.fn(),
+      disconnect,
     } as unknown as AudioWorkletNode;
 
     disposeCaptureResources({
@@ -196,10 +202,10 @@ describe('disposeCaptureResources', () => {
       mediaStream: null,
       socket: null,
     });
-    port.onmessage?.({ data: new ArrayBuffer(0) } as MessageEvent<ArrayBuffer>);
+    port.onmessage?.(queuedMessage);
 
     expect(onSpeechDetected).not.toHaveBeenCalled();
     expect(port.close).toHaveBeenCalledOnce();
-    expect(workletNode.disconnect).toHaveBeenCalledOnce();
+    expect(disconnect).toHaveBeenCalledOnce();
   });
 });

--- a/src/client/features/voice/use-mic-capture.ts
+++ b/src/client/features/voice/use-mic-capture.ts
@@ -78,15 +78,20 @@ interface CaptureResources {
 }
 
 /** Tears down every resource a capture attempt may have created. */
-function disposeCaptureResources({
+export function disposeCaptureResources({
   workletNode,
   silentGain,
   audioContext,
   mediaStream,
   socket,
 }: CaptureResources): void {
-  workletNode?.port.close();
-  workletNode?.disconnect();
+  if (workletNode) {
+    // Detach before closing: messages already queued on the port can still be
+    // delivered afterward and must not escape this capture lifecycle.
+    workletNode.port.onmessage = null;
+    workletNode.port.close();
+    workletNode.disconnect();
+  }
   silentGain?.disconnect();
   audioContext?.close().catch(() => undefined);
   for (const track of mediaStream?.getTracks() ?? []) {


### PR DESCRIPTION
## Summary
- Detach the AudioWorklet message handler before voice capture teardown.
- Prevent queued microphone frames from triggering stale barge-in callbacks in later voice sessions.
- Add regression coverage for handler detachment and teardown ordering.

## Changes
- **Voice capture cleanup**: Clear `workletNode.port.onmessage` before closing the port and disconnecting the node, matching the existing WebSocket lifecycle boundary.
- **Regression coverage**: Simulate queued delivery during and after teardown so detach-before-close ordering remains protected.
- **Documentation**: Record the focused design and implementation plan for the lifecycle fix.

## Testing
- [x] Tests pass (`pnpm test` — 5,162 passed, 4 skipped)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Repository guardrails pass (`pnpm check`)
- [ ] Manual testing: Not run; queued worklet delivery is covered by the focused unit regression test.

Closes #2164

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1d5d43bbad2e88e4809bf34e3b7270ab2dbb9db1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

