### PR TITLE
Extract session termination coordination

### DIFF
--- a/docs/superpowers/plans/2026-08-14-session-termination-coordinator.md
+++ b/docs/superpowers/plans/2026-08-14-session-termination-coordinator.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make `AcpRuntimeManager` the sole owner of client-creation quiescence and extract explicit, workspace, and shutdown stop orchestration into `SessionTerminationCoordinator` without changing the public lifecycle API or observable cleanup order.
 
-**Architecture:** A small ACP-layer `AcpRuntimeQuiescence` unit owns tracked client-creation reconciliation operations and idempotent stop-and-quiesce operations. `AcpRuntimeManager` exposes that behavior through `runClientCreationOperation` and `stopAndQuiesce`, while retaining all subprocess maps and stop mechanics. `SessionStartupCoordinator` runs creation through the runtime-owned fence, and a new `SessionTerminationCoordinator` owns the lifecycle stop barrier, durable reasons, cleanup ordering, workspace stops, and bounded shutdown. `SessionLifecycleService` composes both coordinators and delegates its existing public methods.
+**Architecture:** A small ACP-layer `AcpRuntimeQuiescence` unit owns tracked client-creation reconciliation operations and idempotent stop-and-quiesce operations. `AcpRuntimeManager` exposes that behavior through `runClientCreationOperation` and `stopAndQuiesce`, while retaining all subprocess maps and stop mechanics. `SessionStartupCoordinator` runs creation through the runtime-owned fence, and a new `SessionTerminationCoordinator` owns the lifecycle stop barrier, durable reasons, cleanup ordering, workspace stops, and shutdown. `SessionLifecycleService` composes both coordinators and delegates its existing public methods.
 
 **Tech Stack:** TypeScript 5.9, Vitest 4, pnpm, Biome, dependency-cruiser.
 
@@ -83,11 +83,11 @@
   5. if a barrier existed, call `stopClient` again and use the retry outcome as authoritative;
   6. clear the quiescence entry in `finally` only when it still refers to this operation.
 
-  Expose read-only `getTrackedSessionIds()`, `isBrowseOnlySession(sessionId)`, and `waitForAll()` methods for shutdown integration. Do not expose the records or a manual `release()` function. `waitForAll()` itself is unbounded; `AcpRuntimeManager.stopAllClients(timeoutMs)` applies the existing soft timeout at the boundary.
+  Expose read-only `getTrackedSessionIds()`, `isBrowseOnlySession(sessionId)`, and `waitForAll()` methods for shutdown integration. Do not expose the records or a manual `release()` function. `waitForAll()` is an unbounded lifecycle-reconciliation barrier; process-stop operations retain their existing soft timeouts.
 
 - [ ] **Step 4: Add runtime-manager integration RED tests**
 
-  Extend existing public manager tests without increasing `acp-runtime-manager.test.ts` beyond its 2,714-line ceiling. Rework an existing pending-creation stop case to run a deferred post-creation reconciliation through `runClientCreationOperation`, call `stopAndQuiesce`, and assert that:
+  Extend existing public manager tests without increasing `acp-runtime-manager.test.ts` beyond its 2,705-line ceiling. Rework an existing pending-creation stop case to run a deferred post-creation reconciliation through `runClientCreationOperation`, call `stopAndQuiesce`, and assert that:
 
   - the first stop cannot finish the public quiescence operation while reconciliation is pending;
   - a runtime installed by the operation is stopped by the retry;
@@ -98,7 +98,7 @@
 
 - [ ] **Step 5: Wire the helper into `AcpRuntimeManager`**
 
-  Construct one helper inside `AcpRuntimeManager`, delegate the two new public methods, include `getTrackedSessionIds()` in `beginShutdown()`, and include the helper's purpose classification in `isBrowseOnlySession()`. Insert `raceWithSoftTimeout(quiescence.waitForAll(), timeoutMs)` between the first and final `stopCurrentClients()` passes in `stopAllClients()`.
+  Construct one helper inside `AcpRuntimeManager`, delegate the two new public methods, include `getTrackedSessionIds()` in `beginShutdown()`, and include the helper's purpose classification in `isBrowseOnlySession()`. Await `quiescence.waitForAll()` between the first and final `stopCurrentClients()` passes in `stopAllClients()` so no durable startup reconciliation can outlive shutdown.
 
   Keep `stopClientOnce`, process cancellation, incarnation filtering, creation locks, and `pendingCreation` unchanged. If the 1,449-line manager would grow, extract delegation or shutdown mechanics into the new helper or compact behavior-neutral code; do not raise the baseline.
 
@@ -113,7 +113,7 @@
   pnpm typecheck
   ```
 
-  Expected: both suites pass, TypeScript reports no diagnostics, the manager remains at or below 1,449 lines, and the manager test remains at or below 2,714 lines.
+  Expected: both suites pass, TypeScript reports no diagnostics, the manager remains at or below 1,449 lines, and the manager test remains at or below 2,705 lines.
 
 - [ ] **Step 7: Commit the runtime contract**
 

--- a/docs/superpowers/plans/2026-08-14-session-termination-coordinator.md
+++ b/docs/superpowers/plans/2026-08-14-session-termination-coordinator.md
@@ -1,0 +1,388 @@
+# Session Termination Coordinator Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `AcpRuntimeManager` the sole owner of client-creation quiescence and extract explicit, workspace, and shutdown stop orchestration into `SessionTerminationCoordinator` without changing the public lifecycle API or observable cleanup order.
+
+**Architecture:** A small ACP-layer `AcpRuntimeQuiescence` unit owns tracked client-creation reconciliation operations and idempotent stop-and-quiesce operations. `AcpRuntimeManager` exposes that behavior through `runClientCreationOperation` and `stopAndQuiesce`, while retaining all subprocess maps and stop mechanics. `SessionStartupCoordinator` runs creation through the runtime-owned fence, and a new `SessionTerminationCoordinator` owns the lifecycle stop barrier, durable reasons, cleanup ordering, workspace stops, and bounded shutdown. `SessionLifecycleService` composes both coordinators and delegates its existing public methods.
+
+**Tech Stack:** TypeScript 5.9, Vitest 4, pnpm, Biome, dependency-cruiser.
+
+## Global Constraints
+
+- Preserve the signatures, return values, errors, durable events, logging categories, and side-effect ordering of all existing public lifecycle methods.
+- Keep `SessionLifecycleGate` as the sole domain authority for stop/startup eligibility and `AcpRuntimeManager` as the sole owner of runtime creation and quiescence promises.
+- The runtime-owned creation fence must span the full startup reconciliation operation through the durable `RUNNING` write; `pendingCreation` alone is not a sufficient stop barrier.
+- `stopAndQuiesce` must be idempotent, reject new same-session fenced creation after quiescence begins, wait already-registered operations, retry runtime stop after they settle, and treat a successful retry as authoritative over an earlier stop error.
+- Duplicate lifecycle stops must return without releasing the first stop reservation, repeating durable stop events, or running unmanaged-exit finalization.
+- Preserve the existing stop cleanup order: prompt/queue fencing, session lookup and durable reason, stopping snapshot, ACP and permission cleanup, runtime quiescence, orphan-tool cleanup, durable idle, stopped snapshot, workspace idle, ACP session clear, deliberate workflow finalization on successful runtime stop, inactive cleanup, and trace close.
+- Preserve shutdown admission closure before lifecycle recording, the one-second lifecycle-recording bound, browse-only event omission, and runtime shutdown even when recording fails or times out.
+- Keep each new production unit below 600 lines and below the unbaselined 1,000-line limit. Do not increase any tracked file-length baseline; in particular, the separately baselined runtime manager must remain at or below 1,449 lines.
+- Import within the session capsule according to `src/backend/services/AGENTS.md`; do not introduce cross-capsule deep imports, cycles, or `await import()`.
+- Use TDD for every behavior change. Do not reach private methods from tests; test the public helper, runtime-manager, coordinator, and facade contracts.
+
+---
+
+### Task 1: Establish the runtime-owned client-creation fence
+
+**Files:**
+- Create: `src/backend/services/session/service/acp/acp-runtime-quiescence.ts`
+- Create: `src/backend/services/session/service/acp/acp-runtime-quiescence.test.ts`
+- Modify: `src/backend/services/session/service/acp/acp-runtime-manager.ts`
+- Modify: `src/backend/services/session/service/acp/acp-runtime-manager.test.ts`
+- Modify: `src/backend/services/session/service/acp/index.ts`
+
+**Interfaces:**
+- Produces: `AcpClientCreationOperation`, exposing only `isOnlyOperation(): boolean` to the operation body.
+- Produces: `AcpRuntimeQuiescence`, constructed with a typed `stopClient(sessionId)` port.
+- Produces on `AcpRuntimeManager`:
+
+  ```ts
+  runClientCreationOperation<T>(
+    sessionId: string,
+    purpose: AcpRuntimePurpose,
+    operation: (registration: AcpClientCreationOperation) => Promise<T>
+  ): Promise<T>;
+
+  stopAndQuiesce(sessionId: string): Promise<void>;
+  ```
+
+- Preserves: `stopClient`, `beginShutdown`, and `stopAllClients` as public compatibility methods.
+
+- [ ] **Step 1: Add public quiescence RED tests**
+
+  In `acp-runtime-quiescence.test.ts`, construct the public helper with a typed `stopClient` spy and add tests proving:
+
+  - `runClientCreationOperation` registers synchronously, exposes `isOnlyOperation()`, returns the operation result, and unregisters on both resolve and reject;
+  - concurrent same-session creation operations report the correct only-operation state;
+  - `stopAndQuiesce` calls stop immediately, remains pending while an already-registered creation/reconciliation operation is pending, then stops again after it settles;
+  - if the first stop rejects and a tracked operation exists, a successful retry resolves; if no tracked operation exists, the original stop error rejects;
+  - overlapping `stopAndQuiesce` calls share one operation and do not run duplicate stop sequences;
+  - a new same-session creation operation is rejected after quiescence begins, while a different session remains independent.
+
+- [ ] **Step 2: Run the helper suite and capture RED**
+
+  Run:
+
+  ```bash
+  pnpm test src/backend/services/session/service/acp/acp-runtime-quiescence.test.ts
+  ```
+
+  Expected: FAIL because `./acp-runtime-quiescence` does not exist. No production helper may exist before this failure is captured.
+
+- [ ] **Step 3: Implement the minimal public helper**
+
+  Implement `AcpRuntimeQuiescence` with one session-keyed collection of `{ barrier, purpose }` creation/reconciliation records and one `Map<string, Promise<void>>` for idempotent quiescence calls. Register a deferred barrier before invoking the operation callback and settle/remove it in `finally`. When a same-session quiescence call is active, reject new registration with the existing message `ACP session stop requested; cannot create client ${sessionId}`. Report a tracked session as browse-only only when every live record for it has purpose `browse`.
+
+  Implement `stopAndQuiesce` in this exact order:
+
+  1. synchronously publish the session's quiescence operation;
+  2. attempt `stopClient`, retaining any error;
+  3. snapshot and await all registered creation barriers;
+  4. if no barrier existed, propagate the retained stop error or return;
+  5. if a barrier existed, call `stopClient` again and use the retry outcome as authoritative;
+  6. clear the quiescence entry in `finally` only when it still refers to this operation.
+
+  Expose read-only `getTrackedSessionIds()`, `isBrowseOnlySession(sessionId)`, and `waitForAll()` methods for shutdown integration. Do not expose the records or a manual `release()` function. `waitForAll()` itself is unbounded; `AcpRuntimeManager.stopAllClients(timeoutMs)` applies the existing soft timeout at the boundary.
+
+- [ ] **Step 4: Add runtime-manager integration RED tests**
+
+  Extend existing public manager tests without increasing `acp-runtime-manager.test.ts` beyond its 2,714-line ceiling. Rework an existing pending-creation stop case to run a deferred post-creation reconciliation through `runClientCreationOperation`, call `stopAndQuiesce`, and assert that:
+
+  - the first stop cannot finish the public quiescence operation while reconciliation is pending;
+  - a runtime installed by the operation is stopped by the retry;
+  - `getClient(sessionId)` is undefined when `stopAndQuiesce` resolves;
+  - two callers receive the same idempotent stop outcome.
+
+  Add or amend a shutdown case so `beginShutdown()` reports sessions known only to the creation fence and `stopAllClients()` waits those fences before its final process-stop pass.
+
+- [ ] **Step 5: Wire the helper into `AcpRuntimeManager`**
+
+  Construct one helper inside `AcpRuntimeManager`, delegate the two new public methods, include `getTrackedSessionIds()` in `beginShutdown()`, and include the helper's purpose classification in `isBrowseOnlySession()`. Insert `raceWithSoftTimeout(quiescence.waitForAll(), timeoutMs)` between the first and final `stopCurrentClients()` passes in `stopAllClients()`.
+
+  Keep `stopClientOnce`, process cancellation, incarnation filtering, creation locks, and `pendingCreation` unchanged. If the 1,449-line manager would grow, extract delegation or shutdown mechanics into the new helper or compact behavior-neutral code; do not raise the baseline.
+
+- [ ] **Step 6: Run Task 1 GREEN**
+
+  Run:
+
+  ```bash
+  pnpm test \
+    src/backend/services/session/service/acp/acp-runtime-quiescence.test.ts \
+    src/backend/services/session/service/acp/acp-runtime-manager.test.ts
+  pnpm typecheck
+  ```
+
+  Expected: both suites pass, TypeScript reports no diagnostics, the manager remains at or below 1,449 lines, and the manager test remains at or below 2,714 lines.
+
+- [ ] **Step 7: Commit the runtime contract**
+
+  Inspect the Task 1 diff and commit it with subject `Own runtime creation quiescence`.
+
+---
+
+### Task 2: Move startup reconciliation onto the runtime-owned fence
+
+**Files:**
+- Modify: `src/backend/services/session/service/lifecycle/session-startup.coordinator.ts`
+- Modify: `src/backend/services/session/service/lifecycle/session-startup.coordinator.test.ts`
+- Modify: `src/backend/services/session/service/lifecycle/session.lifecycle.service.ts`
+- Modify: `src/backend/services/session/service/lifecycle/session-lifecycle.test-helpers.ts`
+- Modify: `src/backend/services/session/service/lifecycle/session-termination.coordinator.test.ts`
+
+**Interfaces:**
+- Removes: `ClientCreationRegistration` and `registerClientCreation` from `SessionStartupCoordinatorDependencies`.
+- Consumes: `AcpRuntimeManager['runClientCreationOperation']` through the startup coordinator's typed runtime-manager port.
+- Removes: facade-owned `clientCreationOperations`, `registerClientCreation`, and `stopRuntimeAndPendingCreation`.
+
+- [ ] **Step 1: Add startup/runtime integration RED tests**
+
+  In `session-startup.coordinator.test.ts`, update the typed runtime-manager fixture with `runClientCreationOperation` and add a public test whose runtime handle resolves before `repository.updateSession(...RUNNING)` does. Start the coordinator operation, reserve a stop, and assert that the runtime-owned creation operation remains pending until the durable write settles and then surfaces the existing startup cancellation result.
+
+  In `session-termination.coordinator.test.ts`, change the pending-start race expectation from two calls to `stopClient` to one call to `stopAndQuiesce`, while preserving the assertions that the stop waits, the resulting runtime is absent, and no prompt is sent.
+
+- [ ] **Step 2: Run focused RED**
+
+  Run:
+
+  ```bash
+  pnpm test \
+    src/backend/services/session/service/lifecycle/session-startup.coordinator.test.ts \
+    src/backend/services/session/service/lifecycle/session-termination.coordinator.test.ts
+  ```
+
+  Expected: FAIL because startup still uses the injected facade registration port and termination still calls facade-owned stop/retry logic.
+
+- [ ] **Step 3: Replace the transitional startup tracker**
+
+  Add `runClientCreationOperation` to the startup coordinator's `runtimeManager` pick. Replace both calls to the private `runTrackedClientCreation` with:
+
+  ```ts
+  return await this.dependencies.runtimeManager.runClientCreationOperation(
+    sessionId,
+    purpose,
+    async (registration) => {
+      // Existing creation, configuration, notification recovery,
+      // durable RUNNING reconciliation, and snapshots remain here unchanged.
+    }
+  );
+  ```
+
+  Pass literal `browse` from `ensureSubagentBrowseSession` and literal `active` from active get-or-create. Delete the startup coordinator's deferred-barrier wrapper and transitional dependency. Preserve `registration.isOnlyOperation()` for ACP state cleanup on failure.
+
+- [ ] **Step 4: Remove the facade's parallel authority**
+
+  Delete `clientCreationOperations`, `registerClientCreation`, and `stopRuntimeAndPendingCreation` from `SessionLifecycleService`. Temporarily call `runtimeManager.stopAndQuiesce(sessionId)` from the existing stop body until Task 3 moves that body into the coordinator.
+
+  Update `session-lifecycle.test-helpers.ts` so its typed runtime-manager mock implements `runClientCreationOperation` by immediately invoking the callback with an `isOnlyOperation: () => true` registration and exposes `stopAndQuiesce`. Do not emulate a second promise registry in the fixture.
+
+- [ ] **Step 5: Run Task 2 GREEN**
+
+  Run:
+
+  ```bash
+  pnpm test \
+    src/backend/services/session/service/acp/acp-runtime-quiescence.test.ts \
+    src/backend/services/session/service/acp/acp-runtime-manager.test.ts \
+    src/backend/services/session/service/lifecycle/session-startup.coordinator.test.ts \
+    src/backend/services/session/service/lifecycle/session-termination.coordinator.test.ts \
+    src/backend/services/session/service/lifecycle/session.service.test.ts
+  pnpm typecheck
+  ```
+
+  Expected: all focused tests pass, startup remains below 600 lines, and `rg "clientCreationOperations|registerClientCreation" src/backend/services/session` returns no matches.
+
+- [ ] **Step 6: Commit the ownership migration**
+
+  Inspect the Task 2 diff and commit it with subject `Move startup fences into the runtime`.
+
+---
+
+### Task 3: Extract explicit and workspace stop orchestration
+
+**Files:**
+- Create: `src/backend/services/session/service/lifecycle/session-termination.coordinator.ts`
+- Modify: `src/backend/services/session/service/lifecycle/session-termination.coordinator.test.ts`
+- Modify: `src/backend/services/session/service/lifecycle/session.lifecycle.service.ts`
+- Modify: `src/backend/services/session/service/lifecycle/session.lifecycle.facade.test.ts`
+- Modify: `src/backend/services/session/service/lifecycle/session-lifecycle.test-helpers.ts`
+- Modify: `src/backend/services/session/service/lifecycle/session-startup.coordinator.ts`
+
+**Interfaces:**
+- Produces: `SessionStopReason` and `StopSessionOptions` from `session-termination.coordinator.ts`, re-exported by the facade to keep current import paths valid.
+- Produces: `SessionTerminationCoordinator` with public methods:
+
+  ```ts
+  stopSession(sessionId: string, options?: StopSessionOptions): Promise<void>;
+  stopWorkspaceSessions(
+    workspaceId: string,
+    options?: { reason?: SessionStopReason }
+  ): Promise<void>;
+  stopAllClients(timeoutMs?: number): Promise<void>;
+  ```
+
+- Consumes: explicit typed ports for repository, retry, runtime, domain, permission, ACP cleanup, prompt completion, lifecycle event/gate, workflow finalization, workspace bridge lookup, and optional pre-stop callback.
+
+- [ ] **Step 1: Convert termination tests to the public coordinator and capture RED**
+
+  Import `SessionTerminationCoordinator` directly and build a narrow typed termination harness rather than constructing the full lifecycle service. Move the existing workspace-stop, stop-cause, and race characterizations to that public class. Add explicit ordering assertions for:
+
+  - `reserveStop` occurring synchronously before session loading;
+  - the durable lifecycle event completing before `stopAndQuiesce` begins;
+  - mandatory cleanup continuing when runtime stop fails, while deliberate workflow finalization is skipped;
+  - cleanup steps retaining their current order and the reservation releasing in the outer `finally`;
+  - duplicate stops returning early without a second durable event, runtime stop, cleanup, or barrier release;
+  - workspace stop attempting every eligible persisted, runtime-only, and browse-only session and aggregating failures.
+
+- [ ] **Step 2: Run the direct suite and capture RED**
+
+  Run:
+
+  ```bash
+  pnpm test src/backend/services/session/service/lifecycle/session-termination.coordinator.test.ts
+  ```
+
+  Expected: FAIL because `./session-termination.coordinator` does not exist.
+
+- [ ] **Step 3: Move explicit stop behavior without semantic edits**
+
+  Move the existing `stopSession`, stop body, workspace selection, best-effort session loading, durable idle update, orphan-tool finalization, and workspace-idle reconciliation into the coordinator. Use `runtimeManager.stopAndQuiesce(sessionId)` as the only runtime stop call.
+
+  Keep the stop reservation acquisition in the coordinator's synchronous method prefix and release it only in `finally`. Keep the random durable stop invocation ID per accepted stop. Preserve the existing error precedence: runtime stop failure is logged and cleanup continues; deliberate workflow finalization runs only after successful runtime quiescence; independent cleanup failures retain their current propagate-or-log behavior.
+
+- [ ] **Step 4: Delegate from the compatibility facade**
+
+  Construct one `SessionTerminationCoordinator` beside the startup and runtime-exit coordinators. Supply the workspace bridge through `getWorkspaceBridge: () => this.workspaceBridge` so later `configure()` calls update the same composed instance without reconstructing it.
+
+  Replace facade `stopSession` and `stopWorkspaceSessions` bodies with argument-preserving delegation. Re-export the moved stop types from `session.lifecycle.service.ts`. Point `SessionStartupCoordinator`'s restart-stop callback at the coordinator-backed facade method so restart behavior remains stable.
+
+- [ ] **Step 5: Add facade delegation RED/GREEN coverage**
+
+  In `session.lifecycle.facade.test.ts`, spy on the three `SessionTerminationCoordinator` public methods and assert that the facade forwards exact session IDs, workspace IDs, options, default timeout behavior, results, and rejections. Do not assert coordinator internals in the facade suite.
+
+  Run:
+
+  ```bash
+  pnpm test \
+    src/backend/services/session/service/lifecycle/session-termination.coordinator.test.ts \
+    src/backend/services/session/service/lifecycle/session.lifecycle.facade.test.ts \
+    src/backend/services/session/service/lifecycle/session-startup.coordinator.test.ts \
+    src/backend/services/session/service/lifecycle/session.service.test.ts
+  ```
+
+  Expected: all focused suites pass with unchanged facade behavior.
+
+- [ ] **Step 6: Commit the explicit-stop extraction**
+
+  Inspect the Task 3 diff and commit it with subject `Extract session termination coordinator`.
+
+---
+
+### Task 4: Move bounded shutdown policy and verify the complete PR
+
+**Files:**
+- Modify: `src/backend/services/session/service/lifecycle/session-termination.coordinator.ts`
+- Modify: `src/backend/services/session/service/lifecycle/session-termination.coordinator.test.ts`
+- Modify: `src/backend/services/session/service/lifecycle/session.lifecycle.service.ts`
+- Modify: `src/backend/services/session/service/lifecycle/session-services.composition.test.ts`
+- Modify: `scripts/file-length-baseline.json`
+- Modify: only files listed above if verification exposes an extraction regression
+
+**Interfaces:**
+- Preserves: `SessionLifecycleService.stopAllClients(timeoutMs = 5000)` and `AcpRuntimeManager.stopAllClients(timeoutMs = 5000)`.
+- Produces: one fully composed termination coordinator using the same lifecycle gate, runtime manager, workflow finalizer, and mutable workspace-bridge seam as the facade.
+
+- [ ] **Step 1: Add direct shutdown RED tests**
+
+  Move graceful-shutdown tests onto the public coordinator and add coverage proving:
+
+  - prompt completion clears before `beginShutdown`;
+  - `beginShutdown` atomically closes runtime admission before any durable event await;
+  - shutdown reserves the lifecycle gate only for non-browse sessions;
+  - active, pending, and creation-fenced sessions receive `SYSTEM_STOP`, while browse-only sessions do not;
+  - lifecycle recording failures are logged independently and do not skip runtime shutdown;
+  - the one-second recording timeout is cleared on early completion and allows shutdown to continue on expiry;
+  - caller timeout is forwarded unchanged and runtime shutdown rejection still propagates after logging.
+
+- [ ] **Step 2: Run focused RED**
+
+  Run:
+
+  ```bash
+  pnpm test \
+    src/backend/services/session/service/lifecycle/session-termination.coordinator.test.ts \
+    src/backend/services/session/service/lifecycle/session.lifecycle.facade.test.ts
+  ```
+
+  Expected: at least one direct shutdown or facade delegation assertion fails until shutdown ownership is fully moved.
+
+- [ ] **Step 3: Complete shutdown extraction and composition coverage**
+
+  Move shutdown event recording, timeout handling, and runtime shutdown invocation into `SessionTerminationCoordinator.stopAllClients`. Replace the facade method with a direct delegate.
+
+  In `session-services.composition.test.ts`, assert the public lifecycle singleton uses one fully configured termination coordinator and that the workspace bridge attached through `configure()` is observed by a later stop. Do not export the coordinator from the capsule barrel; callers continue through `SessionLifecycleService`.
+
+- [ ] **Step 4: Run focused lifecycle and runtime GREEN**
+
+  Run:
+
+  ```bash
+  pnpm test \
+    src/backend/services/session/service/acp/acp-runtime-quiescence.test.ts \
+    src/backend/services/session/service/acp/acp-runtime-manager.test.ts \
+    src/backend/services/session/service/lifecycle/session-startup.coordinator.test.ts \
+    src/backend/services/session/service/lifecycle/session-termination.coordinator.test.ts \
+    src/backend/services/session/service/lifecycle/session-runtime-exit.coordinator.test.ts \
+    src/backend/services/session/service/lifecycle/session.lifecycle.facade.test.ts \
+    src/backend/services/session/service/lifecycle/session-services.composition.test.ts \
+    src/backend/services/session/service/lifecycle/session.service.test.ts
+  ```
+
+  Expected: all focused suites pass. Managed stops do not invoke unmanaged-exit finalization, and all public lifecycle signatures remain unchanged.
+
+- [ ] **Step 5: Format, ratchet file sizes, and inspect the baseline**
+
+  Run:
+
+  ```bash
+  pnpm check:fix
+  pnpm check:file-length:update
+  git diff -- scripts/file-length-baseline.json
+  wc -l \
+    src/backend/services/session/service/acp/acp-runtime-quiescence.ts \
+    src/backend/services/session/service/acp/acp-runtime-manager.ts \
+    src/backend/services/session/service/lifecycle/session-startup.coordinator.ts \
+    src/backend/services/session/service/lifecycle/session-termination.coordinator.ts \
+    src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
+  ```
+
+  Expected: every new focused production file is below 600 lines; the facade ceiling decreases; the ACP manager does not exceed 1,449 lines; no recorded ceiling increases.
+
+- [ ] **Step 6: Run the complete handoff sequence**
+
+  Run sequentially on the final formatted tree:
+
+  ```bash
+  pnpm check:fix
+  pnpm typecheck
+  pnpm test --maxWorkers=2
+  pnpm check
+  ```
+
+  Expected: every command exits 0. `pnpm check:prisma-schema` is not required because this PR must not alter `prisma/schema.prisma`.
+
+- [ ] **Step 7: Perform final ownership and behavior review**
+
+  Run:
+
+  ```bash
+  rg "clientCreationOperations|registerClientCreation|stopRuntimeAndPendingCreation" src/backend/services/session
+  git diff --check
+  git status --short
+  ```
+
+  Expected: the ownership search returns no matches, `git diff --check` is clean, and status contains only intended PR files. Review the exact base-to-head diff for stop ordering, error precedence, barrier release, retry authority, shutdown timeout cleanup, capsule imports, and public signature preservation.
+
+- [ ] **Step 8: Commit and prepare the pull request**
+
+  Commit the final extraction with subject `Complete termination coordinator wiring`. After PR #2178 merges, rebase this branch onto current `origin/main`, rerun the complete handoff sequence, then use the finishing workflow to push and open the PR. The PR body must state the ownership change, why the runtime fence spans durable startup reconciliation, the unchanged public API, the downward file-length ratchet, and the exact checks run.

--- a/docs/superpowers/plans/2026-08-14-session-termination-coordinator.md
+++ b/docs/superpowers/plans/2026-08-14-session-termination-coordinator.md
@@ -218,7 +218,6 @@
     workspaceId: string,
     options?: { reason?: SessionStopReason }
   ): Promise<void>;
-  stopAllClients(timeoutMs?: number): Promise<void>;
   ```
 
 - Consumes: explicit typed ports for repository, retry, runtime, domain, permission, ACP cleanup, prompt completion, lifecycle event/gate, workflow finalization, workspace bridge lookup, and optional pre-stop callback.
