### PR TITLE
Centralize session workflow finalization

### DIFF
--- a/scripts/file-length-baseline.json
+++ b/scripts/file-length-baseline.json
@@ -19,7 +19,7 @@
   "src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.test.ts": 1576,
   "src/backend/services/session/service/lifecycle/session.config.service.test.ts": 1159,
   "src/backend/services/session/service/lifecycle/session.config.service.ts": 1080,
-  "src/backend/services/session/service/lifecycle/session.lifecycle.service.ts": 1338,
+  "src/backend/services/session/service/lifecycle/session.lifecycle.service.ts": 1210,
   "src/backend/services/session/service/lifecycle/session.service.test.ts": 2777,
   "src/backend/services/workspace/resources/workspace.accessor.ts": 1055,
   "src/backend/services/workspace/service/lifecycle/state-machine.service.test.ts": 1115,

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -70,7 +70,6 @@ export function createServer(application: Application, requestedPort?: number): 
     schedulerService,
     sessionFileLogger,
     sessionLifecycleService,
-    sessionRepository,
     terminalService,
     workspaceAutoIterationService,
     workspaceGitStateService,
@@ -497,7 +496,7 @@ export function createServer(application: Application, requestedPort?: number): 
         // Live ACP runtimes are in-memory only, so after a backend restart these
         // records must not drive workspace "Working" state.
         await runStartupTask('Failed to recover stale agent sessions on startup', async () => {
-          const recoveredCount = await sessionRepository.recoverStaleRunningSessions();
+          const recoveredCount = await sessionLifecycleService.recoverStaleRunningSessions();
           if (recoveredCount > 0) {
             logger.info('Recovered stale agent session states on startup', {
               recoveredCount,

--- a/src/backend/server.upgrade.test.ts
+++ b/src/backend/server.upgrade.test.ts
@@ -130,10 +130,8 @@ function createTestHarness(options: TestHarnessOptions = {}) {
       cleanupOldLogs: vi.fn(),
     },
     sessionLifecycleService: {
+      recoverStaleRunningSessions: vi.fn(async () => 0),
       stopAllClients: vi.fn(async () => undefined),
-    },
-    sessionRepository: {
-      recoverStaleSessionStates: vi.fn(async () => 0),
     },
     terminalService: {
       cleanup: vi.fn(),
@@ -524,9 +522,9 @@ describe('server websocket upgrade routing', () => {
     vi.mocked(harness.services.reconciliationService.cleanupOrphans).mockRejectedValueOnce(
       new Error('cleanup failed')
     );
-    vi.mocked(harness.services.sessionRepository.recoverStaleSessionStates).mockRejectedValueOnce(
-      new Error('session recovery failed')
-    );
+    vi.mocked(
+      harness.services.sessionLifecycleService.recoverStaleRunningSessions
+    ).mockRejectedValueOnce(new Error('session recovery failed'));
     vi.mocked(harness.services.reconciliationService.reconcile).mockRejectedValueOnce(
       new Error('reconcile failed')
     );
@@ -559,6 +557,24 @@ describe('server websocket upgrade routing', () => {
     expect(harness.logger.error).toHaveBeenCalledWith(
       'Failed to recover stale archiving workspaces on startup',
       expect.any(Object)
+    );
+  });
+
+  it('recovers stale agent session states through the lifecycle service at startup', async () => {
+    const harness = createTestHarness();
+    vi.mocked(
+      harness.services.sessionLifecycleService.recoverStaleRunningSessions
+    ).mockResolvedValueOnce(3);
+    const server = createTestServer(harness.application, 0);
+
+    await expect(server.start()).resolves.toBe('http://localhost:0');
+
+    expect(
+      harness.services.sessionLifecycleService.recoverStaleRunningSessions
+    ).toHaveBeenCalledOnce();
+    expect(harness.logger.info).toHaveBeenCalledWith(
+      'Recovered stale agent session states on startup',
+      { recoveredCount: 3 }
     );
   });
 

--- a/src/backend/services/session/service/data/session-data.service.test.ts
+++ b/src/backend/services/session/service/data/session-data.service.test.ts
@@ -7,7 +7,6 @@ vi.mock('@/backend/services/session/resources/agent-session.accessor', () => ({
   agentSessionAccessor: {
     acquireFixerSession: vi.fn(),
     findById: vi.fn(),
-    recoverStaleRunning: vi.fn(),
   },
 }));
 
@@ -55,14 +54,6 @@ describe('sessionDataService', () => {
       model: 'gpt-5.3-codex',
       providerProjectPath: null,
     });
-  });
-
-  it('recovers stale running agent sessions through the session boundary', async () => {
-    vi.mocked(agentSessionAccessor.recoverStaleRunning).mockResolvedValue(3);
-
-    await expect(sessionDataService.recoverStaleRunningAgentSessions()).resolves.toBe(3);
-
-    expect(agentSessionAccessor.recoverStaleRunning).toHaveBeenCalledOnce();
   });
 
   it('maps persistence rows to capsule-owned session records', async () => {

--- a/src/backend/services/session/service/data/session-data.service.ts
+++ b/src/backend/services/session/service/data/session-data.service.ts
@@ -150,10 +150,6 @@ class SessionDataService {
       .then((sessions) => sessions.map(toAgentSessionRecord));
   }
 
-  recoverStaleRunningAgentSessions(): Promise<number> {
-    return agentSessionAccessor.recoverStaleRunning();
-  }
-
   // Closed sessions
 
   findClosedSessionsByWorkspaceId(

--- a/src/backend/services/session/service/lifecycle/session-workflow-finalizer.test.ts
+++ b/src/backend/services/session/service/lifecycle/session-workflow-finalizer.test.ts
@@ -1,136 +1,33 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { SessionDomainService } from '@/backend/services/session/service/session-domain.service';
-import { workspaceDataService } from '@/backend/services/workspace';
-import { unsafeCoerce } from '@/test-utils/unsafe-coerce';
-import { SessionLifecycleService } from './session.lifecycle.service';
-import { createLifecycleHarness } from './session-lifecycle.test-helpers';
-import { SessionLifecycleEventService } from './session-lifecycle-event.service';
+import type { AgentSessionRecord } from '@/backend/services/session/resources/agent-session.accessor';
+import type { PersistClosedSessionInput } from './closed-session-persistence.service';
+import {
+  createLifecycleTestSession,
+  createLifecycleTestWorkspace,
+} from './session-lifecycle.test-helpers';
+import { SessionWorkflowFinalizer } from './session-workflow-finalizer';
 
-vi.mock('./closed-session-persistence.service', () => ({
-  closedSessionPersistenceService: {
-    persistClosedSession: vi.fn(async () => undefined),
-  },
-}));
+type FinalizerHarness = ReturnType<typeof createFinalizerHarness>;
 
-import { closedSessionPersistenceService } from './closed-session-persistence.service';
-
-vi.mock('@/backend/services/logger.service', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  }),
-  getCurrentProcessEnv: () => ({ NODE_ENV: 'test' }),
-}));
-
-vi.mock('@/backend/services/workspace', () => ({
-  workspaceDataService: { findById: vi.fn() },
-  workspaceNotificationService: {
-    listPendingForDelivery: vi.fn(),
-    markDelivered: vi.fn(),
-  },
-}));
-
-describe('SessionWorkflowFinalizer', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it('hydrates durable lifecycle rows before persisting a closed transcript', async () => {
-    const domain = new SessionDomainService();
-    const hydrateProviderHistory = vi.fn(() => {
-      domain.replaceTranscript('session-1', [
-        {
-          id: 'provider-user-1',
-          source: 'user',
-          text: 'Original provider conversation',
-          timestamp: '2026-07-30T12:00:00.000Z',
-          order: 0,
-        },
-      ]);
-      return Promise.resolve();
-    });
-    const lifecycleEventService = new SessionLifecycleEventService({
-      store: {
-        upsert: vi.fn(),
-        findBySessionId: vi.fn(async () => [
-          {
-            id: 'event-1',
-            workspaceId: 'workspace-1',
-            sessionId: 'session-1',
-            kind: 'TURN_INTERRUPTED',
-            reason: 'PROMPT_TIMEOUT',
-            message: 'Turn stopped: reached the 4-hour limit.',
-            dedupeKey: 'prompt-timeout',
-            createdAt: new Date('2026-07-30T12:22:23.353Z'),
-          },
-        ]),
-      } as never,
-      sessionDomainService: domain,
-    });
-    const hydrateLifecycleEvents = vi.spyOn(lifecycleEventService, 'hydrate');
-    domain.clearSession('session-1');
-    const repository = {
-      getSessionById: vi.fn(async () => ({
-        id: 'session-1',
-        workspaceId: 'workspace-1',
-        name: 'Chat',
-        workflow: 'user',
-        provider: 'CLAUDE',
-        model: 'claude-sonnet',
-        createdAt: new Date('2026-07-30T12:00:00.000Z'),
-      })),
-    };
-    vi.mocked(workspaceDataService.findById).mockResolvedValue({
-      id: 'workspace-1',
-      worktreePath: '/tmp/worktree',
-    } as never);
-    const service = new SessionLifecycleService(
-      unsafeCoerce({
-        repository,
-        contextService: {},
-        acpEnvironment: {},
-        promptBuilder: {},
-        runtimeManager: {},
-        sessionDomainService: domain,
-        sessionPermissionService: {},
-        sessionConfigService: {},
-        acpEventProcessor: {},
-        promptTurnCompletionService: {},
-        retryService: {},
-        sendSessionMessage: vi.fn(),
-        lifecycleEventService,
-        hydrateProviderHistory,
-      })
-    );
-
-    await service.persistClosedSession('session-1');
-
-    expect(closedSessionPersistenceService.persistClosedSession).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sessionId: 'session-1',
-        messages: expect.arrayContaining([
-          expect.objectContaining({ id: 'provider-user-1' }),
-          expect.objectContaining({ id: 'session-lifecycle:event-1' }),
-        ]),
-      })
-    );
-    expect(hydrateProviderHistory).toHaveBeenCalledWith(
-      'session-1',
-      expect.objectContaining({ provider: 'CLAUDE' })
-    );
-    expect(hydrateProviderHistory.mock.invocationCallOrder[0]).toBeLessThan(
-      hydrateLifecycleEvents.mock.invocationCallOrder[0]!
-    );
-  });
-
-  it('repeats closed-session finalization with the same durable transcript', async () => {
-    vi.mocked(workspaceDataService.findById).mockResolvedValue({
-      id: 'workspace-1',
-      worktreePath: '/tmp/worktree',
-    } as never);
-    const transcript = [
+function createFinalizerHarness(options?: {
+  session?: AgentSessionRecord | null;
+  workspace?: ReturnType<typeof createLifecycleTestWorkspace> | null;
+  running?: boolean;
+  viewerCount?: number;
+}) {
+  const session = options?.session === undefined ? createLifecycleTestSession() : options.session;
+  const workspace =
+    options?.workspace === undefined ? createLifecycleTestWorkspace() : options.workspace;
+  const repository = {
+    getSessionById: vi.fn(async () => session),
+    deleteSession: vi.fn(async () => createLifecycleTestSession()),
+    recoverStaleRunningSessions: vi.fn(async () => 2),
+  };
+  const workspaceLookup = {
+    findById: vi.fn(async () => workspace),
+  };
+  const domain = {
+    getTranscriptSnapshot: vi.fn(() => [
       {
         id: 'user-1',
         source: 'user' as const,
@@ -138,21 +35,258 @@ describe('SessionWorkflowFinalizer', () => {
         timestamp: '2026-07-30T12:00:00.000Z',
         order: 0,
       },
-    ];
-    const harness = createLifecycleHarness({ transcript });
+    ]),
+    clearSession: vi.fn(),
+  };
+  const persistence = {
+    persistClosedSession: vi.fn<(input: PersistClosedSessionInput) => Promise<void>>(
+      async () => undefined
+    ),
+  };
+  const lifecycleEvents = {
+    hydrate: vi.fn(async () => undefined),
+  };
+  const hydrateProviderHistory = vi.fn(async () => undefined);
+  const runtime = {
+    isSessionRunning: vi.fn(() => options?.running ?? false),
+    isStopInProgress: vi.fn(() => false),
+  };
+  const viewerCount = vi.fn(() => options?.viewerCount ?? 0);
+  const workspaceBridge = {
+    markSessionRunning: vi.fn(() => 0),
+    markSessionIdle: vi.fn(),
+    recordRatchetSessionEnd: vi.fn(async () => undefined),
+    resetPRDiscoveryBackoff: vi.fn(async () => true),
+  };
+  const autoIterationExit = {
+    onAutoIterationSessionExit: vi.fn(),
+  };
+  const finalizer = new SessionWorkflowFinalizer({
+    repository,
+    workspaceLookup,
+    sessionDomainService: domain,
+    closedSessionPersistenceService: persistence,
+    lifecycleEventService: lifecycleEvents,
+    hydrateProviderHistory,
+    runtimeManager: runtime,
+    countViewers: viewerCount,
+  });
+  finalizer.configure({ workspace: workspaceBridge, autoIterationExit });
 
-    await harness.service.persistClosedSession('session-1');
-    await harness.service.persistClosedSession('session-1');
+  return {
+    finalizer,
+    repository,
+    workspaceLookup,
+    domain,
+    persistence,
+    lifecycleEvents,
+    hydrateProviderHistory,
+    runtime,
+    viewerCount,
+    workspaceBridge,
+    autoIterationExit,
+    session,
+  };
+}
 
-    expect(harness.lifecycleEventService.hydrate).toHaveBeenCalledTimes(2);
-    expect(closedSessionPersistenceService.persistClosedSession).toHaveBeenCalledTimes(2);
-    expect(closedSessionPersistenceService.persistClosedSession).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({ sessionId: 'session-1', messages: transcript })
+describe('SessionWorkflowFinalizer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('hydrates provider and lifecycle history before persisting a closed transcript', async () => {
+    const harness = createFinalizerHarness();
+
+    await harness.finalizer.persistClosedSession('session-1');
+
+    expect(harness.hydrateProviderHistory).toHaveBeenCalledWith(
+      'session-1',
+      expect.objectContaining({
+        id: 'session-1',
+        workspace: { worktreePath: '/tmp/workspace' },
+      })
     );
-    expect(closedSessionPersistenceService.persistClosedSession).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({ sessionId: 'session-1', messages: transcript })
+    expect(harness.hydrateProviderHistory.mock.invocationCallOrder[0]).toBeLessThan(
+      harness.lifecycleEvents.hydrate.mock.invocationCallOrder[0]!
     );
+    expect(harness.lifecycleEvents.hydrate.mock.invocationCallOrder[0]).toBeLessThan(
+      harness.persistence.persistClosedSession.mock.invocationCallOrder[0]!
+    );
+    expect(harness.persistence.persistClosedSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'session-1',
+        worktreePath: '/tmp/workspace',
+        messages: [
+          expect.objectContaining({
+            id: 'user-1',
+            text: 'Keep this transcript durable.',
+          }),
+        ],
+      })
+    );
+  });
+
+  it.each([
+    ['missing session', { session: null }],
+    ['missing worktree', { workspace: createLifecycleTestWorkspace({ worktreePath: null }) }],
+  ] as const)('skips closed persistence for a %s', async (_caseName, options) => {
+    const harness = createFinalizerHarness(options);
+
+    await harness.finalizer.persistClosedSession('session-1');
+
+    expect(harness.hydrateProviderHistory).not.toHaveBeenCalled();
+    expect(harness.lifecycleEvents.hydrate).not.toHaveBeenCalled();
+    expect(harness.persistence.persistClosedSession).not.toHaveBeenCalled();
+  });
+
+  it('settles a deliberate ratchet stop as completed before removing its transient session', async () => {
+    const harness = createFinalizerHarness({
+      session: createLifecycleTestSession({ workflow: 'ratchet' }),
+    });
+
+    await harness.finalizer.finalizeDeliberateStop({
+      session: harness.session,
+      sessionId: 'session-1',
+      cleanupTransientRatchetSession: true,
+    });
+
+    expect(harness.workspaceBridge.recordRatchetSessionEnd).toHaveBeenCalledWith(
+      'workspace-1',
+      'session-1',
+      'COMPLETED'
+    );
+    expect(harness.persistence.persistClosedSession).toHaveBeenCalledOnce();
+    expect(harness.repository.deleteSession).toHaveBeenCalledWith('session-1');
+    expect(harness.domain.clearSession).toHaveBeenCalledWith('session-1');
+  });
+
+  it('keeps deliberate stop cleanup best effort when transient persistence or deletion fails', async () => {
+    const harness = createFinalizerHarness({
+      session: createLifecycleTestSession({ workflow: 'ratchet' }),
+    });
+    harness.persistence.persistClosedSession.mockRejectedValueOnce(new Error('disk unavailable'));
+
+    await expect(
+      harness.finalizer.finalizeDeliberateStop({
+        session: harness.session,
+        sessionId: 'session-1',
+        cleanupTransientRatchetSession: true,
+      })
+    ).resolves.toBeUndefined();
+    expect(harness.repository.deleteSession).not.toHaveBeenCalled();
+
+    harness.persistence.persistClosedSession.mockResolvedValueOnce(undefined);
+    harness.repository.deleteSession.mockRejectedValueOnce(new Error('already deleted'));
+    await expect(
+      harness.finalizer.finalizeDeliberateStop({
+        session: harness.session,
+        sessionId: 'session-1',
+        cleanupTransientRatchetSession: true,
+      })
+    ).resolves.toBeUndefined();
+    expect(harness.domain.clearSession).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [0, false, 'COMPLETED'],
+    [1, false, 'DIED'],
+    [null, true, 'COMPLETED'],
+  ] as const)('settles ratchet runtime exit code %s as %s', async (exitCode, deliberate, outcome) => {
+    const harness = createFinalizerHarness({
+      session: createLifecycleTestSession({ workflow: 'ratchet' }),
+    });
+
+    await harness.finalizer.finalizeRuntimeExit({
+      session: harness.session!,
+      sessionId: 'session-1',
+      exitCode,
+      deliberate,
+    });
+
+    expect(harness.workspaceBridge.recordRatchetSessionEnd).toHaveBeenCalledWith(
+      'workspace-1',
+      'session-1',
+      outcome
+    );
+  });
+
+  it('notifies auto-iteration only for unmanaged runtime exits', async () => {
+    const harness = createFinalizerHarness({
+      session: createLifecycleTestSession({ workflow: 'auto-iteration' }),
+    });
+
+    await harness.finalizer.finalizeRuntimeExit({
+      session: harness.session!,
+      sessionId: 'session-1',
+      exitCode: 0,
+      deliberate: true,
+    });
+    await harness.finalizer.finalizeRuntimeExit({
+      session: harness.session!,
+      sessionId: 'session-1',
+      exitCode: 1,
+      deliberate: false,
+    });
+
+    expect(harness.autoIterationExit.onAutoIterationSessionExit).toHaveBeenCalledOnce();
+    expect(harness.autoIterationExit.onAutoIterationSessionExit).toHaveBeenCalledWith(
+      'workspace-1',
+      'session-1'
+    );
+  });
+
+  it('schedules PR discovery after a runtime exit without delaying finalization', async () => {
+    const harness = createFinalizerHarness();
+
+    await harness.finalizer.finalizeRuntimeExit({
+      session: harness.session!,
+      sessionId: 'session-1',
+      exitCode: 0,
+      deliberate: false,
+    });
+
+    expect(harness.workspaceBridge.resetPRDiscoveryBackoff).toHaveBeenCalledWith('workspace-1');
+  });
+
+  it('retains inactive in-memory session state while a viewer is attached', () => {
+    const harness = createFinalizerHarness({ viewerCount: 1 });
+
+    harness.finalizer.clearInactiveSession('session-1', 'manual_stop');
+
+    expect(harness.domain.clearSession).not.toHaveBeenCalled();
+  });
+
+  it('repeats finalization safely through conditional persistence and bridge operations', async () => {
+    const harness = createFinalizerHarness({
+      session: createLifecycleTestSession({ workflow: 'ratchet' }),
+    });
+
+    await harness.finalizer.finalizeRuntimeExit({
+      session: harness.session!,
+      sessionId: 'session-1',
+      exitCode: 0,
+      deliberate: false,
+    });
+    harness.repository.deleteSession.mockRejectedValueOnce(new Error('already deleted'));
+    await expect(
+      harness.finalizer.finalizeRuntimeExit({
+        session: harness.session!,
+        sessionId: 'session-1',
+        exitCode: 0,
+        deliberate: false,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(harness.workspaceBridge.recordRatchetSessionEnd).toHaveBeenCalledTimes(2);
+    expect(harness.persistence.persistClosedSession).toHaveBeenCalledTimes(2);
+    expect(harness.domain.clearSession).toHaveBeenCalledOnce();
+  });
+
+  it('delegates stale-running recovery to the session repository', async () => {
+    const harness: FinalizerHarness = createFinalizerHarness();
+
+    await expect(harness.finalizer.recoverStaleRunningSessions()).resolves.toBe(2);
+
+    expect(harness.repository.recoverStaleRunningSessions).toHaveBeenCalledOnce();
   });
 });

--- a/src/backend/services/session/service/lifecycle/session-workflow-finalizer.test.ts
+++ b/src/backend/services/session/service/lifecycle/session-workflow-finalizer.test.ts
@@ -176,7 +176,7 @@ describe('SessionWorkflowFinalizer', () => {
     expect(harness.repository.deleteSession).not.toHaveBeenCalled();
 
     harness.persistence.persistClosedSession.mockResolvedValueOnce(undefined);
-    harness.repository.deleteSession.mockRejectedValueOnce(new Error('already deleted'));
+    harness.repository.deleteSession.mockRejectedValueOnce(new Error('database unavailable'));
     await expect(
       harness.finalizer.finalizeDeliberateStop({
         session: harness.session,
@@ -191,7 +191,7 @@ describe('SessionWorkflowFinalizer', () => {
   it.each([
     [0, false, 'COMPLETED'],
     [1, false, 'DIED'],
-    [null, true, 'COMPLETED'],
+    [null, false, 'DIED'],
   ] as const)('settles ratchet runtime exit code %s as %s', async (exitCode, deliberate, outcome) => {
     const harness = createFinalizerHarness({
       session: createLifecycleTestSession({ workflow: 'ratchet' }),
@@ -208,6 +208,26 @@ describe('SessionWorkflowFinalizer', () => {
       'workspace-1',
       'session-1',
       outcome
+    );
+  });
+
+  it('settles a runtime-managed ratchet stop as completed without a lifecycle stop', async () => {
+    const harness = createFinalizerHarness({
+      session: createLifecycleTestSession({ workflow: 'ratchet' }),
+    });
+    harness.runtime.isStopInProgress.mockReturnValue(true);
+
+    await harness.finalizer.finalizeRuntimeExit({
+      session: harness.session!,
+      sessionId: 'session-1',
+      exitCode: 1,
+      deliberate: false,
+    });
+
+    expect(harness.workspaceBridge.recordRatchetSessionEnd).toHaveBeenCalledWith(
+      'workspace-1',
+      'session-1',
+      'COMPLETED'
     );
   });
 
@@ -277,6 +297,47 @@ describe('SessionWorkflowFinalizer', () => {
     expect(harness.workspaceBridge.recordRatchetSessionEnd).toHaveBeenCalledTimes(2);
     expect(harness.persistence.persistClosedSession).toHaveBeenCalledOnce();
     expect(harness.repository.deleteSession).toHaveBeenCalledTimes(2);
+    expect(harness.domain.clearSession).toHaveBeenCalledOnce();
+  });
+
+  it('clears transient state when ratchet deletion reports an externally missing session', async () => {
+    const harness = createFinalizerHarness({
+      session: createLifecycleTestSession({ workflow: 'ratchet' }),
+    });
+    harness.repository.deleteSession.mockRejectedValueOnce(
+      Object.assign(new Error('Record to delete does not exist.'), { code: 'P2025' })
+    );
+
+    await harness.finalizer.finalizeDeliberateStop({
+      session: harness.session,
+      sessionId: 'session-1',
+      cleanupTransientRatchetSession: true,
+    });
+
+    expect(harness.persistence.persistClosedSession).toHaveBeenCalledOnce();
+    expect(harness.repository.deleteSession).toHaveBeenCalledOnce();
+    expect(harness.domain.clearSession).toHaveBeenCalledWith('session-1');
+  });
+
+  it('keeps a transient ratchet session retryable when persistence reports it missing', async () => {
+    const harness = createFinalizerHarness({
+      session: createLifecycleTestSession({ workflow: 'ratchet' }),
+    });
+    harness.persistence.persistClosedSession.mockRejectedValueOnce(new Error('Session not found'));
+
+    await harness.finalizer.finalizeDeliberateStop({
+      session: harness.session,
+      sessionId: 'session-1',
+      cleanupTransientRatchetSession: true,
+    });
+    await harness.finalizer.finalizeDeliberateStop({
+      session: harness.session,
+      sessionId: 'session-1',
+      cleanupTransientRatchetSession: true,
+    });
+
+    expect(harness.persistence.persistClosedSession).toHaveBeenCalledTimes(2);
+    expect(harness.repository.deleteSession).toHaveBeenCalledOnce();
     expect(harness.domain.clearSession).toHaveBeenCalledOnce();
   });
 

--- a/src/backend/services/session/service/lifecycle/session-workflow-finalizer.test.ts
+++ b/src/backend/services/session/service/lifecycle/session-workflow-finalizer.test.ts
@@ -231,6 +231,47 @@ describe('SessionWorkflowFinalizer', () => {
     );
   });
 
+  it('settles a lifecycle-deliberate ratchet exit as completed after the runtime stop clears', async () => {
+    const harness = createFinalizerHarness({
+      session: createLifecycleTestSession({ workflow: 'ratchet' }),
+    });
+
+    await harness.finalizer.finalizeRuntimeExit({
+      session: harness.session!,
+      sessionId: 'session-1',
+      exitCode: 1,
+      deliberate: true,
+    });
+
+    expect(harness.workspaceBridge.recordRatchetSessionEnd).toHaveBeenCalledWith(
+      'workspace-1',
+      'session-1',
+      'COMPLETED'
+    );
+  });
+
+  it('cleans up a transient ratchet session when runtime-exit settlement fails', async () => {
+    const harness = createFinalizerHarness({
+      session: createLifecycleTestSession({ workflow: 'ratchet' }),
+    });
+    harness.workspaceBridge.recordRatchetSessionEnd.mockRejectedValueOnce(
+      new Error('settlement unavailable')
+    );
+
+    await expect(
+      harness.finalizer.finalizeRuntimeExit({
+        session: harness.session!,
+        sessionId: 'session-1',
+        exitCode: 1,
+        deliberate: false,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(harness.persistence.persistClosedSession).toHaveBeenCalledOnce();
+    expect(harness.repository.deleteSession).toHaveBeenCalledWith('session-1');
+    expect(harness.domain.clearSession).toHaveBeenCalledWith('session-1');
+  });
+
   it('notifies auto-iteration only for unmanaged runtime exits', async () => {
     const harness = createFinalizerHarness({
       session: createLifecycleTestSession({ workflow: 'auto-iteration' }),

--- a/src/backend/services/session/service/lifecycle/session-workflow-finalizer.test.ts
+++ b/src/backend/services/session/service/lifecycle/session-workflow-finalizer.test.ts
@@ -184,6 +184,7 @@ describe('SessionWorkflowFinalizer', () => {
         cleanupTransientRatchetSession: true,
       })
     ).resolves.toBeUndefined();
+    expect(harness.persistence.persistClosedSession).toHaveBeenCalledTimes(2);
     expect(harness.domain.clearSession).not.toHaveBeenCalled();
   });
 
@@ -256,29 +257,26 @@ describe('SessionWorkflowFinalizer', () => {
     expect(harness.domain.clearSession).not.toHaveBeenCalled();
   });
 
-  it('repeats finalization safely through conditional persistence and bridge operations', async () => {
+  it('persists a transient ratchet session once when deliberate finalization retries deletion', async () => {
     const harness = createFinalizerHarness({
       session: createLifecycleTestSession({ workflow: 'ratchet' }),
     });
+    harness.repository.deleteSession.mockRejectedValueOnce(new Error('delete failed'));
 
-    await harness.finalizer.finalizeRuntimeExit({
-      session: harness.session!,
+    await harness.finalizer.finalizeDeliberateStop({
+      session: harness.session,
       sessionId: 'session-1',
-      exitCode: 0,
-      deliberate: false,
+      cleanupTransientRatchetSession: true,
     });
-    harness.repository.deleteSession.mockRejectedValueOnce(new Error('already deleted'));
-    await expect(
-      harness.finalizer.finalizeRuntimeExit({
-        session: harness.session!,
-        sessionId: 'session-1',
-        exitCode: 0,
-        deliberate: false,
-      })
-    ).resolves.toBeUndefined();
+    await harness.finalizer.finalizeDeliberateStop({
+      session: harness.session,
+      sessionId: 'session-1',
+      cleanupTransientRatchetSession: true,
+    });
 
     expect(harness.workspaceBridge.recordRatchetSessionEnd).toHaveBeenCalledTimes(2);
-    expect(harness.persistence.persistClosedSession).toHaveBeenCalledTimes(2);
+    expect(harness.persistence.persistClosedSession).toHaveBeenCalledOnce();
+    expect(harness.repository.deleteSession).toHaveBeenCalledTimes(2);
     expect(harness.domain.clearSession).toHaveBeenCalledOnce();
   });
 

--- a/src/backend/services/session/service/lifecycle/session-workflow-finalizer.ts
+++ b/src/backend/services/session/service/lifecycle/session-workflow-finalizer.ts
@@ -40,6 +40,8 @@ type WorkflowFinalizerDependencies = {
 export class SessionWorkflowFinalizer {
   private workspaceBridge: SessionLifecycleWorkspaceBridge | null = null;
   private autoIterationExitBridge: SessionAutoIterationExitBridge | null = null;
+  private readonly persistedTransientSessionIds = new Set<string>();
+  private readonly transientSessionPersistenceOperations = new Map<string, Promise<void>>();
 
   constructor(private readonly dependencies: WorkflowFinalizerDependencies) {}
 
@@ -104,10 +106,14 @@ export class SessionWorkflowFinalizer {
   }
 
   async persistClosedSession(sessionId: string): Promise<void> {
+    await this.persistClosedSessionIfAvailable(sessionId);
+  }
+
+  private async persistClosedSessionIfAvailable(sessionId: string): Promise<boolean> {
     const session = await this.dependencies.repository.getSessionById(sessionId);
     if (!session) {
       logger.warn('Cannot persist closed session: session not found', { sessionId });
-      return;
+      return false;
     }
 
     const workspace = await this.dependencies.workspaceLookup.findById(session.workspaceId);
@@ -116,7 +122,7 @@ export class SessionWorkflowFinalizer {
         sessionId,
         workspaceId: session.workspaceId,
       });
-      return;
+      return false;
     }
 
     await this.dependencies.hydrateProviderHistory(sessionId, {
@@ -136,6 +142,7 @@ export class SessionWorkflowFinalizer {
       startedAt: session.createdAt,
       messages: this.dependencies.sessionDomainService.getTranscriptSnapshot(sessionId),
     });
+    return true;
   }
 
   clearInactiveSession(sessionId: string, reason: 'manual_stop' | 'runtime_exit'): void {
@@ -166,8 +173,9 @@ export class SessionWorkflowFinalizer {
     trigger: 'stop' | 'exit'
   ): Promise<void> {
     try {
-      await this.persistClosedSession(sessionId);
+      await this.persistTransientRatchetSessionOnce(sessionId);
       await this.dependencies.repository.deleteSession(sessionId);
+      this.persistedTransientSessionIds.delete(sessionId);
       this.dependencies.sessionDomainService.clearSession(sessionId);
       logger.debug('Deleted transient ratchet session', { sessionId, trigger });
     } catch (error) {
@@ -176,6 +184,28 @@ export class SessionWorkflowFinalizer {
         trigger,
         error: toErrorMessage(error),
       });
+    }
+  }
+
+  private async persistTransientRatchetSessionOnce(sessionId: string): Promise<void> {
+    if (this.persistedTransientSessionIds.has(sessionId)) {
+      return;
+    }
+
+    let persistence = this.transientSessionPersistenceOperations.get(sessionId);
+    if (!persistence) {
+      persistence = this.persistClosedSessionIfAvailable(sessionId).then((persisted) => {
+        if (persisted) {
+          this.persistedTransientSessionIds.add(sessionId);
+        }
+      });
+      this.transientSessionPersistenceOperations.set(sessionId, persistence);
+    }
+
+    try {
+      await persistence;
+    } finally {
+      this.transientSessionPersistenceOperations.delete(sessionId);
     }
   }
 }

--- a/src/backend/services/session/service/lifecycle/session-workflow-finalizer.ts
+++ b/src/backend/services/session/service/lifecycle/session-workflow-finalizer.ts
@@ -1,0 +1,185 @@
+import { createLogger } from '@/backend/services/logger.service';
+import type { AgentSessionRecord } from '@/backend/services/session/resources/agent-session.accessor';
+import type { AcpRuntimeManager } from '@/backend/services/session/service/acp';
+import type {
+  RatchetSessionEndOutcome,
+  SessionAutoIterationExitBridge,
+  SessionLifecycleWorkspaceBridge,
+} from '@/backend/services/session/service/bridges';
+import type { SessionDomainService } from '@/backend/services/session/service/session-domain.service';
+import type { PersistClosedSessionInput } from './closed-session-persistence.service';
+import type { SessionRepository } from './session.repository';
+import type { SessionLifecycleEventService } from './session-lifecycle-event.service';
+import { maybeDiscoverPROnSessionEnd } from './session-pr-discovery.service';
+
+const logger = createLogger('session-workflow-finalizer');
+
+type HydrateProviderHistory = (
+  sessionId: string,
+  session: AgentSessionRecord & { workspace: { worktreePath: string | null } }
+) => Promise<void>;
+
+type WorkflowFinalizerDependencies = {
+  repository: Pick<
+    SessionRepository,
+    'getSessionById' | 'deleteSession' | 'recoverStaleRunningSessions'
+  >;
+  workspaceLookup: {
+    findById(workspaceId: string): Promise<{ worktreePath: string | null } | null>;
+  };
+  sessionDomainService: Pick<SessionDomainService, 'clearSession' | 'getTranscriptSnapshot'>;
+  closedSessionPersistenceService: {
+    persistClosedSession(input: PersistClosedSessionInput): Promise<void>;
+  };
+  lifecycleEventService: Pick<SessionLifecycleEventService, 'hydrate'>;
+  hydrateProviderHistory: HydrateProviderHistory;
+  runtimeManager: Pick<AcpRuntimeManager, 'isSessionRunning'>;
+  countViewers(sessionId: string): number;
+};
+
+export class SessionWorkflowFinalizer {
+  private workspaceBridge: SessionLifecycleWorkspaceBridge | null = null;
+  private autoIterationExitBridge: SessionAutoIterationExitBridge | null = null;
+
+  constructor(private readonly dependencies: WorkflowFinalizerDependencies) {}
+
+  configure(bridges: {
+    workspace: SessionLifecycleWorkspaceBridge;
+    autoIterationExit?: SessionAutoIterationExitBridge;
+  }): void {
+    this.workspaceBridge = bridges.workspace;
+    this.autoIterationExitBridge = bridges.autoIterationExit ?? null;
+  }
+
+  async finalizeDeliberateStop(input: {
+    session: AgentSessionRecord | null;
+    sessionId: string;
+    cleanupTransientRatchetSession: boolean;
+  }): Promise<void> {
+    const { session, sessionId, cleanupTransientRatchetSession } = input;
+    if (session?.workflow !== 'ratchet') {
+      return;
+    }
+
+    try {
+      await this.recordRatchetSessionEnd(session.workspaceId, sessionId, 'COMPLETED');
+    } catch (error) {
+      logger.warn('Failed settling ratchet dispatch record during stop', {
+        sessionId,
+        workspaceId: session.workspaceId,
+        error: toErrorMessage(error),
+      });
+    }
+
+    if (!cleanupTransientRatchetSession) {
+      return;
+    }
+
+    await this.cleanupTransientRatchetSession(sessionId, 'stop');
+  }
+
+  async finalizeRuntimeExit(input: {
+    session: AgentSessionRecord;
+    sessionId: string;
+    exitCode: number | null;
+    deliberate: boolean;
+  }): Promise<void> {
+    const { session, sessionId, exitCode, deliberate } = input;
+    if (session.workflow === 'ratchet') {
+      const outcome: RatchetSessionEndOutcome = exitCode === 0 || deliberate ? 'COMPLETED' : 'DIED';
+      await this.recordRatchetSessionEnd(session.workspaceId, sessionId, outcome);
+    }
+
+    if (this.workspaceBridge) {
+      void maybeDiscoverPROnSessionEnd(session.workspaceId, logger, this.workspaceBridge);
+    }
+
+    if (session.workflow === 'ratchet') {
+      await this.cleanupTransientRatchetSession(sessionId, 'exit');
+    }
+
+    if (session.workflow === 'auto-iteration' && !deliberate) {
+      this.autoIterationExitBridge?.onAutoIterationSessionExit(session.workspaceId, sessionId);
+    }
+  }
+
+  async persistClosedSession(sessionId: string): Promise<void> {
+    const session = await this.dependencies.repository.getSessionById(sessionId);
+    if (!session) {
+      logger.warn('Cannot persist closed session: session not found', { sessionId });
+      return;
+    }
+
+    const workspace = await this.dependencies.workspaceLookup.findById(session.workspaceId);
+    if (!workspace?.worktreePath) {
+      logger.warn('Cannot persist closed session: no worktree path', {
+        sessionId,
+        workspaceId: session.workspaceId,
+      });
+      return;
+    }
+
+    await this.dependencies.hydrateProviderHistory(sessionId, {
+      ...session,
+      workspace: { worktreePath: workspace.worktreePath },
+    });
+    await this.dependencies.lifecycleEventService.hydrate(sessionId);
+
+    await this.dependencies.closedSessionPersistenceService.persistClosedSession({
+      sessionId,
+      workspaceId: session.workspaceId,
+      worktreePath: workspace.worktreePath,
+      name: session.name,
+      workflow: session.workflow,
+      provider: session.provider,
+      model: session.model,
+      startedAt: session.createdAt,
+      messages: this.dependencies.sessionDomainService.getTranscriptSnapshot(sessionId),
+    });
+  }
+
+  clearInactiveSession(sessionId: string, reason: 'manual_stop' | 'runtime_exit'): void {
+    if (
+      this.dependencies.runtimeManager.isSessionRunning(sessionId) ||
+      this.dependencies.countViewers(sessionId) > 0
+    ) {
+      return;
+    }
+    this.dependencies.sessionDomainService.clearSession(sessionId, { preserveRejections: true });
+    logger.debug('Cleared inactive in-memory session state', { sessionId, reason });
+  }
+
+  recoverStaleRunningSessions(): Promise<number> {
+    return this.dependencies.repository.recoverStaleRunningSessions();
+  }
+
+  private async recordRatchetSessionEnd(
+    workspaceId: string,
+    sessionId: string,
+    outcome: RatchetSessionEndOutcome
+  ): Promise<void> {
+    await this.workspaceBridge?.recordRatchetSessionEnd(workspaceId, sessionId, outcome);
+  }
+
+  private async cleanupTransientRatchetSession(
+    sessionId: string,
+    trigger: 'stop' | 'exit'
+  ): Promise<void> {
+    try {
+      await this.persistClosedSession(sessionId);
+      await this.dependencies.repository.deleteSession(sessionId);
+      this.dependencies.sessionDomainService.clearSession(sessionId);
+      logger.debug('Deleted transient ratchet session', { sessionId, trigger });
+    } catch (error) {
+      logger.warn('Failed persisting or deleting transient ratchet session', {
+        sessionId,
+        trigger,
+        error: toErrorMessage(error),
+      });
+    }
+  }
+}
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/backend/services/session/service/lifecycle/session-workflow-finalizer.ts
+++ b/src/backend/services/session/service/lifecycle/session-workflow-finalizer.ts
@@ -89,10 +89,18 @@ export class SessionWorkflowFinalizer {
     const { session, sessionId, exitCode, deliberate } = input;
     if (session.workflow === 'ratchet') {
       const outcome: RatchetSessionEndOutcome =
-        exitCode === 0 || this.dependencies.runtimeManager.isStopInProgress(sessionId)
+        exitCode === 0 || deliberate || this.dependencies.runtimeManager.isStopInProgress(sessionId)
           ? 'COMPLETED'
           : 'DIED';
-      await this.recordRatchetSessionEnd(session.workspaceId, sessionId, outcome);
+      try {
+        await this.recordRatchetSessionEnd(session.workspaceId, sessionId, outcome);
+      } catch (error) {
+        logger.warn('Failed settling ratchet dispatch record during runtime exit', {
+          sessionId,
+          workspaceId: session.workspaceId,
+          error: toErrorMessage(error),
+        });
+      }
     }
 
     if (this.workspaceBridge) {

--- a/src/backend/services/session/service/lifecycle/session-workflow-finalizer.ts
+++ b/src/backend/services/session/service/lifecycle/session-workflow-finalizer.ts
@@ -33,7 +33,7 @@ type WorkflowFinalizerDependencies = {
   };
   lifecycleEventService: Pick<SessionLifecycleEventService, 'hydrate'>;
   hydrateProviderHistory: HydrateProviderHistory;
-  runtimeManager: Pick<AcpRuntimeManager, 'isSessionRunning'>;
+  runtimeManager: Pick<AcpRuntimeManager, 'isSessionRunning' | 'isStopInProgress'>;
   countViewers(sessionId: string): number;
 };
 
@@ -88,7 +88,10 @@ export class SessionWorkflowFinalizer {
   }): Promise<void> {
     const { session, sessionId, exitCode, deliberate } = input;
     if (session.workflow === 'ratchet') {
-      const outcome: RatchetSessionEndOutcome = exitCode === 0 || deliberate ? 'COMPLETED' : 'DIED';
+      const outcome: RatchetSessionEndOutcome =
+        exitCode === 0 || this.dependencies.runtimeManager.isStopInProgress(sessionId)
+          ? 'COMPLETED'
+          : 'DIED';
       await this.recordRatchetSessionEnd(session.workspaceId, sessionId, outcome);
     }
 
@@ -174,17 +177,39 @@ export class SessionWorkflowFinalizer {
   ): Promise<void> {
     try {
       await this.persistTransientRatchetSessionOnce(sessionId);
-      await this.dependencies.repository.deleteSession(sessionId);
-      this.persistedTransientSessionIds.delete(sessionId);
-      this.dependencies.sessionDomainService.clearSession(sessionId);
-      logger.debug('Deleted transient ratchet session', { sessionId, trigger });
     } catch (error) {
-      logger.warn('Failed persisting or deleting transient ratchet session', {
-        sessionId,
-        trigger,
-        error: toErrorMessage(error),
-      });
+      this.logTransientSessionCleanupFailure(sessionId, trigger, error);
+      return;
     }
+
+    try {
+      await this.dependencies.repository.deleteSession(sessionId);
+      this.clearDeletedTransientSession(sessionId, trigger);
+    } catch (error) {
+      if (isMissingSessionError(error)) {
+        this.clearDeletedTransientSession(sessionId, trigger);
+        return;
+      }
+      this.logTransientSessionCleanupFailure(sessionId, trigger, error);
+    }
+  }
+
+  private logTransientSessionCleanupFailure(
+    sessionId: string,
+    trigger: 'stop' | 'exit',
+    error: unknown
+  ): void {
+    logger.warn('Failed persisting or deleting transient ratchet session', {
+      sessionId,
+      trigger,
+      error: toErrorMessage(error),
+    });
+  }
+
+  private clearDeletedTransientSession(sessionId: string, trigger: 'stop' | 'exit'): void {
+    this.persistedTransientSessionIds.delete(sessionId);
+    this.dependencies.sessionDomainService.clearSession(sessionId);
+    logger.debug('Deleted transient ratchet session', { sessionId, trigger });
   }
 
   private async persistTransientRatchetSessionOnce(sessionId: string): Promise<void> {
@@ -212,4 +237,15 @@ export class SessionWorkflowFinalizer {
 
 function toErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function isMissingSessionError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+  const code = 'code' in error ? error.code : undefined;
+  return (
+    code === 'P2025' ||
+    /already deleted|record to delete does not exist|session not found/i.test(toErrorMessage(error))
+  );
 }

--- a/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
+++ b/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
@@ -138,7 +138,6 @@ export class SessionLifecycleService {
   private workspaceBridge: SessionLifecycleWorkspaceBridge | null = null;
   private messageQueueBridge: SessionLifecycleMessageQueueBridge | null = null;
   private notificationDeliveryService: SessionNotificationDeliveryService | null = null;
-
   constructor(options: SessionLifecycleServiceDependencies) {
     if (!(options.contextService && options.acpEnvironment)) {
       throw new Error('SessionLifecycleService requires context and ACP environment ports');
@@ -171,7 +170,6 @@ export class SessionLifecycleService {
     this.onBeforeStopSession = options.onBeforeStopSession;
     this.onSessionExit = options.onSessionExit;
   }
-
   configure(bridges: {
     workspace: SessionLifecycleWorkspaceBridge;
     messageQueue?: SessionLifecycleMessageQueueBridge;
@@ -1105,7 +1103,9 @@ export class SessionLifecycleService {
   persistClosedSession(sessionId: string): Promise<void> {
     return this.workflowFinalizer.persistClosedSession(sessionId);
   }
-
+  recoverStaleRunningSessions(): Promise<number> {
+    return this.workflowFinalizer.recoverStaleRunningSessions();
+  }
   private async getOrCreateAcpSessionClient(
     sessionId: string,
     options: {

--- a/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
+++ b/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
@@ -10,7 +10,6 @@ import type {
 } from '@/backend/services/session/service/acp';
 import { AcpBrowseSessionUnavailableError } from '@/backend/services/session/service/acp/acp-runtime-manager';
 import type {
-  RatchetSessionEndOutcome,
   SessionAutoIterationExitBridge,
   SessionLifecycleMessageQueueBridge,
   SessionLifecycleWorkspaceBridge,
@@ -47,8 +46,8 @@ import type { SessionAcpEnvironmentPort } from './session-lifecycle.types';
 import type { SessionLifecycleEventService } from './session-lifecycle-event.service';
 import { type SessionLifecycleGate, SessionStartupCancelledError } from './session-lifecycle-gate';
 import type { SessionNotificationDeliveryService } from './session-notification-delivery.service';
-import { maybeDiscoverPROnSessionEnd as maybeDiscoverPROnSessionEndHelper } from './session-pr-discovery.service';
 import { isStaleLoadingRuntime } from './session-runtime-state.helpers';
+import { SessionWorkflowFinalizer } from './session-workflow-finalizer';
 
 const logger = createLogger('session');
 
@@ -131,13 +130,13 @@ export class SessionLifecycleService {
   private readonly lifecycleEventService: SessionLifecycleEventService;
   private readonly lifecycleGate: SessionLifecycleGate;
   private readonly hydrateProviderHistory: HydrateProviderHistory;
+  private readonly workflowFinalizer: SessionWorkflowFinalizer;
   private readonly sendSessionMessage: SendSessionMessage;
   private readonly onBeforeStopSession?: (sessionId: string) => void;
   private readonly onSessionExit?: (sessionId: string) => void;
   private readonly clientCreationOperations = new Map<string, Set<Promise<AcpProcessHandle>>>();
   private workspaceBridge: SessionLifecycleWorkspaceBridge | null = null;
   private messageQueueBridge: SessionLifecycleMessageQueueBridge | null = null;
-  private autoIterationExitBridge: SessionAutoIterationExitBridge | null = null;
   private notificationDeliveryService: SessionNotificationDeliveryService | null = null;
 
   constructor(options: SessionLifecycleServiceDependencies) {
@@ -158,6 +157,16 @@ export class SessionLifecycleService {
     this.lifecycleGate = options.lifecycleGate;
     this.hydrateProviderHistory =
       options.hydrateProviderHistory ?? (async (): Promise<void> => undefined);
+    this.workflowFinalizer = new SessionWorkflowFinalizer({
+      repository: this.repository,
+      workspaceLookup: workspaceDataService,
+      sessionDomainService: this.sessionDomainService,
+      closedSessionPersistenceService,
+      lifecycleEventService: this.lifecycleEventService,
+      hydrateProviderHistory: this.hydrateProviderHistory,
+      runtimeManager: this.runtimeManager,
+      countViewers: (sessionId) => sessionEventBus.countViewers(sessionId),
+    });
     this.sendSessionMessage = options.sendSessionMessage;
     this.onBeforeStopSession = options.onBeforeStopSession;
     this.onSessionExit = options.onSessionExit;
@@ -170,7 +179,10 @@ export class SessionLifecycleService {
   }): void {
     this.workspaceBridge = bridges.workspace;
     this.messageQueueBridge = bridges.messageQueue ?? null;
-    this.autoIterationExitBridge = bridges.autoIterationExit ?? null;
+    this.workflowFinalizer.configure({
+      workspace: bridges.workspace,
+      autoIterationExit: bridges.autoIterationExit,
+    });
   }
 
   configureNotificationDelivery(service: SessionNotificationDeliveryService): void {
@@ -332,15 +344,15 @@ export class SessionLifecycleService {
       if (!stopClientFailed) {
         const shouldCleanupTransientRatchetSession =
           options?.cleanupTransientRatchetSession ?? true;
-        await this.cleanupTransientRatchetOnStop(
+        await this.workflowFinalizer.finalizeDeliberateStop({
           session,
           sessionId,
-          shouldCleanupTransientRatchetSession
-        );
+          cleanupTransientRatchetSession: shouldCleanupTransientRatchetSession,
+        });
       }
 
       try {
-        this.clearSessionStoreIfInactive(sessionId, 'manual_stop');
+        this.workflowFinalizer.clearInactiveSession(sessionId, 'manual_stop');
         logger.info('ACP session stopped', {
           sessionId,
           ...(stopClientFailed ? { runtimeStopFailed: true } : {}),
@@ -798,9 +810,12 @@ export class SessionLifecycleService {
         wasDeliberateStop,
         runtimeIncarnationId
       );
-      await this.recordRatchetSessionEndOnExit(session.workspaceId, sessionId, exitCode);
-      void this.maybeDiscoverPROnSessionEnd(session.workspaceId);
-      await this.cleanupExitedWorkflow(session, sessionId, wasDeliberateStop);
+      await this.workflowFinalizer.finalizeRuntimeExit({
+        session,
+        sessionId,
+        exitCode,
+        deliberate: wasDeliberateStop,
+      });
     } catch (error) {
       logger.warn('Failed to process ACP session exit', {
         sessionId,
@@ -808,7 +823,7 @@ export class SessionLifecycleService {
       });
     } finally {
       try {
-        this.clearSessionStoreIfInactive(sessionId, 'runtime_exit');
+        this.workflowFinalizer.clearInactiveSession(sessionId, 'runtime_exit');
       } finally {
         acpTraceLogger.closeSession(sessionId);
       }
@@ -837,27 +852,6 @@ export class SessionLifecycleService {
           : `Session stopped: agent process exited unexpectedly (code ${exitCode}).`,
       dedupeKey: `process-exit:${runtimeIncarnationId}:${exitCode ?? 'signal'}`,
     });
-  }
-
-  private async cleanupExitedWorkflow(
-    session: AgentSessionRecord,
-    sessionId: string,
-    wasDeliberateStop: boolean
-  ): Promise<void> {
-    if (session.workflow === 'ratchet') {
-      await this.persistRatchetTranscript(sessionId);
-      await this.repository.deleteSession(sessionId);
-      this.sessionDomainService.clearSession(sessionId);
-      logger.debug('Deleted transient ratchet ACP session', { sessionId });
-    }
-
-    if (
-      session.workflow === 'auto-iteration' &&
-      this.autoIterationExitBridge &&
-      !wasDeliberateStop
-    ) {
-      this.autoIterationExitBridge.onAutoIterationSessionExit(session.workspaceId, sessionId);
-    }
   }
 
   private async createAcpClient(
@@ -1108,130 +1102,8 @@ export class SessionLifecycleService {
     }
   }
 
-  private async cleanupTransientRatchetOnStop(
-    session: AgentSessionRecord | null,
-    sessionId: string,
-    shouldCleanupTransientRatchetSession: boolean
-  ): Promise<void> {
-    if (session?.workflow !== 'ratchet') {
-      return;
-    }
-
-    try {
-      // A stop is deliberate, so the dispatch settles as COMPLETED (no retry).
-      // No-ops if another session-end path already settled the record.
-      await this.recordRatchetSessionEnd(session.workspaceId, sessionId, 'COMPLETED');
-    } catch (error) {
-      logger.warn('Failed settling ratchet dispatch record during stop', {
-        sessionId,
-        workspaceId: session.workspaceId,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
-
-    if (!shouldCleanupTransientRatchetSession) {
-      return;
-    }
-
-    try {
-      await this.persistRatchetTranscript(sessionId);
-      await this.repository.deleteSession(sessionId);
-      this.sessionDomainService.clearSession(sessionId);
-      logger.debug('Deleted transient ratchet session after stop', { sessionId });
-    } catch (error) {
-      logger.warn('Failed persisting or deleting transient ratchet session during stop', {
-        sessionId,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
-  }
-
-  private async recordRatchetSessionEnd(
-    workspaceId: string,
-    sessionId: string,
-    outcome: RatchetSessionEndOutcome
-  ): Promise<void> {
-    if (!this.workspaceBridge) {
-      return;
-    }
-
-    await this.workspaceBridge.recordRatchetSessionEnd(workspaceId, sessionId, outcome);
-  }
-
-  /**
-   * Deliberate stops (isStopInProgress) and clean exits settle the ratchet
-   * dispatch as COMPLETED; unexpected exits settle it as DIED so the ratchet
-   * can re-dispatch (bounded) for the same PR state.
-   */
-  private async recordRatchetSessionEndOnExit(
-    workspaceId: string,
-    sessionId: string,
-    exitCode: number | null
-  ): Promise<void> {
-    const outcome =
-      exitCode === 0 || this.runtimeManager.isStopInProgress(sessionId) ? 'COMPLETED' : 'DIED';
-    await this.recordRatchetSessionEnd(workspaceId, sessionId, outcome);
-  }
-
-  private async maybeDiscoverPROnSessionEnd(workspaceId: string): Promise<void> {
-    if (!this.workspaceBridge) {
-      return;
-    }
-    await maybeDiscoverPROnSessionEndHelper(workspaceId, logger, this.workspaceBridge);
-  }
-
-  private clearSessionStoreIfInactive(
-    sessionId: string,
-    reason: 'manual_stop' | 'runtime_exit'
-  ): void {
-    if (
-      this.runtimeManager.isSessionRunning(sessionId) ||
-      sessionEventBus.countViewers(sessionId) > 0
-    ) {
-      return;
-    }
-    this.sessionDomainService.clearSession(sessionId, { preserveRejections: true });
-    logger.debug('Cleared inactive in-memory session state', { sessionId, reason });
-  }
-
-  async persistClosedSession(sessionId: string): Promise<void> {
-    const session = await this.repository.getSessionById(sessionId);
-    if (!session) {
-      logger.warn('Cannot persist closed session: session not found', { sessionId });
-      return;
-    }
-
-    const workspace = await workspaceDataService.findById(session.workspaceId);
-    if (!workspace?.worktreePath) {
-      logger.warn('Cannot persist closed session: no worktree path', {
-        sessionId,
-        workspaceId: session.workspaceId,
-      });
-      return;
-    }
-
-    await this.hydrateProviderHistory(sessionId, {
-      ...session,
-      workspace: { worktreePath: workspace.worktreePath },
-    });
-    await this.lifecycleEventService.hydrate(sessionId);
-
-    const transcript = this.sessionDomainService.getTranscriptSnapshot(sessionId);
-    await closedSessionPersistenceService.persistClosedSession({
-      sessionId,
-      workspaceId: session.workspaceId,
-      worktreePath: workspace.worktreePath,
-      name: session.name,
-      workflow: session.workflow,
-      provider: session.provider,
-      model: session.model,
-      startedAt: session.createdAt,
-      messages: transcript,
-    });
-  }
-
-  private async persistRatchetTranscript(sessionId: string): Promise<void> {
-    await this.persistClosedSession(sessionId);
+  persistClosedSession(sessionId: string): Promise<void> {
+    return this.workflowFinalizer.persistClosedSession(sessionId);
   }
 
   private async getOrCreateAcpSessionClient(


### PR DESCRIPTION
## What changed

- extracted `SessionWorkflowFinalizer` from the lifecycle facade
- centralized ratchet settlement, transient-session cleanup, PR discovery, auto-iteration exit handling, closed-session persistence, inactive cleanup, and stale-running recovery
- preserved managed runtime-stop semantics and made repeated ratchet cleanup persistence-safe
- routed startup stale-session recovery through `SessionLifecycleService`
- removed the duplicate `SessionDataService` recovery entry point
- lowered the lifecycle facade file-length ceiling from 1,338 to 1,210 lines

## Why

Workflow completion and recovery were mixed into the session lifecycle facade and exposed duplicate recovery paths. This gives those behaviors one focused owner while preserving the existing facade API and observable lifecycle behavior.

This is PR 5 in the staged session lifecycle modularization series.

## Validation

- `pnpm check:fix`
- `pnpm typecheck`
- focused finalizer/recovery suites: 7 files, 136 tests
- `pnpm test --maxWorkers=2`: 409 passed / 1 skipped files; 5,219 passed / 4 skipped tests
- `pnpm check`: all guardrails passed; dependency-cruiser reported zero violations across 1,330 modules and 5,323 dependencies

The local Codex schema subcheck skipped because the installed CLI is 0.147.0 while the repository pins 0.145.0; CI installs the pinned CLI and enforces it.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9d5d95795c59abfa6aa51917700c52f1c1535da9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->