### PR TITLE
Extract session startup coordination

### DIFF
--- a/docs/superpowers/plans/2026-08-14-session-startup-coordinator.md
+++ b/docs/superpowers/plans/2026-08-14-session-startup-coordinator.md
@@ -1,0 +1,242 @@
+# Session Startup Coordinator Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract active, restart, get-or-create, and browse startup from `SessionLifecycleService` into a focused `SessionStartupCoordinator` without changing the public lifecycle API or observable behavior.
+
+**Architecture:** `SessionLifecycleService` remains the compatibility facade and delegates startup methods to one coordinator. The coordinator owns startup leases, context and preset resolution, ACP construction inputs, runtime/config snapshots, browse probing, and notification recovery. The facade temporarily retains the client-creation operation tracker used by stop cleanup through a narrow registration port; PR 8 will replace that tracker with the runtime manager's strengthened quiescence contract.
+
+**Tech Stack:** TypeScript 5.9, Vitest 4, pnpm, Biome, dependency-cruiser.
+
+## Global Constraints
+
+- Preserve the signatures, return values, errors, persistence effects, and ordering of all existing public lifecycle methods.
+- Validate the startup lease after every asynchronous boundary at which a stop can invalidate work.
+- Do not move stop orchestration or strengthen runtime quiescence in this PR.
+- Do not add runtime creation deduplication or process-handle state outside `AcpRuntimeManager`.
+- Keep `SessionStartupCoordinator` below 600 lines and every production file below 1,000 lines.
+- Import within the session capsule according to `src/backend/services/AGENTS.md`; do not introduce cross-capsule deep imports or cycles.
+- Use TDD for production changes and lower, never increase, tracked file-length baselines.
+
+---
+
+### Task 1: Define and characterize the public startup coordinator
+
+**Files:**
+- Create: `src/backend/services/session/service/lifecycle/session-startup.coordinator.ts`
+- Modify: `src/backend/services/session/service/lifecycle/session-startup.coordinator.test.ts`
+- Modify: `src/backend/services/session/service/lifecycle/session-lifecycle.test-helpers.ts`
+
+**Interfaces:**
+- Produces: `SessionStartupCoordinator` with public methods `startSession`, `restartSession`, `getOrCreateSessionClient`, `getOrCreateSessionClientFromRecord`, and `ensureSubagentBrowseSession`.
+- Produces: `SessionStartupCoordinatorDependencies`, including explicit repository, context, environment, runtime, domain, configuration, event-handler, lifecycle-gate, notification, prompt-send, message-dispatch, restart-stop, and transitional creation-registration ports.
+- Consumes: existing `StartSessionOptions`, `GetOrCreateSessionClientOptions`, `AgentSessionRecord`, and `SessionLifecycleGate` contracts.
+
+- [ ] **Step 1: Add a direct public-class characterization test**
+
+  Import `SessionStartupCoordinator` from `./session-startup.coordinator`, construct it with typed test ports, call `getOrCreateSessionClient('session-1')`, and assert the returned handle plus the literal persisted `RUNNING` transition and runtime snapshot. The production mutation this test catches is a coordinator that creates a client but fails to reconcile durable and in-memory running state.
+
+- [ ] **Step 2: Run the direct suite and capture RED**
+
+  Run: `pnpm test src/backend/services/session/service/lifecycle/session-startup.coordinator.test.ts`
+
+  Expected: FAIL because `./session-startup.coordinator` does not exist. No production file may exist before this failure is captured.
+
+- [ ] **Step 3: Add the minimal coordinator contract and typed dependencies**
+
+  Create the class and constructor with this public surface:
+
+  ```ts
+  export class SessionStartupCoordinator {
+    constructor(dependencies: SessionStartupCoordinatorDependencies);
+
+    startSession(sessionId: string, options?: StartSessionOptions): Promise<void>;
+    restartSession(sessionId: string, options?: StartSessionOptions): Promise<void>;
+    getOrCreateSessionClient(
+      sessionId: string,
+      options?: GetOrCreateSessionClientOptions
+    ): Promise<unknown>;
+    getOrCreateSessionClientFromRecord(
+      session: AgentSessionRecord,
+      options?: GetOrCreateSessionClientOptions
+    ): Promise<unknown>;
+    ensureSubagentBrowseSession(sessionId: string): Promise<boolean>;
+  }
+  ```
+
+  Implement only enough get-or-create behavior to make the new direct test pass, using a real `SessionLifecycleGate` and typed injected ports.
+
+- [ ] **Step 4: Run GREEN and retain the existing facade characterizations**
+
+  Run: `pnpm test src/backend/services/session/service/lifecycle/session-startup.coordinator.test.ts`
+
+  Expected: PASS. Existing startup behavior tests must remain present; migrate their harness target from the facade only when the test can exercise the real public coordinator without broad mock assertions.
+
+---
+
+### Task 2: Move active, restart, and get-or-create startup behind the coordinator
+
+**Files:**
+- Modify: `src/backend/services/session/service/lifecycle/session-startup.coordinator.ts`
+- Modify: `src/backend/services/session/service/lifecycle/session-startup.coordinator.test.ts`
+- Modify: `src/backend/services/session/service/lifecycle/session.lifecycle.service.ts`
+- Modify: `src/backend/services/session/service/lifecycle/session.lifecycle.facade.test.ts`
+- Modify: `src/backend/services/session/service/lifecycle/session-lifecycle.test-helpers.ts`
+
+**Interfaces:**
+- Consumes: a narrow creation registration port that returns `isOnlyOperation()` and `release()` for the facade-owned `clientCreationOperations` map.
+- Consumes: a restart-stop callback with the existing `stopSession(sessionId, { cleanupTransientRatchetSession: false })` behavior.
+- Produces: facade methods that delegate unchanged arguments and results to the coordinator.
+
+- [ ] **Step 1: Add RED delegation and boundary tests**
+
+  Add public tests that fail if the facade implements startup itself instead of delegating, and direct coordinator cases for stop invalidation after session lookup, permission resolution, client creation, configuration snapshot persistence, notification recovery, preset application, queued dispatch, and initial prompt completion. Each test must assert the consumer-visible cancellation or absence of a later `RUNNING` write.
+
+- [ ] **Step 2: Run the focused suites and verify the expected failures**
+
+  Run:
+
+  ```bash
+  pnpm test \
+    src/backend/services/session/service/lifecycle/session-startup.coordinator.test.ts \
+    src/backend/services/session/service/lifecycle/session.lifecycle.facade.test.ts
+  ```
+
+  Expected: FAIL because facade delegation and the moved coordinator behavior are incomplete.
+
+- [ ] **Step 3: Move startup implementation without semantic edits**
+
+  Move these responsibilities into `SessionStartupCoordinator`:
+
+  - `startSession` and `restartSession`;
+  - both get-or-create entry points;
+  - ACP client option construction and event-handler creation;
+  - permission/startup preset application;
+  - reasoning effort, config snapshot, and capability delta application;
+  - notification recovery and best-effort queued dispatch;
+  - runtime snapshot transitions and the durable `RUNNING` reconciliation point.
+
+  Keep the facade-owned creation tracker accessible only through a narrow port so `stopRuntimeAndPendingCreation` remains unchanged for PR 8. Preserve every existing `assertStartupAllowed` check and add checks only where the approved race matrix already requires one.
+
+- [ ] **Step 4: Replace facade bodies with delegation**
+
+  Construct exactly one coordinator after notification delivery is configured, forward the existing message-queue bridge into it, and delegate the five startup public methods. Keep `getSessionClient`, runtime snapshot reads, lifecycle-gate queries, stop methods, and workflow-finalizer methods on the facade.
+
+- [ ] **Step 5: Run focused GREEN**
+
+  Run the two-file command from Step 2 plus:
+
+  ```bash
+  pnpm test src/backend/services/session/service/lifecycle/session.service.test.ts
+  ```
+
+  Expected: all focused tests pass with unchanged public behavior.
+
+---
+
+### Task 3: Move browse startup and verify composition
+
+**Files:**
+- Modify: `src/backend/services/session/service/lifecycle/session-startup.coordinator.ts`
+- Modify: `src/backend/services/session/service/lifecycle/session-startup.coordinator.test.ts`
+- Modify: `src/backend/services/session/service/lifecycle/session.lifecycle.service.ts`
+- Modify: `src/backend/services/session/service/lifecycle/session-services.composition.test.ts`
+- Modify: `src/backend/services/session/service/lifecycle/session-core-services.ts` only if constructor wiring requires it
+- Modify: `src/backend/services/session/service/lifecycle/session-services.ts` only if notification/message-queue configuration forwarding requires it
+
+**Interfaces:**
+- Produces: browse startup that returns the existing boolean contract and never marks a browse-only runtime `RUNNING`, recovers notifications, or persists a provider session ID.
+- Preserves: one public lifecycle singleton and one coordinator instance before chat transport uses the facade.
+
+- [ ] **Step 1: Add RED browse and composition assertions**
+
+  Characterize stored-provider-session requirements, unusable worktrees, unsupported restore, unsupported capability cleanup, active promotion, concurrent browse cleanup, and cancellation translation to `false`. Add a composition assertion that the public singleton is fully startup-configured before chat dispatch calls it.
+
+- [ ] **Step 2: Run RED**
+
+  Run:
+
+  ```bash
+  pnpm test \
+    src/backend/services/session/service/lifecycle/session-startup.coordinator.test.ts \
+    src/backend/services/session/service/lifecycle/session-services.composition.test.ts
+  ```
+
+  Expected: at least one new direct coordinator or composition assertion fails before browse wiring is complete.
+
+- [ ] **Step 3: Move browse behavior and cancellation translation**
+
+  Move `ensureSubagentBrowseSession` and browse support resolution into the coordinator. Preserve the existing `AcpBrowseSessionUnavailableError` and `SessionStartupCancelledError` translations, the stop reservation around unsupported browse cleanup, and the rule that browse handlers omit provider-session persistence.
+
+- [ ] **Step 4: Run focused lifecycle GREEN**
+
+  Run:
+
+  ```bash
+  pnpm test \
+    src/backend/services/session/service/lifecycle/session-startup.coordinator.test.ts \
+    src/backend/services/session/service/lifecycle/session.lifecycle.facade.test.ts \
+    src/backend/services/session/service/lifecycle/session-termination.coordinator.test.ts \
+    src/backend/services/session/service/lifecycle/session-runtime-exit.coordinator.test.ts \
+    src/backend/services/session/service/lifecycle/session-services.composition.test.ts \
+    src/backend/services/session/service/lifecycle/session.service.test.ts
+  ```
+
+  Expected: all focused suites pass.
+
+---
+
+### Task 4: Ratchet file sizes and complete repository verification
+
+**Files:**
+- Modify: `scripts/file-length-baseline.json`
+- Modify: only files already listed above if verification exposes an extraction regression
+
+**Interfaces:**
+- Produces: no public API change; only lower file ceilings and verified behavior.
+
+- [ ] **Step 1: Format and update the downward baseline**
+
+  Run:
+
+  ```bash
+  pnpm check:fix
+  pnpm check:file-length:update
+  git diff -- scripts/file-length-baseline.json
+  ```
+
+  Expected: the lifecycle facade ceiling decreases, no ceiling increases, and the new coordinator remains below 600 lines.
+
+- [ ] **Step 2: Run type and focused verification**
+
+  Run:
+
+  ```bash
+  pnpm typecheck
+  pnpm test \
+    src/backend/services/session/service/lifecycle/session-startup.coordinator.test.ts \
+    src/backend/services/session/service/lifecycle/session.lifecycle.facade.test.ts \
+    src/backend/services/session/service/lifecycle/session-termination.coordinator.test.ts \
+    src/backend/services/session/service/lifecycle/session-runtime-exit.coordinator.test.ts \
+    src/backend/services/session/service/lifecycle/session-services.composition.test.ts \
+    src/backend/services/session/service/lifecycle/session.service.test.ts
+  ```
+
+  Expected: exit 0 with no TypeScript diagnostics or test failures.
+
+- [ ] **Step 3: Run the complete handoff sequence**
+
+  Run:
+
+  ```bash
+  pnpm check:fix
+  pnpm typecheck
+  pnpm test --maxWorkers=2
+  pnpm check
+  ```
+
+  Expected: every command exits 0. `pnpm check:prisma-schema` is not required because this PR must not alter `prisma/schema.prisma`.
+
+- [ ] **Step 4: Review and commit**
+
+  Inspect `git diff --check`, the exact base-to-head diff, file sizes, imports, public signatures, and startup-boundary assertions. Commit with an imperative subject under 72 characters, then use the finishing workflow to push and open the PR with the checks recorded in its body.