@@ -258,7 +257,7 @@
 
 - [ ] **Step 5: Add facade delegation RED/GREEN coverage**
 
-  In `session.lifecycle.facade.test.ts`, spy on the three `SessionTerminationCoordinator` public methods and assert that the facade forwards exact session IDs, workspace IDs, options, default timeout behavior, results, and rejections. Do not assert coordinator internals in the facade suite.
+  In `session.lifecycle.facade.test.ts`, spy on the two `SessionTerminationCoordinator` public methods and assert that the facade forwards exact session IDs, workspace IDs, options, results, and rejections. Do not assert coordinator internals in the facade suite. `stopAllClients` remains on the facade until Task 4.
 
   Run:
 
@@ -290,6 +289,7 @@
 
 **Interfaces:**
 - Preserves: `SessionLifecycleService.stopAllClients(timeoutMs = 5000)` and `AcpRuntimeManager.stopAllClients(timeoutMs = 5000)`.
+- Adds: `SessionTerminationCoordinator.stopAllClients(timeoutMs = 5000)` and delegates the existing facade method to it.
 - Produces: one fully composed termination coordinator using the same lifecycle gate, runtime manager, workflow finalizer, and mutable workspace-bridge seam as the facade.
 
 - [ ] **Step 1: Add direct shutdown RED tests**

--- a/scripts/file-length-baseline.json
+++ b/scripts/file-length-baseline.json
@@ -13,7 +13,7 @@
   "src/backend/services/ratchet/service/ratchet.service.ts": 1035,
   "src/backend/services/run-script/service/run-script.service.test.ts": 2332,
   "src/backend/services/run-script/service/run-script.service.ts": 1026,
-  "src/backend/services/session/service/acp/acp-runtime-manager.test.ts": 2714,
+  "src/backend/services/session/service/acp/acp-runtime-manager.test.ts": 2705,
   "src/backend/services/session/service/acp/acp-runtime-manager.ts": 1449,
   "src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.test.ts": 3423,
   "src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.test.ts": 1576,

--- a/src/backend/services/session/service/acp/acp-runtime-manager.test.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-manager.test.ts
@@ -1412,40 +1412,37 @@ describe('AcpRuntimeManager', () => {
       expect(child.kill).toHaveBeenCalledWith('SIGTERM');
     });
 
