### PR TITLE
Remove dead browse capability test stubs

### DIFF
--- a/src/backend/services/session/service/lifecycle/session-startup.coordinator.test.ts
+++ b/src/backend/services/session/service/lifecycle/session-startup.coordinator.test.ts
@@ -162,7 +162,7 @@ describe('SessionStartupCoordinator', () => {
     expect(sessionDomainService.setRuntimeSnapshot).not.toHaveBeenCalled();
   });
 
-  it('rejects an existing browse client while stop is in progress', async () => {
+  it('rejects stop before inspecting existing browse support', async () => {
     const harness = createLifecycleHarness();
     const runtimeStop = createDeferred<void>();
     harness.runtimeManager.stopClient.mockReturnValueOnce(runtimeStop.promise);
@@ -173,12 +173,13 @@ describe('SessionStartupCoordinator', () => {
     });
 
     await expect(harness.service.ensureSubagentBrowseSession('session-1')).resolves.toBe(false);
+    expect(harness.runtimeManager.getSubagentBrowseCapability).not.toHaveBeenCalled();
 
     runtimeStop.resolve(undefined);
     await stopPromise;
   });
 
-  it('rejects a pending browse client when stop completes before it settles', async () => {
+  it('rejects a pending browse client before rechecking support after stop', async () => {
     const harness = createLifecycleHarness();
     const pendingClient = createDeferred<typeof harness.handle>();
     harness.runtimeManager.getPendingClient.mockReturnValueOnce(pendingClient.promise);
@@ -191,6 +192,7 @@ describe('SessionStartupCoordinator', () => {
     pendingClient.resolve(harness.handle);
 
     await expect(browseResult).resolves.toBe(false);
+    expect(harness.runtimeManager.getSubagentBrowseCapability).toHaveBeenCalledOnce();
   });
 
   it('does not spawn a browse client without a stored provider session', async () => {

--- a/src/backend/services/session/service/lifecycle/session-startup.coordinator.test.ts
+++ b/src/backend/services/session/service/lifecycle/session-startup.coordinator.test.ts
@@ -165,12 +165,6 @@ describe('SessionStartupCoordinator', () => {
   it('rejects an existing browse client while stop is in progress', async () => {
     const harness = createLifecycleHarness();
     const runtimeStop = createDeferred<void>();
-    harness.runtimeManager.getSubagentBrowseCapability.mockReturnValue({
-      version: 1,
-      list: true,
-      read: true,
-      notifications: true,
-    });
     harness.runtimeManager.stopClient.mockReturnValueOnce(runtimeStop.promise);
 
     const stopPromise = harness.service.stopSession('session-1');
@@ -194,12 +188,6 @@ describe('SessionStartupCoordinator', () => {
       expect(harness.runtimeManager.getPendingClient).toHaveBeenCalledWith('session-1');
     });
     await harness.service.stopSession('session-1');
-    harness.runtimeManager.getSubagentBrowseCapability.mockReturnValue({
-      version: 1,
-      list: true,
-      read: true,
-      notifications: true,
-    });
     pendingClient.resolve(harness.handle);
 
     await expect(browseResult).resolves.toBe(false);


### PR DESCRIPTION
## Summary

- remove two unreachable `getSubagentBrowseCapability` stubs from the stop-cancellation tests
- keep the tests focused on the lifecycle-gate behavior they actually exercise

## Why

Follow-up to #2177 based on Cubic review feedback. In the existing-client case, the startup lease rejects before capability lookup. In the pending-client case, the post-settlement lease check rejects before capability lookup. The stubs therefore never influenced either result and obscured the real cancellation boundary.

This is a test-only cleanup with no production behavior change.

## Validation

- focused cancellation tests: 2 passed
- `pnpm check:fix`
- `pnpm typecheck`
- `pnpm test --maxWorkers=2`: 409 files passed, 1 skipped; 5,243 tests passed, 4 skipped
- `pnpm check`: all enforced guardrails passed
- normal commit hooks: lint-staged, typecheck, Prisma drift, dependency-cruiser, and Knip passed

The local Codex schema check skipped because the installed CLI is 0.147.0 while the repository pins 0.145.0; CI installs the pinned version and enforces that check.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to unit tests with no runtime or API modifications.
> 
> **Overview**
> **Test-only cleanup** in `session-startup.coordinator.test.ts` for stop vs. subagent browse cancellation—no production behavior change.
> 
> Two stop-cancellation cases drop unreachable `getSubagentBrowseCapability` stubs and rename tests to match the lifecycle gate: when stop is in progress, browse is rejected **before** capability is inspected; when a pending browse client settles after stop, rejection happens **before** a post-stop capability recheck.
> 
> New expectations document that boundary: `getSubagentBrowseCapability` is **not** called in the in-flight-stop case, and is called **once** in the pending-client case (initial probe only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c1d8ea1ba39bec55694e39d1838dd4d1722dafb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->