--- a/scripts/file-length-baseline.json
+++ b/scripts/file-length-baseline.json
@@ -19,7 +19,6 @@
   "src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.test.ts": 1576,
   "src/backend/services/session/service/lifecycle/session.config.service.test.ts": 1159,
   "src/backend/services/session/service/lifecycle/session.config.service.ts": 1080,
-  "src/backend/services/session/service/lifecycle/session.lifecycle.service.ts": 1064,
   "src/backend/services/session/service/lifecycle/session.service.test.ts": 2777,
   "src/backend/services/workspace/resources/workspace.accessor.ts": 1055,
   "src/backend/services/workspace/service/lifecycle/state-machine.service.test.ts": 1115,

--- a/src/backend/services/session/service/lifecycle/session-lifecycle.test-helpers.ts
+++ b/src/backend/services/session/service/lifecycle/session-lifecycle.test-helpers.ts
@@ -119,6 +119,8 @@ export type LifecycleHarness = {
   lifecycleEventService: MockedPick<SessionLifecycleEventService, 'record' | 'hydrate'>;
   contextService: SessionContextService;
   acpEnvironment: MockedPick<SessionAcpEnvironmentPort, 'getBackendPort' | 'getMcpServers'>;
+  lifecycleGate: SessionLifecycleGate;
+  notificationDeliveryService: SessionNotificationDeliveryService;
   notificationService: MockedPick<SessionPermissionService, 'cancelPendingRequests'>;
   workspaceBridge: MockedPick<
     SessionLifecycleWorkspaceBridge,
@@ -460,14 +462,13 @@ export function createLifecycleHarness(
       lifecycleGate,
     })
   );
-  service.configureNotificationDelivery(
-    new SessionNotificationDeliveryService({
-      notificationPort: workspaceNotificationService,
-      queuePort: sessionDomainService,
-      transcriptPort: sessionDomainService,
-      deltaPort: sessionDomainService,
-    })
-  );
+  const notificationDeliveryService = new SessionNotificationDeliveryService({
+    notificationPort: workspaceNotificationService,
+    queuePort: sessionDomainService,
+    transcriptPort: sessionDomainService,
+    deltaPort: sessionDomainService,
+  });
+  service.configureNotificationDelivery(notificationDeliveryService);
   service.configure({ workspace: workspaceBridge, messageQueue: messageQueueBridge });
 
   return {
@@ -480,6 +481,8 @@ export function createLifecycleHarness(
     lifecycleEventService,
     contextService,
     acpEnvironment,
+    lifecycleGate,
+    notificationDeliveryService,
     notificationService,
     workspaceBridge,
     messageQueueBridge,

--- a/src/backend/services/session/service/lifecycle/session-services.composition.test.ts
+++ b/src/backend/services/session/service/lifecycle/session-services.composition.test.ts
@@ -7,6 +7,7 @@ import { WorkspaceStatus } from '@/shared/core';
 import { unsafeCoerce } from '@/test-utils/unsafe-coerce';
 import { sessionLifecycleService as coreSessionLifecycleService } from './session-core-services';
 import { chatMessageHandlerService, sessionLifecycleService } from './session-services';
+import { SessionStartupCoordinator } from './session-startup.coordinator';
 
 describe('session services composition', () => {
   afterEach(() => {
@@ -47,5 +48,17 @@ describe('session services composition', () => {
       model: 'opus',
       reasoningEffort: 'high',
     });
+  });
+
+  it('exports the public lifecycle singleton with startup configured', async () => {
+    const ensureSubagentBrowseSession = vi
+      .spyOn(SessionStartupCoordinator.prototype, 'ensureSubagentBrowseSession')
+      .mockResolvedValueOnce(false);
+
+    await expect(
+      publicSessionLifecycleService.ensureSubagentBrowseSession('session-1')
+    ).resolves.toBe(false);
+
+    expect(ensureSubagentBrowseSession).toHaveBeenCalledWith('session-1');
   });
 });

--- a/src/backend/services/session/service/lifecycle/session-startup.coordinator.test.ts
+++ b/src/backend/services/session/service/lifecycle/session-startup.coordinator.test.ts
@@ -80,6 +80,26 @@ describe('SessionStartupCoordinator', () => {
     });
   });
 
