### PR TITLE
Finish session lifecycle modularization

### DIFF
--- a/docs/architecture/agent-runtime.md
+++ b/docs/architecture/agent-runtime.md
@@ -33,6 +33,28 @@ The ACP layer is import-fenced by dependency-cruiser
 app-server schemas are generated — run `pnpm codex:schema:generate` and check
 drift with `pnpm check:codex-schema`.
 
+## Session lifecycle ownership
+
+`SessionLifecycleGate` owns domain startup/stop eligibility. `AcpRuntimeManager`
+owns subprocess handles, pending creation, incarnation filtering, and
+quiescence. Lifecycle work has one owner per responsibility; transport handlers
+consume the composed services and never wire lifecycle dependencies.
+Startup, termination, runtime exit, notifications, context, and workflow
+finalization each have one coordinator or service.
+
+| Responsibility | Owner | Reconciliation point |
+| --- | --- | --- |
+| Startup | `SessionStartupCoordinator` | Persisted `RUNNING` state |
+| Termination | `SessionTerminationCoordinator` | Persisted idle/stopped state |
+| Runtime exit | `SessionRuntimeExitCoordinator` | Terminal status and provider history |
+| Notifications | `SessionNotificationDeliveryService` | Transcript plus delivered evidence |
+| Context | `SessionContextService` | Session context is resolved before lifecycle work |
+| Workflow finalization | `SessionWorkflowFinalizer` | Idempotent workflow completion |
+
+When changing lifecycle behavior, keep these boundaries intact: coordinators
+or services reconcile their own responsibility, while the lifecycle facade
+delegates public operations and the session composition root wires the owners.
+
 ## Provider sub-agents
 
 Provider-initiated sub-agents are session-scoped, read-only, and provider-owned.

--- a/docs/architecture/agent-runtime.md
+++ b/docs/architecture/agent-runtime.md
@@ -39,6 +39,7 @@ drift with `pnpm check:codex-schema`.
 owns subprocess handles, pending creation, incarnation filtering, and
 quiescence. Lifecycle work has one owner per responsibility; transport handlers
 consume the composed services and never wire lifecycle dependencies.
+
 Startup, termination, runtime exit, notifications, context, and workflow
 finalization each have one coordinator or service.
 
@@ -46,14 +47,15 @@ finalization each have one coordinator or service.
 | --- | --- | --- |
 | Startup | `SessionStartupCoordinator` | Persisted `RUNNING` state |
 | Termination | `SessionTerminationCoordinator` | Persisted idle/stopped state |
-| Runtime exit | `SessionRuntimeExitCoordinator` | Terminal status and provider history |
+| Runtime exit | `SessionRuntimeExitCoordinator` | Terminal status and unexpected-exit lifecycle history |
 | Notifications | `SessionNotificationDeliveryService` | Transcript plus delivered evidence |
-| Context | `SessionContextService` | Session context is resolved before lifecycle work |
+| Context | `SessionContextService` | Operational precondition; no durable-state reconciliation |
 | Workflow finalization | `SessionWorkflowFinalizer` | Idempotent workflow completion |
 
 When changing lifecycle behavior, keep these boundaries intact: coordinators
-or services reconcile their own responsibility, while the lifecycle facade
-delegates public operations and the session composition root wires the owners.
+and services own their named responsibility and reconciliation evidence where
+applicable; context supplies operational inputs. The lifecycle facade delegates
+public operations and the session composition root wires the owners.
 
 ## Provider sub-agents
 