-    it('aborts in-flight client creation and cleans up the spawned subprocess', async () => {
-      const child = createMockChildProcess();
+    it('quiesces a deferred post-creation reconciliation before stopping its runtime', async () => {
+      // Catches allowing reconciliation to install a runtime after the final stop pass.
+      const reconciliation = createDeferred<void>();
+      const child = setupSuccessfulSpawn();
       exitChildAfterSigterm(child);
-      mockSpawn.mockReturnValue(child);
-      mockInitialize.mockImplementation(
-        () =>
-          new Promise(() => {
-            // Keep creation pending until the per-session stop aborts it.
-          })
-      );
-
-      const createPromise = manager.getOrCreateClient(
-        'session-1',
-        defaultOptions(),
-        defaultHandlers(),
-        defaultContext()
-      );
-      const createRejection = createPromise.catch((error: unknown) => error);
-
-      await vi.waitFor(() => {
-        expect(mockSpawn).toHaveBeenCalledTimes(1);
-        expect(manager.getPendingClient('session-1')).toBeDefined();
+      const creation = manager.runClientCreationOperation('session-1', 'active', async () => {
+        await reconciliation.promise;
+        return manager.getOrCreateClient(
+          'session-1',
+          defaultOptions(),
+          defaultHandlers(),
+          defaultContext()
+        );
       });
 
-      await manager.stopClient('session-1');
-
-      await expect(createRejection).resolves.toMatchObject({
-        message: expect.stringContaining('ACP session stop requested'),
+      const firstStop = manager.stopAndQuiesce('session-1');
+      const secondStop = manager.stopAndQuiesce('session-1');
+      expect(secondStop).toBe(firstStop);
+      let stopSettled = false;
+      void firstStop.then(() => {
+        stopSettled = true;
       });
+      await Promise.resolve();
+      expect(stopSettled).toBe(false);
+
+      reconciliation.resolve(undefined);
+      await creation;
+      await Promise.all([firstStop, secondStop]);
+
       expect(child.kill).toHaveBeenCalledWith('SIGTERM');
-      expect(child.kill).not.toHaveBeenCalledWith('SIGKILL');
-      expect(manager.isStopInProgress('session-1')).toBe(false);
       expect(manager.getClient('session-1')).toBeUndefined();
-      expect(manager.getPendingClient('session-1')).toBeUndefined();
     });
 
     it('runtime exit event atomically captures browse purpose for a managed stop', async () => {
@@ -1785,7 +1782,8 @@ describe('AcpRuntimeManager', () => {
   });
 
   describe('stopAllClients', () => {
-    it('atomically closes admission and reports active and pending session ids', async () => {
+    it('waits for fence-only reconciliation while closing admission', async () => {
+      // Catches shutdown omitting creation-fence sessions or skipping its barrier wait.
       const activeChild = setupSuccessfulSpawn();
       await manager.getOrCreateClient(
         'session-active',
@@ -1794,32 +1792,20 @@ describe('AcpRuntimeManager', () => {
         defaultContext()
       );
 
-      const pendingChild = createMockChildProcess();
-      exitChildAfterSigterm(pendingChild);
-      mockSpawn.mockReturnValueOnce(pendingChild);
-      mockInitialize.mockImplementationOnce(
-        () =>
-          new Promise(() => {
-            // Remain pending until beginShutdown rejects the creation signal.
-          })
+      const reconciliation = createDeferred<void>();
+      const fenceOnly = manager.runClientCreationOperation(
+        'session-fence-only',
+        'browse',
+        () => reconciliation.promise
       );
-      const pendingCreation = manager
-        .getOrCreateClient(
-          'session-pending',
-          { ...defaultOptions(), sessionId: 'session-pending' },
-          defaultHandlers(),
-          defaultContext()
-        )
-        .catch((error: unknown) => error);
-      await vi.waitFor(() => {
-        expect(manager.getPendingClient('session-pending')).toBeDefined();
-      });
 
       const shutdownSessionIds = (
         manager as unknown as { beginShutdown(): string[] }
       ).beginShutdown();
 
-      expect(new Set(shutdownSessionIds)).toEqual(new Set(['session-active', 'session-pending']));
+      expect(new Set(shutdownSessionIds)).toEqual(
+        new Set(['session-active', 'session-fence-only'])
+      );
       await expect(
         manager.getOrCreateClient(
           'session-too-late',
@@ -1834,10 +1820,15 @@ describe('AcpRuntimeManager', () => {
         activeChild.emit('exit', 0, null);
         return true;
       });
-      await manager.stopAllClients(50);
-      await expect(pendingCreation).resolves.toMatchObject({
-        message: expect.stringContaining('ACP runtime manager is shutting down'),
+      const stopAll = manager.stopAllClients(50);
+      let stopped = false;
+      void stopAll.then(() => {
+        stopped = true;
       });
+      await Promise.resolve();
+      expect(stopped).toBe(false);
+      reconciliation.resolve(undefined);
+      await Promise.all([fenceOnly, stopAll]);
     });
 
     it('clears per-client shutdown timeouts when clients stop quickly', async () => {

--- a/src/backend/services/session/service/acp/acp-runtime-manager.test.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-manager.test.ts
@@ -1791,7 +1791,6 @@ describe('AcpRuntimeManager', () => {
 
   describe('stopAllClients', () => {
     it('waits for fence-only reconciliation while closing admission', async () => {
-      // Catches shutdown omitting creation-fence sessions or skipping its barrier wait.
       const activeChild = setupSuccessfulSpawn();
       await manager.getOrCreateClient(
         'session-active',
@@ -1805,10 +1804,10 @@ describe('AcpRuntimeManager', () => {
         'browse',
         () => reconciliation.promise
       );
+      expect(manager.hasClientCreationOperation('session-fence-only')).toBe(true);
       const shutdownSessionIds = (
         manager as unknown as { beginShutdown(): string[] }
       ).beginShutdown();
-
       expect(new Set(shutdownSessionIds)).toEqual(
         new Set(['session-active', 'session-fence-only'])
       );
@@ -1827,10 +1826,11 @@ describe('AcpRuntimeManager', () => {
       void stopAll.then(() => {
         stopped = true;
       });
-      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 60));
       expect(stopped).toBe(false);
       reconciliation.resolve(undefined);
       await Promise.all([fenceOnly, stopAll]);
+      expect(manager.hasClientCreationOperation('session-fence-only')).toBe(false);
     });
 
     it('clears per-client shutdown timeouts when clients stop quickly', async () => {

--- a/src/backend/services/session/service/acp/acp-runtime-manager.test.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-manager.test.ts
@@ -647,7 +647,6 @@ describe('AcpRuntimeManager', () => {
         sessionId: 'provider-session-123',
         configOptions: expectedConfigOptions,
       });
-
       const handle = await manager.getOrCreateClient(
         'session-1',
         defaultOptions(),
@@ -798,11 +797,9 @@ describe('AcpRuntimeManager', () => {
       const defaultEntry = modelOption?.options.find(
         (option) => 'value' in option && option.value === 'default'
       );
-
       expect(defaultEntry).toMatchObject({ value: 'default', name: 'Default — Opus 4.6' });
     });
   });
-
   describe('sub-agent browsing extensions', () => {
     it('classifies a browse-only client before provider restoration completes', async () => {
       const child = setupSuccessfulSpawn({ ...subagentBrowseCapabilities(), loadSession: true });
@@ -812,7 +809,6 @@ describe('AcpRuntimeManager', () => {
         agentInfo: { name: string };
       }>();
       mockInitialize.mockReturnValueOnce(initialization.promise);
-
       const creation = manager.getOrCreateClient(
         'db-session-1',
         {
@@ -826,9 +822,7 @@ describe('AcpRuntimeManager', () => {
       await vi.waitFor(() => {
         expect(mockSpawn).toHaveBeenCalled();
       });
-
       expect(manager.isBrowseOnlySession('db-session-1')).toBe(true);
-
       initialization.resolve({
         protocolVersion: 1,
         agentCapabilities: { ...subagentBrowseCapabilities(), loadSession: true },
@@ -836,11 +830,9 @@ describe('AcpRuntimeManager', () => {
       });
       await creation;
       expect(manager.isBrowseOnlySession('db-session-1')).toBe(true);
-
       exitChildAfterSigterm(child);
       await manager.stopClient('db-session-1');
     });
-
     it('emits active runtime error purpose after promoting a browse runtime', async () => {
       const child = setupSuccessfulSpawn({ ...subagentBrowseCapabilities(), loadSession: true });
       mockExtMethod.mockResolvedValueOnce({ subagents: [], nextCursor: null });
@@ -878,7 +870,38 @@ describe('AcpRuntimeManager', () => {
         purpose: 'active',
       });
     });
-
+    it('requires every live runtime and fence source to be browse-only', async () => {
+      // Catches treating any browse source as sufficient while active work is live.
+      for (const [runtimePurpose, fencePurpose, expected] of [
+        ['active', 'browse', false],
+        ['browse', 'active', false],
+        ['browse', 'browse', true],
+      ] as const) {
+        const sessionId = `${runtimePurpose}-${fencePurpose}`;
+        setupSuccessfulSpawn(runtimePurpose === 'browse' ? { loadSession: true } : undefined);
+        await manager.getOrCreateClient(
+          sessionId,
+          {
+            ...defaultOptions(),
+            purpose: runtimePurpose,
+            ...(runtimePurpose === 'browse'
+              ? { resumeProviderSessionId: 'provider-session-existing' }
+              : {}),
+          },
+          defaultHandlers(),
+          defaultContext()
+        );
+        const fence = createDeferred<void>();
+        const operation = manager.runClientCreationOperation(
+          sessionId,
+          fencePurpose,
+          () => fence.promise
+        );
+        expect(manager.isBrowseOnlySession(sessionId)).toBe(expected);
+        fence.resolve(undefined);
+        await operation;
+      }
+    });
     it('does not replace a missing browse-only provider session with a new session', async () => {
       const child = setupSuccessfulSpawn({ ...subagentBrowseCapabilities(), loadSession: true });
       exitChildAfterSigterm(child);
@@ -900,7 +923,6 @@ describe('AcpRuntimeManager', () => {
       });
       expect(mockNewSession).not.toHaveBeenCalled();
     });
-
     it('runtime exit event fences replacement creation until current exit handling settles', async () => {
       const firstChild = setupSuccessfulSpawn();
       const exitHandling = createDeferred<void>();
@@ -908,14 +930,12 @@ describe('AcpRuntimeManager', () => {
         ...defaultHandlers(),
         onRuntimeExit: vi.fn(() => exitHandling.promise),
       };
-
       await manager.getOrCreateClient(
         'db-session-1',
         defaultOptions(),
         firstHandlers,
         defaultContext()
       );
-
       firstChild.exitCode = 1;
       firstChild.emit('exit', 1, null);
       firstChild.emit('exit', 1, null);
@@ -931,7 +951,6 @@ describe('AcpRuntimeManager', () => {
         purpose: 'active',
         managed: false,
       });
-
       const replacementChild = setupSuccessfulSpawn();
       const replacementPromise = manager.getOrCreateClient(
         'db-session-1',
@@ -944,22 +963,18 @@ describe('AcpRuntimeManager', () => {
         replacementSettled = true;
       });
       await new Promise((resolve) => setTimeout(resolve, 0));
-
       expect(replacementSettled).toBe(false);
       expect(mockSpawn).toHaveBeenCalledTimes(1);
       expect(manager.getBrowseClient('db-session-1')).toBeUndefined();
-
       exitHandling.resolve();
       const replacementHandle = await replacementPromise;
 
       expect(manager.getBrowseClient('db-session-1')).toBe(replacementHandle);
       expect(manager.isBrowseOnlySession('db-session-1')).toBe(false);
       expect(manager.getClient('db-session-1')).toBe(replacementHandle);
-
       exitChildAfterSigterm(replacementChild);
       await manager.stopClient('db-session-1');
     });
-
     it('classifies a provider without loadSession as unsupported for browse restoration', async () => {
       const child = setupSuccessfulSpawn(subagentBrowseCapabilities());
       exitChildAfterSigterm(child);
@@ -977,7 +992,6 @@ describe('AcpRuntimeManager', () => {
       ).rejects.toMatchObject({ name: 'AcpBrowseSessionUnavailableError' });
       expect(mockNewSession).not.toHaveBeenCalled();
     });
-
     it('returns the negotiated capability only for a live handle', async () => {
       expect(manager.getSubagentBrowseCapability('session-1')).toBeNull();
       const child = setupSuccessfulSpawn(subagentBrowseCapabilities());
@@ -987,18 +1001,15 @@ describe('AcpRuntimeManager', () => {
         defaultHandlers(),
         defaultContext()
       );
-
       expect(manager.getSubagentBrowseCapability('session-1')).toEqual({
         version: 1,
         list: true,
         read: true,
         notifications: true,
       });
-
       child.killed = true;
       expect(manager.getSubagentBrowseCapability('session-1')).toBeNull();
     });
-
     it('lists sub-agents with the provider session ID and unchanged cursor', async () => {
       setupSuccessfulSpawn(subagentBrowseCapabilities());
       mockExtMethod.mockResolvedValueOnce({ subagents: [], nextCursor: null });
@@ -1008,12 +1019,10 @@ describe('AcpRuntimeManager', () => {
         defaultHandlers(),
         defaultContext()
       );
-
       const result = await manager.listSubagents('db-session-1', {
         cursor: 'list-cursor-7',
         limit: 50,
       });
-
       expect(result).toEqual({ subagents: [], nextCursor: null });
       expect(mockExtMethod).toHaveBeenCalledWith(SUBAGENTS_LIST_METHOD, {
         sessionId: 'provider-session-123',
@@ -1041,7 +1050,6 @@ describe('AcpRuntimeManager', () => {
         cursor: 'read-cursor-8',
         limit: 10,
       });
-
       expect(result).toEqual({
         projectionBoundary: 'turn',
         updates: [],
@@ -1791,14 +1799,12 @@ describe('AcpRuntimeManager', () => {
         defaultHandlers(),
         defaultContext()
       );
-
       const reconciliation = createDeferred<void>();
       const fenceOnly = manager.runClientCreationOperation(
         'session-fence-only',
         'browse',
         () => reconciliation.promise
       );
-
       const shutdownSessionIds = (
         manager as unknown as { beginShutdown(): string[] }
       ).beginShutdown();
@@ -1806,15 +1812,11 @@ describe('AcpRuntimeManager', () => {
       expect(new Set(shutdownSessionIds)).toEqual(
         new Set(['session-active', 'session-fence-only'])
       );
+      const lateOperation = vi.fn(() => Promise.resolve(undefined));
       await expect(
-        manager.getOrCreateClient(
-          'session-too-late',
-          { ...defaultOptions(), sessionId: 'session-too-late' },
-          defaultHandlers(),
-          defaultContext()
-        )
+        manager.runClientCreationOperation('session-too-late', 'active', lateOperation)
       ).rejects.toThrow('ACP runtime manager is shutting down');
-
+      expect(lateOperation).not.toHaveBeenCalled();
       activeChild.kill = vi.fn(() => {
         activeChild.exitCode = 0;
         activeChild.emit('exit', 0, null);
@@ -1833,14 +1835,12 @@ describe('AcpRuntimeManager', () => {
 
     it('clears per-client shutdown timeouts when clients stop quickly', async () => {
       const firstChild = setupSuccessfulSpawn();
-
       await manager.getOrCreateClient(
         'session-1',
         defaultOptions(),
         defaultHandlers(),
         defaultContext()
       );
-
       const secondChild = createMockChildProcess();
       mockSpawn.mockReturnValueOnce(secondChild);
 

--- a/src/backend/services/session/service/acp/acp-runtime-manager.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-manager.ts
@@ -35,6 +35,11 @@ import type {
 } from './acp-runtime-events';
 import { createExitFence, dispatchAcpRuntimeExit, guardExit } from './acp-runtime-exit-handler';
 import {
+  type AcpClientCreationOperation,
+  AcpRuntimeQuiescence,
+  raceWithSoftTimeout,
+} from './acp-runtime-quiescence';
+import {
   createAcpSpawnError,
   hasUsableWorkingDir,
   resolveAcpBinary,
@@ -219,31 +224,15 @@ function normalizeSubagentBrowseError(
   });
 }
 
-async function raceWithSoftTimeout<T>(
-  promise: Promise<T>,
-  timeoutMs: number
-): Promise<T | undefined> {
-  let timeout: ReturnType<typeof setTimeout> | undefined;
-  const timeoutPromise = new Promise<undefined>((resolve) => {
-    timeout = setTimeout(() => resolve(undefined), timeoutMs);
-    timeout.unref?.();
-  });
-
-  try {
-    return await Promise.race([promise, timeoutPromise]);
-  } finally {
-    if (timeout !== undefined) {
-      clearTimeout(timeout);
-    }
-  }
-}
-
 export class AcpRuntimeManager {
   private readonly sessions = new Map<string, AcpProcessHandle>();
   private readonly browseOnlySessions = new Set<string>();
   private readonly pendingCreation = new Map<string, Promise<AcpProcessHandle>>();
   private readonly stoppingInProgress = new Set<string>();
   private readonly stopOperations = new Map<string, Promise<void>>();
+  private readonly quiescence = new AcpRuntimeQuiescence({
+    stopClient: (sessionId) => this.stopClient(sessionId),
+  });
   private readonly managedStopChildren = new WeakSet<ChildProcess>();
   private readonly runtimeMetadata = new WeakMap<ChildProcess, AcpRuntimeMetadata>();
   private readonly exitHandling = new Map<string, Promise<void>>();
@@ -286,10 +275,7 @@ export class AcpRuntimeManager {
   }
 
   getClient(sessionId: string): AcpProcessHandle | undefined {
-    if (this.browseOnlySessions.has(sessionId)) {
-      return undefined;
-    }
-    return this.getBrowseClient(sessionId);
+    return this.browseOnlySessions.has(sessionId) ? undefined : this.getBrowseClient(sessionId);
   }
 
   getBrowseClient(sessionId: string): AcpProcessHandle | undefined {
@@ -298,11 +284,23 @@ export class AcpRuntimeManager {
   }
 
   isBrowseOnlySession(sessionId: string): boolean {
-    return this.browseOnlySessions.has(sessionId);
+    return this.browseOnlySessions.has(sessionId) || this.quiescence.isBrowseOnlySession(sessionId);
   }
 
   getPendingClient(sessionId: string): Promise<AcpProcessHandle> | undefined {
     return this.pendingCreation.get(sessionId);
+  }
+
+  runClientCreationOperation<T>(
+    sessionId: string,
+    purpose: AcpRuntimePurpose,
+    operation: (registration: AcpClientCreationOperation) => Promise<T>
+  ): Promise<T> {
+    return this.quiescence.runClientCreationOperation(sessionId, purpose, operation);
+  }
+
+  stopAndQuiesce(sessionId: string): Promise<void> {
+    return this.quiescence.stopAndQuiesce(sessionId);
   }
 
   getSubagentBrowseCapability(sessionId: string): SubagentBrowseCapability | null {
@@ -755,6 +753,7 @@ export class AcpRuntimeManager {
       ...this.sessions.keys(),
       ...this.pendingCreation.keys(),
       ...this.creationLocks.keys(),
+      ...this.quiescence.getTrackedSessionIds(),
     ]);
 
     if (!this.isShuttingDown) {
@@ -1362,6 +1361,7 @@ export class AcpRuntimeManager {
 
     await this.stopCurrentClients(timeoutMs);
     await this.waitForPendingCreations(timeoutMs);
+    await raceWithSoftTimeout(this.quiescence.waitForAll(), timeoutMs);
     await this.stopCurrentClients(timeoutMs);
 
     this.sessions.clear();

--- a/src/backend/services/session/service/acp/acp-runtime-manager.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-manager.ts
@@ -265,14 +265,12 @@ export class AcpRuntimeManager {
   setOnClientCreated(callback: AcpRuntimeCreatedCallback): void {
     this.onClientCreatedCallback = callback;
   }
-
   isStopInProgress(sessionId: string): boolean {
     return this.stoppingInProgress.has(sessionId);
   }
   getClient(sessionId: string): AcpProcessHandle | undefined {
     return this.browseOnlySessions.has(sessionId) ? undefined : this.getBrowseClient(sessionId);
   }
-
   getBrowseClient(sessionId: string): AcpProcessHandle | undefined {
     const handle = this.sessions.get(sessionId);
     return handle?.isRunning() ? handle : undefined;
@@ -285,6 +283,9 @@ export class AcpRuntimeManager {
       (!hasRuntime || this.browseOnlySessions.has(sessionId)) &&
       (fencePurpose === null || fencePurpose === 'browse')
     );
+  }
+  hasClientCreationOperation(sessionId: string): boolean {
+    return this.quiescence.getTrackedSessionPurpose(sessionId) !== null;
   }
   getPendingClient(sessionId: string): Promise<AcpProcessHandle> | undefined {
     return this.pendingCreation.get(sessionId);
@@ -302,7 +303,6 @@ export class AcpRuntimeManager {
   stopAndQuiesce(sessionId: string): Promise<void> {
     return this.quiescence.stopAndQuiesce(sessionId);
   }
-
   getSubagentBrowseCapability(sessionId: string): SubagentBrowseCapability | null {
     return this.getBrowseClient(sessionId)?.getSubagentBrowseCapability() ?? null;
   }
@@ -1361,7 +1361,7 @@ export class AcpRuntimeManager {
 
     await this.stopCurrentClients(timeoutMs);
     await this.waitForPendingCreations(timeoutMs);
-    await raceWithSoftTimeout(this.quiescence.waitForAll(), timeoutMs);
+    await this.quiescence.waitForAll();
     await this.stopCurrentClients(timeoutMs);
 
     this.sessions.clear();

--- a/src/backend/services/session/service/acp/acp-runtime-manager.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-manager.ts
@@ -245,11 +245,9 @@ export class AcpRuntimeManager {
   private acpStartupTimeoutMs = DEFAULT_ACP_STARTUP_TIMEOUT_MS;
   private preferSourceEntrypoint = true;
   private childProcessEnvProvider: () => NodeJS.ProcessEnv = getCurrentProcessEnv;
-
   constructor(options?: { acpStartupTimeoutMs?: number }) {
     this.setAcpStartupTimeoutMs(options?.acpStartupTimeoutMs ?? DEFAULT_ACP_STARTUP_TIMEOUT_MS);
   }
-
   setAcpStartupTimeoutMs(timeoutMs: number): void {
     if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
       this.acpStartupTimeoutMs = DEFAULT_ACP_STARTUP_TIMEOUT_MS;
@@ -257,7 +255,6 @@ export class AcpRuntimeManager {
     }
     this.acpStartupTimeoutMs = Math.floor(timeoutMs);
   }
-
   configureEnvironment(options: {
     preferSourceEntrypoint: boolean;
     childProcessEnvProvider: () => NodeJS.ProcessEnv;
@@ -265,7 +262,6 @@ export class AcpRuntimeManager {
     this.preferSourceEntrypoint = options.preferSourceEntrypoint;
     this.childProcessEnvProvider = options.childProcessEnvProvider;
   }
-
   setOnClientCreated(callback: AcpRuntimeCreatedCallback): void {
     this.onClientCreatedCallback = callback;
   }
@@ -273,7 +269,6 @@ export class AcpRuntimeManager {
   isStopInProgress(sessionId: string): boolean {
     return this.stoppingInProgress.has(sessionId);
   }
-
   getClient(sessionId: string): AcpProcessHandle | undefined {
     return this.browseOnlySessions.has(sessionId) ? undefined : this.getBrowseClient(sessionId);
   }
@@ -282,23 +277,28 @@ export class AcpRuntimeManager {
     const handle = this.sessions.get(sessionId);
     return handle?.isRunning() ? handle : undefined;
   }
-
   isBrowseOnlySession(sessionId: string): boolean {
-    return this.browseOnlySessions.has(sessionId) || this.quiescence.isBrowseOnlySession(sessionId);
+    const hasRuntime = this.sessions.has(sessionId) || this.pendingCreation.has(sessionId);
+    const fencePurpose = this.quiescence.getTrackedSessionPurpose(sessionId);
+    return (
+      (hasRuntime || fencePurpose !== null) &&
+      (!hasRuntime || this.browseOnlySessions.has(sessionId)) &&
+      (fencePurpose === null || fencePurpose === 'browse')
+    );
   }
-
   getPendingClient(sessionId: string): Promise<AcpProcessHandle> | undefined {
     return this.pendingCreation.get(sessionId);
   }
-
   runClientCreationOperation<T>(
     sessionId: string,
     purpose: AcpRuntimePurpose,
     operation: (registration: AcpClientCreationOperation) => Promise<T>
   ): Promise<T> {
+    if (this.isShuttingDown) {
+      return Promise.reject(this.createShutdownError(sessionId));
+    }
     return this.quiescence.runClientCreationOperation(sessionId, purpose, operation);
   }
-
   stopAndQuiesce(sessionId: string): Promise<void> {
     return this.quiescence.stopAndQuiesce(sessionId);
   }

--- a/src/backend/services/session/service/acp/acp-runtime-quiescence.test.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-quiescence.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AcpRuntimeQuiescence } from './acp-runtime-quiescence';
+
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('AcpRuntimeQuiescence', () => {
+  it('keeps a synchronously registered creation operation until its result resolves', async () => {
+    // Catches removing a creation barrier before its operation settles.
+    const result = createDeferred<string>();
+    const quiescence = new AcpRuntimeQuiescence({
+      stopClient: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const operation = quiescence.runClientCreationOperation(
+      'session-1',
+      'active',
+      (registration) => {
+        expect(registration.isOnlyOperation()).toBe(true);
+        expect(quiescence.getTrackedSessionIds()).toEqual(['session-1']);
+        expect(quiescence.isBrowseOnlySession('session-1')).toBe(false);
+        return result.promise;
+      }
+    );
+
+    result.resolve('created');
+
+    await expect(operation).resolves.toBe('created');
+    expect(quiescence.getTrackedSessionIds()).toEqual([]);
+  });
+
+  it('unregisters a rejected creation operation', async () => {
+    // Catches leaving a rejected creation barrier tracked forever.
+    const quiescence = new AcpRuntimeQuiescence({
+      stopClient: vi.fn().mockResolvedValue(undefined),
+    });
+
+    await expect(
+      quiescence.runClientCreationOperation('session-1', 'browse', () =>
+        Promise.reject(new Error('reconciliation failed'))
+      )
+    ).rejects.toThrow('reconciliation failed');
+
+    expect(quiescence.getTrackedSessionIds()).toEqual([]);
+    expect(quiescence.isBrowseOnlySession('session-1')).toBe(false);
+  });
+
+  it('reports only-operation state across concurrent same-session creation operations', async () => {
+    // Catches treating every same-session creation operation as the only operation.
+    const first = createDeferred<void>();
+    const second = createDeferred<void>();
+    const quiescence = new AcpRuntimeQuiescence({
+      stopClient: vi.fn().mockResolvedValue(undefined),
+    });
+    let firstRegistration: { isOnlyOperation(): boolean } | undefined;
+
+    const firstOperation = quiescence.runClientCreationOperation(
+      'session-1',
+      'browse',
+      (registration) => {
+        firstRegistration = registration;
+        return first.promise;
+      }
+    );
+    const secondOperation = quiescence.runClientCreationOperation(
+      'session-1',
+      'browse',
+      (registration) => {
+        expect(registration.isOnlyOperation()).toBe(false);
+        return second.promise;
+      }
+    );
+
+    expect(firstRegistration?.isOnlyOperation()).toBe(false);
+    expect(quiescence.isBrowseOnlySession('session-1')).toBe(true);
+    first.resolve();
+    second.resolve();
+
+    await Promise.all([firstOperation, secondOperation]);
+  });
+
+  it('stops before and after a pending creation operation settles', async () => {
+    // Catches skipping the post-creation stop that closes a reconciliation race.
+    const pending = createDeferred<void>();
+    const stopClient = vi.fn().mockResolvedValue(undefined);
+    const quiescence = new AcpRuntimeQuiescence({ stopClient });
+    const creation = quiescence.runClientCreationOperation(
+      'session-1',
+      'active',
+      () => pending.promise
+    );
+
+    const stop = quiescence.stopAndQuiesce('session-1');
+    await vi.waitFor(() => expect(stopClient).toHaveBeenCalledTimes(1));
+    let stopped = false;
+    void stop.then(() => {
+      stopped = true;
+    });
+    await Promise.resolve();
+    expect(stopped).toBe(false);
+
+    pending.resolve();
+    await Promise.all([creation, stop]);
+    expect(stopClient).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses a successful retry when the initial stop rejects with a pending creation operation', async () => {
+    // Catches propagating the initial stop error after a creation operation requires a retry.
+    const pending = createDeferred<void>();
+    const stopClient = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error('initial stop failed'))
+      .mockResolvedValueOnce(undefined);
+    const quiescence = new AcpRuntimeQuiescence({ stopClient });
+    const creation = quiescence.runClientCreationOperation(
+      'session-1',
+      'active',
+      () => pending.promise
+    );
+
+    const stop = quiescence.stopAndQuiesce('session-1');
+    await vi.waitFor(() => expect(stopClient).toHaveBeenCalledTimes(1));
+    pending.resolve();
+
+    await expect(stop).resolves.toBeUndefined();
+    await creation;
+    expect(stopClient).toHaveBeenCalledTimes(2);
+  });
+
+  it('propagates an initial stop error when no creation operation was tracked', async () => {
+    // Catches swallowing a stop error when there is no barrier that warrants a retry.
+    const stopClient = vi.fn<() => Promise<void>>().mockRejectedValue(new Error('stop failed'));
+    const quiescence = new AcpRuntimeQuiescence({ stopClient });
+
+    await expect(quiescence.stopAndQuiesce('session-1')).rejects.toThrow('stop failed');
+    expect(stopClient).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates an undefined initial stop rejection when no creation operation was tracked', async () => {
+    // Catches treating an undefined rejection reason as a successful first stop.
+    const stopClient = vi.fn<() => Promise<void>>().mockRejectedValue(undefined);
+    const quiescence = new AcpRuntimeQuiescence({ stopClient });
+
+    await expect(quiescence.stopAndQuiesce('session-1')).rejects.toBeUndefined();
+    expect(stopClient).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares overlapping same-session quiescence calls', async () => {
+    // Catches duplicate stop sequences when callers concurrently quiesce one session.
+    const pending = createDeferred<void>();
+    const stopClient = vi.fn().mockResolvedValue(undefined);
+    const quiescence = new AcpRuntimeQuiescence({ stopClient });
+    const creation = quiescence.runClientCreationOperation(
+      'session-1',
+      'active',
+      () => pending.promise
+    );
+
+    const firstStop = quiescence.stopAndQuiesce('session-1');
+    const secondStop = quiescence.stopAndQuiesce('session-1');
+    expect(secondStop).toBe(firstStop);
+    await vi.waitFor(() => expect(stopClient).toHaveBeenCalledTimes(1));
+    pending.resolve();
+
+    await Promise.all([creation, firstStop, secondStop]);
+    expect(stopClient).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects same-session creation after quiescence begins without blocking another session', async () => {
+    // Catches a quiescence fence that either admits its stopped session or blocks unrelated sessions.
+    const firstStop = createDeferred<void>();
+    const quiescence = new AcpRuntimeQuiescence({ stopClient: vi.fn(() => firstStop.promise) });
+
+    const stopping = quiescence.stopAndQuiesce('session-1');
+
+    await expect(
+      quiescence.runClientCreationOperation('session-1', 'active', async () => undefined)
+    ).rejects.toThrow('ACP session stop requested; cannot create client session-1');
+    await expect(
+      quiescence.runClientCreationOperation('session-2', 'active', async () => 'created')
+    ).resolves.toBe('created');
+
+    firstStop.resolve();
+    await stopping;
+  });
+});

--- a/src/backend/services/session/service/acp/acp-runtime-quiescence.test.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-quiescence.test.ts
@@ -102,7 +102,7 @@ describe('AcpRuntimeQuiescence', () => {
     );
 
     const stop = quiescence.stopAndQuiesce('session-1');
-    await vi.waitFor(() => expect(stopClient).toHaveBeenCalledTimes(1));
+    expect(stopClient).toHaveBeenCalledWith('session-1');
     let stopped = false;
     void stop.then(() => {
       stopped = true;
@@ -130,7 +130,7 @@ describe('AcpRuntimeQuiescence', () => {
     );
 
     const stop = quiescence.stopAndQuiesce('session-1');
-    await vi.waitFor(() => expect(stopClient).toHaveBeenCalledTimes(1));
+    expect(stopClient).toHaveBeenCalledWith('session-1');
     pending.resolve();
 
     await expect(stop).resolves.toBeUndefined();
@@ -145,6 +145,32 @@ describe('AcpRuntimeQuiescence', () => {
 
     await expect(quiescence.stopAndQuiesce('session-1')).rejects.toThrow('stop failed');
     expect(stopClient).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries after a creation operation settles before the first stop resolves', async () => {
+    // Catches snapshotting barriers after the initial stop erases a settled reconciliation.
+    const pending = createDeferred<void>();
+    const firstStop = createDeferred<void>();
+    const stopClient = vi
+      .fn<() => Promise<void>>()
+      .mockReturnValueOnce(firstStop.promise)
+      .mockResolvedValueOnce(undefined);
+    const quiescence = new AcpRuntimeQuiescence({ stopClient });
+    const creation = quiescence.runClientCreationOperation(
+      'session-1',
+      'active',
+      () => pending.promise
+    );
+
+    const stop = quiescence.stopAndQuiesce('session-1');
+    expect(stopClient).toHaveBeenCalledWith('session-1');
+    pending.resolve();
+    await creation;
+    firstStop.resolve();
+
+    await stop;
+    expect(stopClient).toHaveBeenCalledTimes(2);
+    expect(stopClient).toHaveBeenLastCalledWith('session-1');
   });
 
   it('propagates an undefined initial stop rejection when no creation operation was tracked', async () => {
@@ -170,7 +196,7 @@ describe('AcpRuntimeQuiescence', () => {
     const firstStop = quiescence.stopAndQuiesce('session-1');
     const secondStop = quiescence.stopAndQuiesce('session-1');
     expect(secondStop).toBe(firstStop);
-    await vi.waitFor(() => expect(stopClient).toHaveBeenCalledTimes(1));
+    expect(stopClient).toHaveBeenCalledWith('session-1');
     pending.resolve();
 
     await Promise.all([creation, firstStop, secondStop]);

--- a/src/backend/services/session/service/acp/acp-runtime-quiescence.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-quiescence.ts
@@ -1,0 +1,138 @@
+import type { AcpRuntimePurpose } from './acp-runtime-events';
+
+export type AcpClientCreationOperation = {
+  isOnlyOperation(): boolean;
+};
+
+type CreationRecord = {
+  barrier: Promise<void>;
+  purpose: AcpRuntimePurpose;
+};
+
+export async function raceWithSoftTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number
+): Promise<T | undefined> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<undefined>((resolve) => {
+    timeout = setTimeout(() => resolve(undefined), timeoutMs);
+    timeout.unref?.();
+  });
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+export class AcpRuntimeQuiescence {
+  private readonly creationRecords = new Map<string, Set<CreationRecord>>();
+  private readonly quiescenceOperations = new Map<string, Promise<void>>();
+
+  constructor(private readonly port: { stopClient(sessionId: string): Promise<void> }) {}
+
+  runClientCreationOperation<T>(
+    sessionId: string,
+    purpose: AcpRuntimePurpose,
+    operation: (registration: AcpClientCreationOperation) => Promise<T>
+  ): Promise<T> {
+    if (this.quiescenceOperations.has(sessionId)) {
+      return Promise.reject(
+        new Error(`ACP session stop requested; cannot create client ${sessionId}`)
+      );
+    }
+
+    let releaseBarrier!: () => void;
+    const record: CreationRecord = {
+      barrier: new Promise<void>((resolve) => {
+        releaseBarrier = resolve;
+      }),
+      purpose,
+    };
+    const records = this.creationRecords.get(sessionId) ?? new Set<CreationRecord>();
+    records.add(record);
+    this.creationRecords.set(sessionId, records);
+
+    let operationPromise: Promise<T>;
+    try {
+      operationPromise = operation({ isOnlyOperation: () => records.size === 1 });
+    } catch (error) {
+      operationPromise = Promise.reject(error);
+    }
+    return operationPromise.finally(() => {
+      releaseBarrier();
+      records.delete(record);
+      if (records.size === 0) {
+        this.creationRecords.delete(sessionId);
+      }
+    });
+  }
+
+  stopAndQuiesce(sessionId: string): Promise<void> {
+    const existing = this.quiescenceOperations.get(sessionId);
+    if (existing) {
+      return existing;
+    }
+
+    let resolveOperation!: () => void;
+    let rejectOperation!: (reason?: unknown) => void;
+    const quiescenceOperation = new Promise<void>((resolve, reject) => {
+      resolveOperation = resolve;
+      rejectOperation = reject;
+    });
+    this.quiescenceOperations.set(sessionId, quiescenceOperation);
+
+    void this.runStopAndQuiesce(sessionId)
+      .then(resolveOperation, rejectOperation)
+      .finally(() => {
+        if (this.quiescenceOperations.get(sessionId) === quiescenceOperation) {
+          this.quiescenceOperations.delete(sessionId);
+        }
+      });
+    return quiescenceOperation;
+  }
+
+  getTrackedSessionIds(): string[] {
+    return [...this.creationRecords.keys()];
+  }
+
+  isBrowseOnlySession(sessionId: string): boolean {
+    const records = this.creationRecords.get(sessionId);
+    return (
+      records !== undefined &&
+      records.size > 0 &&
+      [...records].every(({ purpose }) => purpose === 'browse')
+    );
+  }
+
+  async waitForAll(): Promise<void> {
+    await Promise.all(
+      [...this.creationRecords.values()]
+        .flatMap((records) => [...records])
+        .map(({ barrier }) => barrier)
+    );
+  }
+
+  private async runStopAndQuiesce(sessionId: string): Promise<void> {
+    let firstStopError: unknown;
+    let firstStopRejected = false;
+    try {
+      await this.port.stopClient(sessionId);
+    } catch (error) {
+      firstStopRejected = true;
+      firstStopError = error;
+    }
+
+    const barriers = [...(this.creationRecords.get(sessionId) ?? [])].map(({ barrier }) => barrier);
+    await Promise.all(barriers);
+    if (barriers.length === 0) {
+      if (firstStopRejected) {
+        throw firstStopError;
+      }
+      return;
+    }
+    await this.port.stopClient(sessionId);
+  }
+}

--- a/src/backend/services/session/service/acp/acp-runtime-quiescence.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-quiescence.ts
@@ -100,12 +100,15 @@ export class AcpRuntimeQuiescence {
   }
 
   isBrowseOnlySession(sessionId: string): boolean {
+    return this.getTrackedSessionPurpose(sessionId) === 'browse';
+  }
+
+  getTrackedSessionPurpose(sessionId: string): AcpRuntimePurpose | null {
     const records = this.creationRecords.get(sessionId);
-    return (
-      records !== undefined &&
-      records.size > 0 &&
-      [...records].every(({ purpose }) => purpose === 'browse')
-    );
+    if (records === undefined || records.size === 0) {
+      return null;
+    }
+    return [...records].every(({ purpose }) => purpose === 'browse') ? 'browse' : 'active';
   }
 
   async waitForAll(): Promise<void> {

--- a/src/backend/services/session/service/acp/acp-runtime-quiescence.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-quiescence.ts
@@ -83,8 +83,9 @@ export class AcpRuntimeQuiescence {
       rejectOperation = reject;
     });
     this.quiescenceOperations.set(sessionId, quiescenceOperation);
+    const barriers = [...(this.creationRecords.get(sessionId) ?? [])].map(({ barrier }) => barrier);
 
-    void this.runStopAndQuiesce(sessionId)
+    void this.runStopAndQuiesce(sessionId, barriers)
       .then(resolveOperation, rejectOperation)
       .finally(() => {
         if (this.quiescenceOperations.get(sessionId) === quiescenceOperation) {
@@ -115,7 +116,7 @@ export class AcpRuntimeQuiescence {
     );
   }
 
-  private async runStopAndQuiesce(sessionId: string): Promise<void> {
+  private async runStopAndQuiesce(sessionId: string, barriers: Promise<void>[]): Promise<void> {
     let firstStopError: unknown;
     let firstStopRejected = false;
     try {
@@ -125,7 +126,6 @@ export class AcpRuntimeQuiescence {
       firstStopError = error;
     }
 
-    const barriers = [...(this.creationRecords.get(sessionId) ?? [])].map(({ barrier }) => barrier);
     await Promise.all(barriers);
     if (barriers.length === 0) {
       if (firstStopRejected) {

--- a/src/backend/services/session/service/acp/index.ts
+++ b/src/backend/services/session/service/acp/index.ts
@@ -19,6 +19,10 @@ export {
   PromptTimeoutError,
 } from './acp-runtime-manager';
 export {
+  type AcpClientCreationOperation,
+  AcpRuntimeQuiescence,
+} from './acp-runtime-quiescence';
+export {
   type ClaudeModelCatalogEntry,
   fetchClaudeModelCatalogFromAcp,
 } from './claude-model-catalog-loader';

--- a/src/backend/services/session/service/lifecycle/session-lifecycle.test-helpers.ts
+++ b/src/backend/services/session/service/lifecycle/session-lifecycle.test-helpers.ts
@@ -157,6 +157,8 @@ export type TerminationHarness = {
     | 'isSessionRunning'
     | 'isBrowseOnlySession'
     | 'stopAndQuiesce'
+    | 'beginShutdown'
+    | 'stopAllClients'
   >;
   sessionDomainService: MockedPick<
     SessionDomainService,
@@ -172,7 +174,10 @@ export type TerminationHarness = {
     | 'clearPendingToolCalls'
     | 'getWorkspaceId'
   >;
-  promptTurnCompletionService: { clearSession: Mock<(sessionId: string) => void> };
+  promptTurnCompletionService: {
+    clearSession: Mock<(sessionId: string) => void>;
+    clearAll: Mock<() => void>;
+  };
   lifecycleEventService: MockedPick<SessionLifecycleEventService, 'record'>;
   lifecycleGate: SessionLifecycleGate;
   workflowFinalizer: MockedPick<
@@ -233,6 +238,8 @@ export function createTerminationHarness(
     isSessionRunning: vi.fn((sessionId: string) => sessionId === 'session-runtime-only'),
     isBrowseOnlySession: vi.fn((sessionId: string) => sessionId === 'session-browse-only'),
     stopAndQuiesce: vi.fn(async () => undefined),
+    beginShutdown: vi.fn(() => []),
+    stopAllClients: vi.fn(async () => undefined),
   } satisfies Pick<
     AcpRuntimeManager,
     | 'getClient'
@@ -241,6 +248,8 @@ export function createTerminationHarness(
     | 'isSessionRunning'
     | 'isBrowseOnlySession'
     | 'stopAndQuiesce'
+    | 'beginShutdown'
+    | 'stopAllClients'
   >;
   const sessionDomainService = {
     clearQueuedWork: vi.fn(),
@@ -274,7 +283,10 @@ export function createTerminationHarness(
     | 'clearPendingToolCalls'
     | 'getWorkspaceId'
   >;
-  const promptTurnCompletionService = { clearSession: vi.fn<(sessionId: string) => void>() };
+  const promptTurnCompletionService = {
+    clearSession: vi.fn<(sessionId: string) => void>(),
+    clearAll: vi.fn<() => void>(),
+  };
   const lifecycleEventService = {
     record: vi.fn<SessionLifecycleEventService['record']>(async () => null),
   } satisfies Pick<SessionLifecycleEventService, 'record'>;

--- a/src/backend/services/session/service/lifecycle/session-lifecycle.test-helpers.ts
+++ b/src/backend/services/session/service/lifecycle/session-lifecycle.test-helpers.ts
@@ -10,6 +10,7 @@ import { workspaceNotificationService } from '@/backend/services/workspace';
 import type { ChatMessage } from '@/shared/acp-protocol';
 import { EMPTY_CHAT_BAR_CAPABILITIES } from '@/shared/chat-capabilities';
 import { SessionStatus, WorkspaceStatus } from '@/shared/core';
+import type { SessionRuntimeState } from '@/shared/session-runtime';
 import { unsafeCoerce } from '@/test-utils/unsafe-coerce';
 import type { AcpEventProcessor } from './acp-event-processor';
 import type { SessionConfigService } from './session.config.service';
@@ -75,6 +76,7 @@ export type LifecycleHarness = {
     AcpRuntimeManager,
     | 'isStopInProgress'
     | 'isSessionRunning'
+    | 'hasClientCreationOperation'
     | 'isBrowseOnlySession'
     | 'isSessionWorking'
     | 'getClient'
@@ -155,6 +157,7 @@ export type TerminationHarness = {
     | 'isSessionWorking'
     | 'isStopInProgress'
     | 'isSessionRunning'
+    | 'hasClientCreationOperation'
     | 'isBrowseOnlySession'
     | 'stopAndQuiesce'
     | 'beginShutdown'
@@ -185,6 +188,7 @@ export type TerminationHarness = {
     'finalizeDeliberateStop' | 'clearInactiveSession'
   >;
   workspaceBridge: MockedPick<SessionLifecycleWorkspaceBridge, 'markSessionIdle'>;
+  getRuntimeSnapshot: Mock<(sessionId: string) => SessionRuntimeState>;
   session: AgentSessionRecord;
 };
 
@@ -236,6 +240,7 @@ export function createTerminationHarness(
     isSessionWorking: vi.fn(() => false),
     isStopInProgress: vi.fn(() => false),
     isSessionRunning: vi.fn((sessionId: string) => sessionId === 'session-runtime-only'),
+    hasClientCreationOperation: vi.fn(() => false),
     isBrowseOnlySession: vi.fn((sessionId: string) => sessionId === 'session-browse-only'),
     stopAndQuiesce: vi.fn(async () => undefined),
     beginShutdown: vi.fn(() => []),
@@ -246,6 +251,7 @@ export function createTerminationHarness(
     | 'isSessionWorking'
     | 'isStopInProgress'
     | 'isSessionRunning'
+    | 'hasClientCreationOperation'
     | 'isBrowseOnlySession'
     | 'stopAndQuiesce'
     | 'beginShutdown'
@@ -300,6 +306,12 @@ export function createTerminationHarness(
   const lifecycleGate = new SessionLifecycleGate({
     isRuntimeStopInProgress: () => false,
   });
+  const getRuntimeSnapshot = vi.fn(() => ({
+    phase: 'idle' as const,
+    processState: 'stopped' as const,
+    activity: 'IDLE' as const,
+    updatedAt: '2026-07-15T00:00:00.000Z',
+  }));
   const coordinator = new SessionTerminationCoordinator({
     repository,
     retryService,
@@ -311,6 +323,7 @@ export function createTerminationHarness(
     lifecycleEventService,
     lifecycleGate,
     workflowFinalizer,
+    getRuntimeSnapshot,
     getWorkspaceBridge: () => workspaceBridge,
     onBeforeStopSession: overrides.onBeforeStopSession,
   });
@@ -328,6 +341,7 @@ export function createTerminationHarness(
     lifecycleGate,
     workflowFinalizer,
     workspaceBridge,
+    getRuntimeSnapshot,
     session,
   };
 }
@@ -484,6 +498,7 @@ export function createLifecycleHarness(
   const runtimeManager = {
     isStopInProgress: vi.fn((_sessionId: string) => false),
     isSessionRunning: vi.fn((sessionId: string) => sessionId === 'session-runtime-only'),
+    hasClientCreationOperation: vi.fn(() => false),
     isBrowseOnlySession: vi.fn((sessionId: string) => sessionId === 'session-browse-only'),
     isSessionWorking: vi.fn(() => false),
     getClient: vi.fn(() => undefined),
@@ -507,6 +522,7 @@ export function createLifecycleHarness(
     AcpRuntimeManager,
     | 'isStopInProgress'
     | 'isSessionRunning'
+    | 'hasClientCreationOperation'
     | 'isBrowseOnlySession'
     | 'isSessionWorking'
     | 'getClient'

--- a/src/backend/services/session/service/lifecycle/session-lifecycle.test-helpers.ts
+++ b/src/backend/services/session/service/lifecycle/session-lifecycle.test-helpers.ts
@@ -16,11 +16,17 @@ import type { SessionConfigService } from './session.config.service';
 import { SessionLifecycleService } from './session.lifecycle.service';
 import type { SessionPermissionService } from './session.permission.service';
 import type { SessionRepository } from './session.repository';
+import { SessionRetryService } from './session.retry.service';
 import { SessionContextService, type SessionPermissionPresetPort } from './session-context.service';
 import type { SessionAcpEnvironmentPort } from './session-lifecycle.types';
 import type { SessionLifecycleEventService } from './session-lifecycle-event.service';
 import { SessionLifecycleGate } from './session-lifecycle-gate';
 import { SessionNotificationDeliveryService } from './session-notification-delivery.service';
+import {
+  SessionTerminationCoordinator,
+  type SessionTerminationCoordinatorDependencies,
+} from './session-termination.coordinator';
+import type { SessionWorkflowFinalizer } from './session-workflow-finalizer';
 
 export type Deferred<T> = {
   promise: Promise<T>;
@@ -136,6 +142,54 @@ export type LifecycleHarness = {
   tryDispatchNextMessage: Mock<SessionLifecycleMessageQueueBridge['tryDispatchNextMessage']>;
 };
 
+export type TerminationHarness = {
+  coordinator: SessionTerminationCoordinator;
+  repository: MockedPick<
+    SessionRepository,
+    'getSessionById' | 'getSessionsByWorkspaceId' | 'updateSessionIfStatus'
+  >;
+  retryService: SessionTerminationCoordinatorDependencies['retryService'];
+  runtimeManager: MockedPick<
+    AcpRuntimeManager,
+    | 'getClient'
+    | 'isSessionWorking'
+    | 'isStopInProgress'
+    | 'isSessionRunning'
+    | 'isBrowseOnlySession'
+    | 'stopAndQuiesce'
+  >;
+  sessionDomainService: MockedPick<
+    SessionDomainService,
+    'clearQueuedWork' | 'getRuntimeSnapshot' | 'setRuntimeSnapshot'
+  >;
+  sessionPermissionService: MockedPick<SessionPermissionService, 'cancelPendingRequests'>;
+  acpEventProcessor: MockedPick<
+    AcpEventProcessor,
+    | 'clearSessionState'
+    | 'clearStreamingState'
+    | 'clearReplaySuppression'
+    | 'finalizeOrphanedToolCalls'
+    | 'clearPendingToolCalls'
+    | 'getWorkspaceId'
+  >;
+  promptTurnCompletionService: { clearSession: Mock<(sessionId: string) => void> };
+  lifecycleEventService: MockedPick<SessionLifecycleEventService, 'record'>;
+  lifecycleGate: SessionLifecycleGate;
+  workflowFinalizer: MockedPick<
+    SessionWorkflowFinalizer,
+    'finalizeDeliberateStop' | 'clearInactiveSession'
+  >;
+  workspaceBridge: MockedPick<SessionLifecycleWorkspaceBridge, 'markSessionIdle'>;
+  session: AgentSessionRecord;
+};
+
+export type TerminationHarnessOverrides = Pick<
+  LifecycleHarnessOverrides,
+  'session' | 'getSessionById' | 'getSessionsByWorkspaceId'
+> & {
+  onBeforeStopSession?: (sessionId: string) => void;
+};
+
 export function createDeferred<T>(): Deferred<T> {
   let resolve!: (value: T | PromiseLike<T>) => void;
   let reject!: (reason?: unknown) => void;
@@ -144,6 +198,126 @@ export function createDeferred<T>(): Deferred<T> {
     reject = rejectPromise;
   });
   return { promise, resolve, reject };
+}
+
+export function createTerminationHarness(
+  overrides: TerminationHarnessOverrides = {}
+): TerminationHarness {
+  const session = createLifecycleTestSession(overrides.session);
+  const repository = {
+    getSessionById: vi.fn<SessionRepository['getSessionById']>(
+      overrides.getSessionById ?? (async (sessionId) => ({ ...session, id: sessionId }))
+    ),
+    getSessionsByWorkspaceId: vi.fn<SessionRepository['getSessionsByWorkspaceId']>(
+      overrides.getSessionsByWorkspaceId ??
+        (async () => [
+          createLifecycleTestSession({ id: 'session-running', status: SessionStatus.RUNNING }),
+          createLifecycleTestSession({
+            id: 'session-runtime-only',
+            status: SessionStatus.COMPLETED,
+          }),
+          createLifecycleTestSession({ id: 'session-browse-only', status: SessionStatus.IDLE }),
+          createLifecycleTestSession({ id: 'session-idle', status: SessionStatus.IDLE }),
+        ])
+    ),
+    updateSessionIfStatus: vi.fn<SessionRepository['updateSessionIfStatus']>(async () => 0),
+  } satisfies Pick<
+    SessionRepository,
+    'getSessionById' | 'getSessionsByWorkspaceId' | 'updateSessionIfStatus'
+  >;
+  const retryService = new SessionRetryService();
+  const runtimeManager = {
+    getClient: vi.fn(() => undefined),
+    isSessionWorking: vi.fn(() => false),
+    isStopInProgress: vi.fn(() => false),
+    isSessionRunning: vi.fn((sessionId: string) => sessionId === 'session-runtime-only'),
+    isBrowseOnlySession: vi.fn((sessionId: string) => sessionId === 'session-browse-only'),
+    stopAndQuiesce: vi.fn(async () => undefined),
+  } satisfies Pick<
+    AcpRuntimeManager,
+    | 'getClient'
+    | 'isSessionWorking'
+    | 'isStopInProgress'
+    | 'isSessionRunning'
+    | 'isBrowseOnlySession'
+    | 'stopAndQuiesce'
+  >;
+  const sessionDomainService = {
+    clearQueuedWork: vi.fn(),
+    getRuntimeSnapshot: vi.fn<SessionDomainService['getRuntimeSnapshot']>(() => ({
+      phase: 'idle',
+      processState: 'stopped',
+      activity: 'IDLE',
+      updatedAt: '2026-07-15T00:00:00.000Z',
+    })),
+    setRuntimeSnapshot: vi.fn(),
+  } satisfies Pick<
+    SessionDomainService,
+    'clearQueuedWork' | 'getRuntimeSnapshot' | 'setRuntimeSnapshot'
+  >;
+  const sessionPermissionService = {
+    cancelPendingRequests: vi.fn<SessionPermissionService['cancelPendingRequests']>(),
+  } satisfies Pick<SessionPermissionService, 'cancelPendingRequests'>;
+  const acpEventProcessor = {
+    clearSessionState: vi.fn(),
+    clearStreamingState: vi.fn(),
+    clearReplaySuppression: vi.fn(),
+    finalizeOrphanedToolCalls: vi.fn(),
+    clearPendingToolCalls: vi.fn(),
+    getWorkspaceId: vi.fn(() => undefined),
+  } satisfies Pick<
+    AcpEventProcessor,
+    | 'clearSessionState'
+    | 'clearStreamingState'
+    | 'clearReplaySuppression'
+    | 'finalizeOrphanedToolCalls'
+    | 'clearPendingToolCalls'
+    | 'getWorkspaceId'
+  >;
+  const promptTurnCompletionService = { clearSession: vi.fn<(sessionId: string) => void>() };
+  const lifecycleEventService = {
+    record: vi.fn<SessionLifecycleEventService['record']>(async () => null),
+  } satisfies Pick<SessionLifecycleEventService, 'record'>;
+  const workflowFinalizer = {
+    finalizeDeliberateStop: vi.fn(async () => undefined),
+    clearInactiveSession: vi.fn(),
+  } satisfies Pick<SessionWorkflowFinalizer, 'finalizeDeliberateStop' | 'clearInactiveSession'>;
+  const workspaceBridge = {
+    markSessionIdle: vi.fn(),
+  } satisfies Pick<SessionLifecycleWorkspaceBridge, 'markSessionIdle'>;
+  const lifecycleGate = new SessionLifecycleGate({
+    isRuntimeStopInProgress: () => false,
+  });
+  const coordinator = new SessionTerminationCoordinator({
+    repository,
+    retryService,
+    runtimeManager,
+    sessionDomainService,
+    sessionPermissionService,
+    acpEventProcessor,
+    promptTurnCompletionService,
+    lifecycleEventService,
+    lifecycleGate,
+    workflowFinalizer,
+    getWorkspaceBridge: () => workspaceBridge,
+    onBeforeStopSession: overrides.onBeforeStopSession,
+  });
+
+  return {
+    coordinator,
+    repository,
+    retryService,
+    runtimeManager,
+    sessionDomainService,
+    sessionPermissionService,
+    acpEventProcessor,
+    promptTurnCompletionService,
+    lifecycleEventService,
+    lifecycleGate,
+    workflowFinalizer,
+    workspaceBridge,
+    session,
+  };
 }
 
 export function createLifecycleTestSession(

--- a/src/backend/services/session/service/lifecycle/session-lifecycle.test-helpers.ts
+++ b/src/backend/services/session/service/lifecycle/session-lifecycle.test-helpers.ts
@@ -50,7 +50,7 @@ export type LifecycleHarnessOverrides = {
 };
 
 type MockedPick<T, K extends keyof T> = {
-  [P in K]: T[P] extends (...args: never[]) => unknown ? Mock<T[P]> : T[P];
+  [P in K]: T[P] extends (...args: never[]) => unknown ? Mock<T[P]> & T[P] : T[P];
 };
 
 export type LifecycleHarness = {
@@ -76,7 +76,9 @@ export type LifecycleHarness = {
     | 'getPendingClient'
     | 'getSubagentBrowseCapability'
     | 'getOrCreateClient'
+    | 'runClientCreationOperation'
     | 'stopClient'
+    | 'stopAndQuiesce'
     | 'beginShutdown'
     | 'stopAllClients'
   >;
@@ -288,6 +290,11 @@ export function createLifecycleHarness(
     | 'updateSession'
     | 'updateSessionIfStatus'
   >;
+  const runClientCreationOperation: AcpRuntimeManager['runClientCreationOperation'] = async (
+    _sessionId,
+    _purpose,
+    operation
+  ) => await operation({ isOnlyOperation: () => true });
   const runtimeManager = {
     isStopInProgress: vi.fn((_sessionId: string) => false),
     isSessionRunning: vi.fn((sessionId: string) => sessionId === 'session-runtime-only'),
@@ -302,7 +309,12 @@ export function createLifecycleHarness(
     getOrCreateClient: vi.fn<AcpRuntimeManager['getOrCreateClient']>(
       overrides.getOrCreateClient ?? (async () => handle)
     ),
+    runClientCreationOperation: vi.fn(runClientCreationOperation) as Mock<
+      AcpRuntimeManager['runClientCreationOperation']
+    > &
+      AcpRuntimeManager['runClientCreationOperation'],
     stopClient: vi.fn(async () => undefined),
+    stopAndQuiesce: vi.fn(async () => undefined),
     beginShutdown: vi.fn(() => []),
     stopAllClients: vi.fn(async () => undefined),
   } satisfies Pick<
@@ -316,7 +328,9 @@ export function createLifecycleHarness(
     | 'getPendingClient'
     | 'getSubagentBrowseCapability'
     | 'getOrCreateClient'
+    | 'runClientCreationOperation'
     | 'stopClient'
+    | 'stopAndQuiesce'
     | 'beginShutdown'
     | 'stopAllClients'
   >;

--- a/src/backend/services/session/service/lifecycle/session-services.composition.test.ts
+++ b/src/backend/services/session/service/lifecycle/session-services.composition.test.ts
@@ -3,9 +3,12 @@ import {
   chatMessageHandlerService as publicChatMessageHandlerService,
   sessionLifecycleService as publicSessionLifecycleService,
 } from '@/backend/services/session';
+import { acpRuntimeManager } from '@/backend/services/session/service/acp';
 import { WorkspaceStatus } from '@/shared/core';
 import { unsafeCoerce } from '@/test-utils/unsafe-coerce';
+import { sessionRepository } from './session.repository';
 import { sessionLifecycleService as coreSessionLifecycleService } from './session-core-services';
+import { createLifecycleTestSession } from './session-lifecycle.test-helpers';
 import { chatMessageHandlerService, sessionLifecycleService } from './session-services';
 import { SessionStartupCoordinator } from './session-startup.coordinator';
 
@@ -60,5 +63,29 @@ describe('session services composition', () => {
     ).resolves.toBe(false);
 
     expect(ensureSubagentBrowseSession).toHaveBeenCalledWith('session-1');
+  });
+
+  it('wires the public singleton termination coordinator to the later workspace bridge', async () => {
+    const workspaceBridge = {
+      markSessionIdle: vi.fn(),
+    };
+    publicSessionLifecycleService.configure({ workspace: unsafeCoerce(workspaceBridge) });
+    vi.spyOn(sessionRepository, 'getSessionById').mockResolvedValue(
+      createLifecycleTestSession({ id: 'session-composed', workspaceId: 'workspace-composed' })
+    );
+    vi.spyOn(sessionRepository, 'updateSessionIfStatus').mockResolvedValue(1);
+    const stopAndQuiesce = vi
+      .spyOn(acpRuntimeManager, 'stopAndQuiesce')
+      .mockResolvedValue(undefined);
+
+    await publicSessionLifecycleService.stopSession('session-composed', {
+      recordLifecycleEvent: false,
+    });
+
+    expect(stopAndQuiesce).toHaveBeenCalledWith('session-composed');
+    expect(workspaceBridge.markSessionIdle).toHaveBeenCalledWith(
+      'workspace-composed',
+      'session-composed'
+    );
   });
 });

--- a/src/backend/services/session/service/lifecycle/session-services.composition.test.ts
+++ b/src/backend/services/session/service/lifecycle/session-services.composition.test.ts
@@ -3,12 +3,13 @@ import {
   chatMessageHandlerService as publicChatMessageHandlerService,
   sessionLifecycleService as publicSessionLifecycleService,
 } from '@/backend/services/session';
-import { acpRuntimeManager } from '@/backend/services/session/service/acp';
 import { WorkspaceStatus } from '@/shared/core';
 import { unsafeCoerce } from '@/test-utils/unsafe-coerce';
-import { sessionRepository } from './session.repository';
 import { sessionLifecycleService as coreSessionLifecycleService } from './session-core-services';
-import { createLifecycleTestSession } from './session-lifecycle.test-helpers';
+import {
+  createLifecycleHarness,
+  createLifecycleTestSession,
+} from './session-lifecycle.test-helpers';
 import { chatMessageHandlerService, sessionLifecycleService } from './session-services';
 import { SessionStartupCoordinator } from './session-startup.coordinator';
 
@@ -65,24 +66,22 @@ describe('session services composition', () => {
     expect(ensureSubagentBrowseSession).toHaveBeenCalledWith('session-1');
   });
 
-  it('wires the public singleton termination coordinator to the later workspace bridge', async () => {
+  it('wires a lifecycle coordinator to a later workspace bridge without mutating the singleton', async () => {
+    const { service, repository, runtimeManager } = createLifecycleHarness();
     const workspaceBridge = {
       markSessionIdle: vi.fn(),
     };
-    publicSessionLifecycleService.configure({ workspace: unsafeCoerce(workspaceBridge) });
-    vi.spyOn(sessionRepository, 'getSessionById').mockResolvedValue(
+    service.configure({ workspace: unsafeCoerce(workspaceBridge) });
+    repository.getSessionById.mockResolvedValue(
       createLifecycleTestSession({ id: 'session-composed', workspaceId: 'workspace-composed' })
     );
-    vi.spyOn(sessionRepository, 'updateSessionIfStatus').mockResolvedValue(1);
-    const stopAndQuiesce = vi
-      .spyOn(acpRuntimeManager, 'stopAndQuiesce')
-      .mockResolvedValue(undefined);
+    repository.updateSessionIfStatus.mockResolvedValue(1);
 
-    await publicSessionLifecycleService.stopSession('session-composed', {
+    await service.stopSession('session-composed', {
       recordLifecycleEvent: false,
     });
 
-    expect(stopAndQuiesce).toHaveBeenCalledWith('session-composed');
+    expect(runtimeManager.stopAndQuiesce).toHaveBeenCalledWith('session-composed');
     expect(workspaceBridge.markSessionIdle).toHaveBeenCalledWith(
       'workspace-composed',
       'session-composed'

--- a/src/backend/services/session/service/lifecycle/session-startup.coordinator.test.ts
+++ b/src/backend/services/session/service/lifecycle/session-startup.coordinator.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AcpBrowseSessionUnavailableError } from '@/backend/services/session/service/acp/acp-runtime-manager';
+import { AcpRuntimeQuiescence } from '@/backend/services/session/service/acp/acp-runtime-quiescence';
 import { SessionDomainService } from '@/backend/services/session/service/session-domain.service';
 import { workspaceNotificationService } from '@/backend/services/workspace';
 import { SessionStatus } from '@/shared/core';
@@ -48,12 +49,22 @@ function createStartupCoordinator(harness: LifecycleHarness): SessionStartupCoor
     getMessageQueueBridge: () => harness.messageQueueBridge,
     sendSessionMessage: harness.sendSessionMessage,
     stopSession: (sessionId, options) => harness.service.stopSession(sessionId, options),
-    registerClientCreation: () => ({
-      isOnlyOperation: () => true,
-      release: vi.fn(),
-    }),
   } satisfies SessionStartupCoordinatorDependencies;
   return new SessionStartupCoordinator(dependencies);
+}
+
+function installRuntimeQuiescence(harness: LifecycleHarness): AcpRuntimeQuiescence {
+  const quiescence = new AcpRuntimeQuiescence({
+    stopClient: harness.runtimeManager.stopClient,
+  });
+  harness.runtimeManager.runClientCreationOperation.mockImplementation(
+    (sessionId, purpose, operation) =>
+      quiescence.runClientCreationOperation(sessionId, purpose, operation)
+  );
+  harness.runtimeManager.stopAndQuiesce.mockImplementation((sessionId) =>
+    quiescence.stopAndQuiesce(sessionId)
+  );
+  return quiescence;
 }
 
 describe('SessionStartupCoordinator', () => {
@@ -78,6 +89,55 @@ describe('SessionStartupCoordinator', () => {
       activity: 'IDLE',
       updatedAt: expect.any(String),
     });
+  });
+
+  it('keeps the runtime creation fence pending through durable running reconciliation', async () => {
+    // Catches releasing the runtime creation fence before the durable RUNNING write settles.
+    const harness = createLifecycleHarness();
+    const coordinator = createStartupCoordinator(harness);
+    const runningPersistence = createDeferred<typeof harness.session>();
+    const quiescence = new AcpRuntimeQuiescence({
+      stopClient: harness.runtimeManager.stopClient,
+    });
+    let creationOperation: Promise<unknown> | undefined;
+    harness.runtimeManager.runClientCreationOperation.mockImplementation(
+      (sessionId, purpose, operation) => {
+        creationOperation = quiescence.runClientCreationOperation(sessionId, purpose, operation);
+        return creationOperation;
+      }
+    );
+    harness.repository.updateSession.mockReturnValueOnce(runningPersistence.promise);
+
+    const startup = coordinator.getOrCreateSessionClient('session-1');
+    await vi.waitFor(() => {
+      expect(harness.runtimeManager.runClientCreationOperation).toHaveBeenCalledWith(
+        'session-1',
+        'active',
+        expect.any(Function)
+      );
+      expect(harness.repository.updateSession).toHaveBeenCalledWith('session-1', {
+        status: SessionStatus.RUNNING,
+      });
+    });
+
+    const stopReservation = harness.lifecycleGate.reserveStop('session-1');
+    expect(stopReservation).not.toBeNull();
+    let creationSettled = false;
+    void creationOperation?.then(
+      () => {
+        creationSettled = true;
+      },
+      () => {
+        creationSettled = true;
+      }
+    );
+    await Promise.resolve();
+    expect(creationSettled).toBe(false);
+
+    runningPersistence.resolve(harness.session);
+    await expect(startup).rejects.toThrow('Session is currently being stopped');
+    await expect(creationOperation).rejects.toThrow('Session is currently being stopped');
+    stopReservation?.release();
   });
 
   it('preserves the running-before-stopping restart probe order', async () => {
@@ -165,11 +225,11 @@ describe('SessionStartupCoordinator', () => {
   it('rejects stop before inspecting existing browse support', async () => {
     const harness = createLifecycleHarness();
     const runtimeStop = createDeferred<void>();
-    harness.runtimeManager.stopClient.mockReturnValueOnce(runtimeStop.promise);
+    harness.runtimeManager.stopAndQuiesce.mockReturnValueOnce(runtimeStop.promise);
 
     const stopPromise = harness.service.stopSession('session-1');
     await vi.waitFor(() => {
-      expect(harness.runtimeManager.stopClient).toHaveBeenCalledWith('session-1');
+      expect(harness.runtimeManager.stopAndQuiesce).toHaveBeenCalledWith('session-1');
     });
 
     await expect(harness.service.ensureSubagentBrowseSession('session-1')).resolves.toBe(false);
@@ -323,10 +383,12 @@ describe('SessionStartupCoordinator', () => {
   });
 
   it('does not let a failed browse creation clear a concurrent active startup context', async () => {
-    const { service, handle, runtimeManager, acpEventProcessor } = createLifecycleHarness({
+    const harness = createLifecycleHarness({
       provider: 'CODEX',
       providerSessionId: 'provider-session-existing',
     });
+    const { service, handle, runtimeManager, acpEventProcessor } = harness;
+    installRuntimeQuiescence(harness);
     const browseCreation = createDeferred<typeof handle>();
     const activeCreation = createDeferred<typeof handle>();
     runtimeManager.getOrCreateClient
@@ -659,6 +721,7 @@ describe('SessionStartupCoordinator', () => {
 
   it('does not publish startup capabilities after stop completes during snapshot persistence', async () => {
     const harness = createLifecycleHarness();
+    installRuntimeQuiescence(harness);
     const snapshotPersistence = createDeferred<void>();
     harness.sessionConfigService.persistAcpConfigSnapshot.mockReturnValueOnce(
       snapshotPersistence.promise
@@ -673,7 +736,7 @@ describe('SessionStartupCoordinator', () => {
 
     const stopPromise = harness.service.stopSession('session-1');
     await vi.waitFor(() => {
-      expect(harness.runtimeManager.stopClient).toHaveBeenCalledWith('session-1');
+      expect(harness.runtimeManager.stopAndQuiesce).toHaveBeenCalledWith('session-1');
     });
     const firstSettlement = await Promise.race([
       stopPromise.then(() => 'stopped' as const),
@@ -694,6 +757,7 @@ describe('SessionStartupCoordinator', () => {
 
   it('keeps stop ahead of startup when runtime stop fails during running persistence', async () => {
     const harness = createLifecycleHarness({ session: { workflow: 'ratchet' } });
+    installRuntimeQuiescence(harness);
     const runningPersistence = createDeferred<typeof harness.session>();
     harness.repository.updateSession.mockReturnValueOnce(runningPersistence.promise);
     harness.runtimeManager.stopClient.mockRejectedValueOnce(new Error('stop failed'));
@@ -711,7 +775,7 @@ describe('SessionStartupCoordinator', () => {
       cleanupTransientRatchetSession: false,
     });
     await vi.waitFor(() => {
-      expect(harness.runtimeManager.stopClient).toHaveBeenCalledWith('session-1');
+      expect(harness.runtimeManager.stopAndQuiesce).toHaveBeenCalledWith('session-1');
     });
     const firstSettlement = await Promise.race([
       stopPromise.then(() => 'stopped' as const),
@@ -813,7 +877,7 @@ describe('SessionStartupCoordinator', () => {
 
     const stopPromise = harness.service.stopSession('session-1');
     await vi.waitFor(() => {
-      expect(harness.runtimeManager.stopClient).toHaveBeenCalledWith('session-1');
+      expect(harness.runtimeManager.stopAndQuiesce).toHaveBeenCalledWith('session-1');
     });
     releaseBoundary();
     await stopPromise;

--- a/src/backend/services/session/service/lifecycle/session-startup.coordinator.ts
+++ b/src/backend/services/session/service/lifecycle/session-startup.coordinator.ts
@@ -25,6 +25,7 @@ import type { SessionAcpEnvironmentPort } from './session-lifecycle.types';
 import { type SessionLifecycleGate, SessionStartupCancelledError } from './session-lifecycle-gate';
 import type { SessionNotificationDeliveryService } from './session-notification-delivery.service';
 import type { SessionRuntimeExitCoordinator } from './session-runtime-exit.coordinator';
+import type { StopSessionOptions } from './session-termination.coordinator';
 
 const logger = createLogger('session');
 
@@ -85,10 +86,7 @@ export type SessionStartupCoordinatorDependencies = {
     'tryDispatchNextMessage'
   > | null;
   sendSessionMessage: (sessionId: string, content: string) => Promise<void>;
-  stopSession: (
-    sessionId: string,
-    options: { cleanupTransientRatchetSession: false }
-  ) => Promise<void>;
+  stopSession: (sessionId: string, options: StopSessionOptions) => Promise<void>;
 };
 
 export class SessionStartupCoordinator {

--- a/src/backend/services/session/service/lifecycle/session-startup.coordinator.ts
+++ b/src/backend/services/session/service/lifecycle/session-startup.coordinator.ts
@@ -1,6 +1,7 @@
 import { createLogger } from '@/backend/services/logger.service';
 import type { AgentSessionRecord } from '@/backend/services/session/resources/agent-session.accessor';
 import type {
+  AcpClientCreationOperation,
   AcpClientOptions,
   AcpProcessHandle,
   AcpRuntimeManager,
@@ -41,11 +42,6 @@ export type StartSessionOptions = {
   startupModePreset?: SessionStartupModePreset;
 };
 
-type ClientCreationRegistration = {
-  isOnlyOperation(): boolean;
-  release(): void;
-};
-
 export type SessionStartupCoordinatorDependencies = {
   repository: Pick<
     SessionRepository,
@@ -59,6 +55,7 @@ export type SessionStartupCoordinatorDependencies = {
     | 'getPendingClient'
     | 'getSubagentBrowseCapability'
     | 'getOrCreateClient'
+    | 'runClientCreationOperation'
     | 'isBrowseOnlySession'
     | 'isSessionRunning'
     | 'isStopInProgress'
@@ -92,10 +89,6 @@ export type SessionStartupCoordinatorDependencies = {
     sessionId: string,
     options: { cleanupTransientRatchetSession: false }
   ) => Promise<void>;
-  registerClientCreation: (
-    sessionId: string,
-    operation: Promise<unknown>
-  ) => ClientCreationRegistration;
 };
 
 export class SessionStartupCoordinator {
@@ -234,15 +227,18 @@ export class SessionStartupCoordinator {
         this.assertStartupAllowed(sessionId, stopGeneration);
 
         try {
-          await this.runTrackedClientCreation(sessionId, (registration) =>
-            this.createAcpClient(
-              sessionId,
-              { purpose: 'browse' },
-              session,
-              undefined,
-              stopGeneration,
-              registration
-            )
+          await this.dependencies.runtimeManager.runClientCreationOperation(
+            sessionId,
+            'browse',
+            async (registration) =>
+              await this.createAcpClient(
+                sessionId,
+                { purpose: 'browse' },
+                session,
+                undefined,
+                stopGeneration,
+                registration
+              )
           );
           this.dependencies.lifecycleGate.establishStartup(lease);
         } catch (error) {
@@ -329,7 +325,7 @@ export class SessionStartupCoordinator {
     session: AgentSessionRecord,
     permissionPreset: PermissionPreset | undefined,
     stopGeneration: number,
-    registration: ClientCreationRegistration
+    registration: AcpClientCreationOperation
   ): Promise<{ handle: AcpProcessHandle; dispatchableNotificationCount: number }> {
     const sessionContext = await this.dependencies.contextService.load(sessionId, session);
     if (!sessionContext) {
@@ -462,61 +458,48 @@ export class SessionStartupCoordinator {
     const resolvedPreset = await this.dependencies.contextService.resolvePermissionPreset(session);
     this.assertStartupAllowed(sessionId, stopGeneration);
 
-    return await this.runTrackedClientCreation(sessionId, async (registration) => {
-      let handle: AcpProcessHandle;
-      let dispatchableNotificationCount = 0;
-      try {
-        const created = await this.createAcpClient(
-          sessionId,
-          options,
-          session,
-          resolvedPreset,
-          stopGeneration,
-          registration
-        );
-        handle = created.handle;
-        dispatchableNotificationCount = created.dispatchableNotificationCount;
-      } catch (error) {
+    return await this.dependencies.runtimeManager.runClientCreationOperation(
+      sessionId,
+      'active',
+      async (registration) => {
+        let handle: AcpProcessHandle;
+        let dispatchableNotificationCount = 0;
+        try {
+          const created = await this.createAcpClient(
+            sessionId,
+            options,
+            session,
+            resolvedPreset,
+            stopGeneration,
+            registration
+          );
+          handle = created.handle;
+          dispatchableNotificationCount = created.dispatchableNotificationCount;
+        } catch (error) {
+          this.dependencies.sessionDomainService.setRuntimeSnapshot(sessionId, {
+            phase: 'error',
+            processState: 'stopped',
+            activity: 'IDLE',
+            errorMessage: `Failed to start agent: ${toErrorMessage(error)}`,
+            updatedAt: new Date().toISOString(),
+          });
+          throw error;
+        }
+
+        this.assertStartupAllowed(sessionId, stopGeneration);
+        await this.dependencies.repository.updateSession(sessionId, {
+          status: SessionStatus.RUNNING,
+        });
+        this.assertStartupAllowed(sessionId, stopGeneration);
         this.dependencies.sessionDomainService.setRuntimeSnapshot(sessionId, {
-          phase: 'error',
-          processState: 'stopped',
-          activity: 'IDLE',
-          errorMessage: `Failed to start agent: ${toErrorMessage(error)}`,
+          phase: handle.isPromptInFlight ? 'running' : 'idle',
+          processState: 'alive',
+          activity: handle.isPromptInFlight ? 'WORKING' : 'IDLE',
           updatedAt: new Date().toISOString(),
         });
-        throw error;
+        return { handle, resolvedPreset, dispatchableNotificationCount };
       }
-
-      this.assertStartupAllowed(sessionId, stopGeneration);
-      await this.dependencies.repository.updateSession(sessionId, {
-        status: SessionStatus.RUNNING,
-      });
-      this.assertStartupAllowed(sessionId, stopGeneration);
-      this.dependencies.sessionDomainService.setRuntimeSnapshot(sessionId, {
-        phase: handle.isPromptInFlight ? 'running' : 'idle',
-        processState: 'alive',
-        activity: handle.isPromptInFlight ? 'WORKING' : 'IDLE',
-        updatedAt: new Date().toISOString(),
-      });
-      return { handle, resolvedPreset, dispatchableNotificationCount };
-    });
-  }
-
-  private async runTrackedClientCreation<T>(
-    sessionId: string,
-    operation: (registration: ClientCreationRegistration) => Promise<T>
-  ): Promise<T> {
-    let settleBarrier!: () => void;
-    const barrier = new Promise<void>((resolve) => {
-      settleBarrier = resolve;
-    });
-    const registration = this.dependencies.registerClientCreation(sessionId, barrier);
-    try {
-      return await operation(registration);
-    } finally {
-      settleBarrier();
-      registration.release();
-    }
+    );
   }
 
   private async dispatchQueuedNotificationsIfNeeded(

--- a/src/backend/services/session/service/lifecycle/session-termination.coordinator.test.ts
+++ b/src/backend/services/session/service/lifecycle/session-termination.coordinator.test.ts
@@ -1,19 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AcpRuntimeQuiescence } from '@/backend/services/session/service/acp/acp-runtime-quiescence';
 import { acpTraceLogger } from '@/backend/services/session/service/logging/acp-trace-logger.service';
-import { unsafeCoerce } from '@/test-utils/unsafe-coerce';
-import { SessionLifecycleService } from './session.lifecycle.service';
 import { createDeferred, createTerminationHarness } from './session-lifecycle.test-helpers';
-import { SessionLifecycleGate } from './session-lifecycle-gate';
 import { SessionTerminationCoordinator } from './session-termination.coordinator';
 
+const logger = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
 vi.mock('@/backend/services/logger.service', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  }),
+  createLogger: () => logger,
   getCurrentProcessEnv: () => ({ NODE_ENV: 'test' }),
 }));
 
@@ -33,6 +32,36 @@ vi.mock('@/backend/services/settings', () => ({
     })),
   },
 }));
+
+function createShutdownHarness(
+  sessionIds = ['session-active', 'session-pending', 'session-fenced', 'session-browse-only']
+) {
+  const base = createTerminationHarness();
+  const runtimeManager = {
+    ...base.runtimeManager,
+    beginShutdown: vi.fn(() => sessionIds),
+    stopAllClients: vi.fn(async () => undefined),
+  };
+  const promptTurnCompletionService = {
+    ...base.promptTurnCompletionService,
+    clearAll: vi.fn(),
+  };
+  const coordinator = new SessionTerminationCoordinator({
+    repository: base.repository,
+    retryService: base.retryService,
+    runtimeManager,
+    sessionDomainService: base.sessionDomainService,
+    sessionPermissionService: base.sessionPermissionService,
+    acpEventProcessor: base.acpEventProcessor,
+    promptTurnCompletionService,
+    lifecycleEventService: base.lifecycleEventService,
+    lifecycleGate: base.lifecycleGate,
+    workflowFinalizer: base.workflowFinalizer,
+    getWorkspaceBridge: () => base.workspaceBridge,
+  });
+
+  return { ...base, coordinator, runtimeManager, promptTurnCompletionService };
+}
 
 describe('SessionTerminationCoordinator workspace stops', () => {
   beforeEach(() => {
@@ -138,133 +167,124 @@ describe('SessionTerminationCoordinator stop causes', () => {
   });
 });
 
-describe('SessionLifecycleService graceful shutdown', () => {
-  it('records SYSTEM_STOP for active and pending runtimes before bounded shutdown', async () => {
-    const runtimeManager = {
-      beginShutdown: vi.fn(() => ['session-active', 'session-pending', 'session-browse-only']),
-      stopAllClients: vi.fn(async () => undefined),
-      isStopInProgress: vi.fn(() => false),
-      isBrowseOnlySession: vi.fn((sessionId: string) => sessionId === 'session-browse-only'),
-    };
-    const repository = {
-      getSessionById: vi.fn(async (sessionId: string) => ({
-        id: sessionId,
-        workspaceId: 'workspace-1',
-        workflow: 'code',
-      })),
-    };
-    const lifecycleEventService = {
-      record: vi.fn(async () => null),
-      hydrate: vi.fn(async () => undefined),
-    };
-    const promptTurnCompletionService = {
-      clearAll: vi.fn(),
-    };
-    const service = new SessionLifecycleService(
-      unsafeCoerce({
-        repository,
-        contextService: {},
-        acpEnvironment: {},
-        promptBuilder: {},
-        runtimeManager,
-        sessionDomainService: {},
-        sessionPermissionService: {},
-        sessionConfigService: {},
-        acpEventProcessor: { getWorkspaceId: vi.fn() },
-        promptTurnCompletionService,
-        retryService: {
-          run: vi.fn(async (operation: () => Promise<unknown>) => await operation()),
-        },
-        lifecycleEventService,
-        lifecycleGate: new SessionLifecycleGate({
-          isRuntimeStopInProgress: runtimeManager.isStopInProgress,
-        }),
-        hydrateProviderHistory: vi.fn(),
-        sendSessionMessage: vi.fn(),
-      })
-    );
-
-    await service.stopAllClients(4321);
-
-    expect(runtimeManager.beginShutdown).toHaveBeenCalledOnce();
-    expect(lifecycleEventService.record).toHaveBeenCalledTimes(2);
-    expect(lifecycleEventService.record).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sessionId: 'session-active',
-        reason: 'SYSTEM_STOP',
-      })
-    );
-    expect(lifecycleEventService.record).not.toHaveBeenCalledWith(
-      expect.objectContaining({ sessionId: 'session-browse-only' })
-    );
-    expect(lifecycleEventService.record).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sessionId: 'session-pending',
-        reason: 'SYSTEM_STOP',
-      })
-    );
-    expect(runtimeManager.beginShutdown.mock.invocationCallOrder[0]).toBeLessThan(
-      lifecycleEventService.record.mock.invocationCallOrder[0]!
-    );
-    expect(lifecycleEventService.record.mock.invocationCallOrder.at(-1)).toBeLessThan(
-      runtimeManager.stopAllClients.mock.invocationCallOrder[0]!
-    );
-    expect(runtimeManager.stopAllClients).toHaveBeenCalledWith(4321);
+describe('SessionTerminationCoordinator graceful shutdown', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
   });
 
-  it('continues runtime shutdown after lifecycle recording timeout', async () => {
+  it('closes admission and reserves non-browse sessions before awaiting durable stop events', async () => {
+    const event = createDeferred<null>();
+    const effects: string[] = [];
+    const harness = createShutdownHarness();
+    harness.promptTurnCompletionService.clearAll.mockImplementation(() => {
+      effects.push('clear-prompts');
+    });
+    harness.runtimeManager.beginShutdown.mockImplementation(() => {
+      effects.push('close-admission');
+      return ['session-active', 'session-pending', 'session-fenced', 'session-browse-only'];
+    });
+    harness.lifecycleEventService.record.mockImplementation(({ sessionId }) => {
+      effects.push(`record:${sessionId}`);
+      return event.promise;
+    });
+
+    const shutdown = harness.coordinator.stopAllClients(4321);
+    await vi.waitFor(() => {
+      expect(harness.lifecycleEventService.record).toHaveBeenCalledTimes(3);
+    });
+
+    expect(effects.slice(0, 2)).toEqual(['clear-prompts', 'close-admission']);
+    expect(harness.lifecycleGate.isSessionStopping('session-active')).toBe(true);
+    expect(harness.lifecycleGate.isSessionStopping('session-pending')).toBe(true);
+    expect(harness.lifecycleGate.isSessionStopping('session-fenced')).toBe(true);
+    expect(harness.lifecycleGate.isSessionStopping('session-browse-only')).toBe(false);
+    expect(harness.lifecycleEventService.record.mock.calls.map(([input]) => input)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ sessionId: 'session-active', reason: 'SYSTEM_STOP' }),
+        expect.objectContaining({ sessionId: 'session-pending', reason: 'SYSTEM_STOP' }),
+        expect.objectContaining({ sessionId: 'session-fenced', reason: 'SYSTEM_STOP' }),
+      ])
+    );
+    expect(harness.lifecycleEventService.record).not.toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'session-browse-only' })
+    );
+    expect(harness.runtimeManager.stopAllClients).not.toHaveBeenCalled();
+
+    event.resolve(null);
+    await shutdown;
+
+    expect(harness.runtimeManager.stopAllClients).toHaveBeenCalledWith(4321);
+  });
+
+  it('logs lifecycle recording failures independently and still shuts down the runtime', async () => {
+    const harness = createShutdownHarness(['session-active', 'session-fenced']);
+    harness.lifecycleEventService.record.mockImplementation(({ sessionId }) =>
+      Promise.reject(
+        new Error(sessionId === 'session-active' ? 'active event failed' : 'fenced event failed')
+      )
+    );
+
+    await expect(harness.coordinator.stopAllClients()).resolves.toBeUndefined();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Failed recording shutdown lifecycle event; continuing shutdown',
+      { sessionId: 'session-active', error: 'active event failed' }
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Failed recording shutdown lifecycle event; continuing shutdown',
+      { sessionId: 'session-fenced', error: 'fenced event failed' }
+    );
+    expect(harness.runtimeManager.stopAllClients).toHaveBeenCalledWith(5000);
+  });
+
+  it('clears the one-second lifecycle recording timeout after early completion', async () => {
     vi.useFakeTimers();
     try {
-      const runtimeManager = {
-        beginShutdown: vi.fn(() => ['session-active']),
-        stopAllClients: vi.fn(async () => undefined),
-        isStopInProgress: vi.fn(() => false),
-        isBrowseOnlySession: vi.fn(() => false),
-      };
-      const service = new SessionLifecycleService(
-        unsafeCoerce({
-          repository: {
-            getSessionById: vi.fn(async () => ({
-              id: 'session-active',
-              workspaceId: 'workspace-1',
-              workflow: 'code',
-            })),
-          },
-          contextService: {},
-          acpEnvironment: {},
-          promptBuilder: {},
-          runtimeManager,
-          sessionDomainService: {},
-          sessionPermissionService: {},
-          sessionConfigService: {},
-          acpEventProcessor: { getWorkspaceId: vi.fn() },
-          promptTurnCompletionService: { clearAll: vi.fn() },
-          retryService: {
-            run: vi.fn(async (operation: () => Promise<unknown>) => await operation()),
-          },
-          lifecycleEventService: {
-            record: vi.fn(() => new Promise(() => undefined)),
-            hydrate: vi.fn(async () => undefined),
-          },
-          lifecycleGate: new SessionLifecycleGate({
-            isRuntimeStopInProgress: runtimeManager.isStopInProgress,
-          }),
-          hydrateProviderHistory: vi.fn(),
-          sendSessionMessage: vi.fn(),
-        })
-      );
+      const harness = createShutdownHarness(['session-active']);
 
-      const shutdown = service.stopAllClients(4321);
+      await harness.coordinator.stopAllClients();
+
+      expect(vi.getTimerCount()).toBe(0);
+      expect(harness.runtimeManager.stopAllClients).toHaveBeenCalledWith(5000);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('continues runtime shutdown when lifecycle recording reaches one second', async () => {
+    vi.useFakeTimers();
+    try {
+      const harness = createShutdownHarness(['session-active']);
+      harness.lifecycleEventService.record.mockReturnValue(new Promise(() => undefined));
+
+      const shutdown = harness.coordinator.stopAllClients(4321);
       await vi.advanceTimersByTimeAsync(999);
-      expect(runtimeManager.stopAllClients).not.toHaveBeenCalled();
+      expect(harness.runtimeManager.stopAllClients).not.toHaveBeenCalled();
 
       await vi.advanceTimersByTimeAsync(1);
       await shutdown;
 
-      expect(runtimeManager.stopAllClients).toHaveBeenCalledWith(4321);
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Timed out recording shutdown lifecycle events; continuing shutdown',
+        { timeoutMs: 1000 }
+      );
+      expect(harness.runtimeManager.stopAllClients).toHaveBeenCalledWith(4321);
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('forwards the caller timeout and propagates runtime shutdown rejection after logging', async () => {
+    const runtimeFailure = new Error('runtime shutdown failed');
+    const harness = createShutdownHarness([]);
+    harness.runtimeManager.stopAllClients.mockRejectedValue(runtimeFailure);
+
+    await expect(harness.coordinator.stopAllClients(8765)).rejects.toBe(runtimeFailure);
+
+    expect(harness.runtimeManager.stopAllClients).toHaveBeenCalledWith(8765);
+    expect(logger.error).toHaveBeenCalledWith('Failed to stop ACP clients during shutdown', {
+      error: runtimeFailure.message,
+    });
   });
 });
 

--- a/src/backend/services/session/service/lifecycle/session-termination.coordinator.test.ts
+++ b/src/backend/services/session/service/lifecycle/session-termination.coordinator.test.ts
@@ -57,6 +57,7 @@ function createShutdownHarness(
     lifecycleEventService: base.lifecycleEventService,
     lifecycleGate: base.lifecycleGate,
     workflowFinalizer: base.workflowFinalizer,
+    getRuntimeSnapshot: base.getRuntimeSnapshot,
     getWorkspaceBridge: () => base.workspaceBridge,
   });
 
@@ -72,9 +73,12 @@ describe('SessionTerminationCoordinator workspace stops', () => {
     expect(createTerminationHarness().coordinator).toBeInstanceOf(SessionTerminationCoordinator);
   });
 
-  it('stops running sessions and runtime-only sessions', async () => {
+  it('stops persisted, runtime-owned, and active-creation sessions', async () => {
     const { coordinator, repository, runtimeManager, lifecycleEventService } =
       createTerminationHarness();
+    runtimeManager.hasClientCreationOperation.mockImplementation(
+      (sessionId) => sessionId === 'session-idle'
+    );
 
     await coordinator.stopWorkspaceSessions('workspace-1');
 
@@ -84,8 +88,8 @@ describe('SessionTerminationCoordinator workspace stops', () => {
     expect(runtimeManager.stopAndQuiesce).toHaveBeenCalledWith('session-running');
     expect(runtimeManager.stopAndQuiesce).toHaveBeenCalledWith('session-runtime-only');
     expect(runtimeManager.stopAndQuiesce).toHaveBeenCalledWith('session-browse-only');
-    expect(runtimeManager.stopAndQuiesce).not.toHaveBeenCalledWith('session-idle');
-    expect(lifecycleEventService.record).toHaveBeenCalledTimes(2);
+    expect(runtimeManager.stopAndQuiesce).toHaveBeenCalledWith('session-idle');
+    expect(lifecycleEventService.record).toHaveBeenCalledTimes(3);
     expect(lifecycleEventService.record).not.toHaveBeenCalledWith(
       expect.objectContaining({ sessionId: 'session-browse-only' })
     );
@@ -164,6 +168,30 @@ describe('SessionTerminationCoordinator stop causes', () => {
 
     expect(lifecycleEventService.record).not.toHaveBeenCalled();
     expect(runtimeManager.stopAndQuiesce).toHaveBeenCalledWith('session-1');
+  });
+
+  it('uses the facade-owned runtime snapshot when entering stopping state', async () => {
+    const harness = createTerminationHarness();
+    harness.getRuntimeSnapshot.mockReturnValue({
+      phase: 'running',
+      processState: 'alive',
+      activity: 'WORKING',
+      updatedAt: '2026-08-14T12:00:00.000Z',
+    });
+
+    await harness.coordinator.stopSession('session-1');
+
+    expect(harness.getRuntimeSnapshot).toHaveBeenCalledWith('session-1');
+    expect(harness.sessionDomainService.setRuntimeSnapshot).toHaveBeenNthCalledWith(
+      1,
+      'session-1',
+      {
+        phase: 'stopping',
+        processState: 'alive',
+        activity: 'IDLE',
+        updatedAt: expect.any(String),
+      }
+    );
   });
 });
 

--- a/src/backend/services/session/service/lifecycle/session-termination.coordinator.test.ts
+++ b/src/backend/services/session/service/lifecycle/session-termination.coordinator.test.ts
@@ -1,10 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AcpRuntimeQuiescence } from '@/backend/services/session/service/acp/acp-runtime-quiescence';
-import { sessionEventBus } from '@/backend/services/session/service/session-event-bus';
+import { acpTraceLogger } from '@/backend/services/session/service/logging/acp-trace-logger.service';
 import { unsafeCoerce } from '@/test-utils/unsafe-coerce';
 import { SessionLifecycleService } from './session.lifecycle.service';
-import { createDeferred, createLifecycleHarness } from './session-lifecycle.test-helpers';
+import { createDeferred, createTerminationHarness } from './session-lifecycle.test-helpers';
 import { SessionLifecycleGate } from './session-lifecycle-gate';
+import { SessionTerminationCoordinator } from './session-termination.coordinator';
 
 vi.mock('@/backend/services/logger.service', () => ({
   createLogger: () => ({
@@ -38,39 +39,45 @@ describe('SessionTerminationCoordinator workspace stops', () => {
     vi.clearAllMocks();
   });
 
-  it('stops running sessions and runtime-only sessions', async () => {
-    const { service, repository, runtimeManager } = createLifecycleHarness();
-    const stopSession = vi.spyOn(service, 'stopSession').mockResolvedValue();
+  it('constructs the public coordinator directly through the narrow harness', () => {
+    expect(createTerminationHarness().coordinator).toBeInstanceOf(SessionTerminationCoordinator);
+  });
 
-    await service.stopWorkspaceSessions('workspace-1');
+  it('stops running sessions and runtime-only sessions', async () => {
+    const { coordinator, repository, runtimeManager, lifecycleEventService } =
+      createTerminationHarness();
+
+    await coordinator.stopWorkspaceSessions('workspace-1');
 
     expect(repository.getSessionsByWorkspaceId).toHaveBeenCalledWith('workspace-1');
     expect(runtimeManager.isSessionRunning).toHaveBeenCalledWith('session-runtime-only');
     expect(runtimeManager.isSessionRunning).toHaveBeenCalledWith('session-idle');
-    expect(stopSession).toHaveBeenCalledWith('session-running', { reason: 'SYSTEM_STOP' });
-    expect(stopSession).toHaveBeenCalledWith('session-runtime-only', { reason: 'SYSTEM_STOP' });
-    expect(stopSession).toHaveBeenCalledWith('session-browse-only', {
-      reason: 'SYSTEM_STOP',
-      recordLifecycleEvent: false,
-    });
-    expect(stopSession).not.toHaveBeenCalledWith('session-idle');
+    expect(runtimeManager.stopAndQuiesce).toHaveBeenCalledWith('session-running');
+    expect(runtimeManager.stopAndQuiesce).toHaveBeenCalledWith('session-runtime-only');
+    expect(runtimeManager.stopAndQuiesce).toHaveBeenCalledWith('session-browse-only');
+    expect(runtimeManager.stopAndQuiesce).not.toHaveBeenCalledWith('session-idle');
+    expect(lifecycleEventService.record).toHaveBeenCalledTimes(2);
+    expect(lifecycleEventService.record).not.toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'session-browse-only' })
+    );
   });
 
-  it('attempts every running session and throws when any stop fails', async () => {
-    const { service } = createLifecycleHarness();
-    const stopSession = vi.spyOn(service, 'stopSession').mockResolvedValue();
-    stopSession.mockImplementation((sessionId: string) => {
-      if (sessionId === 'session-running') {
-        return Promise.reject(new Error('stop failed'));
+  it('attempts every eligible persisted and runtime-owned session and aggregates failures', async () => {
+    const { coordinator, lifecycleEventService, runtimeManager } = createTerminationHarness();
+    lifecycleEventService.record.mockImplementation(({ sessionId }) => {
+      if (sessionId === 'session-running' || sessionId === 'session-runtime-only') {
+        return Promise.reject(new Error(`stop failed: ${sessionId}`));
       }
-      return Promise.resolve();
+      return Promise.resolve(null);
     });
 
-    await expect(service.stopWorkspaceSessions('workspace-1')).rejects.toThrow(
-      'Failed to stop 1 workspace session'
+    await expect(coordinator.stopWorkspaceSessions('workspace-1')).rejects.toThrow(
+      'Failed to stop 2 workspace sessions'
     );
-    expect(stopSession).toHaveBeenCalledWith('session-running', { reason: 'SYSTEM_STOP' });
-    expect(stopSession).toHaveBeenCalledWith('session-runtime-only', { reason: 'SYSTEM_STOP' });
+    expect(runtimeManager.stopAndQuiesce).not.toHaveBeenCalledWith('session-running');
+    expect(runtimeManager.stopAndQuiesce).not.toHaveBeenCalledWith('session-runtime-only');
+    expect(runtimeManager.stopAndQuiesce).toHaveBeenCalledWith('session-browse-only');
+    expect(runtimeManager.stopAndQuiesce).not.toHaveBeenCalledWith('session-idle');
   });
 });
 
@@ -85,9 +92,9 @@ describe('SessionTerminationCoordinator stop causes', () => {
     ['WORKSPACE_ARCHIVED', 'Session stopped because the workspace was archived.'],
     ['SYSTEM_STOP', 'Session stopped by the system.'],
   ] as const)('records %s before stopping the runtime', async (reason, message) => {
-    const { service, lifecycleEventService, runtimeManager } = createLifecycleHarness();
+    const { coordinator, lifecycleEventService, runtimeManager } = createTerminationHarness();
 
-    await service.stopSession('session-1', { reason });
+    await coordinator.stopSession('session-1', { reason });
 
     expect(lifecycleEventService.record).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -107,11 +114,11 @@ describe('SessionTerminationCoordinator stop causes', () => {
   });
 
   it('uses a new durable stop identity after lifecycle-service reconstruction', async () => {
-    const first = createLifecycleHarness();
-    const reconstructed = createLifecycleHarness();
+    const first = createTerminationHarness();
+    const reconstructed = createTerminationHarness();
 
-    await first.service.stopSession('session-1', { reason: 'USER_STOP' });
-    await reconstructed.service.stopSession('session-1', { reason: 'USER_STOP' });
+    await first.coordinator.stopSession('session-1', { reason: 'USER_STOP' });
+    await reconstructed.coordinator.stopSession('session-1', { reason: 'USER_STOP' });
 
     const firstKey = first.lifecycleEventService.record.mock.calls[0]?.[0]?.dedupeKey;
     const reconstructedKey =
@@ -122,16 +129,16 @@ describe('SessionTerminationCoordinator stop causes', () => {
   });
 
   it('can clean up a failed startup without recording a stop event', async () => {
-    const { service, lifecycleEventService, runtimeManager } = createLifecycleHarness();
+    const { coordinator, lifecycleEventService, runtimeManager } = createTerminationHarness();
 
-    await service.stopSession('session-1', { recordLifecycleEvent: false });
+    await coordinator.stopSession('session-1', { recordLifecycleEvent: false });
 
     expect(lifecycleEventService.record).not.toHaveBeenCalled();
     expect(runtimeManager.stopAndQuiesce).toHaveBeenCalledWith('session-1');
   });
 });
 
-describe('SessionTerminationCoordinator graceful shutdown', () => {
+describe('SessionLifecycleService graceful shutdown', () => {
   it('records SYSTEM_STOP for active and pending runtimes before bounded shutdown', async () => {
     const runtimeManager = {
       beginShutdown: vi.fn(() => ['session-active', 'session-pending', 'session-browse-only']),
@@ -262,73 +269,250 @@ describe('SessionTerminationCoordinator graceful shutdown', () => {
 });
 
 describe('SessionTerminationCoordinator races', () => {
-  it('forwards the session id to the runtime stop visibility query', () => {
-    const harness = createLifecycleHarness();
+  it('reserves the stop synchronously before loading the session', async () => {
+    const effects: string[] = [];
+    const harness = createTerminationHarness({
+      getSessionById: () => {
+        effects.push('load-session');
+        return Promise.resolve(harness.session);
+      },
+    });
+    const originalReserveStop = harness.lifecycleGate.reserveStop.bind(harness.lifecycleGate);
+    vi.spyOn(harness.lifecycleGate, 'reserveStop').mockImplementation((sessionId) => {
+      effects.push('reserve-stop');
+      return originalReserveStop(sessionId);
+    });
 
-    expect(harness.service.isSessionStopping('session-1')).toBe(false);
+    const stop = harness.coordinator.stopSession('session-1');
 
-    expect(harness.runtimeManager.isStopInProgress).toHaveBeenCalledWith('session-1');
+    expect(effects.indexOf('reserve-stop')).toBe(0);
+    expect(effects.indexOf('reserve-stop')).toBeLessThan(effects.indexOf('load-session'));
+    await stop;
+  });
+
+  it('waits for the durable event to complete before runtime quiescence begins', async () => {
+    const effects: string[] = [];
+    const harness = createTerminationHarness();
+    const durableEvent = createDeferred<null>();
+    harness.lifecycleEventService.record.mockImplementation(async () => {
+      await durableEvent.promise;
+      effects.push('durable-event-complete');
+      return null;
+    });
+    harness.runtimeManager.stopAndQuiesce.mockImplementation(() => {
+      effects.push('runtime-stop');
+      return Promise.resolve();
+    });
+
+    const stop = harness.coordinator.stopSession('session-1');
+    await vi.waitFor(() => {
+      expect(harness.lifecycleEventService.record).toHaveBeenCalledOnce();
+    });
+    expect(harness.runtimeManager.stopAndQuiesce).not.toHaveBeenCalled();
+
+    durableEvent.resolve(null);
+    await stop;
+
+    expect(effects).toEqual(['durable-event-complete', 'runtime-stop']);
+  });
+
+  it('keeps cleanup order and releases the reservation after a propagated cleanup failure', async () => {
+    const effects: string[] = [];
+    const harness = createTerminationHarness({
+      onBeforeStopSession: () => effects.push('before-stop'),
+      getSessionById: () => {
+        effects.push('load-session');
+        return Promise.resolve(harness.session);
+      },
+    });
+    harness.promptTurnCompletionService.clearSession.mockImplementation(() => {
+      effects.push('clear-prompt');
+    });
+    harness.sessionDomainService.clearQueuedWork.mockImplementation(() => {
+      effects.push('clear-queued-work');
+    });
+    harness.lifecycleEventService.record.mockImplementation(() => {
+      effects.push('durable-event');
+      return Promise.resolve(null);
+    });
+    harness.sessionDomainService.setRuntimeSnapshot.mockImplementation((_sessionId, snapshot) => {
+      effects.push(snapshot.phase === 'stopping' ? 'snapshot-stopping' : 'snapshot-idle');
+    });
+    harness.acpEventProcessor.clearStreamingState.mockImplementation(() => {
+      effects.push('clear-streaming');
+    });
+    harness.acpEventProcessor.clearReplaySuppression.mockImplementation(() => {
+      effects.push('clear-replay');
+    });
+    harness.sessionPermissionService.cancelPendingRequests.mockImplementation(() => {
+      effects.push('cancel-permissions');
+    });
+    harness.runtimeManager.stopAndQuiesce.mockImplementation(() => {
+      effects.push('runtime-stop');
+      return Promise.resolve();
+    });
+    harness.acpEventProcessor.finalizeOrphanedToolCalls.mockImplementation(() => {
+      effects.push('finalize-orphans');
+    });
+    harness.repository.updateSessionIfStatus.mockImplementation(() => {
+      effects.push('update-idle-status');
+      return Promise.resolve(0);
+    });
+    harness.workspaceBridge.markSessionIdle.mockImplementation(() => {
+      effects.push('workspace-idle');
+    });
+    harness.acpEventProcessor.clearSessionState.mockImplementation(() => {
+      effects.push('clear-acp-state');
+    });
+    harness.workflowFinalizer.finalizeDeliberateStop.mockImplementation(() => {
+      effects.push('deliberate-finalization');
+      return Promise.resolve();
+    });
+    harness.workflowFinalizer.clearInactiveSession.mockImplementation(() => {
+      effects.push('clear-inactive');
+      throw new Error('clear inactive failed');
+    });
+    const closeTrace = vi.spyOn(acpTraceLogger, 'closeSession').mockImplementation(() => {
+      effects.push('close-trace');
+    });
+    const originalReserveStop = harness.lifecycleGate.reserveStop.bind(harness.lifecycleGate);
+    vi.spyOn(harness.lifecycleGate, 'reserveStop').mockImplementation((sessionId) => {
+      effects.push('reserve-stop');
+      const reservation = originalReserveStop(sessionId);
+      if (!reservation) {
+        return null;
+      }
+      return {
+        generation: reservation.generation,
+        release: () => {
+          effects.push('release-stop');
+          reservation.release();
+        },
+      };
+    });
+
+    try {
+      await expect(harness.coordinator.stopSession('session-1')).rejects.toThrow(
+        'clear inactive failed'
+      );
+    } finally {
+      closeTrace.mockRestore();
+    }
+
+    expect(effects).toEqual([
+      'reserve-stop',
+      'clear-prompt',
+      'before-stop',
+      'clear-queued-work',
+      'load-session',
+      'durable-event',
+      'snapshot-stopping',
+      'clear-streaming',
+      'clear-replay',
+      'cancel-permissions',
+      'runtime-stop',
+      'finalize-orphans',
+      'update-idle-status',
+      'snapshot-idle',
+      'workspace-idle',
+      'clear-acp-state',
+      'deliberate-finalization',
+      'clear-inactive',
+      'close-trace',
+      'release-stop',
+    ]);
+    expect(harness.lifecycleGate.isStopReserved('session-1')).toBe(false);
+  });
+
+  it('continues mandatory cleanup after runtime stop fails and skips deliberate finalization', async () => {
+    const effects: string[] = [];
+    const harness = createTerminationHarness();
+    harness.runtimeManager.stopAndQuiesce.mockImplementation(() => {
+      effects.push('runtime-stop-failed');
+      return Promise.reject(new Error('runtime stop failed'));
+    });
+    harness.acpEventProcessor.finalizeOrphanedToolCalls.mockImplementation(() => {
+      effects.push('finalize-orphans');
+    });
+    harness.repository.updateSessionIfStatus.mockImplementation(() => {
+      effects.push('update-idle-status');
+      return Promise.resolve(0);
+    });
+    harness.sessionDomainService.setRuntimeSnapshot.mockImplementation((_sessionId, snapshot) => {
+      if (snapshot.phase === 'idle') {
+        effects.push('snapshot-idle');
+      }
+    });
+    harness.workspaceBridge.markSessionIdle.mockImplementation(() => {
+      effects.push('workspace-idle');
+    });
+    harness.acpEventProcessor.clearSessionState.mockImplementation(() => {
+      effects.push('clear-acp-state');
+    });
+    harness.workflowFinalizer.clearInactiveSession.mockImplementation(() => {
+      effects.push('clear-inactive');
+    });
+
+    await expect(harness.coordinator.stopSession('session-1')).resolves.toBeUndefined();
+
+    expect(effects).toEqual([
+      'runtime-stop-failed',
+      'finalize-orphans',
+      'update-idle-status',
+      'snapshot-idle',
+      'workspace-idle',
+      'clear-acp-state',
+      'clear-inactive',
+    ]);
+    expect(harness.workflowFinalizer.finalizeDeliberateStop).not.toHaveBeenCalled();
+    expect(harness.lifecycleGate.isStopReserved('session-1')).toBe(false);
   });
 
   it('releases the stop generation after a session stops', async () => {
-    const { service } = createLifecycleHarness();
-    const stopGeneration = service.getStopGeneration('session-1');
+    const { coordinator, lifecycleGate } = createTerminationHarness();
+    const stopGeneration = lifecycleGate.getGeneration('session-1');
 
-    await service.stopSession('session-1');
+    await coordinator.stopSession('session-1');
 
-    const sentinelGeneration = service.getStopGeneration('sentinel-session');
+    const sentinelGeneration = lifecycleGate.getGeneration('sentinel-session');
     expect(sentinelGeneration).toBeGreaterThan(stopGeneration);
-    expect(service.getStopGeneration('session-1')).toBeGreaterThan(sentinelGeneration);
+    expect(lifecycleGate.getGeneration('session-1')).toBeGreaterThan(sentinelGeneration);
   });
 
-  it('releases the stop generation when viewers retain inactive session state', async () => {
-    const { service, sessionDomainService } = createLifecycleHarness();
-    const stopGeneration = service.getStopGeneration('session-1');
-    sessionEventBus.registerViewerCountProvider((sessionId) => (sessionId === 'session-1' ? 1 : 0));
+  it('releases the stop generation when finalization retains inactive session state', async () => {
+    const { coordinator, lifecycleGate, workflowFinalizer } = createTerminationHarness();
+    const stopGeneration = lifecycleGate.getGeneration('session-1');
 
-    try {
-      await service.stopSession('session-1');
-    } finally {
-      sessionEventBus.registerViewerCountProvider(null);
-    }
+    await coordinator.stopSession('session-1');
 
-    expect(sessionDomainService.clearSession).not.toHaveBeenCalled();
-    const sentinelGeneration = service.getStopGeneration('sentinel-session');
+    expect(workflowFinalizer.clearInactiveSession).toHaveBeenCalledWith('session-1', 'manual_stop');
+    const sentinelGeneration = lifecycleGate.getGeneration('sentinel-session');
     expect(sentinelGeneration).toBeGreaterThan(stopGeneration);
-    expect(service.getStopGeneration('session-1')).toBeGreaterThan(sentinelGeneration);
+    expect(lifecycleGate.getGeneration('session-1')).toBeGreaterThan(sentinelGeneration);
   });
 
   it('waits for a runtime-owned client creation fence and stops the resulting runtime', async () => {
-    const { service, sendSessionMessage, runtimeManager } = createLifecycleHarness();
-    type RuntimeHandle = Awaited<ReturnType<typeof runtimeManager.getOrCreateClient>>;
+    const { coordinator, runtimeManager } = createTerminationHarness();
+    type RuntimeHandle = { id: string };
     let activeHandle: RuntimeHandle | undefined;
     let resolveClient!: (handle: RuntimeHandle) => void;
     const pendingClient = new Promise<RuntimeHandle>((resolve) => {
       resolveClient = resolve;
     });
-    const quiescence = new AcpRuntimeQuiescence({ stopClient: runtimeManager.stopClient });
-    runtimeManager.getClient.mockImplementation(() => activeHandle);
-    runtimeManager.getOrCreateClient.mockImplementation(async () => {
-      activeHandle = await pendingClient;
-      return activeHandle;
-    });
-    runtimeManager.runClientCreationOperation.mockImplementation((sessionId, purpose, operation) =>
-      quiescence.runClientCreationOperation(sessionId, purpose, operation)
-    );
-    runtimeManager.stopAndQuiesce.mockImplementation((sessionId) =>
-      quiescence.stopAndQuiesce(sessionId)
-    );
-    runtimeManager.stopClient.mockImplementation(() => {
+    const stopClient = vi.fn(() => {
       activeHandle = undefined;
       return Promise.resolve();
     });
-
-    const startResult = service.startSession('session-1').catch((error) => error);
-    await vi.waitFor(() => {
-      expect(runtimeManager.getOrCreateClient).toHaveBeenCalled();
+    const quiescence = new AcpRuntimeQuiescence({ stopClient });
+    runtimeManager.stopAndQuiesce.mockImplementation((sessionId) =>
+      quiescence.stopAndQuiesce(sessionId)
+    );
+    const creation = quiescence.runClientCreationOperation('session-1', 'active', async () => {
+      activeHandle = await pendingClient;
+      return activeHandle;
     });
 
-    const stopPromise = service.stopSession('session-1');
+    const stopPromise = coordinator.stopSession('session-1');
     await vi.waitFor(() => {
       expect(runtimeManager.stopAndQuiesce).toHaveBeenCalledWith('session-1');
     });
@@ -338,50 +522,55 @@ describe('SessionTerminationCoordinator races', () => {
     });
     await Promise.resolve();
     expect(stopSettled).toBe(false);
-    resolveClient(
-      unsafeCoerce<RuntimeHandle>({
-        provider: 'CLAUDE',
-        providerSessionId: 'provider-session-1',
-        configOptions: [],
-        isPromptInFlight: false,
-      })
-    );
+    resolveClient({ id: 'runtime-handle' });
 
     await stopPromise;
-    await expect(startResult).resolves.toEqual(
-      expect.objectContaining({ message: 'Session is currently being stopped' })
-    );
+    await creation;
     expect(runtimeManager.stopAndQuiesce).toHaveBeenCalledTimes(1);
-    expect(runtimeManager.getClient('session-1')).toBeUndefined();
-    expect(sendSessionMessage).not.toHaveBeenCalled();
+    expect(stopClient).toHaveBeenCalledWith('session-1');
+    expect(activeHandle).toBeUndefined();
   });
 
-  it('returns a duplicate stop early while preserving the active stop barrier', async () => {
-    const harness = createLifecycleHarness();
+  it('returns a duplicate stop without repeating effects or releasing the active reservation', async () => {
+    const harness = createTerminationHarness();
     const stopEvent = createDeferred<null>();
     harness.lifecycleEventService.record.mockReturnValueOnce(stopEvent.promise);
+    const originalReserveStop = harness.lifecycleGate.reserveStop.bind(harness.lifecycleGate);
+    const releases = vi.fn();
+    vi.spyOn(harness.lifecycleGate, 'reserveStop').mockImplementation((sessionId) => {
+      const reservation = originalReserveStop(sessionId);
+      if (!reservation) {
+        return null;
+      }
+      return {
+        generation: reservation.generation,
+        release: () => {
+          releases();
+          reservation.release();
+        },
+      };
+    });
 
-    const firstStop = harness.service.stopSession('session-1');
+    const firstStop = harness.coordinator.stopSession('session-1');
     await vi.waitFor(() => {
       expect(harness.lifecycleEventService.record).toHaveBeenCalledTimes(1);
     });
 
-    await expect(harness.service.stopSession('session-1')).resolves.toBeUndefined();
-    expect(harness.service.isSessionStopping('session-1')).toBe(true);
-    await expect(harness.service.getOrCreateSessionClient('session-1')).rejects.toThrow(
-      'Session is currently being stopped'
-    );
+    await expect(harness.coordinator.stopSession('session-1')).resolves.toBeUndefined();
+    expect(harness.lifecycleGate.isSessionStopping('session-1')).toBe(true);
     expect(harness.lifecycleEventService.record).toHaveBeenCalledTimes(1);
-    expect(harness.runtimeManager.getOrCreateClient).not.toHaveBeenCalled();
     expect(harness.runtimeManager.stopAndQuiesce).not.toHaveBeenCalled();
     expect(harness.sessionDomainService.clearQueuedWork).toHaveBeenCalledTimes(1);
+    expect(harness.acpEventProcessor.clearSessionState).not.toHaveBeenCalled();
+    expect(releases).not.toHaveBeenCalled();
 
     stopEvent.resolve(null);
     await firstStop;
 
-    expect(harness.service.isSessionStopping('session-1')).toBe(false);
+    expect(harness.lifecycleGate.isSessionStopping('session-1')).toBe(false);
     expect(harness.runtimeManager.stopAndQuiesce).toHaveBeenCalledTimes(1);
     expect(harness.repository.updateSessionIfStatus).toHaveBeenCalledTimes(1);
-    expect(harness.sessionDomainService.clearSession).toHaveBeenCalledTimes(1);
+    expect(harness.acpEventProcessor.clearSessionState).toHaveBeenCalledTimes(1);
+    expect(releases).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/backend/services/session/service/lifecycle/session-termination.coordinator.test.ts
+++ b/src/backend/services/session/service/lifecycle/session-termination.coordinator.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AcpRuntimeQuiescence } from '@/backend/services/session/service/acp/acp-runtime-quiescence';
 import { sessionEventBus } from '@/backend/services/session/service/session-event-bus';
 import { unsafeCoerce } from '@/test-utils/unsafe-coerce';
 import { SessionLifecycleService } from './session.lifecycle.service';
@@ -101,7 +102,7 @@ describe('SessionTerminationCoordinator stop causes', () => {
       })
     );
     expect(lifecycleEventService.record.mock.invocationCallOrder[0]).toBeLessThan(
-      runtimeManager.stopClient.mock.invocationCallOrder[0]!
+      runtimeManager.stopAndQuiesce.mock.invocationCallOrder[0]!
     );
   });
 
@@ -126,7 +127,7 @@ describe('SessionTerminationCoordinator stop causes', () => {
     await service.stopSession('session-1', { recordLifecycleEvent: false });
 
     expect(lifecycleEventService.record).not.toHaveBeenCalled();
-    expect(runtimeManager.stopClient).toHaveBeenCalledWith('session-1');
+    expect(runtimeManager.stopAndQuiesce).toHaveBeenCalledWith('session-1');
   });
 });
 
@@ -297,14 +298,30 @@ describe('SessionTerminationCoordinator races', () => {
     expect(service.getStopGeneration('session-1')).toBeGreaterThan(sentinelGeneration);
   });
 
-  it('waits for a registered client creation and stops the resulting runtime', async () => {
+  it('waits for a runtime-owned client creation fence and stops the resulting runtime', async () => {
     const { service, sendSessionMessage, runtimeManager } = createLifecycleHarness();
     type RuntimeHandle = Awaited<ReturnType<typeof runtimeManager.getOrCreateClient>>;
+    let activeHandle: RuntimeHandle | undefined;
     let resolveClient!: (handle: RuntimeHandle) => void;
     const pendingClient = new Promise<RuntimeHandle>((resolve) => {
       resolveClient = resolve;
     });
-    runtimeManager.getOrCreateClient.mockReturnValueOnce(pendingClient);
+    const quiescence = new AcpRuntimeQuiescence({ stopClient: runtimeManager.stopClient });
+    runtimeManager.getClient.mockImplementation(() => activeHandle);
+    runtimeManager.getOrCreateClient.mockImplementation(async () => {
+      activeHandle = await pendingClient;
+      return activeHandle;
+    });
+    runtimeManager.runClientCreationOperation.mockImplementation((sessionId, purpose, operation) =>
+      quiescence.runClientCreationOperation(sessionId, purpose, operation)
+    );
+    runtimeManager.stopAndQuiesce.mockImplementation((sessionId) =>
+      quiescence.stopAndQuiesce(sessionId)
+    );
+    runtimeManager.stopClient.mockImplementation(() => {
+      activeHandle = undefined;
+      return Promise.resolve();
+    });
 
     const startResult = service.startSession('session-1').catch((error) => error);
     await vi.waitFor(() => {
@@ -313,8 +330,14 @@ describe('SessionTerminationCoordinator races', () => {
 
     const stopPromise = service.stopSession('session-1');
     await vi.waitFor(() => {
-      expect(runtimeManager.stopClient).toHaveBeenCalledTimes(1);
+      expect(runtimeManager.stopAndQuiesce).toHaveBeenCalledWith('session-1');
     });
+    let stopSettled = false;
+    void stopPromise.then(() => {
+      stopSettled = true;
+    });
+    await Promise.resolve();
+    expect(stopSettled).toBe(false);
     resolveClient(
       unsafeCoerce<RuntimeHandle>({
         provider: 'CLAUDE',
@@ -328,7 +351,8 @@ describe('SessionTerminationCoordinator races', () => {
     await expect(startResult).resolves.toEqual(
       expect.objectContaining({ message: 'Session is currently being stopped' })
     );
-    expect(runtimeManager.stopClient).toHaveBeenCalledTimes(2);
+    expect(runtimeManager.stopAndQuiesce).toHaveBeenCalledTimes(1);
+    expect(runtimeManager.getClient('session-1')).toBeUndefined();
     expect(sendSessionMessage).not.toHaveBeenCalled();
   });
 
@@ -349,14 +373,14 @@ describe('SessionTerminationCoordinator races', () => {
     );
     expect(harness.lifecycleEventService.record).toHaveBeenCalledTimes(1);
     expect(harness.runtimeManager.getOrCreateClient).not.toHaveBeenCalled();
-    expect(harness.runtimeManager.stopClient).not.toHaveBeenCalled();
+    expect(harness.runtimeManager.stopAndQuiesce).not.toHaveBeenCalled();
     expect(harness.sessionDomainService.clearQueuedWork).toHaveBeenCalledTimes(1);
 
     stopEvent.resolve(null);
     await firstStop;
 
     expect(harness.service.isSessionStopping('session-1')).toBe(false);
-    expect(harness.runtimeManager.stopClient).toHaveBeenCalledTimes(1);
+    expect(harness.runtimeManager.stopAndQuiesce).toHaveBeenCalledTimes(1);
     expect(harness.repository.updateSessionIfStatus).toHaveBeenCalledTimes(1);
     expect(harness.sessionDomainService.clearSession).toHaveBeenCalledTimes(1);
   });

--- a/src/backend/services/session/service/lifecycle/session-termination.coordinator.ts
+++ b/src/backend/services/session/service/lifecycle/session-termination.coordinator.ts
@@ -5,7 +5,11 @@ import type { AcpRuntimeManager } from '@/backend/services/session/service/acp';
 import type { SessionLifecycleWorkspaceBridge } from '@/backend/services/session/service/bridges';
 import { acpTraceLogger } from '@/backend/services/session/service/logging/acp-trace-logger.service';
 import type { SessionDomainService } from '@/backend/services/session/service/session-domain.service';
-import { SessionLifecycleEventKind, SessionStatus } from '@/shared/core';
+import {
+  SessionLifecycleEventKind,
+  SessionLifecycleEventReason,
+  SessionStatus,
+} from '@/shared/core';
 import {
   createInitialSessionRuntimeState,
   type SessionRuntimeState,
@@ -21,6 +25,8 @@ import { isStaleLoadingRuntime } from './session-runtime-state.helpers';
 import type { SessionWorkflowFinalizer } from './session-workflow-finalizer';
 
 const logger = createLogger('session');
+const SHUTDOWN_LIFECYCLE_RECORD_TIMEOUT_MS = 1000;
+const SHUTDOWN_SESSION_STOP_MESSAGE = 'Session stopped by the system.';
 
 export type SessionStopReason =
   | 'USER_STOP'
@@ -55,6 +61,8 @@ export type SessionTerminationCoordinatorDependencies = {
     | 'isSessionRunning'
     | 'isBrowseOnlySession'
     | 'stopAndQuiesce'
+    | 'beginShutdown'
+    | 'stopAllClients'
   >;
   sessionDomainService: Pick<
     SessionDomainService,
@@ -70,9 +78,12 @@ export type SessionTerminationCoordinatorDependencies = {
     | 'clearPendingToolCalls'
     | 'getWorkspaceId'
   >;
-  promptTurnCompletionService: Pick<SessionPromptTurnCompletionService, 'clearSession'>;
+  promptTurnCompletionService: Pick<
+    SessionPromptTurnCompletionService,
+    'clearSession' | 'clearAll'
+  >;
   lifecycleEventService: Pick<SessionLifecycleEventService, 'record'>;
-  lifecycleGate: Pick<SessionLifecycleGate, 'reserveStop'>;
+  lifecycleGate: Pick<SessionLifecycleGate, 'reserveStop' | 'reserveShutdown'>;
   workflowFinalizer: Pick<
     SessionWorkflowFinalizer,
     'finalizeDeliberateStop' | 'clearInactiveSession'
@@ -133,6 +144,26 @@ export class SessionTerminationCoordinator {
     }
 
     logger.info('Stopped all workspace sessions', { workspaceId, count: sessions.length });
+  }
+
+  async stopAllClients(timeoutMs = 5000): Promise<void> {
+    this.dependencies.promptTurnCompletionService.clearAll();
+    const shutdownSessionIds = this.dependencies.runtimeManager.beginShutdown();
+    const activeShutdownSessionIds = shutdownSessionIds.filter(
+      (sessionId) => !this.dependencies.runtimeManager.isBrowseOnlySession(sessionId)
+    );
+    this.dependencies.lifecycleGate.reserveShutdown(activeShutdownSessionIds);
+
+    await this.recordShutdownLifecycleEvents(activeShutdownSessionIds);
+
+    try {
+      await this.dependencies.runtimeManager.stopAllClients(timeoutMs);
+    } catch (error) {
+      logger.error('Failed to stop ACP clients during shutdown', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
   }
 
   private async stopSessionWithBarrier(
@@ -312,6 +343,54 @@ export class SessionTerminationCoordinator {
         error: error instanceof Error ? error.message : String(error),
       });
       return null;
+    }
+  }
+
+  private async recordShutdownLifecycleEvent(sessionId: string): Promise<void> {
+    const session = await this.loadSessionForStop(sessionId);
+    const workspaceId =
+      session?.workspaceId ?? this.dependencies.acpEventProcessor.getWorkspaceId(sessionId);
+    if (!workspaceId) {
+      logger.warn('Skipped shutdown lifecycle event without workspace owner', { sessionId });
+      return;
+    }
+    await this.dependencies.lifecycleEventService.record({
+      workspaceId,
+      sessionId,
+      kind: SessionLifecycleEventKind.SESSION_STOPPED,
+      reason: SessionLifecycleEventReason.SYSTEM_STOP,
+      message: SHUTDOWN_SESSION_STOP_MESSAGE,
+      dedupeKey: `session-stop:${randomUUID()}`,
+    });
+  }
+
+  private async recordShutdownLifecycleEvents(sessionIds: string[]): Promise<void> {
+    const resultsPromise = Promise.allSettled(
+      sessionIds.map((sessionId) => this.recordShutdownLifecycleEvent(sessionId))
+    );
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const results = await Promise.race([
+      resultsPromise,
+      new Promise<null>((resolve) => {
+        timeout = setTimeout(() => resolve(null), SHUTDOWN_LIFECYCLE_RECORD_TIMEOUT_MS);
+      }),
+    ]);
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    if (results === null) {
+      logger.warn('Timed out recording shutdown lifecycle events; continuing shutdown', {
+        timeoutMs: SHUTDOWN_LIFECYCLE_RECORD_TIMEOUT_MS,
+      });
+      return;
+    }
+    for (const [index, result] of results.entries()) {
+      if (result.status === 'rejected') {
+        logger.warn('Failed recording shutdown lifecycle event; continuing shutdown', {
+          sessionId: sessionIds[index],
+          error: result.reason instanceof Error ? result.reason.message : String(result.reason),
+        });
+      }
     }
   }
 

--- a/src/backend/services/session/service/lifecycle/session-termination.coordinator.ts
+++ b/src/backend/services/session/service/lifecycle/session-termination.coordinator.ts
@@ -1,0 +1,340 @@
+import { randomUUID } from 'node:crypto';
+import { createLogger } from '@/backend/services/logger.service';
+import type { AgentSessionRecord } from '@/backend/services/session/resources/agent-session.accessor';
+import type { AcpRuntimeManager } from '@/backend/services/session/service/acp';
+import type { SessionLifecycleWorkspaceBridge } from '@/backend/services/session/service/bridges';
+import { acpTraceLogger } from '@/backend/services/session/service/logging/acp-trace-logger.service';
+import type { SessionDomainService } from '@/backend/services/session/service/session-domain.service';
+import { SessionLifecycleEventKind, SessionStatus } from '@/shared/core';
+import {
+  createInitialSessionRuntimeState,
+  type SessionRuntimeState,
+} from '@/shared/session-runtime';
+import type { AcpEventProcessor } from './acp-event-processor';
+import type { SessionPermissionService } from './session.permission.service';
+import type { SessionPromptTurnCompletionService } from './session.prompt-turn-completion.service';
+import type { SessionRepository } from './session.repository';
+import type { SessionRetryService } from './session.retry.service';
+import type { SessionLifecycleEventService } from './session-lifecycle-event.service';
+import type { SessionLifecycleGate } from './session-lifecycle-gate';
+import { isStaleLoadingRuntime } from './session-runtime-state.helpers';
+import type { SessionWorkflowFinalizer } from './session-workflow-finalizer';
+
+const logger = createLogger('session');
+
+export type SessionStopReason =
+  | 'USER_STOP'
+  | 'SESSION_CLOSED'
+  | 'WORKSPACE_ARCHIVED'
+  | 'SYSTEM_STOP';
+
+export type StopSessionOptions = {
+  cleanupTransientRatchetSession?: boolean;
+  recordLifecycleEvent?: boolean;
+  reason?: SessionStopReason;
+};
+
+const SESSION_STOP_MESSAGES: Record<SessionStopReason, string> = {
+  USER_STOP: 'Session stopped by you.',
+  SESSION_CLOSED: 'Session closed by you.',
+  WORKSPACE_ARCHIVED: 'Session stopped because the workspace was archived.',
+  SYSTEM_STOP: 'Session stopped by the system.',
+};
+
+export type SessionTerminationCoordinatorDependencies = {
+  repository: Pick<
+    SessionRepository,
+    'getSessionById' | 'getSessionsByWorkspaceId' | 'updateSessionIfStatus'
+  >;
+  retryService: Pick<SessionRetryService, 'run'>;
+  runtimeManager: Pick<
+    AcpRuntimeManager,
+    | 'getClient'
+    | 'isSessionWorking'
+    | 'isStopInProgress'
+    | 'isSessionRunning'
+    | 'isBrowseOnlySession'
+    | 'stopAndQuiesce'
+  >;
+  sessionDomainService: Pick<
+    SessionDomainService,
+    'clearQueuedWork' | 'getRuntimeSnapshot' | 'setRuntimeSnapshot'
+  >;
+  sessionPermissionService: Pick<SessionPermissionService, 'cancelPendingRequests'>;
+  acpEventProcessor: Pick<
+    AcpEventProcessor,
+    | 'clearSessionState'
+    | 'clearStreamingState'
+    | 'clearReplaySuppression'
+    | 'finalizeOrphanedToolCalls'
+    | 'clearPendingToolCalls'
+    | 'getWorkspaceId'
+  >;
+  promptTurnCompletionService: Pick<SessionPromptTurnCompletionService, 'clearSession'>;
+  lifecycleEventService: Pick<SessionLifecycleEventService, 'record'>;
+  lifecycleGate: Pick<SessionLifecycleGate, 'reserveStop'>;
+  workflowFinalizer: Pick<
+    SessionWorkflowFinalizer,
+    'finalizeDeliberateStop' | 'clearInactiveSession'
+  >;
+  getWorkspaceBridge: () => Pick<SessionLifecycleWorkspaceBridge, 'markSessionIdle'> | null;
+  onBeforeStopSession?: (sessionId: string) => void;
+};
+
+export class SessionTerminationCoordinator {
+  constructor(private readonly dependencies: SessionTerminationCoordinatorDependencies) {}
+
+  async stopSession(sessionId: string, options?: StopSessionOptions): Promise<void> {
+    const stopReservation = this.dependencies.lifecycleGate.reserveStop(sessionId);
+    if (!stopReservation) {
+      logger.debug('Session stop already in progress', { sessionId });
+      return;
+    }
+
+    const stopInvocationId = randomUUID();
+    try {
+      await this.stopSessionWithBarrier(sessionId, stopInvocationId, options);
+    } finally {
+      stopReservation.release();
+    }
+  }
+
+  async stopWorkspaceSessions(
+    workspaceId: string,
+    options?: { reason?: SessionStopReason }
+  ): Promise<void> {
+    const sessions = await this.dependencies.repository.getSessionsByWorkspaceId(workspaceId);
+    const stopErrors: unknown[] = [];
+
+    for (const session of sessions) {
+      const stopOptions = this.getWorkspaceSessionStopOptions(
+        session,
+        options?.reason ?? 'SYSTEM_STOP'
+      );
+      if (!stopOptions) {
+        continue;
+      }
+      try {
+        await this.stopSession(session.id, stopOptions);
+      } catch (error) {
+        logger.error('Failed to stop workspace session', {
+          sessionId: session.id,
+          workspaceId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        stopErrors.push(error);
+      }
+    }
+
+    if (stopErrors.length > 0) {
+      throw new Error(
+        `Failed to stop ${stopErrors.length} workspace session${stopErrors.length === 1 ? '' : 's'}`
+      );
+    }
+
+    logger.info('Stopped all workspace sessions', { workspaceId, count: sessions.length });
+  }
+
+  private async stopSessionWithBarrier(
+    sessionId: string,
+    stopInvocationId: string,
+    options?: StopSessionOptions
+  ): Promise<void> {
+    this.dependencies.promptTurnCompletionService.clearSession(sessionId);
+    this.dependencies.onBeforeStopSession?.(sessionId);
+    this.dependencies.sessionDomainService.clearQueuedWork(sessionId, { emitSnapshot: true });
+    const session = await this.loadSessionForStop(sessionId);
+    const workspaceId =
+      session?.workspaceId ?? this.dependencies.acpEventProcessor.getWorkspaceId(sessionId);
+    const reason = options?.reason ?? 'SYSTEM_STOP';
+
+    if (workspaceId && options?.recordLifecycleEvent !== false) {
+      await this.dependencies.lifecycleEventService.record({
+        workspaceId,
+        sessionId,
+        kind: SessionLifecycleEventKind.SESSION_STOPPED,
+        reason,
+        message: SESSION_STOP_MESSAGES[reason],
+        dedupeKey: `session-stop:${stopInvocationId}`,
+      });
+    }
+
+    const current = this.getRuntimeSnapshot(sessionId);
+    this.dependencies.sessionDomainService.setRuntimeSnapshot(sessionId, {
+      ...current,
+      phase: 'stopping',
+      activity: 'IDLE',
+      updatedAt: new Date().toISOString(),
+    });
+
+    this.dependencies.acpEventProcessor.clearStreamingState(sessionId);
+    this.dependencies.acpEventProcessor.clearReplaySuppression(sessionId);
+    this.dependencies.sessionPermissionService.cancelPendingRequests(sessionId);
+
+    let stopClientFailed = false;
+    try {
+      await this.dependencies.runtimeManager.stopAndQuiesce(sessionId);
+    } catch (error) {
+      stopClientFailed = true;
+      logger.warn('Error stopping ACP session runtime; continuing cleanup', {
+        sessionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      this.finalizeOrphanedToolCalls(sessionId, 'session_stop');
+      await this.updateStoppedSessionState(sessionId);
+      this.dependencies.sessionDomainService.setRuntimeSnapshot(sessionId, {
+        phase: 'idle',
+        processState: 'stopped',
+        activity: 'IDLE',
+        updatedAt: new Date().toISOString(),
+      });
+      this.markWorkspaceSessionIdleOnStop(workspaceId, sessionId);
+      this.dependencies.acpEventProcessor.clearSessionState(sessionId);
+
+      if (!stopClientFailed) {
+        const shouldCleanupTransientRatchetSession =
+          options?.cleanupTransientRatchetSession ?? true;
+        await this.dependencies.workflowFinalizer.finalizeDeliberateStop({
+          session,
+          sessionId,
+          cleanupTransientRatchetSession: shouldCleanupTransientRatchetSession,
+        });
+      }
+
+      try {
+        this.dependencies.workflowFinalizer.clearInactiveSession(sessionId, 'manual_stop');
+        logger.info('ACP session stopped', {
+          sessionId,
+          ...(stopClientFailed ? { runtimeStopFailed: true } : {}),
+        });
+      } finally {
+        acpTraceLogger.closeSession(sessionId);
+      }
+    }
+  }
+
+  private getWorkspaceSessionStopOptions(
+    session: { id: string; status: SessionStatus },
+    reason: SessionStopReason
+  ): StopSessionOptions | null {
+    const browseOnlyClient = this.dependencies.runtimeManager.isBrowseOnlySession(session.id);
+    const activeClient = this.dependencies.runtimeManager.isSessionRunning(session.id);
+    if (!(session.status === SessionStatus.RUNNING || activeClient || browseOnlyClient)) {
+      return null;
+    }
+    return {
+      reason,
+      ...(browseOnlyClient && !activeClient ? { recordLifecycleEvent: false } : {}),
+    };
+  }
+
+  private getRuntimeSnapshot(sessionId: string): SessionRuntimeState {
+    const fallback = createInitialSessionRuntimeState();
+    const persisted = this.dependencies.sessionDomainService.getRuntimeSnapshot(sessionId);
+    const base = persisted ?? fallback;
+
+    const acpClient = this.dependencies.runtimeManager.getClient(sessionId);
+    if (acpClient) {
+      const isWorking = this.dependencies.runtimeManager.isSessionWorking(sessionId);
+      return {
+        phase: isWorking ? 'running' : 'idle',
+        processState: 'alive',
+        activity: isWorking ? 'WORKING' : 'IDLE',
+        updatedAt: base.updatedAt,
+      };
+    }
+
+    if (this.dependencies.runtimeManager.isStopInProgress(sessionId)) {
+      return {
+        ...base,
+        phase: 'stopping',
+        updatedAt: base.updatedAt,
+      };
+    }
+
+    if (isStaleLoadingRuntime(base)) {
+      return {
+        ...base,
+        phase: 'idle',
+        processState: 'stopped',
+        activity: 'IDLE',
+        updatedAt: base.updatedAt,
+      };
+    }
+
+    return base;
+  }
+
+  private finalizeOrphanedToolCalls(sessionId: string, reason: string): void {
+    try {
+      this.dependencies.acpEventProcessor.finalizeOrphanedToolCalls(sessionId, reason);
+    } catch (error) {
+      logger.warn('Failed finalizing orphaned ACP tool calls', {
+        sessionId,
+        reason,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      this.dependencies.acpEventProcessor.clearPendingToolCalls(sessionId);
+    }
+  }
+
+  private markWorkspaceSessionIdleOnStop(workspaceId: string | undefined, sessionId: string): void {
+    const workspaceBridge = this.dependencies.getWorkspaceBridge();
+    if (!(workspaceId && workspaceBridge)) {
+      return;
+    }
+
+    try {
+      workspaceBridge.markSessionIdle(workspaceId, sessionId);
+    } catch (error) {
+      logger.warn('Failed to mark workspace session idle during stop', {
+        sessionId,
+        workspaceId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private async loadSessionForStop(sessionId: string): Promise<AgentSessionRecord | null> {
+    try {
+      return await this.dependencies.retryService.run(
+        () => this.dependencies.repository.getSessionById(sessionId),
+        {
+          attempts: 2,
+          operationName: 'loadSessionForStop',
+          context: { sessionId },
+        }
+      );
+    } catch (error) {
+      logger.warn('Failed to load session before stop; continuing with process shutdown', {
+        sessionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
+  }
+
+  private async updateStoppedSessionState(sessionId: string): Promise<void> {
+    try {
+      await this.dependencies.retryService.run(
+        () =>
+          this.dependencies.repository.updateSessionIfStatus(
+            sessionId,
+            { status: SessionStatus.IDLE },
+            [SessionStatus.RUNNING]
+          ),
+        {
+          attempts: 2,
+          operationName: 'updateStoppedSessionState',
+          context: { sessionId },
+        }
+      );
+    } catch (error) {
+      logger.warn('Failed to update session state during stop; continuing cleanup', {
+        sessionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+}

--- a/src/backend/services/session/service/lifecycle/session-termination.coordinator.ts
+++ b/src/backend/services/session/service/lifecycle/session-termination.coordinator.ts
@@ -10,10 +10,7 @@ import {
   SessionLifecycleEventReason,
   SessionStatus,
 } from '@/shared/core';
-import {
-  createInitialSessionRuntimeState,
-  type SessionRuntimeState,
-} from '@/shared/session-runtime';
+import type { SessionRuntimeState } from '@/shared/session-runtime';
 import type { AcpEventProcessor } from './acp-event-processor';
 import type { SessionPermissionService } from './session.permission.service';
 import type { SessionPromptTurnCompletionService } from './session.prompt-turn-completion.service';
@@ -21,7 +18,6 @@ import type { SessionRepository } from './session.repository';
 import type { SessionRetryService } from './session.retry.service';
 import type { SessionLifecycleEventService } from './session-lifecycle-event.service';
 import type { SessionLifecycleGate } from './session-lifecycle-gate';
-import { isStaleLoadingRuntime } from './session-runtime-state.helpers';
 import type { SessionWorkflowFinalizer } from './session-workflow-finalizer';
 
 const logger = createLogger('session');
@@ -55,19 +51,14 @@ export type SessionTerminationCoordinatorDependencies = {
   retryService: Pick<SessionRetryService, 'run'>;
   runtimeManager: Pick<
     AcpRuntimeManager,
-    | 'getClient'
-    | 'isSessionWorking'
-    | 'isStopInProgress'
     | 'isSessionRunning'
     | 'isBrowseOnlySession'
+    | 'hasClientCreationOperation'
     | 'stopAndQuiesce'
     | 'beginShutdown'
     | 'stopAllClients'
   >;
-  sessionDomainService: Pick<
-    SessionDomainService,
-    'clearQueuedWork' | 'getRuntimeSnapshot' | 'setRuntimeSnapshot'
-  >;
+  sessionDomainService: Pick<SessionDomainService, 'clearQueuedWork' | 'setRuntimeSnapshot'>;
   sessionPermissionService: Pick<SessionPermissionService, 'cancelPendingRequests'>;
   acpEventProcessor: Pick<
     AcpEventProcessor,
@@ -88,6 +79,7 @@ export type SessionTerminationCoordinatorDependencies = {
     SessionWorkflowFinalizer,
     'finalizeDeliberateStop' | 'clearInactiveSession'
   >;
+  getRuntimeSnapshot: (sessionId: string) => SessionRuntimeState;
   getWorkspaceBridge: () => Pick<SessionLifecycleWorkspaceBridge, 'markSessionIdle'> | null;
   onBeforeStopSession?: (sessionId: string) => void;
 };
@@ -190,7 +182,7 @@ export class SessionTerminationCoordinator {
       });
     }
 
-    const current = this.getRuntimeSnapshot(sessionId);
+    const current = this.dependencies.getRuntimeSnapshot(sessionId);
     this.dependencies.sessionDomainService.setRuntimeSnapshot(sessionId, {
       ...current,
       phase: 'stopping',
@@ -251,50 +243,23 @@ export class SessionTerminationCoordinator {
   ): StopSessionOptions | null {
     const browseOnlyClient = this.dependencies.runtimeManager.isBrowseOnlySession(session.id);
     const activeClient = this.dependencies.runtimeManager.isSessionRunning(session.id);
-    if (!(session.status === SessionStatus.RUNNING || activeClient || browseOnlyClient)) {
+    const creationOperation = this.dependencies.runtimeManager.hasClientCreationOperation(
+      session.id
+    );
+    if (
+      !(
+        session.status === SessionStatus.RUNNING ||
+        activeClient ||
+        browseOnlyClient ||
+        creationOperation
+      )
+    ) {
       return null;
     }
     return {
       reason,
       ...(browseOnlyClient && !activeClient ? { recordLifecycleEvent: false } : {}),
     };
-  }
-
-  private getRuntimeSnapshot(sessionId: string): SessionRuntimeState {
-    const fallback = createInitialSessionRuntimeState();
-    const persisted = this.dependencies.sessionDomainService.getRuntimeSnapshot(sessionId);
-    const base = persisted ?? fallback;
-
-    const acpClient = this.dependencies.runtimeManager.getClient(sessionId);
-    if (acpClient) {
-      const isWorking = this.dependencies.runtimeManager.isSessionWorking(sessionId);
-      return {
-        phase: isWorking ? 'running' : 'idle',
-        processState: 'alive',
-        activity: isWorking ? 'WORKING' : 'IDLE',
-        updatedAt: base.updatedAt,
-      };
-    }
-
-    if (this.dependencies.runtimeManager.isStopInProgress(sessionId)) {
-      return {
-        ...base,
-        phase: 'stopping',
-        updatedAt: base.updatedAt,
-      };
-    }
-
-    if (isStaleLoadingRuntime(base)) {
-      return {
-        ...base,
-        phase: 'idle',
-        processState: 'stopped',
-        activity: 'IDLE',
-        updatedAt: base.updatedAt,
-      };
-    }
-
-    return base;
   }
 
   private finalizeOrphanedToolCalls(sessionId: string, reason: string): void {

--- a/src/backend/services/session/service/lifecycle/session.lifecycle.facade.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.lifecycle.facade.test.ts
@@ -8,6 +8,7 @@ import {
   createPendingWorkspaceNotification,
 } from './session-lifecycle.test-helpers';
 import { SessionStartupCoordinator } from './session-startup.coordinator';
+import { SessionTerminationCoordinator } from './session-termination.coordinator';
 
 vi.mock('@/backend/services/logger.service', () => ({
   createLogger: () => ({
@@ -118,6 +119,52 @@ describe('SessionLifecycleFacade', () => {
     expect(getOrCreateSessionClient).toHaveBeenCalledWith('session-3', clientOptions);
     expect(getOrCreateSessionClientFromRecord).toHaveBeenCalledWith(session, clientOptions);
     expect(ensureSubagentBrowseSession).toHaveBeenCalledWith('session-4');
+  });
+
+  it('forwards explicit and workspace stops to the termination coordinator', async () => {
+    const stopSession = vi
+      .spyOn(SessionTerminationCoordinator.prototype, 'stopSession')
+      .mockResolvedValueOnce(undefined);
+    const stopWorkspaceSessions = vi
+      .spyOn(SessionTerminationCoordinator.prototype, 'stopWorkspaceSessions')
+      .mockResolvedValueOnce(undefined);
+    const { service } = createLifecycleHarness();
+    const sessionOptions = {
+      cleanupTransientRatchetSession: false,
+      recordLifecycleEvent: false,
+      reason: 'USER_STOP',
+    } as const;
+    const workspaceOptions = { reason: 'WORKSPACE_ARCHIVED' } as const;
+
+    await expect(service.stopSession('session-exact', sessionOptions)).resolves.toBeUndefined();
+    await expect(
+      service.stopWorkspaceSessions('workspace-exact', workspaceOptions)
+    ).resolves.toBeUndefined();
+
+    expect(stopSession).toHaveBeenCalledWith('session-exact', sessionOptions);
+    expect(stopWorkspaceSessions).toHaveBeenCalledWith('workspace-exact', workspaceOptions);
+    stopSession.mockRestore();
+    stopWorkspaceSessions.mockRestore();
+  });
+
+  it('preserves termination coordinator rejections', async () => {
+    const sessionFailure = new Error('session stop rejected');
+    const workspaceFailure = new Error('workspace stop rejected');
+    const stopSession = vi
+      .spyOn(SessionTerminationCoordinator.prototype, 'stopSession')
+      .mockRejectedValueOnce(sessionFailure);
+    const stopWorkspaceSessions = vi
+      .spyOn(SessionTerminationCoordinator.prototype, 'stopWorkspaceSessions')
+      .mockRejectedValueOnce(workspaceFailure);
+    const { service } = createLifecycleHarness();
+
+    await expect(service.stopSession('session-rejected')).rejects.toBe(sessionFailure);
+    await expect(service.stopWorkspaceSessions('workspace-rejected')).rejects.toBe(
+      workspaceFailure
+    );
+
+    stopSession.mockRestore();
+    stopWorkspaceSessions.mockRestore();
   });
 
   it('skips the restart default continue prompt when notifications are queued', async () => {

--- a/src/backend/services/session/service/lifecycle/session.lifecycle.facade.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.lifecycle.facade.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { workspaceNotificationService } from '@/backend/services/workspace';
 import { WorkspaceStatus } from '@/shared/core';
 import { unsafeCoerce } from '@/test-utils/unsafe-coerce';
@@ -50,6 +50,10 @@ it('preserves an explicit null lifecycle provider process ID', () =>
   ).toBeNull());
 
 describe('SessionLifecycleFacade', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(workspaceNotificationService.listPendingForDelivery).mockResolvedValue([
@@ -150,24 +154,22 @@ describe('SessionLifecycleFacade', () => {
     expect(stopWorkspaceSessions).toHaveBeenCalledWith('workspace-exact', workspaceOptions);
     expect(stopAllClients).toHaveBeenNthCalledWith(1, 4321);
     expect(stopAllClients).toHaveBeenNthCalledWith(2, 5000);
-    stopSession.mockRestore();
-    stopWorkspaceSessions.mockRestore();
-    stopAllClients.mockRestore();
   });
 
   it('preserves termination coordinator rejections', async () => {
     const sessionFailure = new Error('session stop rejected');
     const workspaceFailure = new Error('workspace stop rejected');
     const shutdownFailure = new Error('shutdown rejected');
-    const stopSession = vi
-      .spyOn(SessionTerminationCoordinator.prototype, 'stopSession')
-      .mockRejectedValueOnce(sessionFailure);
-    const stopWorkspaceSessions = vi
-      .spyOn(SessionTerminationCoordinator.prototype, 'stopWorkspaceSessions')
-      .mockRejectedValueOnce(workspaceFailure);
-    const stopAllClients = vi
-      .spyOn(SessionTerminationCoordinator.prototype, 'stopAllClients')
-      .mockRejectedValueOnce(shutdownFailure);
+    vi.spyOn(SessionTerminationCoordinator.prototype, 'stopSession').mockRejectedValueOnce(
+      sessionFailure
+    );
+    vi.spyOn(
+      SessionTerminationCoordinator.prototype,
+      'stopWorkspaceSessions'
+    ).mockRejectedValueOnce(workspaceFailure);
+    vi.spyOn(SessionTerminationCoordinator.prototype, 'stopAllClients').mockRejectedValueOnce(
+      shutdownFailure
+    );
     const { service } = createLifecycleHarness();
 
     await expect(service.stopSession('session-rejected')).rejects.toBe(sessionFailure);
@@ -175,10 +177,6 @@ describe('SessionLifecycleFacade', () => {
       workspaceFailure
     );
     await expect(service.stopAllClients()).rejects.toBe(shutdownFailure);
-
-    stopSession.mockRestore();
-    stopWorkspaceSessions.mockRestore();
-    stopAllClients.mockRestore();
   });
 
   it('skips the restart default continue prompt when notifications are queued', async () => {

--- a/src/backend/services/session/service/lifecycle/session.lifecycle.facade.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.lifecycle.facade.test.ts
@@ -128,6 +128,9 @@ describe('SessionLifecycleFacade', () => {
     const stopWorkspaceSessions = vi
       .spyOn(SessionTerminationCoordinator.prototype, 'stopWorkspaceSessions')
       .mockResolvedValueOnce(undefined);
+    const stopAllClients = vi
+      .spyOn(SessionTerminationCoordinator.prototype, 'stopAllClients')
+      .mockResolvedValue(undefined);
     const { service } = createLifecycleHarness();
     const sessionOptions = {
       cleanupTransientRatchetSession: false,
@@ -140,31 +143,42 @@ describe('SessionLifecycleFacade', () => {
     await expect(
       service.stopWorkspaceSessions('workspace-exact', workspaceOptions)
     ).resolves.toBeUndefined();
+    await expect(service.stopAllClients(4321)).resolves.toBeUndefined();
+    await expect(service.stopAllClients()).resolves.toBeUndefined();
 
     expect(stopSession).toHaveBeenCalledWith('session-exact', sessionOptions);
     expect(stopWorkspaceSessions).toHaveBeenCalledWith('workspace-exact', workspaceOptions);
+    expect(stopAllClients).toHaveBeenNthCalledWith(1, 4321);
+    expect(stopAllClients).toHaveBeenNthCalledWith(2, 5000);
     stopSession.mockRestore();
     stopWorkspaceSessions.mockRestore();
+    stopAllClients.mockRestore();
   });
 
   it('preserves termination coordinator rejections', async () => {
     const sessionFailure = new Error('session stop rejected');
     const workspaceFailure = new Error('workspace stop rejected');
+    const shutdownFailure = new Error('shutdown rejected');
     const stopSession = vi
       .spyOn(SessionTerminationCoordinator.prototype, 'stopSession')
       .mockRejectedValueOnce(sessionFailure);
     const stopWorkspaceSessions = vi
       .spyOn(SessionTerminationCoordinator.prototype, 'stopWorkspaceSessions')
       .mockRejectedValueOnce(workspaceFailure);
+    const stopAllClients = vi
+      .spyOn(SessionTerminationCoordinator.prototype, 'stopAllClients')
+      .mockRejectedValueOnce(shutdownFailure);
     const { service } = createLifecycleHarness();
 
     await expect(service.stopSession('session-rejected')).rejects.toBe(sessionFailure);
     await expect(service.stopWorkspaceSessions('workspace-rejected')).rejects.toBe(
       workspaceFailure
     );
+    await expect(service.stopAllClients()).rejects.toBe(shutdownFailure);
 
     stopSession.mockRestore();
     stopWorkspaceSessions.mockRestore();
+    stopAllClients.mockRestore();
   });
 
   it('skips the restart default continue prompt when notifications are queued', async () => {

--- a/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
+++ b/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
@@ -109,7 +109,6 @@ export class SessionLifecycleService {
   private readonly runtimeExitCoordinator: SessionRuntimeExitCoordinator;
   private readonly sendSessionMessage: SendSessionMessage;
   private readonly onBeforeStopSession?: (sessionId: string) => void;
-  private readonly clientCreationOperations = new Map<string, Set<Promise<unknown>>>();
   private startupCoordinator: SessionStartupCoordinator | null = null;
   private workspaceBridge: SessionLifecycleWorkspaceBridge | null = null;
   private messageQueueBridge: SessionLifecycleMessageQueueBridge | null = null;
@@ -183,8 +182,6 @@ export class SessionLifecycleService {
       getMessageQueueBridge: () => this.messageQueueBridge,
       sendSessionMessage: this.sendSessionMessage,
       stopSession: (sessionId, options) => this.stopSession(sessionId, options),
-      registerClientCreation: (sessionId, operation) =>
-        this.registerClientCreation(sessionId, operation),
     });
   }
 
@@ -257,7 +254,7 @@ export class SessionLifecycleService {
 
     let stopClientFailed = false;
     try {
-      await this.stopRuntimeAndPendingCreation(sessionId);
+      await this.runtimeManager.stopAndQuiesce(sessionId);
     } catch (error) {
       stopClientFailed = true;
       logger.warn('Error stopping ACP session runtime; continuing cleanup', {
@@ -296,26 +293,6 @@ export class SessionLifecycleService {
         acpTraceLogger.closeSession(sessionId);
       }
     }
-  }
-
-  private async stopRuntimeAndPendingCreation(sessionId: string): Promise<void> {
-    let stopError: { cause: unknown } | undefined;
-    try {
-      await this.runtimeManager.stopClient(sessionId);
-    } catch (error) {
-      stopError = { cause: error };
-    }
-
-    const pendingCreations = this.clientCreationOperations.get(sessionId);
-    if (!pendingCreations || pendingCreations.size === 0) {
-      if (stopError) {
-        throw stopError.cause;
-      }
-      return;
-    }
-
-    await Promise.allSettled([...pendingCreations]);
-    await this.runtimeManager.stopClient(sessionId);
   }
 
   async stopWorkspaceSessions(
@@ -592,23 +569,5 @@ export class SessionLifecycleService {
   }
   recoverStaleRunningSessions(): Promise<number> {
     return this.workflowFinalizer.recoverStaleRunningSessions();
-  }
-
-  private registerClientCreation(
-    sessionId: string,
-    operation: Promise<unknown>
-  ): { isOnlyOperation: () => boolean; release: () => void } {
-    const operations = this.clientCreationOperations.get(sessionId) ?? new Set<Promise<unknown>>();
-    operations.add(operation);
-    this.clientCreationOperations.set(sessionId, operations);
-    return {
-      isOnlyOperation: () => operations.size === 1,
-      release: () => {
-        operations.delete(operation);
-        if (operations.size === 0) {
-          this.clientCreationOperations.delete(sessionId);
-        }
-      },
-    };
   }
 }

--- a/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
+++ b/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
@@ -7,14 +7,12 @@ import type {
   SessionLifecycleMessageQueueBridge,
   SessionLifecycleWorkspaceBridge,
 } from '@/backend/services/session/service/bridges';
-import { acpTraceLogger } from '@/backend/services/session/service/logging/acp-trace-logger.service';
 import type { SessionDomainService } from '@/backend/services/session/service/session-domain.service';
 import { sessionEventBus } from '@/backend/services/session/service/session-event-bus';
 import { workspaceDataService } from '@/backend/services/workspace';
 import {
   SessionLifecycleEventKind,
   SessionLifecycleEventReason,
-  SessionStatus,
   type WorkspaceStatus,
 } from '@/shared/core';
 import {
@@ -40,29 +38,19 @@ import {
   SessionStartupCoordinator,
   type StartSessionOptions,
 } from './session-startup.coordinator';
+import {
+  type SessionStopReason,
+  SessionTerminationCoordinator,
+  type StopSessionOptions,
+} from './session-termination.coordinator';
 import { SessionWorkflowFinalizer } from './session-workflow-finalizer';
+
+export type { SessionStopReason, StopSessionOptions } from './session-termination.coordinator';
 
 const logger = createLogger('session');
 
-export type SessionStopReason =
-  | 'USER_STOP'
-  | 'SESSION_CLOSED'
-  | 'WORKSPACE_ARCHIVED'
-  | 'SYSTEM_STOP';
-
-export type StopSessionOptions = {
-  cleanupTransientRatchetSession?: boolean;
-  recordLifecycleEvent?: boolean;
-  reason?: SessionStopReason;
-};
-
-const SESSION_STOP_MESSAGES: Record<SessionStopReason, string> = {
-  USER_STOP: 'Session stopped by you.',
-  SESSION_CLOSED: 'Session closed by you.',
-  WORKSPACE_ARCHIVED: 'Session stopped because the workspace was archived.',
-  SYSTEM_STOP: 'Session stopped by the system.',
-};
 const SHUTDOWN_LIFECYCLE_RECORD_TIMEOUT_MS = 1000;
+const SHUTDOWN_SESSION_STOP_MESSAGE = 'Session stopped by the system.';
 
 type SendSessionMessage = (sessionId: string, content: string) => Promise<void>;
 type HydrateProviderHistory = (
@@ -106,9 +94,9 @@ export class SessionLifecycleService {
   private readonly lifecycleGate: SessionLifecycleGate;
   private readonly hydrateProviderHistory: HydrateProviderHistory;
   private readonly workflowFinalizer: SessionWorkflowFinalizer;
+  private readonly terminationCoordinator: SessionTerminationCoordinator;
   private readonly runtimeExitCoordinator: SessionRuntimeExitCoordinator;
   private readonly sendSessionMessage: SendSessionMessage;
-  private readonly onBeforeStopSession?: (sessionId: string) => void;
   private startupCoordinator: SessionStartupCoordinator | null = null;
   private workspaceBridge: SessionLifecycleWorkspaceBridge | null = null;
   private messageQueueBridge: SessionLifecycleMessageQueueBridge | null = null;
@@ -140,6 +128,20 @@ export class SessionLifecycleService {
       runtimeManager: this.runtimeManager,
       countViewers: (sessionId) => sessionEventBus.countViewers(sessionId),
     });
+    this.terminationCoordinator = new SessionTerminationCoordinator({
+      repository: this.repository,
+      retryService: this.retryService,
+      runtimeManager: this.runtimeManager,
+      sessionDomainService: this.sessionDomainService,
+      sessionPermissionService: this.sessionPermissionService,
+      acpEventProcessor: this.acpEventProcessor,
+      promptTurnCompletionService: this.promptTurnCompletionService,
+      lifecycleEventService: this.lifecycleEventService,
+      lifecycleGate: this.lifecycleGate,
+      workflowFinalizer: this.workflowFinalizer,
+      getWorkspaceBridge: () => this.workspaceBridge,
+      onBeforeStopSession: options.onBeforeStopSession,
+    });
     this.runtimeExitCoordinator = new SessionRuntimeExitCoordinator({
       repository: this.repository,
       sessionDomainService: this.sessionDomainService,
@@ -152,7 +154,6 @@ export class SessionLifecycleService {
       onSessionExit: options.onSessionExit,
     });
     this.sendSessionMessage = options.sendSessionMessage;
-    this.onBeforeStopSession = options.onBeforeStopSession;
   }
   configure(bridges: {
     workspace: SessionLifecycleWorkspaceBridge;
@@ -203,147 +204,14 @@ export class SessionLifecycleService {
   }
 
   async stopSession(sessionId: string, options?: StopSessionOptions): Promise<void> {
-    const stopReservation = this.lifecycleGate.reserveStop(sessionId);
-    if (!stopReservation) {
-      logger.debug('Session stop already in progress', { sessionId });
-      return;
-    }
-
-    const stopInvocationId = randomUUID();
-    try {
-      await this.stopSessionWithBarrier(sessionId, stopInvocationId, options);
-    } finally {
-      stopReservation.release();
-    }
-  }
-
-  private async stopSessionWithBarrier(
-    sessionId: string,
-    stopInvocationId: string,
-    options?: StopSessionOptions
-  ): Promise<void> {
-    this.promptTurnCompletionService.clearSession(sessionId);
-    this.onBeforeStopSession?.(sessionId);
-    this.sessionDomainService.clearQueuedWork(sessionId, { emitSnapshot: true });
-    const session = await this.loadSessionForStop(sessionId);
-    const workspaceId = session?.workspaceId ?? this.acpEventProcessor.getWorkspaceId(sessionId);
-    const reason = options?.reason ?? 'SYSTEM_STOP';
-
-    if (workspaceId && options?.recordLifecycleEvent !== false) {
-      await this.lifecycleEventService.record({
-        workspaceId,
-        sessionId,
-        kind: SessionLifecycleEventKind.SESSION_STOPPED,
-        reason,
-        message: SESSION_STOP_MESSAGES[reason],
-        dedupeKey: `session-stop:${stopInvocationId}`,
-      });
-    }
-
-    const current = this.getRuntimeSnapshot(sessionId);
-    this.sessionDomainService.setRuntimeSnapshot(sessionId, {
-      ...current,
-      phase: 'stopping',
-      activity: 'IDLE',
-      updatedAt: new Date().toISOString(),
-    });
-
-    this.acpEventProcessor.clearStreamingState(sessionId);
-    this.acpEventProcessor.clearReplaySuppression(sessionId);
-    this.sessionPermissionService.cancelPendingRequests(sessionId);
-
-    let stopClientFailed = false;
-    try {
-      await this.runtimeManager.stopAndQuiesce(sessionId);
-    } catch (error) {
-      stopClientFailed = true;
-      logger.warn('Error stopping ACP session runtime; continuing cleanup', {
-        sessionId,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    } finally {
-      this.finalizeOrphanedToolCalls(sessionId, 'session_stop');
-      await this.updateStoppedSessionState(sessionId);
-      this.sessionDomainService.setRuntimeSnapshot(sessionId, {
-        phase: 'idle',
-        processState: 'stopped',
-        activity: 'IDLE',
-        updatedAt: new Date().toISOString(),
-      });
-      this.markWorkspaceSessionIdleOnStop(workspaceId, sessionId);
-      this.acpEventProcessor.clearSessionState(sessionId);
-
-      if (!stopClientFailed) {
-        const shouldCleanupTransientRatchetSession =
-          options?.cleanupTransientRatchetSession ?? true;
-        await this.workflowFinalizer.finalizeDeliberateStop({
-          session,
-          sessionId,
-          cleanupTransientRatchetSession: shouldCleanupTransientRatchetSession,
-        });
-      }
-
-      try {
-        this.workflowFinalizer.clearInactiveSession(sessionId, 'manual_stop');
-        logger.info('ACP session stopped', {
-          sessionId,
-          ...(stopClientFailed ? { runtimeStopFailed: true } : {}),
-        });
-      } finally {
-        acpTraceLogger.closeSession(sessionId);
-      }
-    }
+    await this.terminationCoordinator.stopSession(sessionId, options);
   }
 
   async stopWorkspaceSessions(
     workspaceId: string,
     options?: { reason?: SessionStopReason }
   ): Promise<void> {
-    const sessions = await this.repository.getSessionsByWorkspaceId(workspaceId);
-    const stopErrors: unknown[] = [];
-
-    for (const session of sessions) {
-      const stopOptions = this.getWorkspaceSessionStopOptions(
-        session,
-        options?.reason ?? 'SYSTEM_STOP'
-      );
-      if (!stopOptions) {
-        continue;
-      }
-      try {
-        await this.stopSession(session.id, stopOptions);
-      } catch (error) {
-        logger.error('Failed to stop workspace session', {
-          sessionId: session.id,
-          workspaceId,
-          error: error instanceof Error ? error.message : String(error),
-        });
-        stopErrors.push(error);
-      }
-    }
-
-    if (stopErrors.length > 0) {
-      throw new Error(
-        `Failed to stop ${stopErrors.length} workspace session${stopErrors.length === 1 ? '' : 's'}`
-      );
-    }
-
-    logger.info('Stopped all workspace sessions', { workspaceId, count: sessions.length });
-  }
-
-  private getWorkspaceSessionStopOptions(
-    session: { id: string; status: SessionStatus },
-    reason: SessionStopReason
-  ): StopSessionOptions | null {
-    const browseOnlyClient = this.runtimeManager.isBrowseOnlySession(session.id);
-    const activeClient = this.runtimeManager.isSessionRunning(session.id);
-    if (!(session.status === SessionStatus.RUNNING || activeClient || browseOnlyClient)) {
-      return null;
-    }
-    return {
-      reason,
-      ...(browseOnlyClient && !activeClient ? { recordLifecycleEvent: false } : {}),
-    };
+    await this.terminationCoordinator.stopWorkspaceSessions(workspaceId, options);
   }
 
   async getOrCreateSessionClient(
@@ -459,7 +327,7 @@ export class SessionLifecycleService {
       sessionId,
       kind: SessionLifecycleEventKind.SESSION_STOPPED,
       reason: SessionLifecycleEventReason.SYSTEM_STOP,
-      message: SESSION_STOP_MESSAGES.SYSTEM_STOP,
+      message: SHUTDOWN_SESSION_STOP_MESSAGE,
       dedupeKey: `session-stop:${randomUUID()}`,
     });
   }
@@ -494,35 +362,6 @@ export class SessionLifecycleService {
     }
   }
 
-  private finalizeOrphanedToolCalls(sessionId: string, reason: string): void {
-    try {
-      this.acpEventProcessor.finalizeOrphanedToolCalls(sessionId, reason);
-    } catch (error) {
-      logger.warn('Failed finalizing orphaned ACP tool calls', {
-        sessionId,
-        reason,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      this.acpEventProcessor.clearPendingToolCalls(sessionId);
-    }
-  }
-
-  private markWorkspaceSessionIdleOnStop(workspaceId: string | undefined, sessionId: string): void {
-    if (!(workspaceId && this.workspaceBridge)) {
-      return;
-    }
-
-    try {
-      this.workspaceBridge.markSessionIdle(workspaceId, sessionId);
-    } catch (error) {
-      logger.warn('Failed to mark workspace session idle during stop', {
-        sessionId,
-        workspaceId,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
-  }
-
   private async loadSessionForStop(sessionId: string): Promise<AgentSessionRecord | null> {
     try {
       return await this.retryService.run(() => this.repository.getSessionById(sessionId), {
@@ -536,31 +375,6 @@ export class SessionLifecycleService {
         error: error instanceof Error ? error.message : String(error),
       });
       return null;
-    }
-  }
-
-  private async updateStoppedSessionState(sessionId: string): Promise<void> {
-    try {
-      await this.retryService.run(
-        () =>
-          this.repository.updateSessionIfStatus(
-            sessionId,
-            {
-              status: SessionStatus.IDLE,
-            },
-            [SessionStatus.RUNNING]
-          ),
-        {
-          attempts: 2,
-          operationName: 'updateStoppedSessionState',
-          context: { sessionId },
-        }
-      );
-    } catch (error) {
-      logger.warn('Failed to update session state during stop; continuing cleanup', {
-        sessionId,
-        error: error instanceof Error ? error.message : String(error),
-      });
     }
   }
 

--- a/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
+++ b/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-import { createLogger } from '@/backend/services/logger.service';
 import type { AgentSessionRecord } from '@/backend/services/session/resources/agent-session.accessor';
 import type { AcpRuntimeManager } from '@/backend/services/session/service/acp';
 import type {
@@ -10,11 +8,7 @@ import type {
 import type { SessionDomainService } from '@/backend/services/session/service/session-domain.service';
 import { sessionEventBus } from '@/backend/services/session/service/session-event-bus';
 import { workspaceDataService } from '@/backend/services/workspace';
-import {
-  SessionLifecycleEventKind,
-  SessionLifecycleEventReason,
-  type WorkspaceStatus,
-} from '@/shared/core';
+import type { WorkspaceStatus } from '@/shared/core';
 import {
   createInitialSessionRuntimeState,
   type SessionRuntimeState,
@@ -46,11 +40,6 @@ import {
 import { SessionWorkflowFinalizer } from './session-workflow-finalizer';
 
 export type { SessionStopReason, StopSessionOptions } from './session-termination.coordinator';
-
-const logger = createLogger('session');
-
-const SHUTDOWN_LIFECYCLE_RECORD_TIMEOUT_MS = 1000;
-const SHUTDOWN_SESSION_STOP_MESSAGE = 'Session stopped by the system.';
 
 type SendSessionMessage = (sessionId: string, content: string) => Promise<void>;
 type HydrateProviderHistory = (
@@ -296,86 +285,7 @@ export class SessionLifecycleService {
   }
 
   async stopAllClients(timeoutMs = 5000): Promise<void> {
-    this.promptTurnCompletionService.clearAll();
-    const shutdownSessionIds = this.runtimeManager.beginShutdown();
-    const activeShutdownSessionIds = shutdownSessionIds.filter(
-      (sessionId) => !this.runtimeManager.isBrowseOnlySession(sessionId)
-    );
-    this.lifecycleGate.reserveShutdown(activeShutdownSessionIds);
-
-    await this.recordShutdownLifecycleEvents(activeShutdownSessionIds);
-
-    try {
-      await this.runtimeManager.stopAllClients(timeoutMs);
-    } catch (error) {
-      logger.error('Failed to stop ACP clients during shutdown', {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      throw error;
-    }
-  }
-
-  private async recordShutdownLifecycleEvent(sessionId: string): Promise<void> {
-    const session = await this.loadSessionForStop(sessionId);
-    const workspaceId = session?.workspaceId ?? this.acpEventProcessor.getWorkspaceId(sessionId);
-    if (!workspaceId) {
-      logger.warn('Skipped shutdown lifecycle event without workspace owner', { sessionId });
-      return;
-    }
-    await this.lifecycleEventService.record({
-      workspaceId,
-      sessionId,
-      kind: SessionLifecycleEventKind.SESSION_STOPPED,
-      reason: SessionLifecycleEventReason.SYSTEM_STOP,
-      message: SHUTDOWN_SESSION_STOP_MESSAGE,
-      dedupeKey: `session-stop:${randomUUID()}`,
-    });
-  }
-
-  private async recordShutdownLifecycleEvents(sessionIds: string[]): Promise<void> {
-    const resultsPromise = Promise.allSettled(
-      sessionIds.map((sessionId) => this.recordShutdownLifecycleEvent(sessionId))
-    );
-    let timeout: ReturnType<typeof setTimeout> | undefined;
-    const results = await Promise.race([
-      resultsPromise,
-      new Promise<null>((resolve) => {
-        timeout = setTimeout(() => resolve(null), SHUTDOWN_LIFECYCLE_RECORD_TIMEOUT_MS);
-      }),
-    ]);
-    if (timeout) {
-      clearTimeout(timeout);
-    }
-    if (results === null) {
-      logger.warn('Timed out recording shutdown lifecycle events; continuing shutdown', {
-        timeoutMs: SHUTDOWN_LIFECYCLE_RECORD_TIMEOUT_MS,
-      });
-      return;
-    }
-    for (const [index, result] of results.entries()) {
-      if (result.status === 'rejected') {
-        logger.warn('Failed recording shutdown lifecycle event; continuing shutdown', {
-          sessionId: sessionIds[index],
-          error: result.reason instanceof Error ? result.reason.message : String(result.reason),
-        });
-      }
-    }
-  }
-
-  private async loadSessionForStop(sessionId: string): Promise<AgentSessionRecord | null> {
-    try {
-      return await this.retryService.run(() => this.repository.getSessionById(sessionId), {
-        attempts: 2,
-        operationName: 'loadSessionForStop',
-        context: { sessionId },
-      });
-    } catch (error) {
-      logger.warn('Failed to load session before stop; continuing with process shutdown', {
-        sessionId,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return null;
-    }
+    await this.terminationCoordinator.stopAllClients(timeoutMs);
   }
 
   persistClosedSession(sessionId: string): Promise<void> {

--- a/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
+++ b/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
@@ -128,6 +128,7 @@ export class SessionLifecycleService {
       lifecycleEventService: this.lifecycleEventService,
       lifecycleGate: this.lifecycleGate,
       workflowFinalizer: this.workflowFinalizer,
+      getRuntimeSnapshot: (sessionId) => this.getRuntimeSnapshot(sessionId),
       getWorkspaceBridge: () => this.workspaceBridge,
       onBeforeStopSession: options.onBeforeStopSession,
     });

--- a/src/backend/services/session/service/lifecycle/session.service.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.service.test.ts
@@ -9,7 +9,6 @@ const mockNotifyToolStart = vi.fn();
 const mockNotifyToolComplete = vi.fn();
 const mockRecordRatchetSessionEnd = vi.fn();
 const mockAcpTraceLoggerCloseSession = vi.fn();
-
 vi.mock('@/backend/services/logger.service', () => ({
   createLogger: () => ({
     debug: vi.fn(),
@@ -19,12 +18,31 @@ vi.mock('@/backend/services/logger.service', () => ({
   }),
   getCurrentProcessEnv: () => ({ ...process.env }),
 }));
-
 vi.mock('@/backend/services/workspace');
 vi.mock('./closed-session-persistence.service');
-
 vi.mock('@/backend/services/session/service/acp', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
+  const runtimeManager = {
+    getClient: vi.fn().mockReturnValue(undefined),
+    getOrCreateClient: vi.fn(),
+    runClientCreationOperation: vi.fn(
+      async (_sessionId, _purpose, operation) => await operation({ isOnlyOperation: () => true })
+    ),
+    stopClient: vi.fn(),
+    stopAndQuiesce: vi.fn(async (sessionId: string) => await runtimeManager.stopClient(sessionId)),
+    beginShutdown: vi.fn().mockReturnValue([]),
+    stopAllClients: vi.fn(),
+    sendPrompt: vi.fn(),
+    cancelPrompt: vi.fn(),
+    isSessionRunning: vi.fn().mockReturnValue(false),
+    isSessionWorking: vi.fn().mockReturnValue(false),
+    isAnySessionWorking: vi.fn().mockReturnValue(false),
+    isBrowseOnlySession: vi.fn().mockReturnValue(false),
+    isStopInProgress: vi.fn().mockReturnValue(false),
+    setConfigOption: vi.fn(),
+    setSessionMode: vi.fn(),
+    setSessionModel: vi.fn(),
+  };
   return {
     ...actual,
     AcpEventTranslator: class MockAcpEventTranslator {
@@ -34,33 +52,15 @@ vi.mock('@/backend/services/session/service/acp', async (importOriginal) => {
       cancelAll = vi.fn();
       resolvePermission = vi.fn();
     },
-    acpRuntimeManager: {
-      getClient: vi.fn().mockReturnValue(undefined),
-      getOrCreateClient: vi.fn(),
-      stopClient: vi.fn(),
-      beginShutdown: vi.fn().mockReturnValue([]),
-      stopAllClients: vi.fn(),
-      sendPrompt: vi.fn(),
-      cancelPrompt: vi.fn(),
-      isSessionRunning: vi.fn().mockReturnValue(false),
-      isSessionWorking: vi.fn().mockReturnValue(false),
-      isAnySessionWorking: vi.fn().mockReturnValue(false),
-      isBrowseOnlySession: vi.fn().mockReturnValue(false),
-      isStopInProgress: vi.fn().mockReturnValue(false),
-      setConfigOption: vi.fn(),
-      setSessionMode: vi.fn(),
-      setSessionModel: vi.fn(),
-    },
+    acpRuntimeManager: runtimeManager,
   };
 });
-
 vi.mock('@/backend/interceptors/registry', () => ({
   interceptorRegistry: {
     notifyToolStart: (...args: unknown[]) => mockNotifyToolStart(...args),
     notifyToolComplete: (...args: unknown[]) => mockNotifyToolComplete(...args),
   },
 }));
-
 vi.mock('./session.repository', () => ({
   SessionRepository: class {},
   sessionRepository: {

--- a/src/backend/services/session/service/lifecycle/session.service.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.service.test.ts
@@ -25,11 +25,17 @@ vi.mock('@/backend/services/session/service/acp', async (importOriginal) => {
   const RuntimeQuiescence =
     actual.AcpRuntimeQuiescence as typeof import('@/backend/services/session/service/acp').AcpRuntimeQuiescence;
   const stopClient = vi.fn(async () => undefined);
-  const quiescence = new RuntimeQuiescence({ stopClient });
+  let quiescence = new RuntimeQuiescence({ stopClient });
+  beforeEach(() => {
+    stopClient.mockReset().mockResolvedValue(undefined);
+    quiescence = new RuntimeQuiescence({ stopClient });
+  });
   const runtimeManager = {
     getClient: vi.fn().mockReturnValue(undefined),
     getOrCreateClient: vi.fn(),
-    runClientCreationOperation: vi.fn(quiescence.runClientCreationOperation.bind(quiescence)),
+    runClientCreationOperation: vi.fn((sessionId, purpose, operation) =>
+      quiescence.runClientCreationOperation(sessionId, purpose, operation)
+    ),
     stopClient,
     stopAndQuiesce: vi.fn((sessionId: string) => quiescence.stopAndQuiesce(sessionId)),
     beginShutdown: vi.fn().mockReturnValue([]),
@@ -97,6 +103,7 @@ import { workspaceDataService } from '@/backend/services/workspace';
 import { closedSessionPersistenceService } from './closed-session-persistence.service';
 import { sessionPromptBuilder } from './session.prompt-builder';
 import { sessionRepository } from './session.repository';
+import { createDeferred } from './session-lifecycle.test-helpers';
 import {
   acpEventProcessor,
   sessionLifecycleService,
@@ -104,32 +111,15 @@ import {
   sessionService,
 } from './session-services';
 
-function getAcpProcessorState() {
-  return acpEventProcessor;
-}
-
+const getAcpProcessorState = () => acpEventProcessor;
 function mockCreatedAcpClient(acpHandle: AcpProcessHandle): void {
   vi.mocked(acpRuntimeManager.getOrCreateClient).mockImplementation(() => {
     vi.mocked(acpRuntimeManager.getClient).mockReturnValue(acpHandle);
     return Promise.resolve(acpHandle);
   });
 }
-
-function createDeferred<T>(): {
-  promise: Promise<T>;
-  resolve: (value: T) => void;
-  reject: (reason?: unknown) => void;
-} {
-  let resolvePromise!: (value: T) => void;
-  let rejectPromise!: (reason?: unknown) => void;
-  const promise = new Promise<T>((resolve, reject) => {
-    resolvePromise = resolve;
-    rejectPromise = reject;
-  });
-  return { promise, resolve: resolvePromise, reject: rejectPromise };
-}
-
 describe('SessionService', () => {
+  const sessionId = 'session-fixture-isolation';
   beforeEach(() => {
     vi.clearAllMocks();
     mockNotifyToolStart.mockReset();
@@ -147,12 +137,8 @@ describe('SessionService', () => {
       recordRatchetSessionEnd: mockRecordRatchetSessionEnd,
       resetPRDiscoveryBackoff: vi.fn(async () => true),
     };
-    sessionService.configure({
-      workspace: workspaceBridge,
-    });
-    sessionLifecycleService.configure({
-      workspace: workspaceBridge,
-    });
+    sessionService.configure({ workspace: workspaceBridge });
+    sessionLifecycleService.configure({ workspace: workspaceBridge });
     vi.mocked(acpRuntimeManager.getClient).mockReturnValue(undefined);
     vi.mocked(acpRuntimeManager.isSessionRunning).mockReturnValue(false);
     vi.mocked(acpRuntimeManager.isSessionWorking).mockReturnValue(false);
@@ -168,7 +154,24 @@ describe('SessionService', () => {
     vi.mocked(closedSessionPersistenceService.persistClosedSession).mockResolvedValue();
     vi.mocked(sessionRepository.updateSessionIfStatus).mockResolvedValue(1);
   });
-
+  it('can leave a runtime quiescence barrier pending', async () => {
+    const pending = createDeferred<void>();
+    void acpRuntimeManager.runClientCreationOperation(sessionId, 'active', () => pending.promise);
+    void acpRuntimeManager.stopAndQuiesce(sessionId);
+    await expect(
+      acpRuntimeManager.runClientCreationOperation(sessionId, 'active', () =>
+        Promise.resolve('late')
+      )
+    ).rejects.toThrow('ACP session stop requested');
+  });
+  it('starts the next test with isolated runtime quiescence state', async () => {
+    await expect(
+      acpRuntimeManager.runClientCreationOperation(sessionId, 'active', (registration) => {
+        expect(registration.isOnlyOperation()).toBe(true);
+        return Promise.resolve('created');
+      })
+    ).resolves.toBe('created');
+  });
   it('starts a session via ACP runtime and updates DB state', async () => {
     const session = unsafeCoerce<
       NonNullable<Awaited<ReturnType<typeof sessionRepository.getSessionById>>>
@@ -181,7 +184,6 @@ describe('SessionService', () => {
       provider: 'CLAUDE',
       providerSessionId: null,
     });
-
     const workspace = unsafeCoerce<Awaited<ReturnType<typeof sessionRepository.getWorkspaceById>>>({
       id: 'workspace-1',
       worktreePath: '/tmp/work',
@@ -192,12 +194,10 @@ describe('SessionService', () => {
       description: null,
       projectId: 'project-1',
     });
-
     const project = unsafeCoerce<Awaited<ReturnType<typeof sessionRepository.getProjectById>>>({
       id: 'project-1',
       githubOwner: 'owner',
     });
-
     const acpHandle = unsafeCoerce<AcpProcessHandle>({
       getPid: vi.fn().mockReturnValue(123),
       isPromptInFlight: false,

--- a/src/backend/services/session/service/lifecycle/session.service.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.service.test.ts
@@ -22,14 +22,16 @@ vi.mock('@/backend/services/workspace');
 vi.mock('./closed-session-persistence.service');
 vi.mock('@/backend/services/session/service/acp', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
+  const RuntimeQuiescence =
+    actual.AcpRuntimeQuiescence as typeof import('@/backend/services/session/service/acp').AcpRuntimeQuiescence;
+  const stopClient = vi.fn(async () => undefined);
+  const quiescence = new RuntimeQuiescence({ stopClient });
   const runtimeManager = {
     getClient: vi.fn().mockReturnValue(undefined),
     getOrCreateClient: vi.fn(),
-    runClientCreationOperation: vi.fn(
-      async (_sessionId, _purpose, operation) => await operation({ isOnlyOperation: () => true })
-    ),
-    stopClient: vi.fn(),
-    stopAndQuiesce: vi.fn(async (sessionId: string) => await runtimeManager.stopClient(sessionId)),
+    runClientCreationOperation: vi.fn(quiescence.runClientCreationOperation.bind(quiescence)),
+    stopClient,
+    stopAndQuiesce: vi.fn((sessionId: string) => quiescence.stopAndQuiesce(sessionId)),
     beginShutdown: vi.fn().mockReturnValue([]),
     stopAllClients: vi.fn(),
     sendPrompt: vi.fn(),
@@ -75,7 +77,6 @@ vi.mock('./session.repository', () => ({
     recoverStaleRunningSessions: vi.fn(),
   },
 }));
-
 vi.mock('./session.prompt-builder', () => ({
   SessionPromptBuilder: class {},
   sessionPromptBuilder: {
@@ -83,7 +84,6 @@ vi.mock('./session.prompt-builder', () => ({
     buildSystemPrompt: vi.fn(),
   },
 }));
-
 vi.mock('@/backend/services/session/service/logging/acp-trace-logger.service', () => ({
   acpTraceLogger: {
     log: vi.fn(),


### PR DESCRIPTION
## Summary

- move client-creation reconciliation fences into `AcpRuntimeManager` and add an idempotent `stopAndQuiesce` contract
- extract explicit, workspace, and shutdown stop policy into `SessionTerminationCoordinator`
- preserve the public lifecycle facade while reducing it from 614 to 297 lines
- add public race coverage for startup/stop overlap, duplicate stops, shutdown admission, mixed active/browse work, and bounded shutdown recording

## Why

Lifecycle and runtime layers both tracked client creation, so stop and shutdown had overlapping authorities and subtle windows where startup reconciliation could outlive a stop. This gives runtime promises and process state one owner while keeping domain eligibility and cleanup policy behind the lifecycle gate/coordinator.

The runtime fence deliberately spans the full startup operation through durable `RUNNING` reconciliation—not just ACP process creation—so a completed stop cannot leave a newly persisted running session behind.

## Validation

- `pnpm check:fix`
- `pnpm typecheck`
- `pnpm test --maxWorkers=2` — 5,265 passed, 4 skipped
- `pnpm check` — all guardrails passed
- task-scoped reviews after each extraction plus a whole-branch concurrency review and scoped fix re-review

The local Codex schema subcheck used its normal skip because installed CLI 0.147.0 differs from pinned 0.145.0; CI installs the pinned CLI and enforces it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 68e0e627a496fdcc3c52ddfd41ee11234f9eacef. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->