+  it('preserves the running-before-stopping restart probe order', async () => {
+    const harness = createLifecycleHarness();
+    const probes: string[] = [];
+    harness.runtimeManager.isSessionRunning.mockImplementationOnce(() => {
+      probes.push('running');
+      return true;
+    });
+    harness.runtimeManager.isStopInProgress.mockImplementationOnce(() => {
+      probes.push('stopping');
+      return true;
+    });
+    const coordinator = createStartupCoordinator(harness);
+
+    await expect(coordinator.restartSession('session-1')).rejects.toThrow(
+      'Cannot restart: session is currently being stopped. Please try again shortly.'
+    );
+
+    expect(probes).toEqual(['running', 'stopping']);
+  });
+
   it('builds ACP startup options through the injected environment port', async () => {
     const { service, runtimeManager, acpEnvironment } = createLifecycleHarness({
       workspace: { parentWorkspaceId: 'parent-workspace' },
@@ -618,13 +638,63 @@ describe('SessionStartupCoordinator', () => {
       expect(harness.sessionConfigService.persistAcpConfigSnapshot).toHaveBeenCalledOnce();
     });
 
-    await harness.service.stopSession('session-1');
+    const stopPromise = harness.service.stopSession('session-1');
+    await vi.waitFor(() => {
+      expect(harness.runtimeManager.stopClient).toHaveBeenCalledWith('session-1');
+    });
+    const firstSettlement = await Promise.race([
+      stopPromise.then(() => 'stopped' as const),
+      new Promise<'blocked'>((resolve) => {
+        setImmediate(() => resolve('blocked'));
+      }),
+    ]);
+
+    expect(firstSettlement).toBe('blocked');
     snapshotPersistence.resolve(undefined);
+    await stopPromise;
 
     await expect(startResult).resolves.toEqual(
       expect.objectContaining({ message: 'Session is currently being stopped' })
     );
     expect(harness.sessionDomainService.emitDelta).not.toHaveBeenCalled();
+  });
+
+  it('keeps stop ahead of startup during durable running-state persistence', async () => {
+    const harness = createLifecycleHarness();
+    const runningPersistence = createDeferred<typeof harness.session>();
+    harness.repository.updateSession.mockReturnValueOnce(runningPersistence.promise);
+
+    const startResult = harness.service
+      .startSession('session-1', { initialPrompt: '' })
+      .catch((error: unknown) => error);
+    await vi.waitFor(() => {
+      expect(harness.repository.updateSession).toHaveBeenCalledWith('session-1', {
+        status: SessionStatus.RUNNING,
+      });
+    });
+
+    const stopPromise = harness.service.stopSession('session-1');
+    await vi.waitFor(() => {
+      expect(harness.runtimeManager.stopClient).toHaveBeenCalledWith('session-1');
+    });
+    const firstSettlement = await Promise.race([
+      stopPromise.then(() => 'stopped' as const),
+      new Promise<'blocked'>((resolve) => {
+        setImmediate(() => resolve('blocked'));
+      }),
+    ]);
+
+    expect(firstSettlement).toBe('blocked');
+    runningPersistence.resolve(harness.session);
+    await stopPromise;
+    await expect(startResult).resolves.toEqual(
+      expect.objectContaining({ message: 'Session is currently being stopped' })
+    );
+    expect(harness.sessionDomainService.getRuntimeSnapshot('session-1')).toMatchObject({
+      phase: 'idle',
+      processState: 'stopped',
+      activity: 'IDLE',
+    });
   });
 
   it('does not fail startup when queued notification dispatch fails', async () => {

--- a/src/backend/services/session/service/lifecycle/session-startup.coordinator.test.ts
+++ b/src/backend/services/session/service/lifecycle/session-startup.coordinator.test.ts
@@ -659,10 +659,11 @@ describe('SessionStartupCoordinator', () => {
     expect(harness.sessionDomainService.emitDelta).not.toHaveBeenCalled();
   });
 
-  it('keeps stop ahead of startup during durable running-state persistence', async () => {
+  it('keeps stop ahead of startup when runtime stop fails during running persistence', async () => {
     const harness = createLifecycleHarness();
     const runningPersistence = createDeferred<typeof harness.session>();
     harness.repository.updateSession.mockReturnValueOnce(runningPersistence.promise);
+    harness.runtimeManager.stopClient.mockRejectedValueOnce(new Error('stop failed'));
 
     const startResult = harness.service
       .startSession('session-1', { initialPrompt: '' })
@@ -687,6 +688,7 @@ describe('SessionStartupCoordinator', () => {
     expect(firstSettlement).toBe('blocked');
     runningPersistence.resolve(harness.session);
     await stopPromise;
+    expect(harness.runtimeManager.stopClient).toHaveBeenCalledTimes(2);
     await expect(startResult).resolves.toEqual(
       expect.objectContaining({ message: 'Session is currently being stopped' })
     );

--- a/src/backend/services/session/service/lifecycle/session-startup.coordinator.test.ts
+++ b/src/backend/services/session/service/lifecycle/session-startup.coordinator.test.ts
@@ -162,6 +162,49 @@ describe('SessionStartupCoordinator', () => {
     expect(sessionDomainService.setRuntimeSnapshot).not.toHaveBeenCalled();
   });
 
+  it('rejects an existing browse client while stop is in progress', async () => {
+    const harness = createLifecycleHarness();
+    const runtimeStop = createDeferred<void>();
+    harness.runtimeManager.getSubagentBrowseCapability.mockReturnValue({
+      version: 1,
+      list: true,
+      read: true,
+      notifications: true,
+    });
+    harness.runtimeManager.stopClient.mockReturnValueOnce(runtimeStop.promise);
+
+    const stopPromise = harness.service.stopSession('session-1');
+    await vi.waitFor(() => {
+      expect(harness.runtimeManager.stopClient).toHaveBeenCalledWith('session-1');
+    });
+
+    await expect(harness.service.ensureSubagentBrowseSession('session-1')).resolves.toBe(false);
+
+    runtimeStop.resolve(undefined);
+    await stopPromise;
+  });
+
+  it('rejects a pending browse client when stop completes before it settles', async () => {
+    const harness = createLifecycleHarness();
+    const pendingClient = createDeferred<typeof harness.handle>();
+    harness.runtimeManager.getPendingClient.mockReturnValueOnce(pendingClient.promise);
+
+    const browseResult = harness.service.ensureSubagentBrowseSession('session-1');
+    await vi.waitFor(() => {
+      expect(harness.runtimeManager.getPendingClient).toHaveBeenCalledWith('session-1');
+    });
+    await harness.service.stopSession('session-1');
+    harness.runtimeManager.getSubagentBrowseCapability.mockReturnValue({
+      version: 1,
+      list: true,
+      read: true,
+      notifications: true,
+    });
+    pendingClient.resolve(harness.handle);
+
+    await expect(browseResult).resolves.toBe(false);
+  });
+
   it('does not spawn a browse client without a stored provider session', async () => {
     const { service, runtimeManager } = createLifecycleHarness({
       provider: 'CODEX',
@@ -660,7 +703,7 @@ describe('SessionStartupCoordinator', () => {
   });
 
   it('keeps stop ahead of startup when runtime stop fails during running persistence', async () => {
-    const harness = createLifecycleHarness();
+    const harness = createLifecycleHarness({ session: { workflow: 'ratchet' } });
     const runningPersistence = createDeferred<typeof harness.session>();
     harness.repository.updateSession.mockReturnValueOnce(runningPersistence.promise);
     harness.runtimeManager.stopClient.mockRejectedValueOnce(new Error('stop failed'));
@@ -674,7 +717,9 @@ describe('SessionStartupCoordinator', () => {
       });
     });
 
-    const stopPromise = harness.service.stopSession('session-1');
+    const stopPromise = harness.service.stopSession('session-1', {
+      cleanupTransientRatchetSession: false,
+    });
     await vi.waitFor(() => {
       expect(harness.runtimeManager.stopClient).toHaveBeenCalledWith('session-1');
     });
@@ -689,14 +734,18 @@ describe('SessionStartupCoordinator', () => {
     runningPersistence.resolve(harness.session);
     await stopPromise;
     expect(harness.runtimeManager.stopClient).toHaveBeenCalledTimes(2);
+    expect(harness.workspaceBridge.recordRatchetSessionEnd).toHaveBeenCalledWith(
+      'workspace-1',
+      'session-1',
+      'COMPLETED'
+    );
     await expect(startResult).resolves.toEqual(
       expect.objectContaining({ message: 'Session is currently being stopped' })
     );
-    expect(harness.sessionDomainService.getRuntimeSnapshot('session-1')).toMatchObject({
-      phase: 'idle',
-      processState: 'stopped',
-      activity: 'IDLE',
-    });
+    expect(harness.sessionDomainService.setRuntimeSnapshot).toHaveBeenLastCalledWith(
+      'session-1',
+      expect.objectContaining({ phase: 'idle', processState: 'stopped', activity: 'IDLE' })
+    );
   });
 
   it('does not fail startup when queued notification dispatch fails', async () => {

--- a/src/backend/services/session/service/lifecycle/session-startup.coordinator.test.ts
+++ b/src/backend/services/session/service/lifecycle/session-startup.coordinator.test.ts
@@ -8,7 +8,12 @@ import {
   createDeferred,
   createLifecycleHarness,
   createPendingWorkspaceNotification,
+  type LifecycleHarness,
 } from './session-lifecycle.test-helpers';
+import {
+  SessionStartupCoordinator,
+  type SessionStartupCoordinatorDependencies,
+} from './session-startup.coordinator';
 
 vi.mock('@/backend/services/logger.service', () => ({
   createLogger: () => ({
@@ -28,11 +33,51 @@ vi.mock('@/backend/services/workspace', () => ({
   },
 }));
 
+function createStartupCoordinator(harness: LifecycleHarness): SessionStartupCoordinator {
+  const dependencies = {
+    repository: harness.repository,
+    contextService: harness.contextService,
+    acpEnvironment: harness.acpEnvironment,
+    runtimeManager: harness.runtimeManager,
+    sessionDomainService: harness.sessionDomainService,
+    sessionConfigService: harness.sessionConfigService,
+    acpEventProcessor: harness.acpEventProcessor,
+    runtimeExitCoordinator: { createHandlers: vi.fn(() => ({})) },
+    lifecycleGate: harness.lifecycleGate,
+    notificationDelivery: harness.notificationDeliveryService,
+    getMessageQueueBridge: () => harness.messageQueueBridge,
+    sendSessionMessage: harness.sendSessionMessage,
+    stopSession: (sessionId, options) => harness.service.stopSession(sessionId, options),
+    registerClientCreation: () => ({
+      isOnlyOperation: () => true,
+      release: vi.fn(),
+    }),
+  } satisfies SessionStartupCoordinatorDependencies;
+  return new SessionStartupCoordinator(dependencies);
+}
+
 describe('SessionStartupCoordinator', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(workspaceNotificationService.listPendingForDelivery).mockResolvedValue([]);
     vi.mocked(workspaceNotificationService.markDelivered).mockResolvedValue();
+  });
+
+  it('reconciles a newly created client to durable and in-memory running state', async () => {
+    const harness = createLifecycleHarness();
+    const coordinator = createStartupCoordinator(harness);
+
+    await expect(coordinator.getOrCreateSessionClient('session-1')).resolves.toBe(harness.handle);
+
+    expect(harness.repository.updateSession).toHaveBeenCalledWith('session-1', {
+      status: SessionStatus.RUNNING,
+    });
+    expect(harness.sessionDomainService.setRuntimeSnapshot).toHaveBeenLastCalledWith('session-1', {
+      phase: 'idle',
+      processState: 'alive',
+      activity: 'IDLE',
+      updatedAt: expect.any(String),
+    });
   });
 
   it('builds ACP startup options through the injected environment port', async () => {
@@ -557,6 +602,29 @@ describe('SessionStartupCoordinator', () => {
     expect(runtimeManager.getOrCreateClient).not.toHaveBeenCalled();
     expect(sendSessionMessage).not.toHaveBeenCalled();
     expect(service.getStopGeneration('session-1')).not.toBe(startupGeneration);
+  });
+
+  it('does not publish startup capabilities after stop completes during snapshot persistence', async () => {
+    const harness = createLifecycleHarness();
+    const snapshotPersistence = createDeferred<void>();
+    harness.sessionConfigService.persistAcpConfigSnapshot.mockReturnValueOnce(
+      snapshotPersistence.promise
+    );
+
+    const startResult = harness.service
+      .startSession('session-1', { initialPrompt: '' })
+      .catch((error: unknown) => error);
+    await vi.waitFor(() => {
+      expect(harness.sessionConfigService.persistAcpConfigSnapshot).toHaveBeenCalledOnce();
+    });
+
+    await harness.service.stopSession('session-1');
+    snapshotPersistence.resolve(undefined);
+
+    await expect(startResult).resolves.toEqual(
+      expect.objectContaining({ message: 'Session is currently being stopped' })
+    );
+    expect(harness.sessionDomainService.emitDelta).not.toHaveBeenCalled();
   });
 
   it('does not fail startup when queued notification dispatch fails', async () => {

--- a/src/backend/services/session/service/lifecycle/session-startup.coordinator.ts
+++ b/src/backend/services/session/service/lifecycle/session-startup.coordinator.ts
@@ -204,26 +204,19 @@ export class SessionStartupCoordinator {
   }
 
   async ensureSubagentBrowseSession(sessionId: string): Promise<boolean> {
-    if (this.dependencies.runtimeManager.getSubagentBrowseCapability(sessionId)) {
-      return true;
-    }
-
-    const pendingClient = this.dependencies.runtimeManager.getPendingClient(sessionId);
-    if (pendingClient) {
-      try {
-        await pendingClient;
-      } catch (error) {
-        if (error instanceof AcpBrowseSessionUnavailableError) {
-          return false;
-        }
-        throw error;
-      }
-      return await this.resolveSubagentBrowseSupport(sessionId);
-    }
-
     return await this.dependencies.lifecycleGate
       .runStartup(sessionId, async (lease) => {
         const stopGeneration = lease.generation;
+        this.assertStartupAllowed(sessionId, stopGeneration);
+
+        const existingBrowseSupport = await this.resolveExistingBrowseSupport(
+          sessionId,
+          stopGeneration
+        );
+        if (existingBrowseSupport !== null) {
+          return existingBrowseSupport;
+        }
+
         const session = await this.dependencies.repository.getSessionById(sessionId);
         if (!(session?.provider === 'CODEX' && session.providerSessionId)) {
           return false;
@@ -267,6 +260,30 @@ export class SessionStartupCoordinator {
         }
         throw error;
       });
+  }
+
+  private async resolveExistingBrowseSupport(
+    sessionId: string,
+    stopGeneration: number
+  ): Promise<boolean | null> {
+    if (this.dependencies.runtimeManager.getSubagentBrowseCapability(sessionId)) {
+      return true;
+    }
+
+    const pendingClient = this.dependencies.runtimeManager.getPendingClient(sessionId);
+    if (!pendingClient) {
+      return null;
+    }
+    try {
+      await pendingClient;
+    } catch (error) {
+      if (error instanceof AcpBrowseSessionUnavailableError) {
+        return false;
+      }
+      throw error;
+    }
+    this.assertStartupAllowed(sessionId, stopGeneration);
+    return await this.resolveSubagentBrowseSupport(sessionId);
   }
 
   private async getOrCreateFromRecord(

--- a/src/backend/services/session/service/lifecycle/session-startup.coordinator.ts
+++ b/src/backend/services/session/service/lifecycle/session-startup.coordinator.ts
@@ -1,0 +1,550 @@
+import { createLogger } from '@/backend/services/logger.service';
+import type { AgentSessionRecord } from '@/backend/services/session/resources/agent-session.accessor';
+import type {
+  AcpClientOptions,
+  AcpProcessHandle,
+  AcpRuntimeManager,
+  PermissionPreset,
+} from '@/backend/services/session/service/acp';
+import { AcpBrowseSessionUnavailableError } from '@/backend/services/session/service/acp/acp-runtime-manager';
+import type { SessionLifecycleMessageQueueBridge } from '@/backend/services/session/service/bridges';
+import type { SessionDomainService } from '@/backend/services/session/service/session-domain.service';
+import type { SessionDeltaEvent } from '@/shared/acp-protocol';
+import type { ChatBarCapabilities } from '@/shared/chat-capabilities';
+import { SessionStatus } from '@/shared/core';
+import type { AcpEventProcessor } from './acp-event-processor';
+import type {
+  PersistAcpConfigSnapshotParams,
+  SessionConfigService,
+} from './session.config.service';
+import { toErrorMessage } from './session.error-message';
+import type { SessionRepository } from './session.repository';
+import type { SessionContextService } from './session-context.service';
+import type { SessionAcpEnvironmentPort } from './session-lifecycle.types';
+import { type SessionLifecycleGate, SessionStartupCancelledError } from './session-lifecycle-gate';
+import type { SessionNotificationDeliveryService } from './session-notification-delivery.service';
+import type { SessionRuntimeExitCoordinator } from './session-runtime-exit.coordinator';
+
+const logger = createLogger('session');
+
+export type SessionStartupModePreset = 'non_interactive' | 'plan';
+
+export type GetOrCreateSessionClientOptions = {
+  thinkingEnabled?: boolean;
+  model?: string;
+  reasoningEffort?: string;
+};
+
+export type StartSessionOptions = {
+  initialPrompt?: string;
+  initialPromptIsDefault?: boolean;
+  startupModePreset?: SessionStartupModePreset;
+};
+
+type ClientCreationRegistration = {
+  isOnlyOperation(): boolean;
+  release(): void;
+};
+
+export type SessionStartupCoordinatorDependencies = {
+  repository: Pick<
+    SessionRepository,
+    'getSessionById' | 'getWorkspaceById' | 'markWorkspaceHasHadSessions' | 'updateSession'
+  >;
+  contextService: Pick<SessionContextService, 'load' | 'resolvePermissionPreset'>;
+  acpEnvironment: SessionAcpEnvironmentPort;
+  runtimeManager: Pick<
+    AcpRuntimeManager,
+    | 'getClient'
+    | 'getPendingClient'
+    | 'getSubagentBrowseCapability'
+    | 'getOrCreateClient'
+    | 'isBrowseOnlySession'
+    | 'isSessionRunning'
+    | 'isStopInProgress'
+    | 'stopClient'
+  >;
+  sessionDomainService: Pick<
+    SessionDomainService,
+    'emitDelta' | 'getTranscriptSnapshot' | 'isHistoryHydrated' | 'setRuntimeSnapshot'
+  >;
+  sessionConfigService: Pick<
+    SessionConfigService,
+    | 'applyConfiguredPermissionPreset'
+    | 'applyConfiguredReasoningEffort'
+    | 'applyStartupModePreset'
+    | 'buildAcpChatBarCapabilities'
+    | 'persistAcpConfigSnapshot'
+  >;
+  acpEventProcessor: Pick<
+    AcpEventProcessor,
+    'clearSessionState' | 'registerSessionContext' | 'setReplaySuppression'
+  >;
+  runtimeExitCoordinator: Pick<SessionRuntimeExitCoordinator, 'createHandlers'>;
+  lifecycleGate: SessionLifecycleGate;
+  notificationDelivery: Pick<SessionNotificationDeliveryService, 'recoverPending'>;
+  getMessageQueueBridge: () => Pick<
+    SessionLifecycleMessageQueueBridge,
+    'tryDispatchNextMessage'
+  > | null;
+  sendSessionMessage: (sessionId: string, content: string) => Promise<void>;
+  stopSession: (
+    sessionId: string,
+    options: { cleanupTransientRatchetSession: false }
+  ) => Promise<void>;
+  registerClientCreation: (
+    sessionId: string,
+    operation: Promise<AcpProcessHandle>
+  ) => ClientCreationRegistration;
+};
+
+export class SessionStartupCoordinator {
+  constructor(private readonly dependencies: SessionStartupCoordinatorDependencies) {}
+
+  async startSession(sessionId: string, options?: StartSessionOptions): Promise<void> {
+    await this.dependencies.lifecycleGate.runStartup(sessionId, async (lease) => {
+      const stopGeneration = lease.generation;
+      const session = await this.dependencies.repository.getSessionById(sessionId);
+      if (!session) {
+        throw new Error(`Session not found: ${sessionId}`);
+      }
+      this.assertStartupAllowed(sessionId, stopGeneration);
+
+      const existingClient = this.dependencies.runtimeManager.getClient(sessionId);
+      if (existingClient) {
+        this.dependencies.lifecycleGate.establishStartup(lease);
+        throw new Error('Session is already running');
+      }
+
+      const { handle, resolvedPreset, dispatchableNotificationCount } =
+        await this.getOrCreateAcpSessionClient(sessionId, {}, session, stopGeneration);
+      this.dependencies.lifecycleGate.establishStartup(lease);
+      this.assertStartupAllowed(sessionId, stopGeneration);
+      await this.applyStartupModePreset(
+        sessionId,
+        handle,
+        options?.startupModePreset,
+        session.workflow
+      );
+      this.assertStartupAllowed(sessionId, stopGeneration);
+      await this.applyConfiguredPermissionPreset(sessionId, session, handle, resolvedPreset);
+      this.assertStartupAllowed(sessionId, stopGeneration);
+      await this.dispatchQueuedNotificationsIfNeeded(sessionId, dispatchableNotificationCount);
+      this.assertStartupAllowed(sessionId, stopGeneration);
+
+      const initialPrompt = options?.initialPrompt ?? 'Continue with the task.';
+      const shouldSendInitialPrompt =
+        dispatchableNotificationCount === 0 ||
+        (typeof options?.initialPrompt === 'string' && !options.initialPromptIsDefault);
+      if (shouldSendInitialPrompt && initialPrompt) {
+        await this.dependencies.sendSessionMessage(sessionId, initialPrompt);
+      }
+      this.assertStartupAllowed(sessionId, stopGeneration);
+
+      logger.info('Session started', { sessionId, provider: session.provider });
+    });
+  }
+
+  async restartSession(sessionId: string, options?: StartSessionOptions): Promise<void> {
+    if (this.dependencies.runtimeManager.isStopInProgress(sessionId)) {
+      throw new Error(
+        'Cannot restart: session is currently being stopped. Please try again shortly.'
+      );
+    }
+
+    if (this.dependencies.runtimeManager.isSessionRunning(sessionId)) {
+      try {
+        await this.dependencies.stopSession(sessionId, {
+          cleanupTransientRatchetSession: false,
+        });
+      } catch (error) {
+        logger.warn('Error stopping session during restart; continuing with start', {
+          sessionId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+    await this.startSession(
+      sessionId,
+      options ?? {
+        initialPrompt: 'Continue with the task.',
+        initialPromptIsDefault: true,
+      }
+    );
+    logger.info('Session restarted', { sessionId });
+  }
+
+  async getOrCreateSessionClient(
+    sessionId: string,
+    options?: GetOrCreateSessionClientOptions
+  ): Promise<unknown> {
+    return await this.dependencies.lifecycleGate.runStartup(sessionId, async (lease) => {
+      const stopGeneration = lease.generation;
+      const session = await this.dependencies.repository.getSessionById(sessionId);
+      if (!session) {
+        throw new Error(`Session not found: ${sessionId}`);
+      }
+      this.assertStartupAllowed(sessionId, stopGeneration);
+
+      return await this.getOrCreateFromRecord(session, options ?? {}, lease);
+    });
+  }
+
+  async getOrCreateSessionClientFromRecord(
+    session: AgentSessionRecord,
+    options?: GetOrCreateSessionClientOptions
+  ): Promise<unknown> {
+    return await this.dependencies.lifecycleGate.runStartup(session.id, async (lease) => {
+      this.assertStartupAllowed(session.id, lease.generation);
+      return await this.getOrCreateFromRecord(session, options ?? {}, lease);
+    });
+  }
+
+  async ensureSubagentBrowseSession(sessionId: string): Promise<boolean> {
+    if (this.dependencies.runtimeManager.getSubagentBrowseCapability(sessionId)) {
+      return true;
+    }
+
+    const pendingClient = this.dependencies.runtimeManager.getPendingClient(sessionId);
+    if (pendingClient) {
+      try {
+        await pendingClient;
+      } catch (error) {
+        if (error instanceof AcpBrowseSessionUnavailableError) {
+          return false;
+        }
+        throw error;
+      }
+      return await this.resolveSubagentBrowseSupport(sessionId);
+    }
+
+    return await this.dependencies.lifecycleGate
+      .runStartup(sessionId, async (lease) => {
+        const stopGeneration = lease.generation;
+        const session = await this.dependencies.repository.getSessionById(sessionId);
+        if (!(session?.provider === 'CODEX' && session.providerSessionId)) {
+          return false;
+        }
+        this.assertStartupAllowed(sessionId, stopGeneration);
+
+        const workspace = await this.dependencies.repository.getWorkspaceById(session.workspaceId);
+        if (
+          !workspace?.worktreePath ||
+          workspace.status === 'ARCHIVING' ||
+          workspace.status === 'ARCHIVED'
+        ) {
+          return false;
+        }
+        this.assertStartupAllowed(sessionId, stopGeneration);
+
+        try {
+          await this.createAcpClient(
+            sessionId,
+            { purpose: 'browse' },
+            session,
+            undefined,
+            stopGeneration
+          );
+          this.dependencies.lifecycleGate.establishStartup(lease);
+        } catch (error) {
+          if (error instanceof AcpBrowseSessionUnavailableError) {
+            return false;
+          }
+          throw error;
+        }
+
+        return await this.resolveSubagentBrowseSupport(sessionId);
+      })
+      .catch((error: unknown) => {
+        if (error instanceof SessionStartupCancelledError) {
+          return false;
+        }
+        throw error;
+      });
+  }
+
+  private async getOrCreateFromRecord(
+    session: AgentSessionRecord,
+    options: GetOrCreateSessionClientOptions,
+    lease: Readonly<{ sessionId: string; generation: number }>
+  ): Promise<AcpProcessHandle> {
+    const hadClient = !!this.dependencies.runtimeManager.getClient(session.id);
+    const { handle, resolvedPreset, dispatchableNotificationCount } =
+      await this.getOrCreateAcpSessionClient(session.id, options, session, lease.generation);
+    this.dependencies.lifecycleGate.establishStartup(lease);
+    this.assertStartupAllowed(session.id, lease.generation);
+    if (!hadClient) {
+      await this.applyConfiguredPermissionPreset(session.id, session, handle, resolvedPreset);
+      this.assertStartupAllowed(session.id, lease.generation);
+      await this.dispatchQueuedNotificationsIfNeeded(session.id, dispatchableNotificationCount);
+      this.assertStartupAllowed(session.id, lease.generation);
+    }
+    return handle;
+  }
+
+  private async resolveSubagentBrowseSupport(sessionId: string): Promise<boolean> {
+    if (this.dependencies.runtimeManager.getSubagentBrowseCapability(sessionId) !== null) {
+      return true;
+    }
+    if (!this.dependencies.runtimeManager.isBrowseOnlySession(sessionId)) {
+      return false;
+    }
+
+    const stopReservation = this.dependencies.lifecycleGate.reserveStop(sessionId);
+    try {
+      await this.dependencies.runtimeManager.stopClient(sessionId);
+    } finally {
+      this.dependencies.acpEventProcessor.clearSessionState(sessionId);
+      stopReservation?.release();
+    }
+    return false;
+  }
+
+  private async createAcpClient(
+    sessionId: string,
+    options: { model?: string; purpose?: 'active' | 'browse' },
+    session: AgentSessionRecord,
+    permissionPreset: PermissionPreset | undefined,
+    stopGeneration: number
+  ): Promise<{ handle: AcpProcessHandle; dispatchableNotificationCount: number }> {
+    const sessionContext = await this.dependencies.contextService.load(sessionId, session);
+    if (!sessionContext) {
+      throw new Error(`Session context not ready: ${sessionId}`);
+    }
+    this.assertStartupAllowed(sessionId, stopGeneration);
+
+    const browseOnly = options.purpose === 'browse';
+    if (!browseOnly) {
+      await this.dependencies.repository.markWorkspaceHasHadSessions(sessionContext.workspaceId);
+      this.assertStartupAllowed(sessionId, stopGeneration);
+    }
+    this.dependencies.acpEventProcessor.registerSessionContext(sessionId, {
+      workspaceId: sessionContext.workspaceId,
+      workingDir: sessionContext.workingDir,
+      provider: session.provider,
+    });
+
+    const handlers = this.dependencies.runtimeExitCoordinator.createHandlers({
+      sessionId,
+      purpose: browseOnly ? 'browse' : 'active',
+      persistProviderSessionId: !browseOnly,
+    });
+    this.dependencies.acpEventProcessor.setReplaySuppression(
+      sessionId,
+      this.shouldSuppressReplayDuringAcpResume(sessionId, session)
+    );
+
+    const clientOptions: AcpClientOptions = {
+      provider: session.provider,
+      purpose: options.purpose,
+      workingDir: sessionContext.workingDir,
+      model: options.model ?? sessionContext.model,
+      systemPrompt: sessionContext.systemPrompt,
+      permissionPreset,
+      sessionId,
+      resumeProviderSessionId: session.providerSessionId ?? undefined,
+      mcpServers: this.dependencies.acpEnvironment.getMcpServers({
+        workspaceId: sessionContext.workspaceId,
+        parentWorkspaceId: sessionContext.parentWorkspaceId,
+      }),
+    };
+
+    this.assertStartupAllowed(sessionId, stopGeneration);
+    const creationPromise = this.dependencies.runtimeManager.getOrCreateClient(
+      sessionId,
+      clientOptions,
+      handlers,
+      {
+        workspaceId: sessionContext.workspaceId,
+        workingDir: sessionContext.workingDir,
+      }
+    );
+    const registration = this.dependencies.registerClientCreation(sessionId, creationPromise);
+    let handle: AcpProcessHandle;
+    try {
+      handle = await creationPromise;
+      this.assertStartupAllowed(sessionId, stopGeneration);
+      if (browseOnly) {
+        return { handle, dispatchableNotificationCount: 0 };
+      }
+      await this.dependencies.sessionConfigService.applyConfiguredReasoningEffort(
+        sessionId,
+        handle,
+        { persistSnapshot: false, emitUpdates: false }
+      );
+    } catch (error) {
+      if (registration.isOnlyOperation()) {
+        this.dependencies.acpEventProcessor.clearSessionState(sessionId);
+      }
+      throw error;
+    } finally {
+      registration.release();
+    }
+
+    this.assertStartupAllowed(sessionId, stopGeneration);
+    await this.persistAcpConfigSnapshot(sessionId, {
+      provider: handle.provider as PersistAcpConfigSnapshotParams['provider'],
+      providerSessionId: handle.providerSessionId,
+      configOptions: handle.configOptions,
+      existingMetadata: session.providerMetadata ?? undefined,
+    });
+    this.assertStartupAllowed(sessionId, stopGeneration);
+
+    if (handle.configOptions.length > 0) {
+      this.dependencies.sessionDomainService.emitDelta(sessionId, {
+        type: 'config_options_update',
+        configOptions: handle.configOptions,
+      } as SessionDeltaEvent);
+    }
+    this.dependencies.sessionDomainService.emitDelta(sessionId, {
+      type: 'chat_capabilities',
+      capabilities: this.buildAcpChatBarCapabilities(handle),
+    });
+
+    this.assertStartupAllowed(sessionId, stopGeneration);
+    const { dispatchableCount } = await this.dependencies.notificationDelivery.recoverPending({
+      sessionId,
+      workspaceId: sessionContext.workspaceId,
+      assertAllowed: () => this.assertStartupAllowed(sessionId, stopGeneration),
+    });
+    return { handle, dispatchableNotificationCount: dispatchableCount };
+  }
+
+  private async getOrCreateAcpSessionClient(
+    sessionId: string,
+    options: { model?: string },
+    session: AgentSessionRecord,
+    stopGeneration: number
+  ): Promise<{
+    handle: AcpProcessHandle;
+    resolvedPreset?: PermissionPreset;
+    dispatchableNotificationCount: number;
+  }> {
+    this.assertStartupAllowed(sessionId, stopGeneration);
+    const existingAcp = this.dependencies.runtimeManager.getClient(sessionId);
+    if (existingAcp) {
+      this.dependencies.sessionDomainService.setRuntimeSnapshot(sessionId, {
+        phase: existingAcp.isPromptInFlight ? 'running' : 'idle',
+        processState: 'alive',
+        activity: existingAcp.isPromptInFlight ? 'WORKING' : 'IDLE',
+        updatedAt: new Date().toISOString(),
+      });
+      return { handle: existingAcp, dispatchableNotificationCount: 0 };
+    }
+
+    this.dependencies.sessionDomainService.setRuntimeSnapshot(sessionId, {
+      phase: 'starting',
+      processState: 'alive',
+      activity: 'IDLE',
+      updatedAt: new Date().toISOString(),
+    });
+    const resolvedPreset = await this.dependencies.contextService.resolvePermissionPreset(session);
+    this.assertStartupAllowed(sessionId, stopGeneration);
+
+    let handle: AcpProcessHandle;
+    let dispatchableNotificationCount = 0;
+    try {
+      const created = await this.createAcpClient(
+        sessionId,
+        options,
+        session,
+        resolvedPreset,
+        stopGeneration
+      );
+      handle = created.handle;
+      dispatchableNotificationCount = created.dispatchableNotificationCount;
+    } catch (error) {
+      this.dependencies.sessionDomainService.setRuntimeSnapshot(sessionId, {
+        phase: 'error',
+        processState: 'stopped',
+        activity: 'IDLE',
+        errorMessage: `Failed to start agent: ${toErrorMessage(error)}`,
+        updatedAt: new Date().toISOString(),
+      });
+      throw error;
+    }
+
+    this.assertStartupAllowed(sessionId, stopGeneration);
+    await this.dependencies.repository.updateSession(sessionId, { status: SessionStatus.RUNNING });
+    this.dependencies.sessionDomainService.setRuntimeSnapshot(sessionId, {
+      phase: handle.isPromptInFlight ? 'running' : 'idle',
+      processState: 'alive',
+      activity: handle.isPromptInFlight ? 'WORKING' : 'IDLE',
+      updatedAt: new Date().toISOString(),
+    });
+    return { handle, resolvedPreset, dispatchableNotificationCount };
+  }
+
+  private async dispatchQueuedNotificationsIfNeeded(
+    sessionId: string,
+    dispatchableNotificationCount: number
+  ): Promise<void> {
+    const messageQueueBridge = this.dependencies.getMessageQueueBridge();
+    if (dispatchableNotificationCount === 0 || !messageQueueBridge) {
+      return;
+    }
+    try {
+      await messageQueueBridge.tryDispatchNextMessage(sessionId);
+    } catch (error) {
+      logger.warn('Failed to dispatch queued workspace notifications', {
+        sessionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private shouldSuppressReplayDuringAcpResume(
+    sessionId: string,
+    session: AgentSessionRecord
+  ): boolean {
+    return !!(
+      session.providerSessionId &&
+      this.dependencies.sessionDomainService.isHistoryHydrated(sessionId) &&
+      this.dependencies.sessionDomainService.getTranscriptSnapshot(sessionId).length > 0
+    );
+  }
+
+  private async applyStartupModePreset(
+    sessionId: string,
+    handle: AcpProcessHandle,
+    startupModePreset: SessionStartupModePreset | undefined,
+    workflow: string
+  ): Promise<void> {
+    await this.dependencies.sessionConfigService.applyStartupModePreset(
+      sessionId,
+      handle,
+      startupModePreset,
+      workflow,
+      { persistSnapshot: this.persistAcpConfigSnapshot.bind(this) }
+    );
+  }
+
+  private async applyConfiguredPermissionPreset(
+    sessionId: string,
+    session: AgentSessionRecord,
+    handle: AcpProcessHandle,
+    permissionPreset?: PermissionPreset
+  ): Promise<void> {
+    await this.dependencies.sessionConfigService.applyConfiguredPermissionPreset(
+      sessionId,
+      session,
+      handle,
+      permissionPreset
+    );
+  }
+
+  private async persistAcpConfigSnapshot(
+    sessionId: string,
+    params: PersistAcpConfigSnapshotParams
+  ): Promise<void> {
+    await this.dependencies.sessionConfigService.persistAcpConfigSnapshot(sessionId, params);
+  }
+
+  private buildAcpChatBarCapabilities(handle: AcpProcessHandle): ChatBarCapabilities {
+    return this.dependencies.sessionConfigService.buildAcpChatBarCapabilities(handle);
+  }
+
+  private assertStartupAllowed(sessionId: string, generation: number): void {
+    this.dependencies.lifecycleGate.assertStartupAllowed({ sessionId, generation });
+  }
+}

--- a/src/backend/services/session/service/lifecycle/session-startup.coordinator.ts
+++ b/src/backend/services/session/service/lifecycle/session-startup.coordinator.ts
@@ -94,7 +94,7 @@ export type SessionStartupCoordinatorDependencies = {
   ) => Promise<void>;
   registerClientCreation: (
     sessionId: string,
-    operation: Promise<AcpProcessHandle>
+    operation: Promise<unknown>
   ) => ClientCreationRegistration;
 };
 
@@ -146,13 +146,16 @@ export class SessionStartupCoordinator {
   }
 
   async restartSession(sessionId: string, options?: StartSessionOptions): Promise<void> {
-    if (this.dependencies.runtimeManager.isStopInProgress(sessionId)) {
+    const isRunning = this.dependencies.runtimeManager.isSessionRunning(sessionId);
+    const isStopInProgress = this.dependencies.runtimeManager.isStopInProgress(sessionId);
+
+    if (isStopInProgress) {
       throw new Error(
         'Cannot restart: session is currently being stopped. Please try again shortly.'
       );
     }
 
-    if (this.dependencies.runtimeManager.isSessionRunning(sessionId)) {
+    if (isRunning) {
       try {
         await this.dependencies.stopSession(sessionId, {
           cleanupTransientRatchetSession: false,
@@ -238,12 +241,15 @@ export class SessionStartupCoordinator {
         this.assertStartupAllowed(sessionId, stopGeneration);
 
         try {
-          await this.createAcpClient(
-            sessionId,
-            { purpose: 'browse' },
-            session,
-            undefined,
-            stopGeneration
+          await this.runTrackedClientCreation(sessionId, (registration) =>
+            this.createAcpClient(
+              sessionId,
+              { purpose: 'browse' },
+              session,
+              undefined,
+              stopGeneration,
+              registration
+            )
           );
           this.dependencies.lifecycleGate.establishStartup(lease);
         } catch (error) {
@@ -305,7 +311,8 @@ export class SessionStartupCoordinator {
     options: { model?: string; purpose?: 'active' | 'browse' },
     session: AgentSessionRecord,
     permissionPreset: PermissionPreset | undefined,
-    stopGeneration: number
+    stopGeneration: number,
+    registration: ClientCreationRegistration
   ): Promise<{ handle: AcpProcessHandle; dispatchableNotificationCount: number }> {
     const sessionContext = await this.dependencies.contextService.load(sessionId, session);
     if (!sessionContext) {
@@ -359,7 +366,6 @@ export class SessionStartupCoordinator {
         workingDir: sessionContext.workingDir,
       }
     );
-    const registration = this.dependencies.registerClientCreation(sessionId, creationPromise);
     let handle: AcpProcessHandle;
     try {
       handle = await creationPromise;
@@ -377,8 +383,6 @@ export class SessionStartupCoordinator {
         this.dependencies.acpEventProcessor.clearSessionState(sessionId);
       }
       throw error;
-    } finally {
-      registration.release();
     }
 
     this.assertStartupAllowed(sessionId, stopGeneration);
@@ -441,38 +445,61 @@ export class SessionStartupCoordinator {
     const resolvedPreset = await this.dependencies.contextService.resolvePermissionPreset(session);
     this.assertStartupAllowed(sessionId, stopGeneration);
 
-    let handle: AcpProcessHandle;
-    let dispatchableNotificationCount = 0;
-    try {
-      const created = await this.createAcpClient(
-        sessionId,
-        options,
-        session,
-        resolvedPreset,
-        stopGeneration
-      );
-      handle = created.handle;
-      dispatchableNotificationCount = created.dispatchableNotificationCount;
-    } catch (error) {
+    return await this.runTrackedClientCreation(sessionId, async (registration) => {
+      let handle: AcpProcessHandle;
+      let dispatchableNotificationCount = 0;
+      try {
+        const created = await this.createAcpClient(
+          sessionId,
+          options,
+          session,
+          resolvedPreset,
+          stopGeneration,
+          registration
+        );
+        handle = created.handle;
+        dispatchableNotificationCount = created.dispatchableNotificationCount;
+      } catch (error) {
+        this.dependencies.sessionDomainService.setRuntimeSnapshot(sessionId, {
+          phase: 'error',
+          processState: 'stopped',
+          activity: 'IDLE',
+          errorMessage: `Failed to start agent: ${toErrorMessage(error)}`,
+          updatedAt: new Date().toISOString(),
+        });
+        throw error;
+      }
+
+      this.assertStartupAllowed(sessionId, stopGeneration);
+      await this.dependencies.repository.updateSession(sessionId, {
+        status: SessionStatus.RUNNING,
+      });
+      this.assertStartupAllowed(sessionId, stopGeneration);
       this.dependencies.sessionDomainService.setRuntimeSnapshot(sessionId, {
-        phase: 'error',
-        processState: 'stopped',
-        activity: 'IDLE',
-        errorMessage: `Failed to start agent: ${toErrorMessage(error)}`,
+        phase: handle.isPromptInFlight ? 'running' : 'idle',
+        processState: 'alive',
+        activity: handle.isPromptInFlight ? 'WORKING' : 'IDLE',
         updatedAt: new Date().toISOString(),
       });
-      throw error;
-    }
-
-    this.assertStartupAllowed(sessionId, stopGeneration);
-    await this.dependencies.repository.updateSession(sessionId, { status: SessionStatus.RUNNING });
-    this.dependencies.sessionDomainService.setRuntimeSnapshot(sessionId, {
-      phase: handle.isPromptInFlight ? 'running' : 'idle',
-      processState: 'alive',
-      activity: handle.isPromptInFlight ? 'WORKING' : 'IDLE',
-      updatedAt: new Date().toISOString(),
+      return { handle, resolvedPreset, dispatchableNotificationCount };
     });
-    return { handle, resolvedPreset, dispatchableNotificationCount };
+  }
+
+  private async runTrackedClientCreation<T>(
+    sessionId: string,
+    operation: (registration: ClientCreationRegistration) => Promise<T>
+  ): Promise<T> {
+    let settleBarrier!: () => void;
+    const barrier = new Promise<void>((resolve) => {
+      settleBarrier = resolve;
+    });
+    const registration = this.dependencies.registerClientCreation(sessionId, barrier);
+    try {
+      return await operation(registration);
+    } finally {
+      settleBarrier();
+      registration.release();
+    }
   }
 
   private async dispatchQueuedNotificationsIfNeeded(

--- a/src/backend/services/session/service/lifecycle/session.lifecycle.facade.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.lifecycle.facade.test.ts
@@ -7,6 +7,7 @@ import {
   createLifecycleHarness,
   createPendingWorkspaceNotification,
 } from './session-lifecycle.test-helpers';
+import { SessionStartupCoordinator } from './session-startup.coordinator';
 
 vi.mock('@/backend/services/logger.service', () => ({
   createLogger: () => ({
@@ -80,6 +81,18 @@ describe('SessionLifecycleFacade', () => {
     await expect(service.getSessionOptions('session-1')).resolves.toEqual(options);
 
     expect(getOptions).toHaveBeenCalledWith('session-1');
+  });
+
+  it('delegates startup through the configured startup coordinator', async () => {
+    const startSession = vi
+      .spyOn(SessionStartupCoordinator.prototype, 'startSession')
+      .mockResolvedValueOnce(undefined);
+    const { service } = createLifecycleHarness();
+    const options = { initialPrompt: 'Resume the task', startupModePreset: 'plan' } as const;
+
+    await service.startSession('session-1', options);
+
+    expect(startSession).toHaveBeenCalledWith('session-1', options);
   });
 
   it('skips the restart default continue prompt when notifications are queued', async () => {

--- a/src/backend/services/session/service/lifecycle/session.lifecycle.facade.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.lifecycle.facade.test.ts
@@ -83,16 +83,41 @@ describe('SessionLifecycleFacade', () => {
     expect(getOptions).toHaveBeenCalledWith('session-1');
   });
 
-  it('delegates startup through the configured startup coordinator', async () => {
+  it('delegates every startup entry point through the configured coordinator', async () => {
     const startSession = vi
       .spyOn(SessionStartupCoordinator.prototype, 'startSession')
       .mockResolvedValueOnce(undefined);
-    const { service } = createLifecycleHarness();
+    const restartSession = vi
+      .spyOn(SessionStartupCoordinator.prototype, 'restartSession')
+      .mockResolvedValueOnce(undefined);
+    const getOrCreateSessionClient = vi
+      .spyOn(SessionStartupCoordinator.prototype, 'getOrCreateSessionClient')
+      .mockResolvedValueOnce('client-by-id');
+    const getOrCreateSessionClientFromRecord = vi
+      .spyOn(SessionStartupCoordinator.prototype, 'getOrCreateSessionClientFromRecord')
+      .mockResolvedValueOnce('client-by-record');
+    const ensureSubagentBrowseSession = vi
+      .spyOn(SessionStartupCoordinator.prototype, 'ensureSubagentBrowseSession')
+      .mockResolvedValueOnce(true);
+    const { service, session } = createLifecycleHarness();
     const options = { initialPrompt: 'Resume the task', startupModePreset: 'plan' } as const;
+    const clientOptions = { model: 'claude-opus', reasoningEffort: 'high' };
 
     await service.startSession('session-1', options);
+    await service.restartSession('session-2', options);
+    await expect(service.getOrCreateSessionClient('session-3', clientOptions)).resolves.toBe(
+      'client-by-id'
+    );
+    await expect(service.getOrCreateSessionClientFromRecord(session, clientOptions)).resolves.toBe(
+      'client-by-record'
+    );
+    await expect(service.ensureSubagentBrowseSession('session-4')).resolves.toBe(true);
 
     expect(startSession).toHaveBeenCalledWith('session-1', options);
+    expect(restartSession).toHaveBeenCalledWith('session-2', options);
+    expect(getOrCreateSessionClient).toHaveBeenCalledWith('session-3', clientOptions);
+    expect(getOrCreateSessionClientFromRecord).toHaveBeenCalledWith(session, clientOptions);
+    expect(ensureSubagentBrowseSession).toHaveBeenCalledWith('session-4');
   });
 
   it('skips the restart default continue prompt when notifications are queued', async () => {

--- a/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
+++ b/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
@@ -299,15 +299,30 @@ export class SessionLifecycleService {
   }
 
   private async stopRuntimeAndPendingCreation(sessionId: string): Promise<void> {
-    await this.runtimeManager.stopClient(sessionId);
+    let stopError: { cause: unknown } | undefined;
+    try {
+      await this.runtimeManager.stopClient(sessionId);
+    } catch (error) {
+      stopError = { cause: error };
+    }
 
     const pendingCreations = this.clientCreationOperations.get(sessionId);
     if (!pendingCreations || pendingCreations.size === 0) {
+      if (stopError) {
+        throw stopError.cause;
+      }
       return;
     }
 
     await Promise.allSettled([...pendingCreations]);
-    await this.runtimeManager.stopClient(sessionId);
+    try {
+      await this.runtimeManager.stopClient(sessionId);
+    } catch (error) {
+      stopError ??= { cause: error };
+    }
+    if (stopError) {
+      throw stopError.cause;
+    }
   }
 
   async stopWorkspaceSessions(

--- a/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
+++ b/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
@@ -315,14 +315,7 @@ export class SessionLifecycleService {
     }
 
     await Promise.allSettled([...pendingCreations]);
-    try {
-      await this.runtimeManager.stopClient(sessionId);
-    } catch (error) {
-      stopError ??= { cause: error };
-    }
-    if (stopError) {
-      throw stopError.cause;
-    }
+    await this.runtimeManager.stopClient(sessionId);
   }
 
   async stopWorkspaceSessions(

--- a/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
+++ b/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
@@ -1,13 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { createLogger } from '@/backend/services/logger.service';
 import type { AgentSessionRecord } from '@/backend/services/session/resources/agent-session.accessor';
-import type {
-  AcpClientOptions,
-  AcpProcessHandle,
-  AcpRuntimeManager,
-  PermissionPreset,
-} from '@/backend/services/session/service/acp';
-import { AcpBrowseSessionUnavailableError } from '@/backend/services/session/service/acp/acp-runtime-manager';
+import type { AcpProcessHandle, AcpRuntimeManager } from '@/backend/services/session/service/acp';
 import type {
   SessionAutoIterationExitBridge,
   SessionLifecycleMessageQueueBridge,
@@ -17,8 +11,6 @@ import { acpTraceLogger } from '@/backend/services/session/service/logging/acp-t
 import type { SessionDomainService } from '@/backend/services/session/service/session-domain.service';
 import { sessionEventBus } from '@/backend/services/session/service/session-event-bus';
 import { workspaceDataService } from '@/backend/services/workspace';
-import type { SessionDeltaEvent } from '@/shared/acp-protocol';
-import type { ChatBarCapabilities } from '@/shared/chat-capabilities';
 import {
   SessionLifecycleEventKind,
   SessionLifecycleEventReason,
@@ -31,11 +23,7 @@ import {
 } from '@/shared/session-runtime';
 import type { AcpEventProcessor } from './acp-event-processor';
 import { closedSessionPersistenceService } from './closed-session-persistence.service';
-import type {
-  PersistAcpConfigSnapshotParams,
-  SessionConfigService,
-} from './session.config.service';
-import { toErrorMessage } from './session.error-message';
+import type { SessionConfigService } from './session.config.service';
 import type { SessionPermissionService } from './session.permission.service';
 import type { SessionPromptTurnCompletionService } from './session.prompt-turn-completion.service';
 import type { SessionRepository } from './session.repository';
@@ -43,27 +31,18 @@ import type { SessionRetryService } from './session.retry.service';
 import type { SessionContextService } from './session-context.service';
 import type { SessionAcpEnvironmentPort } from './session-lifecycle.types';
 import type { SessionLifecycleEventService } from './session-lifecycle-event.service';
-import { type SessionLifecycleGate, SessionStartupCancelledError } from './session-lifecycle-gate';
+import type { SessionLifecycleGate } from './session-lifecycle-gate';
 import type { SessionNotificationDeliveryService } from './session-notification-delivery.service';
 import { SessionRuntimeExitCoordinator } from './session-runtime-exit.coordinator';
 import { isStaleLoadingRuntime } from './session-runtime-state.helpers';
+import {
+  type GetOrCreateSessionClientOptions,
+  SessionStartupCoordinator,
+  type StartSessionOptions,
+} from './session-startup.coordinator';
 import { SessionWorkflowFinalizer } from './session-workflow-finalizer';
 
 const logger = createLogger('session');
-
-type SessionStartupModePreset = 'non_interactive' | 'plan';
-
-type GetOrCreateSessionClientOptions = {
-  thinkingEnabled?: boolean;
-  model?: string;
-  reasoningEffort?: string;
-};
-
-type StartSessionOptions = {
-  initialPrompt?: string;
-  initialPromptIsDefault?: boolean;
-  startupModePreset?: SessionStartupModePreset;
-};
 
 export type SessionStopReason =
   | 'USER_STOP'
@@ -131,9 +110,9 @@ export class SessionLifecycleService {
   private readonly sendSessionMessage: SendSessionMessage;
   private readonly onBeforeStopSession?: (sessionId: string) => void;
   private readonly clientCreationOperations = new Map<string, Set<Promise<AcpProcessHandle>>>();
+  private startupCoordinator: SessionStartupCoordinator | null = null;
   private workspaceBridge: SessionLifecycleWorkspaceBridge | null = null;
   private messageQueueBridge: SessionLifecycleMessageQueueBridge | null = null;
-  private notificationDeliveryService: SessionNotificationDeliveryService | null = null;
   constructor(options: SessionLifecycleServiceDependencies) {
     if (!(options.contextService && options.acpEnvironment)) {
       throw new Error('SessionLifecycleService requires context and ACP environment ports');
@@ -190,88 +169,40 @@ export class SessionLifecycleService {
   }
 
   configureNotificationDelivery(service: SessionNotificationDeliveryService): void {
-    this.notificationDeliveryService = service;
+    this.startupCoordinator = new SessionStartupCoordinator({
+      repository: this.repository,
+      contextService: this.contextService,
+      acpEnvironment: this.acpEnvironment,
+      runtimeManager: this.runtimeManager,
+      sessionDomainService: this.sessionDomainService,
+      sessionConfigService: this.sessionConfigService,
+      acpEventProcessor: this.acpEventProcessor,
+      runtimeExitCoordinator: this.runtimeExitCoordinator,
+      lifecycleGate: this.lifecycleGate,
+      notificationDelivery: service,
+      getMessageQueueBridge: () => this.messageQueueBridge,
+      sendSessionMessage: this.sendSessionMessage,
+      stopSession: (sessionId, options) => this.stopSession(sessionId, options),
+      registerClientCreation: (sessionId, operation) =>
+        this.registerClientCreation(sessionId, operation),
+    });
   }
 
-  private get notificationDelivery(): SessionNotificationDeliveryService {
-    if (!this.notificationDeliveryService) {
+  private get startup(): SessionStartupCoordinator {
+    if (!this.startupCoordinator) {
       throw new Error(
         'SessionLifecycleService not configured: notification delivery service missing'
       );
     }
-    return this.notificationDeliveryService;
+    return this.startupCoordinator;
   }
 
   async startSession(sessionId: string, options?: StartSessionOptions): Promise<void> {
-    await this.lifecycleGate.runStartup(sessionId, async (lease) => {
-      const stopGeneration = lease.generation;
-      const session = await this.repository.getSessionById(sessionId);
-      if (!session) {
-        throw new Error(`Session not found: ${sessionId}`);
-      }
-      this.lifecycleGate.assertStartupAllowed({ sessionId, generation: stopGeneration });
-
-      const existingClient = this.runtimeManager.getClient(sessionId);
-      if (existingClient) {
-        this.lifecycleGate.establishStartup(lease);
-        throw new Error('Session is already running');
-      }
-
-      const startupModePreset = options?.startupModePreset;
-
-      const { handle, resolvedPreset, dispatchableNotificationCount } =
-        await this.getOrCreateAcpSessionClient(sessionId, {}, session, stopGeneration);
-      this.lifecycleGate.establishStartup(lease);
-      this.lifecycleGate.assertStartupAllowed({ sessionId, generation: stopGeneration });
-      await this.applyStartupModePreset(sessionId, handle, startupModePreset, session.workflow);
-      this.lifecycleGate.assertStartupAllowed({ sessionId, generation: stopGeneration });
-      await this.applyConfiguredPermissionPreset(sessionId, session, handle, resolvedPreset);
-      this.lifecycleGate.assertStartupAllowed({ sessionId, generation: stopGeneration });
-      await this.dispatchQueuedNotificationsIfNeeded(sessionId, dispatchableNotificationCount);
-      this.lifecycleGate.assertStartupAllowed({ sessionId, generation: stopGeneration });
-
-      const initialPrompt = options?.initialPrompt ?? 'Continue with the task.';
-      const shouldSendInitialPrompt =
-        dispatchableNotificationCount === 0 ||
-        (typeof options?.initialPrompt === 'string' && !options.initialPromptIsDefault);
-      if (shouldSendInitialPrompt && initialPrompt) {
-        await this.sendSessionMessage(sessionId, initialPrompt);
-      }
-      this.lifecycleGate.assertStartupAllowed({ sessionId, generation: stopGeneration });
-
-      logger.info('Session started', { sessionId, provider: session.provider });
-    });
+    await this.startup.startSession(sessionId, options);
   }
 
   async restartSession(sessionId: string, options?: StartSessionOptions): Promise<void> {
-    const isRunning = this.runtimeManager.isSessionRunning(sessionId);
-    const isStopInProgress = this.runtimeManager.isStopInProgress(sessionId);
-
-    if (isStopInProgress) {
-      // A stop is already under way; starting now would throw "Session is currently being stopped".
-      throw new Error(
-        'Cannot restart: session is currently being stopped. Please try again shortly.'
-      );
-    }
-
-    if (isRunning) {
-      try {
-        await this.stopSession(sessionId, { cleanupTransientRatchetSession: false });
-      } catch (error) {
-        logger.warn('Error stopping session during restart; continuing with start', {
-          sessionId,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-    }
-    await this.startSession(
-      sessionId,
-      options ?? {
-        initialPrompt: 'Continue with the task.',
-        initialPromptIsDefault: true,
-      }
-    );
-    logger.info('Session restarted', { sessionId });
+    await this.startup.restartSession(sessionId, options);
   }
 
   async stopSession(sessionId: string, options?: StopSessionOptions): Promise<void> {
@@ -434,144 +365,18 @@ export class SessionLifecycleService {
     sessionId: string,
     options?: GetOrCreateSessionClientOptions
   ): Promise<unknown> {
-    return await this.lifecycleGate.runStartup(sessionId, async (lease) => {
-      const stopGeneration = lease.generation;
-      const session = await this.repository.getSessionById(sessionId);
-      if (!session) {
-        throw new Error(`Session not found: ${sessionId}`);
-      }
-      this.lifecycleGate.assertStartupAllowed({ sessionId, generation: stopGeneration });
-
-      const hadClient = !!this.runtimeManager.getClient(sessionId);
-      const { handle, resolvedPreset, dispatchableNotificationCount } =
-        await this.getOrCreateAcpSessionClient(sessionId, options ?? {}, session, stopGeneration);
-      this.lifecycleGate.establishStartup(lease);
-      this.lifecycleGate.assertStartupAllowed({ sessionId, generation: stopGeneration });
-      if (!hadClient) {
-        await this.applyConfiguredPermissionPreset(sessionId, session, handle, resolvedPreset);
-        this.lifecycleGate.assertStartupAllowed({ sessionId, generation: stopGeneration });
-        await this.dispatchQueuedNotificationsIfNeeded(sessionId, dispatchableNotificationCount);
-        this.lifecycleGate.assertStartupAllowed({ sessionId, generation: stopGeneration });
-      }
-
-      return handle;
-    });
+    return await this.startup.getOrCreateSessionClient(sessionId, options);
   }
 
   async getOrCreateSessionClientFromRecord(
     session: AgentSessionRecord,
     options?: GetOrCreateSessionClientOptions
   ): Promise<unknown> {
-    return await this.lifecycleGate.runStartup(session.id, async (lease) => {
-      const stopGeneration = lease.generation;
-      this.lifecycleGate.assertStartupAllowed({
-        sessionId: session.id,
-        generation: stopGeneration,
-      });
-      const hadClient = !!this.runtimeManager.getClient(session.id);
-      const { handle, resolvedPreset, dispatchableNotificationCount } =
-        await this.getOrCreateAcpSessionClient(session.id, options ?? {}, session, stopGeneration);
-      this.lifecycleGate.establishStartup(lease);
-      this.lifecycleGate.assertStartupAllowed({
-        sessionId: session.id,
-        generation: stopGeneration,
-      });
-      if (!hadClient) {
-        await this.applyConfiguredPermissionPreset(session.id, session, handle, resolvedPreset);
-        this.lifecycleGate.assertStartupAllowed({
-          sessionId: session.id,
-          generation: stopGeneration,
-        });
-        await this.dispatchQueuedNotificationsIfNeeded(session.id, dispatchableNotificationCount);
-        this.lifecycleGate.assertStartupAllowed({
-          sessionId: session.id,
-          generation: stopGeneration,
-        });
-      }
-
-      return handle;
-    });
+    return await this.startup.getOrCreateSessionClientFromRecord(session, options);
   }
 
   async ensureSubagentBrowseSession(sessionId: string): Promise<boolean> {
-    if (this.runtimeManager.getSubagentBrowseCapability(sessionId)) {
-      return true;
-    }
-
-    const pendingClient = this.runtimeManager.getPendingClient(sessionId);
-    if (pendingClient) {
-      try {
-        await pendingClient;
-      } catch (error) {
-        if (error instanceof AcpBrowseSessionUnavailableError) {
-          return false;
-        }
-        throw error;
-      }
-      return await this.resolveSubagentBrowseSupport(sessionId);
-    }
-
-    return await this.lifecycleGate
-      .runStartup(sessionId, async (lease) => {
-        const stopGeneration = lease.generation;
-        const session = await this.repository.getSessionById(sessionId);
-        if (!(session?.provider === 'CODEX' && session.providerSessionId)) {
-          return false;
-        }
-        this.lifecycleGate.assertStartupAllowed({ sessionId, generation: stopGeneration });
-
-        const workspace = await this.repository.getWorkspaceById(session.workspaceId);
-        if (
-          !workspace?.worktreePath ||
-          workspace.status === 'ARCHIVING' ||
-          workspace.status === 'ARCHIVED'
-        ) {
-          return false;
-        }
-        this.lifecycleGate.assertStartupAllowed({ sessionId, generation: stopGeneration });
-
-        try {
-          await this.createAcpClient(
-            sessionId,
-            { purpose: 'browse' },
-            session,
-            undefined,
-            stopGeneration
-          );
-          this.lifecycleGate.establishStartup(lease);
-        } catch (error) {
-          if (error instanceof AcpBrowseSessionUnavailableError) {
-            return false;
-          }
-          throw error;
-        }
-
-        return await this.resolveSubagentBrowseSupport(sessionId);
-      })
-      .catch((error: unknown) => {
-        if (error instanceof SessionStartupCancelledError) {
-          return false;
-        }
-        throw error;
-      });
-  }
-
-  private async resolveSubagentBrowseSupport(sessionId: string): Promise<boolean> {
-    if (this.runtimeManager.getSubagentBrowseCapability(sessionId) !== null) {
-      return true;
-    }
-    if (!this.runtimeManager.isBrowseOnlySession(sessionId)) {
-      return false;
-    }
-
-    const stopReservation = this.lifecycleGate.reserveStop(sessionId);
-    try {
-      await this.runtimeManager.stopClient(sessionId);
-    } finally {
-      this.acpEventProcessor.clearSessionState(sessionId);
-      stopReservation?.release();
-    }
-    return false;
+    return await this.startup.ensureSubagentBrowseSession(sessionId);
   }
 
   getSessionClient(sessionId: string): unknown | undefined {
@@ -704,186 +509,6 @@ export class SessionLifecycleService {
     }
   }
 
-  private async createAcpClient(
-    sessionId: string,
-    options?: {
-      model?: string;
-      purpose?: 'active' | 'browse';
-    },
-    session?: AgentSessionRecord,
-    permissionPreset?: PermissionPreset,
-    stopGeneration = this.lifecycleGate.getGeneration(sessionId)
-  ): Promise<{ handle: AcpProcessHandle; dispatchableNotificationCount: number }> {
-    const sessionContext = await this.contextService.load(sessionId, session);
-    if (!sessionContext) {
-      throw new Error(`Session context not ready: ${sessionId}`);
-    }
-    this.lifecycleGate.assertStartupAllowed({ sessionId, generation: stopGeneration });
-
-    const browseOnly = options?.purpose === 'browse';
-    if (!browseOnly) {
-      await this.repository.markWorkspaceHasHadSessions(sessionContext.workspaceId);
-      this.lifecycleGate.assertStartupAllowed({ sessionId, generation: stopGeneration });
-    }
-    this.acpEventProcessor.registerSessionContext(sessionId, {
-      workspaceId: sessionContext.workspaceId,
-      workingDir: sessionContext.workingDir,
-      provider: session?.provider ?? 'CLAUDE',
-    });
-
-    const handlers = this.runtimeExitCoordinator.createHandlers({
-      sessionId,
-      purpose: browseOnly ? 'browse' : 'active',
-      persistProviderSessionId: !browseOnly,
-    });
-    const shouldSuppressReplay = this.shouldSuppressReplayDuringAcpResume(sessionId, session);
-    this.acpEventProcessor.setReplaySuppression(sessionId, shouldSuppressReplay);
-
-    const mcpServers = this.acpEnvironment.getMcpServers({
-      workspaceId: sessionContext.workspaceId,
-      parentWorkspaceId: sessionContext.parentWorkspaceId,
-    });
-
-    const clientOptions: AcpClientOptions = {
-      provider: session?.provider ?? 'CLAUDE',
-      purpose: options?.purpose,
-      workingDir: sessionContext.workingDir,
-      model: options?.model ?? sessionContext.model,
-      systemPrompt: sessionContext.systemPrompt,
-      permissionPreset,
-      sessionId,
-      resumeProviderSessionId: session?.providerSessionId ?? undefined,
-      mcpServers,
-    };
-
-    let handle: AcpProcessHandle;
-    this.lifecycleGate.assertStartupAllowed({ sessionId, generation: stopGeneration });
-    const creationPromise = this.runtimeManager.getOrCreateClient(
-      sessionId,
-      clientOptions,
-      handlers,
-      {
-        workspaceId: sessionContext.workspaceId,
-        workingDir: sessionContext.workingDir,
-      }
-    );
-    const sessionCreations =
-      this.clientCreationOperations.get(sessionId) ?? new Set<Promise<AcpProcessHandle>>();
-    sessionCreations.add(creationPromise);
-    this.clientCreationOperations.set(sessionId, sessionCreations);
-    try {
-      handle = await creationPromise;
-      this.lifecycleGate.assertStartupAllowed({ sessionId, generation: stopGeneration });
-      if (browseOnly) {
-        return { handle, dispatchableNotificationCount: 0 };
-      }
-      await this.sessionConfigService.applyConfiguredReasoningEffort(sessionId, handle, {
-        persistSnapshot: false,
-        emitUpdates: false,
-      });
-    } catch (error) {
-      this.clearAcpSessionStateAfterFailedCreation(sessionId, sessionCreations);
-      throw error;
-    } finally {
-      sessionCreations.delete(creationPromise);
-      if (sessionCreations.size === 0) {
-        this.clientCreationOperations.delete(sessionId);
-      }
-    }
-
-    this.lifecycleGate.assertStartupAllowed({ sessionId, generation: stopGeneration });
-
-    await this.persistAcpConfigSnapshot(sessionId, {
-      provider: handle.provider as PersistAcpConfigSnapshotParams['provider'],
-      providerSessionId: handle.providerSessionId,
-      configOptions: handle.configOptions,
-      existingMetadata: session?.providerMetadata ?? undefined,
-    });
-
-    if (handle.configOptions.length > 0) {
-      this.sessionDomainService.emitDelta(sessionId, {
-        type: 'config_options_update',
-        configOptions: handle.configOptions,
-      } as SessionDeltaEvent);
-    }
-
-    this.sessionDomainService.emitDelta(sessionId, {
-      type: 'chat_capabilities',
-      capabilities: this.buildAcpChatBarCapabilities(handle),
-    });
-
-    // Queue pending notifications only after the ACP client starts successfully.
-    // Callers decide when dispatch is safe for their startup flow.
-    this.lifecycleGate.assertStartupAllowed({ sessionId, generation: stopGeneration });
-    const { dispatchableCount: dispatchableNotificationCount } =
-      await this.notificationDelivery.recoverPending({
-        sessionId,
-        workspaceId: sessionContext.workspaceId,
-        assertAllowed: () =>
-          this.lifecycleGate.assertStartupAllowed({
-            sessionId,
-            generation: stopGeneration,
-          }),
-      });
-
-    return { handle, dispatchableNotificationCount };
-  }
-
-  private clearAcpSessionStateAfterFailedCreation(
-    sessionId: string,
-    sessionCreations: Set<Promise<AcpProcessHandle>>
-  ): void {
-    if (sessionCreations.size === 1) {
-      this.acpEventProcessor.clearSessionState(sessionId);
-    }
-  }
-
-  private shouldSuppressReplayDuringAcpResume(
-    sessionId: string,
-    session: AgentSessionRecord | undefined
-  ): boolean {
-    if (!session?.providerSessionId) {
-      return false;
-    }
-
-    if (!this.sessionDomainService.isHistoryHydrated(sessionId)) {
-      return false;
-    }
-
-    return this.sessionDomainService.getTranscriptSnapshot(sessionId).length > 0;
-  }
-
-  private async applyStartupModePreset(
-    sessionId: string,
-    handle: AcpProcessHandle,
-    startupModePreset: SessionStartupModePreset | undefined,
-    workflow: string
-  ): Promise<void> {
-    await this.sessionConfigService.applyStartupModePreset(
-      sessionId,
-      handle,
-      startupModePreset,
-      workflow,
-      {
-        persistSnapshot: this.persistAcpConfigSnapshot.bind(this),
-      }
-    );
-  }
-
-  private async applyConfiguredPermissionPreset(
-    sessionId: string,
-    session: AgentSessionRecord,
-    handle: AcpProcessHandle,
-    permissionPreset?: PermissionPreset
-  ): Promise<void> {
-    await this.sessionConfigService.applyConfiguredPermissionPreset(
-      sessionId,
-      session,
-      handle,
-      permissionPreset
-    );
-  }
-
   private finalizeOrphanedToolCalls(sessionId: string, reason: string): void {
     try {
       this.acpEventProcessor.finalizeOrphanedToolCalls(sessionId, reason);
@@ -960,105 +585,23 @@ export class SessionLifecycleService {
   recoverStaleRunningSessions(): Promise<number> {
     return this.workflowFinalizer.recoverStaleRunningSessions();
   }
-  private async getOrCreateAcpSessionClient(
+
+  private registerClientCreation(
     sessionId: string,
-    options: {
-      model?: string;
-    },
-    session: AgentSessionRecord,
-    stopGeneration: number
-  ): Promise<{
-    handle: AcpProcessHandle;
-    resolvedPreset?: PermissionPreset;
-    dispatchableNotificationCount: number;
-  }> {
-    this.lifecycleGate.assertStartupAllowed({ sessionId, generation: stopGeneration });
-
-    const existingAcp = this.runtimeManager.getClient(sessionId);
-    if (existingAcp) {
-      this.sessionDomainService.setRuntimeSnapshot(sessionId, {
-        phase: existingAcp.isPromptInFlight ? 'running' : 'idle',
-        processState: 'alive',
-        activity: existingAcp.isPromptInFlight ? 'WORKING' : 'IDLE',
-        updatedAt: new Date().toISOString(),
-      });
-      return { handle: existingAcp, dispatchableNotificationCount: 0 };
-    }
-
-    this.sessionDomainService.setRuntimeSnapshot(sessionId, {
-      phase: 'starting',
-      processState: 'alive',
-      activity: 'IDLE',
-      updatedAt: new Date().toISOString(),
-    });
-
-    const resolvedPreset = await this.contextService.resolvePermissionPreset(session);
-    this.lifecycleGate.assertStartupAllowed({ sessionId, generation: stopGeneration });
-
-    let handle: AcpProcessHandle;
-    let dispatchableNotificationCount = 0;
-    try {
-      const created = await this.createAcpClient(
-        sessionId,
-        options,
-        session,
-        resolvedPreset,
-        stopGeneration
-      );
-      handle = created.handle;
-      dispatchableNotificationCount = created.dispatchableNotificationCount;
-    } catch (error) {
-      this.sessionDomainService.setRuntimeSnapshot(sessionId, {
-        phase: 'error',
-        processState: 'stopped',
-        activity: 'IDLE',
-        errorMessage: `Failed to start agent: ${toErrorMessage(error)}`,
-        updatedAt: new Date().toISOString(),
-      });
-      throw error;
-    }
-
-    this.lifecycleGate.assertStartupAllowed({ sessionId, generation: stopGeneration });
-
-    await this.repository.updateSession(sessionId, {
-      status: SessionStatus.RUNNING,
-    });
-
-    this.sessionDomainService.setRuntimeSnapshot(sessionId, {
-      phase: handle.isPromptInFlight ? 'running' : 'idle',
-      processState: 'alive',
-      activity: handle.isPromptInFlight ? 'WORKING' : 'IDLE',
-      updatedAt: new Date().toISOString(),
-    });
-
-    return { handle, resolvedPreset, dispatchableNotificationCount };
-  }
-
-  private async dispatchQueuedNotificationsIfNeeded(
-    sessionId: string,
-    dispatchableNotificationCount: number
-  ): Promise<void> {
-    if (dispatchableNotificationCount === 0 || !this.messageQueueBridge) {
-      return;
-    }
-    try {
-      await this.messageQueueBridge.tryDispatchNextMessage(sessionId);
-    } catch (error) {
-      logger.warn('Failed to dispatch queued workspace notifications', {
-        sessionId,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
-  }
-
-  private async persistAcpConfigSnapshot(
-    sessionId: string,
-    params: PersistAcpConfigSnapshotParams
-  ): Promise<void> {
-    await this.sessionConfigService.persistAcpConfigSnapshot(sessionId, params);
-  }
-
-  private buildAcpChatBarCapabilities(handle: AcpProcessHandle): ChatBarCapabilities {
-    return this.sessionConfigService.buildAcpChatBarCapabilities(handle);
+    operation: Promise<AcpProcessHandle>
+  ): { isOnlyOperation: () => boolean; release: () => void } {
+    const operations =
+      this.clientCreationOperations.get(sessionId) ?? new Set<Promise<AcpProcessHandle>>();
+    operations.add(operation);
+    this.clientCreationOperations.set(sessionId, operations);
+    return {
+      isOnlyOperation: () => operations.size === 1,
+      release: () => {
+        operations.delete(operation);
+        if (operations.size === 0) {
+          this.clientCreationOperations.delete(sessionId);
+        }
+      },
+    };
   }
 }

--- a/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
+++ b/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { createLogger } from '@/backend/services/logger.service';
 import type { AgentSessionRecord } from '@/backend/services/session/resources/agent-session.accessor';
-import type { AcpProcessHandle, AcpRuntimeManager } from '@/backend/services/session/service/acp';
+import type { AcpRuntimeManager } from '@/backend/services/session/service/acp';
 import type {
   SessionAutoIterationExitBridge,
   SessionLifecycleMessageQueueBridge,
@@ -109,7 +109,7 @@ export class SessionLifecycleService {
   private readonly runtimeExitCoordinator: SessionRuntimeExitCoordinator;
   private readonly sendSessionMessage: SendSessionMessage;
   private readonly onBeforeStopSession?: (sessionId: string) => void;
-  private readonly clientCreationOperations = new Map<string, Set<Promise<AcpProcessHandle>>>();
+  private readonly clientCreationOperations = new Map<string, Set<Promise<unknown>>>();
   private startupCoordinator: SessionStartupCoordinator | null = null;
   private workspaceBridge: SessionLifecycleWorkspaceBridge | null = null;
   private messageQueueBridge: SessionLifecycleMessageQueueBridge | null = null;
@@ -588,10 +588,9 @@ export class SessionLifecycleService {
 
   private registerClientCreation(
     sessionId: string,
-    operation: Promise<AcpProcessHandle>
+    operation: Promise<unknown>
   ): { isOnlyOperation: () => boolean; release: () => void } {
-    const operations =
-      this.clientCreationOperations.get(sessionId) ?? new Set<Promise<AcpProcessHandle>>();
+    const operations = this.clientCreationOperations.get(sessionId) ?? new Set<Promise<unknown>>();
     operations.add(operation);
     this.clientCreationOperations.set(sessionId, operations);
     return {


### PR DESCRIPTION
## Summary

- extract active, restart, get-or-create, and browse startup orchestration into `SessionStartupCoordinator`
- keep `SessionLifecycleService` as the stable public facade while composing one coordinator instance behind it
- preserve startup presets, ACP configuration snapshots, notification recovery, and existing public method contracts
- fence startup reconciliation through durable `RUNNING` persistence so stop wins at every async boundary, including when the first runtime stop attempt fails
- remove the lifecycle facade from the large-file baseline after reducing it from 1,064 to 621 lines

## Why

Session startup behavior was still concentrated in the lifecycle facade, mixing orchestration, configuration, notification recovery, and stop/start concurrency. Moving that behavior into a focused coordinator makes the lifecycle capsule easier to reason about and continues the staged decomposition without moving stop/quiescence ownership ahead of the next PR.

The extraction also closes two race windows discovered during review: stop now waits for post-creation reconciliation through durable status persistence, and a failed initial runtime stop cannot bypass that barrier.

## Validation

- `pnpm check:fix`
- `pnpm typecheck`
- focused lifecycle verification: 6 files, 138 tests passed
- `pnpm test --maxWorkers=2`: 409 files passed, 1 skipped; 5,241 tests passed, 4 skipped
- `pnpm check`: file length, environment, ownership, service registry, foreign-key indexes, and dependency-cruiser passed
- normal commit hooks: lint-staged, typecheck, Prisma drift, dependency-cruiser, and Knip passed

The local Codex schema check skipped because the installed CLI is 0.147.0 while the repository pins 0.145.0; CI installs the pinned version and enforces that check.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session start/stop concurrency and durable status writes; behavior is meant to be identical but race fixes change timing around failed runtime stops and post-creation reconciliation.
> 
> **Overview**
> Moves **start**, **restart**, **get-or-create**, and **subagent browse** startup out of `SessionLifecycleService` into a new **`SessionStartupCoordinator`**, while the lifecycle service stays the public API and forwards those five methods unchanged.
> 
> The coordinator owns startup leases, ACP client construction, presets, config snapshots, notification recovery, browse probing, and durable **`RUNNING`** reconciliation, with **`assertStartupAllowed`** after async steps. Client creation still registers through a narrow **`registerClientCreation`** port on the facade so **`stopRuntimeAndPendingCreation`** can wait on in-flight work; that path now **settles pending creations and retries `stopClient` even when the first stop throws**, so stop can win through **`RUNNING`** persistence.
> 
> Adds coordinator and delegation tests (including stop/startup races), a composition check on the public singleton, test harness tweaks, a superpowers implementation plan doc, and drops the lifecycle facade from the file-length baseline after the shrink.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf3774602ec4ac098675ac1c73c5aca06a2b2949. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->