--- a/src/backend/services/session/service/index.ts
+++ b/src/backend/services/session/service/index.ts
@@ -34,8 +34,12 @@ export { sessionInterceptorBridge } from './interceptor.bridge';
 export type { ClosedSessionTranscript } from './lifecycle/closed-session-persistence.service';
 export { SessionConfigService } from './lifecycle/session.config.service';
 export {
+  type GetOrCreateSessionClientOptions,
+  type LifecycleBridges,
   SessionLifecycleService,
   type SessionStopReason,
+  type StartSessionOptions,
+  type StopSessionOptions,
 } from './lifecycle/session.lifecycle.service';
 export { SessionPermissionService } from './lifecycle/session.permission.service';
 export {

--- a/src/backend/services/session/service/lifecycle/session-core-services.ts
+++ b/src/backend/services/session/service/lifecycle/session-core-services.ts
@@ -2,7 +2,10 @@ import { createLogger } from '@/backend/services/logger.service';
 import { sessionLifecycleEventAccessor } from '@/backend/services/session/resources/session-lifecycle-event.accessor';
 import { acpRuntimeManager } from '@/backend/services/session/service/acp';
 import { sessionDomainService } from '@/backend/services/session/service/session-domain.service';
+import { sessionEventBus } from '@/backend/services/session/service/session-event-bus';
+import { workspaceDataService, workspaceNotificationService } from '@/backend/services/workspace';
 import { AcpEventProcessor } from './acp-event-processor';
+import { closedSessionPersistenceService } from './closed-session-persistence.service';
 import { SessionConfigService } from './session.config.service';
 import { SessionLifecycleService } from './session.lifecycle.service';
 import { SessionPermissionService } from './session.permission.service';
@@ -13,7 +16,12 @@ import { SessionService } from './session.service';
 import { SessionLifecycleEventService } from './session-lifecycle-event.service';
 import { sessionAcpEnvironment, sessionContextService } from './session-lifecycle-external-ports';
 import { SessionLifecycleGate } from './session-lifecycle-gate';
+import { SessionNotificationDeliveryService } from './session-notification-delivery.service';
 import { hydrateProviderHistoryIfNeeded } from './session-provider-history-hydrator';
+import { SessionRuntimeExitCoordinator } from './session-runtime-exit.coordinator';
+import { SessionStartupCoordinator } from './session-startup.coordinator';
+import { SessionTerminationCoordinator } from './session-termination.coordinator';
+import { SessionWorkflowFinalizer } from './session-workflow-finalizer';
 
 const logger = createLogger('session');
 
@@ -77,6 +85,24 @@ export const sessionLifecycleGate = new SessionLifecycleGate({
   isRuntimeStopInProgress: (sessionId) => acpRuntimeManager.isStopInProgress(sessionId),
 });
 
+export const sessionNotificationDeliveryService = new SessionNotificationDeliveryService({
+  notificationPort: workspaceNotificationService,
+  queuePort: sessionDomainService,
+  transcriptPort: sessionDomainService,
+  deltaPort: sessionDomainService,
+});
+
+const sessionWorkflowFinalizer = new SessionWorkflowFinalizer({
+  repository: sessionRepository,
+  workspaceLookup: workspaceDataService,
+  sessionDomainService,
+  closedSessionPersistenceService,
+  lifecycleEventService: sessionLifecycleEventService,
+  hydrateProviderHistory: hydrateProviderHistoryIfNeeded,
+  runtimeManager: acpRuntimeManager,
+  countViewers: (sessionId) => sessionEventBus.countViewers(sessionId),
+});
+
 const sessionPromptCoordinator = new SessionService({
   runtimeManager: acpRuntimeManager,
   sessionDomainService,
@@ -88,26 +114,64 @@ const sessionPromptCoordinator = new SessionService({
 
 export const sessionService: SessionPromptService = sessionPromptCoordinator;
 
-export const sessionLifecycleService = new SessionLifecycleService({
+const sessionRuntimeExitCoordinator = new SessionRuntimeExitCoordinator({
+  repository: sessionRepository,
+  sessionDomainService,
+  sessionPermissionService,
+  acpEventProcessor,
+  promptTurnCompletionService: sessionPromptTurnCompletionService,
+  lifecycleEventService: sessionLifecycleEventService,
+  lifecycleGate: sessionLifecycleGate,
+  workflowFinalizer: sessionWorkflowFinalizer,
+  onSessionExit: (sessionId) => {
+    sessionPromptCoordinator.clearQueuedAcpPrompts(sessionId);
+  },
+});
+
+let sessionLifecycleServiceInstance: SessionLifecycleService;
+
+const sessionTerminationCoordinator = new SessionTerminationCoordinator({
+  repository: sessionRepository,
+  retryService: sessionRetryService,
+  runtimeManager: acpRuntimeManager,
+  sessionDomainService,
+  sessionPermissionService,
+  acpEventProcessor,
+  promptTurnCompletionService: sessionPromptTurnCompletionService,
+  lifecycleEventService: sessionLifecycleEventService,
+  lifecycleGate: sessionLifecycleGate,
+  workflowFinalizer: sessionWorkflowFinalizer,
+  getRuntimeSnapshot: (sessionId) => sessionLifecycleServiceInstance.getRuntimeSnapshot(sessionId),
+  onBeforeStopSession: (sessionId) => {
+    sessionPromptCoordinator.clearQueuedAcpPrompts(sessionId);
+  },
+});
+
+const sessionStartupCoordinator = new SessionStartupCoordinator({
   repository: sessionRepository,
   contextService: sessionContextService,
   acpEnvironment: sessionAcpEnvironment,
   runtimeManager: acpRuntimeManager,
   sessionDomainService,
-  sessionPermissionService,
   sessionConfigService,
   acpEventProcessor,
-  promptTurnCompletionService: sessionPromptTurnCompletionService,
-  retryService: sessionRetryService,
-  lifecycleEventService: sessionLifecycleEventService,
+  runtimeExitCoordinator: sessionRuntimeExitCoordinator,
   lifecycleGate: sessionLifecycleGate,
-  hydrateProviderHistory: hydrateProviderHistoryIfNeeded,
+  notificationDelivery: sessionNotificationDeliveryService,
   sendSessionMessage: (sessionId, content): Promise<void> =>
     sessionService.sendSessionMessage(sessionId, content),
-  onBeforeStopSession: (sessionId) => {
-    sessionPromptCoordinator.clearQueuedAcpPrompts(sessionId);
-  },
-  onSessionExit: (sessionId) => {
-    sessionPromptCoordinator.clearQueuedAcpPrompts(sessionId);
-  },
+  stopSession: (sessionId, options) =>
+    sessionLifecycleServiceInstance.stopSession(sessionId, options),
 });
+
+sessionLifecycleServiceInstance = new SessionLifecycleService({
+  startupCoordinator: sessionStartupCoordinator,
+  terminationCoordinator: sessionTerminationCoordinator,
+  workflowFinalizer: sessionWorkflowFinalizer,
+  contextService: sessionContextService,
+  runtimeManager: acpRuntimeManager,
+  sessionDomainService,
+  lifecycleGate: sessionLifecycleGate,
+});
+
+export { sessionLifecycleServiceInstance as sessionLifecycleService };

--- a/src/backend/services/session/service/lifecycle/session-lifecycle.test-helpers.ts
+++ b/src/backend/services/session/service/lifecycle/session-lifecycle.test-helpers.ts
@@ -23,11 +23,13 @@ import type { SessionAcpEnvironmentPort } from './session-lifecycle.types';
 import type { SessionLifecycleEventService } from './session-lifecycle-event.service';
 import { SessionLifecycleGate } from './session-lifecycle-gate';
 import { SessionNotificationDeliveryService } from './session-notification-delivery.service';
+import { SessionRuntimeExitCoordinator } from './session-runtime-exit.coordinator';
+import { SessionStartupCoordinator } from './session-startup.coordinator';
 import {
   SessionTerminationCoordinator,
   type SessionTerminationCoordinatorDependencies,
 } from './session-termination.coordinator';
-import type { SessionWorkflowFinalizer } from './session-workflow-finalizer';
+import { SessionWorkflowFinalizer } from './session-workflow-finalizer';
 
 export type Deferred<T> = {
   promise: Promise<T>;
@@ -324,9 +326,9 @@ export function createTerminationHarness(
     lifecycleGate,
     workflowFinalizer,
     getRuntimeSnapshot,
-    getWorkspaceBridge: () => workspaceBridge,
     onBeforeStopSession: overrides.onBeforeStopSession,
   });
+  coordinator.configure({ workspace: workspaceBridge });
 
   return {
     coordinator,
@@ -659,32 +661,83 @@ export function createLifecycleHarness(
       },
     ]),
   } satisfies SessionAcpEnvironmentPort;
-  const service = new SessionLifecycleService(
-    unsafeCoerce({
-      repository,
-      contextService,
-      acpEnvironment,
-      runtimeManager,
-      sessionDomainService,
-      sessionPermissionService: notificationService,
-      sessionConfigService,
-      acpEventProcessor,
-      promptTurnCompletionService: { clearSession: vi.fn(), clearAll: vi.fn() },
-      retryService: {
-        run: vi.fn(async (operation: () => Promise<unknown>) => await operation()),
-      },
-      sendSessionMessage,
-      lifecycleEventService,
-      lifecycleGate,
-    })
-  );
+  const promptTurnCompletionService = { clearSession: vi.fn(), clearAll: vi.fn() };
+  const retryService = {
+    run: vi.fn(async (operation: () => Promise<unknown>) => await operation()),
+  };
   const notificationDeliveryService = new SessionNotificationDeliveryService({
     notificationPort: workspaceNotificationService,
     queuePort: sessionDomainService,
     transcriptPort: sessionDomainService,
     deltaPort: sessionDomainService,
   });
-  service.configureNotificationDelivery(notificationDeliveryService);
+  const workflowFinalizer = new SessionWorkflowFinalizer(
+    unsafeCoerce({
+      repository,
+      workspaceLookup: { findById: async () => workspace },
+      sessionDomainService,
+      closedSessionPersistenceService: { persistClosedSession: vi.fn(async () => undefined) },
+      lifecycleEventService,
+      hydrateProviderHistory: async () => undefined,
+      runtimeManager,
+      countViewers: () => 0,
+    })
+  );
+  const runtimeExitCoordinator = new SessionRuntimeExitCoordinator(
+    unsafeCoerce({
+      repository,
+      sessionDomainService,
+      sessionPermissionService: notificationService,
+      acpEventProcessor,
+      promptTurnCompletionService,
+      lifecycleEventService,
+      lifecycleGate,
+      workflowFinalizer,
+      onSessionExit: vi.fn(),
+    })
+  );
+  let service: SessionLifecycleService;
+  const terminationCoordinator = new SessionTerminationCoordinator(
+    unsafeCoerce({
+      repository,
+      retryService,
+      runtimeManager,
+      sessionDomainService,
+      sessionPermissionService: notificationService,
+      acpEventProcessor,
+      promptTurnCompletionService,
+      lifecycleEventService,
+      lifecycleGate,
+      workflowFinalizer,
+      getRuntimeSnapshot: (sessionId: string) => service.getRuntimeSnapshot(sessionId),
+    })
+  );
+  const startupCoordinator = new SessionStartupCoordinator(
+    unsafeCoerce({
+      repository,
+      contextService,
+      acpEnvironment,
+      runtimeManager,
+      sessionDomainService,
+      sessionConfigService,
+      acpEventProcessor,
+      runtimeExitCoordinator,
+      lifecycleGate,
+      notificationDelivery: notificationDeliveryService,
+      sendSessionMessage,
+      stopSession: (sessionId: string, options: unknown) =>
+        service.stopSession(sessionId, unsafeCoerce(options)),
+    })
+  );
+  service = new SessionLifecycleService({
+    startupCoordinator,
+    terminationCoordinator,
+    workflowFinalizer,
+    contextService,
+    runtimeManager,
+    sessionDomainService,
+    lifecycleGate,
+  });
   service.configure({ workspace: workspaceBridge, messageQueue: messageQueueBridge });
 
   return {

--- a/src/backend/services/session/service/lifecycle/session-lifecycle.test-helpers.ts
+++ b/src/backend/services/session/service/lifecycle/session-lifecycle.test-helpers.ts
@@ -73,6 +73,8 @@ export type LifecycleHarness = {
     | 'markWorkspaceHasHadSessions'
     | 'updateSession'
     | 'updateSessionIfStatus'
+    | 'deleteSession'
+    | 'recoverStaleRunningSessions'
   >;
   runtimeManager: MockedPick<
     AcpRuntimeManager,
@@ -107,6 +109,7 @@ export type LifecycleHarness = {
     | 'clearQueuedWork'
     | 'clearSession'
     | 'markProcessExit'
+    | 'markError'
   >;
   acpEventProcessor: MockedPick<
     AcpEventProcessor,
@@ -117,8 +120,10 @@ export type LifecycleHarness = {
     | 'clearStreamingState'
     | 'clearReplaySuppression'
     | 'finalizeOrphanedToolCalls'
+    | 'clearPendingToolCalls'
     | 'clearSessionContext'
     | 'getWorkspaceId'
+    | 'handleAcpLog'
   >;
   sessionConfigService: MockedPick<
     SessionConfigService,
@@ -482,6 +487,10 @@ export function createLifecycleHarness(
     ),
     updateSession: vi.fn<SessionRepository['updateSession']>(async () => session),
     updateSessionIfStatus: vi.fn<SessionRepository['updateSessionIfStatus']>(async () => 0),
+    deleteSession: vi.fn<SessionRepository['deleteSession']>(async () => session),
+    recoverStaleRunningSessions: vi.fn<SessionRepository['recoverStaleRunningSessions']>(
+      async () => 0
+    ),
   } satisfies Pick<
     SessionRepository,
     | 'getSessionById'
@@ -491,6 +500,8 @@ export function createLifecycleHarness(
     | 'markWorkspaceHasHadSessions'
     | 'updateSession'
     | 'updateSessionIfStatus'
+    | 'deleteSession'
+    | 'recoverStaleRunningSessions'
   >;
   const runClientCreationOperation: AcpRuntimeManager['runClientCreationOperation'] = async (
     _sessionId,
@@ -557,6 +568,7 @@ export function createLifecycleHarness(
     clearQueuedWork: vi.fn(),
     clearSession: vi.fn(),
     markProcessExit: vi.fn(),
+    markError: vi.fn(),
   } satisfies Pick<
     SessionDomainService,
     | 'appendClaudeEvent'
@@ -572,6 +584,7 @@ export function createLifecycleHarness(
     | 'clearQueuedWork'
     | 'clearSession'
     | 'markProcessExit'
+    | 'markError'
   >;
   const sessionConfigService = {
     applyConfiguredReasoningEffort: vi.fn(async () => undefined),
@@ -597,8 +610,10 @@ export function createLifecycleHarness(
     clearStreamingState: vi.fn(),
     clearReplaySuppression: vi.fn(),
     finalizeOrphanedToolCalls: vi.fn(),
+    clearPendingToolCalls: vi.fn(),
     clearSessionContext: vi.fn(),
     getWorkspaceId: vi.fn(() => undefined),
+    handleAcpLog: vi.fn(),
   } satisfies Pick<
     AcpEventProcessor,
     | 'createRuntimeEventHandler'
@@ -608,8 +623,10 @@ export function createLifecycleHarness(
     | 'clearStreamingState'
     | 'clearReplaySuppression'
     | 'finalizeOrphanedToolCalls'
+    | 'clearPendingToolCalls'
     | 'clearSessionContext'
     | 'getWorkspaceId'
+    | 'handleAcpLog'
   >;
   const lifecycleEventService = {
     record: vi.fn<SessionLifecycleEventService['record']>(async () => null),

--- a/src/backend/services/session/service/lifecycle/session-services.composition.test.ts
+++ b/src/backend/services/session/service/lifecycle/session-services.composition.test.ts
@@ -53,6 +53,73 @@ describe('session services composition', () => {
     });
   });
 
+  it('composes browse startup through the real startup coordinator', async () => {
+    const { service, runtimeManager } = createLifecycleHarness({
+      provider: 'CODEX',
+      providerSessionId: 'provider-session-1',
+    });
+    runtimeManager.getSubagentBrowseCapability.mockImplementation(() =>
+      runtimeManager.getOrCreateClient.mock.calls.length > 0
+        ? { version: 1, list: true, read: true, notifications: true }
+        : null
+    );
+
+    await expect(service.ensureSubagentBrowseSession('session-1')).resolves.toBe(true);
+
+    expect(runtimeManager.getOrCreateClient).toHaveBeenCalledWith(
+      'session-1',
+      expect.objectContaining({
+        provider: 'CODEX',
+        purpose: 'browse',
+        resumeProviderSessionId: 'provider-session-1',
+      }),
+      expect.objectContaining({
+        onRuntimeError: expect.any(Function),
+        onRuntimeExit: expect.any(Function),
+      }),
+      {
+        workspaceId: 'workspace-1',
+        workingDir: '/tmp/workspace',
+      }
+    );
+  });
+
+  it('builds runtime handlers backed by complete lifecycle harness ports', async () => {
+    const { service, runtimeManager, sessionDomainService, acpEventProcessor } =
+      createLifecycleHarness();
+    await service.getOrCreateSessionClient('session-1');
+    const handlers = runtimeManager.getOrCreateClient.mock.calls[0]?.[2];
+    expect(handlers?.onRuntimeError).toEqual(expect.any(Function));
+    expect(handlers?.onAcpLog).toEqual(expect.any(Function));
+
+    handlers?.onRuntimeError?.({
+      sessionId: 'session-1',
+      error: new Error('runtime failed'),
+      incarnationId: 'incarnation-1',
+      purpose: 'active',
+    });
+    handlers?.onAcpLog?.('session-1', { message: 'provider log' });
+
+    expect(sessionDomainService.markError).toHaveBeenCalledWith('session-1', 'runtime failed');
+    expect(acpEventProcessor.handleAcpLog).toHaveBeenCalledWith('session-1', {
+      message: 'provider log',
+    });
+  });
+
+  it('builds workflow finalization with recovery and transient deletion ports', async () => {
+    const { service, sessionDomainService } = createLifecycleHarness({
+      session: { workflow: 'ratchet' },
+    });
+
+    await expect(service.recoverStaleRunningSessions()).resolves.toBe(0);
+    await service.stopSession('session-1', {
+      cleanupTransientRatchetSession: true,
+      recordLifecycleEvent: false,
+    });
+
+    expect(sessionDomainService.clearSession).toHaveBeenCalledWith('session-1');
+  });
+
   it('wires a lifecycle coordinator to a later workspace bridge without mutating the singleton', async () => {
     const { service, repository, runtimeManager } = createLifecycleHarness();
     const workspaceBridge = {

--- a/src/backend/services/session/service/lifecycle/session-services.composition.test.ts
+++ b/src/backend/services/session/service/lifecycle/session-services.composition.test.ts
@@ -11,7 +11,6 @@ import {
   createLifecycleTestSession,
 } from './session-lifecycle.test-helpers';
 import { chatMessageHandlerService, sessionLifecycleService } from './session-services';
-import { SessionStartupCoordinator } from './session-startup.coordinator';
 
 describe('session services composition', () => {
   afterEach(() => {
@@ -52,18 +51,6 @@ describe('session services composition', () => {
       model: 'opus',
       reasoningEffort: 'high',
     });
-  });
-
-  it('exports the public lifecycle singleton with startup configured', async () => {
-    const ensureSubagentBrowseSession = vi
-      .spyOn(SessionStartupCoordinator.prototype, 'ensureSubagentBrowseSession')
-      .mockResolvedValueOnce(false);
-
-    await expect(
-      publicSessionLifecycleService.ensureSubagentBrowseSession('session-1')
-    ).resolves.toBe(false);
-
-    expect(ensureSubagentBrowseSession).toHaveBeenCalledWith('session-1');
   });
 
   it('wires a lifecycle coordinator to a later workspace bridge without mutating the singleton', async () => {

--- a/src/backend/services/session/service/lifecycle/session-services.ts
+++ b/src/backend/services/session/service/lifecycle/session-services.ts
@@ -1,18 +1,16 @@
 import { ChatMessageHandlerService } from '@/backend/services/session/service/chat/chat-message-handlers.service';
-import { sessionDomainService } from '@/backend/services/session/service/session-domain.service';
-import { workspaceNotificationService } from '@/backend/services/workspace';
 import {
   acpEventProcessor,
   sessionConfigService,
   sessionLifecycleEventService,
   sessionLifecycleGate,
   sessionLifecycleService,
+  sessionNotificationDeliveryService,
   sessionPermissionService,
   sessionPromptTurnCompletionService,
   sessionRetryService,
   sessionService,
 } from './session-core-services';
-import { SessionNotificationDeliveryService } from './session-notification-delivery.service';
 
 export type { SessionPromptService } from './session-core-services';
 export {
@@ -25,15 +23,6 @@ export {
   sessionRetryService,
   sessionService,
 };
-
-const sessionNotificationDeliveryService = new SessionNotificationDeliveryService({
-  notificationPort: workspaceNotificationService,
-  queuePort: sessionDomainService,
-  transcriptPort: sessionDomainService,
-  deltaPort: sessionDomainService,
-});
-
-sessionLifecycleService.configureNotificationDelivery(sessionNotificationDeliveryService);
 
 export const chatMessageHandlerService = new ChatMessageHandlerService();
 

--- a/src/backend/services/session/service/lifecycle/session-startup.coordinator.test.ts
+++ b/src/backend/services/session/service/lifecycle/session-startup.coordinator.test.ts
@@ -46,11 +46,12 @@ function createStartupCoordinator(harness: LifecycleHarness): SessionStartupCoor
     runtimeExitCoordinator: { createHandlers: vi.fn(() => ({})) },
     lifecycleGate: harness.lifecycleGate,
     notificationDelivery: harness.notificationDeliveryService,
-    getMessageQueueBridge: () => harness.messageQueueBridge,
     sendSessionMessage: harness.sendSessionMessage,
     stopSession: (sessionId, options) => harness.service.stopSession(sessionId, options),
   } satisfies SessionStartupCoordinatorDependencies;
-  return new SessionStartupCoordinator(dependencies);
+  const coordinator = new SessionStartupCoordinator(dependencies);
+  coordinator.configure({ messageQueue: harness.messageQueueBridge });
+  return coordinator;
 }
 
 function installRuntimeQuiescence(harness: LifecycleHarness): AcpRuntimeQuiescence {

--- a/src/backend/services/session/service/lifecycle/session-startup.coordinator.ts
+++ b/src/backend/services/session/service/lifecycle/session-startup.coordinator.ts
@@ -81,16 +81,23 @@ export type SessionStartupCoordinatorDependencies = {
   runtimeExitCoordinator: Pick<SessionRuntimeExitCoordinator, 'createHandlers'>;
   lifecycleGate: SessionLifecycleGate;
   notificationDelivery: Pick<SessionNotificationDeliveryService, 'recoverPending'>;
-  getMessageQueueBridge: () => Pick<
-    SessionLifecycleMessageQueueBridge,
-    'tryDispatchNextMessage'
-  > | null;
   sendSessionMessage: (sessionId: string, content: string) => Promise<void>;
   stopSession: (sessionId: string, options: StopSessionOptions) => Promise<void>;
 };
 
 export class SessionStartupCoordinator {
+  private messageQueueBridge: Pick<
+    SessionLifecycleMessageQueueBridge,
+    'tryDispatchNextMessage'
+  > | null = null;
+
   constructor(private readonly dependencies: SessionStartupCoordinatorDependencies) {}
+
+  configure(bridges: {
+    messageQueue?: Pick<SessionLifecycleMessageQueueBridge, 'tryDispatchNextMessage'>;
+  }): void {
+    this.messageQueueBridge = bridges.messageQueue ?? null;
+  }
 
   async startSession(sessionId: string, options?: StartSessionOptions): Promise<void> {
     await this.dependencies.lifecycleGate.runStartup(sessionId, async (lease) => {
@@ -504,7 +511,7 @@ export class SessionStartupCoordinator {
     sessionId: string,
     dispatchableNotificationCount: number
   ): Promise<void> {
-    const messageQueueBridge = this.dependencies.getMessageQueueBridge();
+    const messageQueueBridge = this.messageQueueBridge;
     if (dispatchableNotificationCount === 0 || !messageQueueBridge) {
       return;
     }

--- a/src/backend/services/session/service/lifecycle/session-termination.coordinator.test.ts
+++ b/src/backend/services/session/service/lifecycle/session-termination.coordinator.test.ts
@@ -58,8 +58,8 @@ function createShutdownHarness(
     lifecycleGate: base.lifecycleGate,
     workflowFinalizer: base.workflowFinalizer,
     getRuntimeSnapshot: base.getRuntimeSnapshot,
-    getWorkspaceBridge: () => base.workspaceBridge,
   });
+  coordinator.configure({ workspace: base.workspaceBridge });
 
   return { ...base, coordinator, runtimeManager, promptTurnCompletionService };
 }

--- a/src/backend/services/session/service/lifecycle/session-termination.coordinator.ts
+++ b/src/backend/services/session/service/lifecycle/session-termination.coordinator.ts
@@ -80,12 +80,19 @@ export type SessionTerminationCoordinatorDependencies = {
     'finalizeDeliberateStop' | 'clearInactiveSession'
   >;
   getRuntimeSnapshot: (sessionId: string) => SessionRuntimeState;
-  getWorkspaceBridge: () => Pick<SessionLifecycleWorkspaceBridge, 'markSessionIdle'> | null;
   onBeforeStopSession?: (sessionId: string) => void;
 };
 
 export class SessionTerminationCoordinator {
+  private workspaceBridge: Pick<SessionLifecycleWorkspaceBridge, 'markSessionIdle'> | null = null;
+
   constructor(private readonly dependencies: SessionTerminationCoordinatorDependencies) {}
+
+  configure(bridges: {
+    workspace: Pick<SessionLifecycleWorkspaceBridge, 'markSessionIdle'>;
+  }): void {
+    this.workspaceBridge = bridges.workspace;
+  }
 
   async stopSession(sessionId: string, options?: StopSessionOptions): Promise<void> {
     const stopReservation = this.dependencies.lifecycleGate.reserveStop(sessionId);
@@ -276,13 +283,12 @@ export class SessionTerminationCoordinator {
   }
 
   private markWorkspaceSessionIdleOnStop(workspaceId: string | undefined, sessionId: string): void {
-    const workspaceBridge = this.dependencies.getWorkspaceBridge();
-    if (!(workspaceId && workspaceBridge)) {
+    if (!(workspaceId && this.workspaceBridge)) {
       return;
     }
 
     try {
-      workspaceBridge.markSessionIdle(workspaceId, sessionId);
+      this.workspaceBridge.markSessionIdle(workspaceId, sessionId);
     } catch (error) {
       logger.warn('Failed to mark workspace session idle during stop', {
         sessionId,

--- a/src/backend/services/session/service/lifecycle/session.lifecycle.facade.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.lifecycle.facade.test.ts
@@ -1,14 +1,24 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentSessionRecord } from '@/backend/services/session/resources/agent-session.accessor';
+import type { AcpRuntimeManager } from '@/backend/services/session/service/acp';
+import type { SessionLifecycleWorkspaceBridge } from '@/backend/services/session/service/bridges';
+import type { SessionDomainService } from '@/backend/services/session/service/session-domain.service';
 import { workspaceNotificationService } from '@/backend/services/workspace';
 import { WorkspaceStatus } from '@/shared/core';
 import { unsafeCoerce } from '@/test-utils/unsafe-coerce';
-import { SessionLifecycleService } from './session.lifecycle.service';
+import {
+  SessionLifecycleService,
+  type SessionLifecycleServiceDependencies,
+} from './session.lifecycle.service';
+import type { SessionContextService } from './session-context.service';
 import {
   createLifecycleHarness,
   createPendingWorkspaceNotification,
 } from './session-lifecycle.test-helpers';
-import { SessionStartupCoordinator } from './session-startup.coordinator';
-import { SessionTerminationCoordinator } from './session-termination.coordinator';
+import type { SessionLifecycleGate } from './session-lifecycle-gate';
+import type { SessionStartupCoordinator } from './session-startup.coordinator';
+import type { SessionTerminationCoordinator } from './session-termination.coordinator';
+import type { SessionWorkflowFinalizer } from './session-workflow-finalizer';
 
 vi.mock('@/backend/services/logger.service', () => ({
   createLogger: () => ({
@@ -61,15 +71,162 @@ describe('SessionLifecycleFacade', () => {
     ] as never);
   });
 
-  it('fails during construction when required external ports are missing', () => {
-    expect(
-      () =>
-        new SessionLifecycleService(
-          unsafeCoerce({
-            repository: {},
-          })
-        )
-    ).toThrow('SessionLifecycleService requires context and ACP environment ports');
+  it('forwards its public lifecycle contract to configured collaborators', async () => {
+    const startupFailure = new Error('startup rejected');
+    const stopFailure = new Error('stop rejected');
+    const persistFailure = new Error('persist rejected');
+    const startupCoordinator = {
+      configure: vi.fn<SessionStartupCoordinator['configure']>(),
+      startSession: vi
+        .fn<SessionStartupCoordinator['startSession']>()
+        .mockRejectedValueOnce(startupFailure),
+      restartSession: vi.fn<SessionStartupCoordinator['restartSession']>(async () => undefined),
+      getOrCreateSessionClient: vi.fn<SessionStartupCoordinator['getOrCreateSessionClient']>(
+        async () => 'client-by-id'
+      ),
+      getOrCreateSessionClientFromRecord: vi.fn<
+        SessionStartupCoordinator['getOrCreateSessionClientFromRecord']
+      >(async () => 'client-by-record'),
+      ensureSubagentBrowseSession: vi.fn<SessionStartupCoordinator['ensureSubagentBrowseSession']>(
+        async () => true
+      ),
+    } satisfies SessionLifecycleServiceDependencies['startupCoordinator'];
+    const terminationCoordinator = {
+      configure: vi.fn<SessionTerminationCoordinator['configure']>(),
+      stopSession: vi.fn<SessionTerminationCoordinator['stopSession']>(async () => undefined),
+      stopWorkspaceSessions: vi.fn<SessionTerminationCoordinator['stopWorkspaceSessions']>(
+        async () => undefined
+      ),
+      stopAllClients: vi.fn<SessionTerminationCoordinator['stopAllClients']>(async () => undefined),
+    } satisfies SessionLifecycleServiceDependencies['terminationCoordinator'];
+    const workflowFinalizer = {
+      configure: vi.fn<SessionWorkflowFinalizer['configure']>(),
+      persistClosedSession: vi.fn<SessionWorkflowFinalizer['persistClosedSession']>(
+        async () => undefined
+      ),
+      recoverStaleRunningSessions: vi.fn<SessionWorkflowFinalizer['recoverStaleRunningSessions']>(
+        async () => 3
+      ),
+    } satisfies SessionLifecycleServiceDependencies['workflowFinalizer'];
+    const lifecycleGate = {
+      isSessionStopping: vi.fn<SessionLifecycleGate['isSessionStopping']>(() => true),
+      getGeneration: vi.fn<SessionLifecycleGate['getGeneration']>(() => 7),
+      isGenerationCurrent: vi.fn<SessionLifecycleGate['isGenerationCurrent']>(() => false),
+    } satisfies SessionLifecycleServiceDependencies['lifecycleGate'];
+    const sessionOptions = {
+      workingDir: '/delegated/worktree',
+      resumeProviderSessionId: 'provider-session-1',
+      systemPrompt: 'delegated prompt',
+      model: 'delegated-model',
+      workspaceStatus: WorkspaceStatus.READY,
+    };
+    const contextService = {
+      getOptions: vi.fn<SessionContextService['getOptions']>(async () => sessionOptions),
+    } satisfies SessionLifecycleServiceDependencies['contextService'];
+    const runtimeManager = {
+      getClient: vi.fn<AcpRuntimeManager['getClient']>(() => unsafeCoerce('runtime-client')),
+      isSessionWorking: vi.fn<AcpRuntimeManager['isSessionWorking']>(() => true),
+      isStopInProgress: vi.fn<AcpRuntimeManager['isStopInProgress']>(() => false),
+    } satisfies SessionLifecycleServiceDependencies['runtimeManager'];
+    const sessionDomainService = {
+      getRuntimeSnapshot: vi.fn<SessionDomainService['getRuntimeSnapshot']>(() => ({
+        phase: 'idle' as const,
+        processState: 'stopped' as const,
+        activity: 'IDLE' as const,
+        updatedAt: '2026-08-12T00:00:00.000Z',
+      })),
+    } satisfies SessionLifecycleServiceDependencies['sessionDomainService'];
+    const service = new SessionLifecycleService({
+      startupCoordinator,
+      terminationCoordinator,
+      workflowFinalizer,
+      lifecycleGate,
+      contextService,
+      runtimeManager,
+      sessionDomainService,
+    });
+    const workspaceBridge = unsafeCoerce<SessionLifecycleWorkspaceBridge>({
+      markSessionIdle: vi.fn(),
+    });
+    const messageQueueBridge = { tryDispatchNextMessage: vi.fn(async () => undefined) };
+    const autoIterationExit = { onAutoIterationSessionExit: vi.fn() };
+    const startOptions = { initialPrompt: 'Continue exactly' };
+    const stopOptions = { reason: 'USER_STOP' as const };
+    const clientOptions = { model: 'delegated-model', reasoningEffort: 'high' };
+    const session = unsafeCoerce<AgentSessionRecord>({ id: 'record-session' });
+
+    service.configure({
+      workspace: workspaceBridge,
+      messageQueue: messageQueueBridge,
+      autoIterationExit,
+    });
+    await expect(service.startSession('start-session', startOptions)).rejects.toBe(startupFailure);
+    await service.restartSession('restart-session', startOptions);
+    await expect(service.getOrCreateSessionClient('client-session', clientOptions)).resolves.toBe(
+      'client-by-id'
+    );
+    await expect(service.getOrCreateSessionClientFromRecord(session, clientOptions)).resolves.toBe(
+      'client-by-record'
+    );
+    await expect(service.ensureSubagentBrowseSession('browse-session')).resolves.toBe(true);
+    await expect(service.stopSession('stop-session', stopOptions)).resolves.toBeUndefined();
+    await expect(
+      service.stopWorkspaceSessions('workspace-session', stopOptions)
+    ).resolves.toBeUndefined();
+    await expect(service.stopAllClients(3210)).resolves.toBeUndefined();
+    expect(service.getSessionClient('runtime-session')).toBe('runtime-client');
+    expect(service.getRuntimeSnapshot('runtime-session')).toEqual({
+      phase: 'running',
+      processState: 'alive',
+      activity: 'WORKING',
+      updatedAt: '2026-08-12T00:00:00.000Z',
+    });
+    await expect(service.getSessionOptions('options-session')).resolves.toEqual(sessionOptions);
+    await expect(service.persistClosedSession('closed-session')).resolves.toBeUndefined();
+    await expect(service.recoverStaleRunningSessions()).resolves.toBe(3);
+    expect(service.isSessionStopping('gate-session')).toBe(true);
+    expect(service.getStopGeneration('gate-session')).toBe(7);
+    expect(service.isStopGenerationCurrent('gate-session', 6)).toBe(false);
+
+    expect(workflowFinalizer.configure).toHaveBeenCalledExactlyOnceWith({
+      workspace: workspaceBridge,
+      autoIterationExit,
+    });
+    expect(terminationCoordinator.configure).toHaveBeenCalledExactlyOnceWith({
+      workspace: workspaceBridge,
+    });
+    expect(startupCoordinator.configure).toHaveBeenCalledExactlyOnceWith({
+      messageQueue: messageQueueBridge,
+    });
+    expect(startupCoordinator.startSession).toHaveBeenCalledWith('start-session', startOptions);
+    expect(startupCoordinator.restartSession).toHaveBeenCalledWith('restart-session', startOptions);
+    expect(startupCoordinator.getOrCreateSessionClient).toHaveBeenCalledWith(
+      'client-session',
+      clientOptions
+    );
+    expect(startupCoordinator.getOrCreateSessionClientFromRecord).toHaveBeenCalledWith(
+      session,
+      clientOptions
+    );
+    expect(startupCoordinator.ensureSubagentBrowseSession).toHaveBeenCalledWith('browse-session');
+    expect(terminationCoordinator.stopSession).toHaveBeenCalledWith('stop-session', stopOptions);
+    expect(terminationCoordinator.stopWorkspaceSessions).toHaveBeenCalledWith(
+      'workspace-session',
+      stopOptions
+    );
+    expect(terminationCoordinator.stopAllClients).toHaveBeenCalledWith(3210);
+    expect(runtimeManager.getClient).toHaveBeenCalledWith('runtime-session');
+    expect(contextService.getOptions).toHaveBeenCalledWith('options-session');
+    expect(workflowFinalizer.persistClosedSession).toHaveBeenCalledWith('closed-session');
+    expect(workflowFinalizer.recoverStaleRunningSessions).toHaveBeenCalledOnce();
+    expect(lifecycleGate.isSessionStopping).toHaveBeenCalledWith('gate-session');
+    expect(lifecycleGate.getGeneration).toHaveBeenCalledWith('gate-session');
+    expect(lifecycleGate.isGenerationCurrent).toHaveBeenCalledWith('gate-session', 6);
+
+    terminationCoordinator.stopSession.mockRejectedValueOnce(stopFailure);
+    workflowFinalizer.persistClosedSession.mockRejectedValueOnce(persistFailure);
+    await expect(service.stopSession('rejected-stop')).rejects.toBe(stopFailure);
+    await expect(service.persistClosedSession('rejected-persist')).rejects.toBe(persistFailure);
   });
 
   it('delegates session option reads to the injected context service', async () => {
@@ -86,97 +243,6 @@ describe('SessionLifecycleFacade', () => {
     await expect(service.getSessionOptions('session-1')).resolves.toEqual(options);
 
     expect(getOptions).toHaveBeenCalledWith('session-1');
-  });
-
-  it('delegates every startup entry point through the configured coordinator', async () => {
-    const startSession = vi
-      .spyOn(SessionStartupCoordinator.prototype, 'startSession')
-      .mockResolvedValueOnce(undefined);
-    const restartSession = vi
-      .spyOn(SessionStartupCoordinator.prototype, 'restartSession')
-      .mockResolvedValueOnce(undefined);
-    const getOrCreateSessionClient = vi
-      .spyOn(SessionStartupCoordinator.prototype, 'getOrCreateSessionClient')
-      .mockResolvedValueOnce('client-by-id');
-    const getOrCreateSessionClientFromRecord = vi
-      .spyOn(SessionStartupCoordinator.prototype, 'getOrCreateSessionClientFromRecord')
-      .mockResolvedValueOnce('client-by-record');
-    const ensureSubagentBrowseSession = vi
-      .spyOn(SessionStartupCoordinator.prototype, 'ensureSubagentBrowseSession')
-      .mockResolvedValueOnce(true);
-    const { service, session } = createLifecycleHarness();
-    const options = { initialPrompt: 'Resume the task', startupModePreset: 'plan' } as const;
-    const clientOptions = { model: 'claude-opus', reasoningEffort: 'high' };
-
-    await service.startSession('session-1', options);
-    await service.restartSession('session-2', options);
-    await expect(service.getOrCreateSessionClient('session-3', clientOptions)).resolves.toBe(
-      'client-by-id'
-    );
-    await expect(service.getOrCreateSessionClientFromRecord(session, clientOptions)).resolves.toBe(
-      'client-by-record'
-    );
-    await expect(service.ensureSubagentBrowseSession('session-4')).resolves.toBe(true);
-
-    expect(startSession).toHaveBeenCalledWith('session-1', options);
-    expect(restartSession).toHaveBeenCalledWith('session-2', options);
-    expect(getOrCreateSessionClient).toHaveBeenCalledWith('session-3', clientOptions);
-    expect(getOrCreateSessionClientFromRecord).toHaveBeenCalledWith(session, clientOptions);
-    expect(ensureSubagentBrowseSession).toHaveBeenCalledWith('session-4');
-  });
-
-  it('forwards explicit and workspace stops to the termination coordinator', async () => {
-    const stopSession = vi
-      .spyOn(SessionTerminationCoordinator.prototype, 'stopSession')
-      .mockResolvedValueOnce(undefined);
-    const stopWorkspaceSessions = vi
-      .spyOn(SessionTerminationCoordinator.prototype, 'stopWorkspaceSessions')
-      .mockResolvedValueOnce(undefined);
-    const stopAllClients = vi
-      .spyOn(SessionTerminationCoordinator.prototype, 'stopAllClients')
-      .mockResolvedValue(undefined);
-    const { service } = createLifecycleHarness();
-    const sessionOptions = {
-      cleanupTransientRatchetSession: false,
-      recordLifecycleEvent: false,
-      reason: 'USER_STOP',
-    } as const;
-    const workspaceOptions = { reason: 'WORKSPACE_ARCHIVED' } as const;
-
-    await expect(service.stopSession('session-exact', sessionOptions)).resolves.toBeUndefined();
-    await expect(
-      service.stopWorkspaceSessions('workspace-exact', workspaceOptions)
-    ).resolves.toBeUndefined();
-    await expect(service.stopAllClients(4321)).resolves.toBeUndefined();
-    await expect(service.stopAllClients()).resolves.toBeUndefined();
-
-    expect(stopSession).toHaveBeenCalledWith('session-exact', sessionOptions);
-    expect(stopWorkspaceSessions).toHaveBeenCalledWith('workspace-exact', workspaceOptions);
-    expect(stopAllClients).toHaveBeenNthCalledWith(1, 4321);
-    expect(stopAllClients).toHaveBeenNthCalledWith(2, 5000);
-  });
-
-  it('preserves termination coordinator rejections', async () => {
-    const sessionFailure = new Error('session stop rejected');
-    const workspaceFailure = new Error('workspace stop rejected');
-    const shutdownFailure = new Error('shutdown rejected');
-    vi.spyOn(SessionTerminationCoordinator.prototype, 'stopSession').mockRejectedValueOnce(
-      sessionFailure
-    );
-    vi.spyOn(
-      SessionTerminationCoordinator.prototype,
-      'stopWorkspaceSessions'
-    ).mockRejectedValueOnce(workspaceFailure);
-    vi.spyOn(SessionTerminationCoordinator.prototype, 'stopAllClients').mockRejectedValueOnce(
-      shutdownFailure
-    );
-    const { service } = createLifecycleHarness();
-
-    await expect(service.stopSession('session-rejected')).rejects.toBe(sessionFailure);
-    await expect(service.stopWorkspaceSessions('workspace-rejected')).rejects.toBe(
-      workspaceFailure
-    );
-    await expect(service.stopAllClients()).rejects.toBe(shutdownFailure);
   });
 
   it('skips the restart default continue prompt when notifications are queued', async () => {

--- a/src/backend/services/session/service/lifecycle/session.lifecycle.facade.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.lifecycle.facade.test.ts
@@ -155,6 +155,51 @@ describe('SessionLifecycleFacade', () => {
     const clientOptions = { model: 'delegated-model', reasoningEffort: 'high' };
     const session = unsafeCoerce<AgentSessionRecord>({ id: 'record-session' });
 
+    const guardedOperations = [
+      ['start', () => service.startSession('unconfigured-start'), startupCoordinator.startSession],
+      [
+        'restart',
+        () => service.restartSession('unconfigured-restart'),
+        startupCoordinator.restartSession,
+      ],
+      ['stop', () => service.stopSession('unconfigured-stop'), terminationCoordinator.stopSession],
+      [
+        'workspace stop',
+        () => service.stopWorkspaceSessions('unconfigured-workspace'),
+        terminationCoordinator.stopWorkspaceSessions,
+      ],
+      ['stop all', () => service.stopAllClients(), terminationCoordinator.stopAllClients],
+      [
+        'client creation',
+        () => service.getOrCreateSessionClient('unconfigured-client'),
+        startupCoordinator.getOrCreateSessionClient,
+      ],
+      [
+        'record client creation',
+        () => service.getOrCreateSessionClientFromRecord(session),
+        startupCoordinator.getOrCreateSessionClientFromRecord,
+      ],
+      [
+        'browse client creation',
+        () => service.ensureSubagentBrowseSession('unconfigured-browse'),
+        startupCoordinator.ensureSubagentBrowseSession,
+      ],
+    ] as const;
+
+    for (const [operation, invoke, collaborator] of guardedOperations) {
+      await expect(invoke()).rejects.toThrow('SessionLifecycleService not configured');
+      expect(collaborator).not.toHaveBeenCalled();
+      expect(operation).toBeTruthy();
+    }
+    expect(() => service.persistClosedSession('unconfigured-closed')).toThrow(
+      'SessionLifecycleService not configured'
+    );
+    expect(workflowFinalizer.persistClosedSession).not.toHaveBeenCalled();
+    expect(() => service.recoverStaleRunningSessions()).toThrow(
+      'SessionLifecycleService not configured'
+    );
+    expect(workflowFinalizer.recoverStaleRunningSessions).not.toHaveBeenCalled();
+
     service.configure({
       workspace: workspaceBridge,
       messageQueue: messageQueueBridge,
@@ -227,6 +272,166 @@ describe('SessionLifecycleFacade', () => {
     workflowFinalizer.persistClosedSession.mockRejectedValueOnce(persistFailure);
     await expect(service.stopSession('rejected-stop')).rejects.toBe(stopFailure);
     await expect(service.persistClosedSession('rejected-persist')).rejects.toBe(persistFailure);
+
+    const rejectedDelegations = [
+      {
+        name: 'restart',
+        reject: (error: Error) => startupCoordinator.restartSession.mockRejectedValueOnce(error),
+        invoke: () => service.restartSession('rejected-restart'),
+      },
+      {
+        name: 'workspace stop',
+        reject: (error: Error) =>
+          terminationCoordinator.stopWorkspaceSessions.mockRejectedValueOnce(error),
+        invoke: () => service.stopWorkspaceSessions('rejected-workspace'),
+      },
+      {
+        name: 'stop all',
+        reject: (error: Error) =>
+          terminationCoordinator.stopAllClients.mockRejectedValueOnce(error),
+        invoke: () => service.stopAllClients(),
+      },
+      {
+        name: 'client acquisition',
+        reject: (error: Error) =>
+          startupCoordinator.getOrCreateSessionClient.mockRejectedValueOnce(error),
+        invoke: () => service.getOrCreateSessionClient('rejected-client'),
+      },
+      {
+        name: 'record client acquisition',
+        reject: (error: Error) =>
+          startupCoordinator.getOrCreateSessionClientFromRecord.mockRejectedValueOnce(error),
+        invoke: () => service.getOrCreateSessionClientFromRecord(session),
+      },
+      {
+        name: 'browse acquisition',
+        reject: (error: Error) =>
+          startupCoordinator.ensureSubagentBrowseSession.mockRejectedValueOnce(error),
+        invoke: () => service.ensureSubagentBrowseSession('rejected-browse'),
+      },
+      {
+        name: 'option read',
+        reject: (error: Error) => contextService.getOptions.mockRejectedValueOnce(error),
+        invoke: () => service.getSessionOptions('rejected-options'),
+      },
+      {
+        name: 'stale-session recovery',
+        reject: (error: Error) =>
+          workflowFinalizer.recoverStaleRunningSessions.mockRejectedValueOnce(error),
+        invoke: () => service.recoverStaleRunningSessions(),
+      },
+    ] as const;
+
+    for (const { name, reject, invoke } of rejectedDelegations) {
+      const failure = new Error(`${name} rejected`);
+      reject(failure);
+      await expect(invoke()).rejects.toBe(failure);
+    }
+
+    const synchronousThrowCases = [
+      {
+        name: 'session client read',
+        throwFrom: (error: Error) =>
+          runtimeManager.getClient.mockImplementationOnce(() => {
+            throw error;
+          }),
+        invoke: () => service.getSessionClient('throwing-client-read'),
+      },
+      {
+        name: 'runtime snapshot domain read',
+        throwFrom: (error: Error) =>
+          sessionDomainService.getRuntimeSnapshot.mockImplementationOnce(() => {
+            throw error;
+          }),
+        invoke: () => service.getRuntimeSnapshot('throwing-domain-snapshot'),
+      },
+      {
+        name: 'runtime snapshot client read',
+        throwFrom: (error: Error) =>
+          runtimeManager.getClient.mockImplementationOnce(() => {
+            throw error;
+          }),
+        invoke: () => service.getRuntimeSnapshot('throwing-runtime-snapshot'),
+      },
+      {
+        name: 'runtime snapshot activity read',
+        throwFrom: (error: Error) =>
+          runtimeManager.isSessionWorking.mockImplementationOnce(() => {
+            throw error;
+          }),
+        invoke: () => service.getRuntimeSnapshot('throwing-runtime-activity'),
+      },
+      {
+        name: 'runtime snapshot stop read',
+        throwFrom: (error: Error) => {
+          runtimeManager.getClient.mockReturnValueOnce(undefined);
+          runtimeManager.isStopInProgress.mockImplementationOnce(() => {
+            throw error;
+          });
+        },
+        invoke: () => service.getRuntimeSnapshot('throwing-runtime-stop'),
+      },
+      {
+        name: 'stopping gate read',
+        throwFrom: (error: Error) =>
+          lifecycleGate.isSessionStopping.mockImplementationOnce(() => {
+            throw error;
+          }),
+        invoke: () => service.isSessionStopping('throwing-stopping-gate'),
+      },
+      {
+        name: 'generation gate read',
+        throwFrom: (error: Error) =>
+          lifecycleGate.getGeneration.mockImplementationOnce(() => {
+            throw error;
+          }),
+        invoke: () => service.getStopGeneration('throwing-generation-gate'),
+      },
+      {
+        name: 'generation-current gate read',
+        throwFrom: (error: Error) =>
+          lifecycleGate.isGenerationCurrent.mockImplementationOnce(() => {
+            throw error;
+          }),
+        invoke: () => service.isStopGenerationCurrent('throwing-current-gate', 1),
+      },
+    ] as const;
+
+    for (const { name, throwFrom, invoke } of synchronousThrowCases) {
+      const failure = new Error(`${name} threw`);
+      throwFrom(failure);
+      expect(invoke).toThrow(failure);
+    }
+
+    const configurationThrowCases = [
+      {
+        name: 'workflow finalizer configuration',
+        throwFrom: (error: Error) =>
+          workflowFinalizer.configure.mockImplementationOnce(() => {
+            throw error;
+          }),
+      },
+      {
+        name: 'termination configuration',
+        throwFrom: (error: Error) =>
+          terminationCoordinator.configure.mockImplementationOnce(() => {
+            throw error;
+          }),
+      },
+      {
+        name: 'startup configuration',
+        throwFrom: (error: Error) =>
+          startupCoordinator.configure.mockImplementationOnce(() => {
+            throw error;
+          }),
+      },
+    ] as const;
+
+    for (const { name, throwFrom } of configurationThrowCases) {
+      const failure = new Error(`${name} threw`);
+      throwFrom(failure);
+      expect(() => service.configure({ workspace: workspaceBridge })).toThrow(failure);
+    }
   });
 
   it('delegates session option reads to the injected context service', async () => {

--- a/src/backend/services/session/service/lifecycle/session.lifecycle.facade.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.lifecycle.facade.test.ts
@@ -156,40 +156,31 @@ describe('SessionLifecycleFacade', () => {
     const session = unsafeCoerce<AgentSessionRecord>({ id: 'record-session' });
 
     const guardedOperations = [
-      ['start', () => service.startSession('unconfigured-start'), startupCoordinator.startSession],
+      [() => service.startSession('unconfigured-start'), startupCoordinator.startSession],
+      [() => service.restartSession('unconfigured-restart'), startupCoordinator.restartSession],
+      [() => service.stopSession('unconfigured-stop'), terminationCoordinator.stopSession],
       [
-        'restart',
-        () => service.restartSession('unconfigured-restart'),
-        startupCoordinator.restartSession,
-      ],
-      ['stop', () => service.stopSession('unconfigured-stop'), terminationCoordinator.stopSession],
-      [
-        'workspace stop',
         () => service.stopWorkspaceSessions('unconfigured-workspace'),
         terminationCoordinator.stopWorkspaceSessions,
       ],
-      ['stop all', () => service.stopAllClients(), terminationCoordinator.stopAllClients],
+      [() => service.stopAllClients(), terminationCoordinator.stopAllClients],
       [
-        'client creation',
         () => service.getOrCreateSessionClient('unconfigured-client'),
         startupCoordinator.getOrCreateSessionClient,
       ],
       [
-        'record client creation',
         () => service.getOrCreateSessionClientFromRecord(session),
         startupCoordinator.getOrCreateSessionClientFromRecord,
       ],
       [
-        'browse client creation',
         () => service.ensureSubagentBrowseSession('unconfigured-browse'),
         startupCoordinator.ensureSubagentBrowseSession,
       ],
     ] as const;
 
-    for (const [operation, invoke, collaborator] of guardedOperations) {
+    for (const [invoke, collaborator] of guardedOperations) {
       await expect(invoke()).rejects.toThrow('SessionLifecycleService not configured');
       expect(collaborator).not.toHaveBeenCalled();
-      expect(operation).toBeTruthy();
     }
     expect(() => service.persistClosedSession('unconfigured-closed')).toThrow(
       'SessionLifecycleService not configured'

--- a/src/backend/services/session/service/lifecycle/session.lifecycle.facade.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.lifecycle.facade.test.ts
@@ -432,6 +432,72 @@ describe('SessionLifecycleFacade', () => {
       throwFrom(failure);
       expect(() => service.configure({ workspace: workspaceBridge })).toThrow(failure);
     }
+
+    const retryWorkspaceBridge = unsafeCoerce<SessionLifecycleWorkspaceBridge>({
+      markSessionIdle: vi.fn(),
+    });
+    const retryMessageQueueBridge = { tryDispatchNextMessage: vi.fn(async () => undefined) };
+    const retryAutoIterationExit = { onAutoIterationSessionExit: vi.fn() };
+    const reconfigurationFailures = [
+      {
+        name: 'workflow finalizer',
+        throwFrom: (error: Error) =>
+          workflowFinalizer.configure.mockImplementationOnce(() => {
+            throw error;
+          }),
+      },
+      {
+        name: 'termination coordinator',
+        throwFrom: (error: Error) =>
+          terminationCoordinator.configure.mockImplementationOnce(() => {
+            throw error;
+          }),
+      },
+      {
+        name: 'startup coordinator',
+        throwFrom: (error: Error) =>
+          startupCoordinator.configure.mockImplementationOnce(() => {
+            throw error;
+          }),
+      },
+    ] as const;
+
+    for (const { name, throwFrom } of reconfigurationFailures) {
+      service.configure({ workspace: workspaceBridge });
+      const failure = new Error(`${name} reconfiguration failed`);
+      throwFrom(failure);
+
+      expect(() =>
+        service.configure({
+          workspace: retryWorkspaceBridge,
+          messageQueue: retryMessageQueueBridge,
+          autoIterationExit: retryAutoIterationExit,
+        })
+      ).toThrow(failure);
+
+      const operationCallsBeforeFailure = startupCoordinator.startSession.mock.calls.length;
+      await expect(service.startSession(`blocked-after-${name}`)).rejects.toThrow(
+        'SessionLifecycleService not configured'
+      );
+      expect(startupCoordinator.startSession).toHaveBeenCalledTimes(operationCallsBeforeFailure);
+
+      service.configure({
+        workspace: retryWorkspaceBridge,
+        messageQueue: retryMessageQueueBridge,
+        autoIterationExit: retryAutoIterationExit,
+      });
+      await expect(service.startSession(`restored-after-${name}`)).resolves.toBeUndefined();
+      expect(workflowFinalizer.configure).toHaveBeenLastCalledWith({
+        workspace: retryWorkspaceBridge,
+        autoIterationExit: retryAutoIterationExit,
+      });
+      expect(terminationCoordinator.configure).toHaveBeenLastCalledWith({
+        workspace: retryWorkspaceBridge,
+      });
+      expect(startupCoordinator.configure).toHaveBeenLastCalledWith({
+        messageQueue: retryMessageQueueBridge,
+      });
+    }
   });
 
   it('delegates session option reads to the injected context service', async () => {

--- a/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
+++ b/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
@@ -6,234 +6,123 @@ import type {
   SessionLifecycleWorkspaceBridge,
 } from '@/backend/services/session/service/bridges';
 import type { SessionDomainService } from '@/backend/services/session/service/session-domain.service';
-import { sessionEventBus } from '@/backend/services/session/service/session-event-bus';
-import { workspaceDataService } from '@/backend/services/workspace';
 import type { WorkspaceStatus } from '@/shared/core';
 import {
   createInitialSessionRuntimeState,
   type SessionRuntimeState,
 } from '@/shared/session-runtime';
-import type { AcpEventProcessor } from './acp-event-processor';
-import { closedSessionPersistenceService } from './closed-session-persistence.service';
-import type { SessionConfigService } from './session.config.service';
-import type { SessionPermissionService } from './session.permission.service';
-import type { SessionPromptTurnCompletionService } from './session.prompt-turn-completion.service';
-import type { SessionRepository } from './session.repository';
-import type { SessionRetryService } from './session.retry.service';
 import type { SessionContextService } from './session-context.service';
-import type { SessionAcpEnvironmentPort } from './session-lifecycle.types';
-import type { SessionLifecycleEventService } from './session-lifecycle-event.service';
 import type { SessionLifecycleGate } from './session-lifecycle-gate';
-import type { SessionNotificationDeliveryService } from './session-notification-delivery.service';
-import { SessionRuntimeExitCoordinator } from './session-runtime-exit.coordinator';
 import { isStaleLoadingRuntime } from './session-runtime-state.helpers';
-import {
-  type GetOrCreateSessionClientOptions,
-  SessionStartupCoordinator,
-  type StartSessionOptions,
+import type {
+  GetOrCreateSessionClientOptions,
+  StartSessionOptions,
 } from './session-startup.coordinator';
-import {
-  type SessionStopReason,
-  SessionTerminationCoordinator,
-  type StopSessionOptions,
-} from './session-termination.coordinator';
-import { SessionWorkflowFinalizer } from './session-workflow-finalizer';
+import type { SessionStopReason, StopSessionOptions } from './session-termination.coordinator';
 
+export type {
+  GetOrCreateSessionClientOptions,
+  StartSessionOptions,
+} from './session-startup.coordinator';
 export type { SessionStopReason, StopSessionOptions } from './session-termination.coordinator';
 
-type SendSessionMessage = (sessionId: string, content: string) => Promise<void>;
-type HydrateProviderHistory = (
-  sessionId: string,
-  session: AgentSessionRecord & {
-    workspace: { worktreePath: string | null };
-  }
-) => Promise<void>;
+export type LifecycleBridges = {
+  workspace: SessionLifecycleWorkspaceBridge;
+  messageQueue?: SessionLifecycleMessageQueueBridge;
+  autoIterationExit?: SessionAutoIterationExitBridge;
+};
 
 export type SessionLifecycleServiceDependencies = {
-  repository: SessionRepository;
-  contextService: SessionContextService;
-  acpEnvironment: SessionAcpEnvironmentPort;
-  runtimeManager: AcpRuntimeManager;
-  sessionDomainService: SessionDomainService;
-  sessionPermissionService: SessionPermissionService;
-  sessionConfigService: SessionConfigService;
-  acpEventProcessor: AcpEventProcessor;
-  promptTurnCompletionService: SessionPromptTurnCompletionService;
-  retryService: SessionRetryService;
-  lifecycleEventService: SessionLifecycleEventService;
-  lifecycleGate: SessionLifecycleGate;
-  hydrateProviderHistory?: HydrateProviderHistory;
-  sendSessionMessage: SendSessionMessage;
-  onBeforeStopSession?: (sessionId: string) => void;
-  onSessionExit?: (sessionId: string) => void;
+  startupCoordinator: Pick<
+    import('./session-startup.coordinator').SessionStartupCoordinator,
+    | 'configure'
+    | 'startSession'
+    | 'restartSession'
+    | 'getOrCreateSessionClient'
+    | 'getOrCreateSessionClientFromRecord'
+    | 'ensureSubagentBrowseSession'
+  >;
+  terminationCoordinator: Pick<
+    import('./session-termination.coordinator').SessionTerminationCoordinator,
+    'configure' | 'stopSession' | 'stopWorkspaceSessions' | 'stopAllClients'
+  >;
+  workflowFinalizer: Pick<
+    import('./session-workflow-finalizer').SessionWorkflowFinalizer,
+    'configure' | 'persistClosedSession' | 'recoverStaleRunningSessions'
+  >;
+  contextService: Pick<SessionContextService, 'getOptions'>;
+  runtimeManager: Pick<AcpRuntimeManager, 'getClient' | 'isSessionWorking' | 'isStopInProgress'>;
+  sessionDomainService: Pick<SessionDomainService, 'getRuntimeSnapshot'>;
+  lifecycleGate: Pick<
+    SessionLifecycleGate,
+    'isSessionStopping' | 'getGeneration' | 'isGenerationCurrent'
+  >;
 };
 
 export class SessionLifecycleService {
-  private readonly repository: SessionRepository;
-  private readonly contextService: SessionContextService;
-  private readonly acpEnvironment: SessionAcpEnvironmentPort;
-  private readonly runtimeManager: AcpRuntimeManager;
-  private readonly sessionDomainService: SessionDomainService;
-  private readonly sessionPermissionService: SessionPermissionService;
-  private readonly sessionConfigService: SessionConfigService;
-  private readonly acpEventProcessor: AcpEventProcessor;
-  private readonly promptTurnCompletionService: SessionPromptTurnCompletionService;
-  private readonly retryService: SessionRetryService;
-  private readonly lifecycleEventService: SessionLifecycleEventService;
-  private readonly lifecycleGate: SessionLifecycleGate;
-  private readonly hydrateProviderHistory: HydrateProviderHistory;
-  private readonly workflowFinalizer: SessionWorkflowFinalizer;
-  private readonly terminationCoordinator: SessionTerminationCoordinator;
-  private readonly runtimeExitCoordinator: SessionRuntimeExitCoordinator;
-  private readonly sendSessionMessage: SendSessionMessage;
-  private startupCoordinator: SessionStartupCoordinator | null = null;
-  private workspaceBridge: SessionLifecycleWorkspaceBridge | null = null;
-  private messageQueueBridge: SessionLifecycleMessageQueueBridge | null = null;
-  constructor(options: SessionLifecycleServiceDependencies) {
-    if (!(options.contextService && options.acpEnvironment)) {
-      throw new Error('SessionLifecycleService requires context and ACP environment ports');
-    }
-    this.repository = options.repository;
-    this.contextService = options.contextService;
-    this.acpEnvironment = options.acpEnvironment;
-    this.runtimeManager = options.runtimeManager;
-    this.sessionDomainService = options.sessionDomainService;
-    this.sessionPermissionService = options.sessionPermissionService;
-    this.sessionConfigService = options.sessionConfigService;
-    this.acpEventProcessor = options.acpEventProcessor;
-    this.promptTurnCompletionService = options.promptTurnCompletionService;
-    this.retryService = options.retryService;
-    this.lifecycleEventService = options.lifecycleEventService;
-    this.lifecycleGate = options.lifecycleGate;
-    this.hydrateProviderHistory =
-      options.hydrateProviderHistory ?? (async (): Promise<void> => undefined);
-    this.workflowFinalizer = new SessionWorkflowFinalizer({
-      repository: this.repository,
-      workspaceLookup: workspaceDataService,
-      sessionDomainService: this.sessionDomainService,
-      closedSessionPersistenceService,
-      lifecycleEventService: this.lifecycleEventService,
-      hydrateProviderHistory: this.hydrateProviderHistory,
-      runtimeManager: this.runtimeManager,
-      countViewers: (sessionId) => sessionEventBus.countViewers(sessionId),
-    });
-    this.terminationCoordinator = new SessionTerminationCoordinator({
-      repository: this.repository,
-      retryService: this.retryService,
-      runtimeManager: this.runtimeManager,
-      sessionDomainService: this.sessionDomainService,
-      sessionPermissionService: this.sessionPermissionService,
-      acpEventProcessor: this.acpEventProcessor,
-      promptTurnCompletionService: this.promptTurnCompletionService,
-      lifecycleEventService: this.lifecycleEventService,
-      lifecycleGate: this.lifecycleGate,
-      workflowFinalizer: this.workflowFinalizer,
-      getRuntimeSnapshot: (sessionId) => this.getRuntimeSnapshot(sessionId),
-      getWorkspaceBridge: () => this.workspaceBridge,
-      onBeforeStopSession: options.onBeforeStopSession,
-    });
-    this.runtimeExitCoordinator = new SessionRuntimeExitCoordinator({
-      repository: this.repository,
-      sessionDomainService: this.sessionDomainService,
-      sessionPermissionService: this.sessionPermissionService,
-      acpEventProcessor: this.acpEventProcessor,
-      promptTurnCompletionService: this.promptTurnCompletionService,
-      lifecycleEventService: this.lifecycleEventService,
-      lifecycleGate: this.lifecycleGate,
-      workflowFinalizer: this.workflowFinalizer,
-      onSessionExit: options.onSessionExit,
-    });
-    this.sendSessionMessage = options.sendSessionMessage;
-  }
-  configure(bridges: {
-    workspace: SessionLifecycleWorkspaceBridge;
-    messageQueue?: SessionLifecycleMessageQueueBridge;
-    autoIterationExit?: SessionAutoIterationExitBridge;
-  }): void {
-    this.workspaceBridge = bridges.workspace;
-    this.messageQueueBridge = bridges.messageQueue ?? null;
-    this.workflowFinalizer.configure({
+  constructor(private readonly dependencies: SessionLifecycleServiceDependencies) {}
+
+  configure(bridges: LifecycleBridges): void {
+    this.dependencies.workflowFinalizer.configure({
       workspace: bridges.workspace,
       autoIterationExit: bridges.autoIterationExit,
     });
-  }
-
-  configureNotificationDelivery(service: SessionNotificationDeliveryService): void {
-    this.startupCoordinator = new SessionStartupCoordinator({
-      repository: this.repository,
-      contextService: this.contextService,
-      acpEnvironment: this.acpEnvironment,
-      runtimeManager: this.runtimeManager,
-      sessionDomainService: this.sessionDomainService,
-      sessionConfigService: this.sessionConfigService,
-      acpEventProcessor: this.acpEventProcessor,
-      runtimeExitCoordinator: this.runtimeExitCoordinator,
-      lifecycleGate: this.lifecycleGate,
-      notificationDelivery: service,
-      getMessageQueueBridge: () => this.messageQueueBridge,
-      sendSessionMessage: this.sendSessionMessage,
-      stopSession: (sessionId, options) => this.stopSession(sessionId, options),
-    });
-  }
-
-  private get startup(): SessionStartupCoordinator {
-    if (!this.startupCoordinator) {
-      throw new Error(
-        'SessionLifecycleService not configured: notification delivery service missing'
-      );
-    }
-    return this.startupCoordinator;
+    this.dependencies.terminationCoordinator.configure({ workspace: bridges.workspace });
+    this.dependencies.startupCoordinator.configure({ messageQueue: bridges.messageQueue });
   }
 
   async startSession(sessionId: string, options?: StartSessionOptions): Promise<void> {
-    await this.startup.startSession(sessionId, options);
+    await this.dependencies.startupCoordinator.startSession(sessionId, options);
   }
 
   async restartSession(sessionId: string, options?: StartSessionOptions): Promise<void> {
-    await this.startup.restartSession(sessionId, options);
+    await this.dependencies.startupCoordinator.restartSession(sessionId, options);
   }
 
   async stopSession(sessionId: string, options?: StopSessionOptions): Promise<void> {
-    await this.terminationCoordinator.stopSession(sessionId, options);
+    await this.dependencies.terminationCoordinator.stopSession(sessionId, options);
   }
 
   async stopWorkspaceSessions(
     workspaceId: string,
     options?: { reason?: SessionStopReason }
   ): Promise<void> {
-    await this.terminationCoordinator.stopWorkspaceSessions(workspaceId, options);
+    await this.dependencies.terminationCoordinator.stopWorkspaceSessions(workspaceId, options);
   }
 
   async getOrCreateSessionClient(
     sessionId: string,
     options?: GetOrCreateSessionClientOptions
   ): Promise<unknown> {
-    return await this.startup.getOrCreateSessionClient(sessionId, options);
+    return await this.dependencies.startupCoordinator.getOrCreateSessionClient(sessionId, options);
   }
 
   async getOrCreateSessionClientFromRecord(
     session: AgentSessionRecord,
     options?: GetOrCreateSessionClientOptions
   ): Promise<unknown> {
-    return await this.startup.getOrCreateSessionClientFromRecord(session, options);
+    return await this.dependencies.startupCoordinator.getOrCreateSessionClientFromRecord(
+      session,
+      options
+    );
   }
 
   async ensureSubagentBrowseSession(sessionId: string): Promise<boolean> {
-    return await this.startup.ensureSubagentBrowseSession(sessionId);
+    return await this.dependencies.startupCoordinator.ensureSubagentBrowseSession(sessionId);
   }
 
   getSessionClient(sessionId: string): unknown | undefined {
-    return this.runtimeManager.getClient(sessionId);
+    return this.dependencies.runtimeManager.getClient(sessionId);
   }
 
   getRuntimeSnapshot(sessionId: string): SessionRuntimeState {
     const fallback = createInitialSessionRuntimeState();
-    const persisted = this.sessionDomainService.getRuntimeSnapshot(sessionId);
+    const persisted = this.dependencies.sessionDomainService.getRuntimeSnapshot(sessionId);
     const base = persisted ?? fallback;
 
-    const acpClient = this.runtimeManager.getClient(sessionId);
+    const acpClient = this.dependencies.runtimeManager.getClient(sessionId);
     if (acpClient) {
-      const isWorking = this.runtimeManager.isSessionWorking(sessionId);
+      const isWorking = this.dependencies.runtimeManager.isSessionWorking(sessionId);
       return {
         phase: isWorking ? 'running' : 'idle',
         processState: 'alive',
@@ -242,7 +131,7 @@ export class SessionLifecycleService {
       };
     }
 
-    if (this.runtimeManager.isStopInProgress(sessionId)) {
+    if (this.dependencies.runtimeManager.isStopInProgress(sessionId)) {
       return {
         ...base,
         phase: 'stopping',
@@ -264,15 +153,15 @@ export class SessionLifecycleService {
   }
 
   isSessionStopping(sessionId: string): boolean {
-    return this.lifecycleGate.isSessionStopping(sessionId);
+    return this.dependencies.lifecycleGate.isSessionStopping(sessionId);
   }
 
   getStopGeneration(sessionId: string): number {
-    return this.lifecycleGate.getGeneration(sessionId);
+    return this.dependencies.lifecycleGate.getGeneration(sessionId);
   }
 
   isStopGenerationCurrent(sessionId: string, stopGeneration: number): boolean {
-    return this.lifecycleGate.isGenerationCurrent(sessionId, stopGeneration);
+    return this.dependencies.lifecycleGate.isGenerationCurrent(sessionId, stopGeneration);
   }
 
   getSessionOptions(sessionId: string): Promise<{
@@ -282,17 +171,17 @@ export class SessionLifecycleService {
     model: string;
     workspaceStatus: WorkspaceStatus;
   } | null> {
-    return this.contextService.getOptions(sessionId);
+    return this.dependencies.contextService.getOptions(sessionId);
   }
 
   async stopAllClients(timeoutMs = 5000): Promise<void> {
-    await this.terminationCoordinator.stopAllClients(timeoutMs);
+    await this.dependencies.terminationCoordinator.stopAllClients(timeoutMs);
   }
 
   persistClosedSession(sessionId: string): Promise<void> {
-    return this.workflowFinalizer.persistClosedSession(sessionId);
+    return this.dependencies.workflowFinalizer.persistClosedSession(sessionId);
   }
   recoverStaleRunningSessions(): Promise<number> {
-    return this.workflowFinalizer.recoverStaleRunningSessions();
+    return this.dependencies.workflowFinalizer.recoverStaleRunningSessions();
   }
 }

--- a/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
+++ b/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
@@ -60,6 +60,8 @@ export type SessionLifecycleServiceDependencies = {
 };
 
 export class SessionLifecycleService {
+  private configured = false;
+
   constructor(private readonly dependencies: SessionLifecycleServiceDependencies) {}
 
   configure(bridges: LifecycleBridges): void {
@@ -69,17 +71,21 @@ export class SessionLifecycleService {
     });
     this.dependencies.terminationCoordinator.configure({ workspace: bridges.workspace });
     this.dependencies.startupCoordinator.configure({ messageQueue: bridges.messageQueue });
+    this.configured = true;
   }
 
   async startSession(sessionId: string, options?: StartSessionOptions): Promise<void> {
+    this.assertConfigured();
     await this.dependencies.startupCoordinator.startSession(sessionId, options);
   }
 
   async restartSession(sessionId: string, options?: StartSessionOptions): Promise<void> {
+    this.assertConfigured();
     await this.dependencies.startupCoordinator.restartSession(sessionId, options);
   }
 
   async stopSession(sessionId: string, options?: StopSessionOptions): Promise<void> {
+    this.assertConfigured();
     await this.dependencies.terminationCoordinator.stopSession(sessionId, options);
   }
 
@@ -87,6 +93,7 @@ export class SessionLifecycleService {
     workspaceId: string,
     options?: { reason?: SessionStopReason }
   ): Promise<void> {
+    this.assertConfigured();
     await this.dependencies.terminationCoordinator.stopWorkspaceSessions(workspaceId, options);
   }
 
@@ -94,6 +101,7 @@ export class SessionLifecycleService {
     sessionId: string,
     options?: GetOrCreateSessionClientOptions
   ): Promise<unknown> {
+    this.assertConfigured();
     return await this.dependencies.startupCoordinator.getOrCreateSessionClient(sessionId, options);
   }
 
@@ -101,6 +109,7 @@ export class SessionLifecycleService {
     session: AgentSessionRecord,
     options?: GetOrCreateSessionClientOptions
   ): Promise<unknown> {
+    this.assertConfigured();
     return await this.dependencies.startupCoordinator.getOrCreateSessionClientFromRecord(
       session,
       options
@@ -108,6 +117,7 @@ export class SessionLifecycleService {
   }
 
   async ensureSubagentBrowseSession(sessionId: string): Promise<boolean> {
+    this.assertConfigured();
     return await this.dependencies.startupCoordinator.ensureSubagentBrowseSession(sessionId);
   }
 
@@ -175,13 +185,22 @@ export class SessionLifecycleService {
   }
 
   async stopAllClients(timeoutMs = 5000): Promise<void> {
+    this.assertConfigured();
     await this.dependencies.terminationCoordinator.stopAllClients(timeoutMs);
   }
 
   persistClosedSession(sessionId: string): Promise<void> {
+    this.assertConfigured();
     return this.dependencies.workflowFinalizer.persistClosedSession(sessionId);
   }
   recoverStaleRunningSessions(): Promise<number> {
+    this.assertConfigured();
     return this.dependencies.workflowFinalizer.recoverStaleRunningSessions();
+  }
+
+  private assertConfigured(): void {
+    if (!this.configured) {
+      throw new Error('SessionLifecycleService not configured: lifecycle bridges missing');
+    }
   }
 }

--- a/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
+++ b/src/backend/services/session/service/lifecycle/session.lifecycle.service.ts
@@ -65,6 +65,7 @@ export class SessionLifecycleService {
   constructor(private readonly dependencies: SessionLifecycleServiceDependencies) {}
 
   configure(bridges: LifecycleBridges): void {
+    this.configured = false;
     this.dependencies.workflowFinalizer.configure({
       workspace: bridges.workspace,
       autoIterationExit: bridges.autoIterationExit,


### PR DESCRIPTION
## Summary

- collapse `SessionLifecycleService` into a 207-line compatibility facade over injected lifecycle collaborators
- move lifecycle coordinator/finalizer construction into the cycle-safe session composition root and remove transitional notification wiring
- make required bridge configuration fail fast, including failed reconfiguration and complete-retry behavior
- preserve public lifecycle signatures, return values, errors, and read-only pre-configuration queries with exhaustive facade contracts
- document final lifecycle ownership and reconciliation boundaries

## Why

This completes the staged session-lifecycle modularization. Startup, termination, runtime exit, notification delivery, context, workflow finalization, domain eligibility, and ACP runtime state now each have one explicit owner while callers retain the existing lifecycle facade.

Public lifecycle behavior and signatures remain unchanged.

## Final size and ownership audit

- `session.lifecycle.service.ts`: 207 lines
- focused lifecycle units: 173–582 lines, all below the 600-line target and 1,000-line hard limit
- no lifecycle-side `clientCreationOperations`
- no direct settings/workspace singleton imports in coordinators
- no lifecycle client-creator wiring in WebSocket/chat transport
- no private lifecycle test reach-through matches
- no file-length baseline increase or schema change

## Verification

- `pnpm check:fix`
- `pnpm typecheck`
- focused session/WebSocket suite: 90 files, 1,118 tests passed; 4 skipped
- `pnpm test --maxWorkers=4`: 410 files, 5,264 tests passed; 4 skipped
- `pnpm check`: all guardrails passed; local Codex schema drift check skipped by its normal version policy because local CLI 0.147.0 differs from pinned 0.145.0
- `git diff --check`
- final task reviews and whole-branch architecture review: approved after fixes



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core session start/stop/runtime-exit paths and composition order, but behavior is intended to be unchanged and heavily covered by lifecycle tests.
> 
> **Overview**
> Completes session lifecycle modularization by shrinking **`SessionLifecycleService`** into a compatibility facade that only delegates to injected startup, termination, and workflow collaborators, with coordinator construction and cycle-safe wiring moved into **`session-core-services`**.
> 
> **Composition changes:** `SessionNotificationDeliveryService` and the full coordinator graph are built in the composition root; transitional `configureNotificationDelivery` is removed. **`SessionStartupCoordinator`** and **`SessionTerminationCoordinator`** take workspace/message-queue bridges via **`configure()`** instead of constructor getter callbacks.
> 
> **Guardrails:** Mutating lifecycle operations fail fast until `configure()` runs; failed reconfiguration leaves the service unconfigured until a successful retry. Public lifecycle types are re-exported from the facade module.
> 
> **Docs/tests:** `docs/architecture/agent-runtime.md` documents lifecycle ownership boundaries; harnesses and facade/composition tests cover delegation, runtime handlers, and reconfiguration behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b908c6fa655e80511a0e20cbd0806206500c76f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->