### PR TITLE
Fix subagent activity canceling long turns

### DIFF
--- a/src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.notification-ordering.test.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.notification-ordering.test.ts
@@ -138,12 +138,10 @@ describe('CodexAppServerAcpAdapter notification ordering', () => {
       }
     ).handleCodexNotification.bind(adapter);
     const item = {
-      type: 'subAgentActivity',
+      type: 'commandExecution',
       id: 'item_notification_order',
       callId: 'call_notification_order',
-      agentThreadId: 'child_notification_order',
-      agentPath: 'review/notification_order',
-      kind: 'started',
+      command: 'cat README.md',
     };
     const started = handleCodexNotification('item/started', {
       threadId: 'thread_notification_order',

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.test.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.test.ts
@@ -700,9 +700,10 @@ describe('stream-event-handler', () => {
     expect(recordSubagentActivity).toHaveBeenCalledWith('sess_thread_1', ['child_1'], 'created');
   });
 
-  it('bounds synthetic completions while suppressing recent sub-agent progress', async () => {
+  it('bounds completed tombstones without evicting in-flight sub-agent activity', async () => {
     const session = createSession();
     const reportShapeDrift = vi.fn();
+    const recordSubagentActivity = vi.fn(async () => undefined);
     const handler = new CodexStreamEventHandler({
       codex: { request: vi.fn() },
       sessionIdByThreadId: new Map([['thread_1', 'sess_thread_1']]),
@@ -717,6 +718,7 @@ describe('stream-event-handler', () => {
             kind: 'other',
             title: 'Start subagent',
             locations: [],
+            ...(item.id === 'item_subagent_0' ? { affectedSubagentIds: ['child_0'] } : {}),
           }) satisfies ToolCallState
       ),
       emitReasoningThoughtChunkFromItem: vi.fn(async () => undefined),
@@ -726,11 +728,15 @@ describe('stream-event-handler', () => {
       hasPendingPlanApprovals: vi.fn(() => false),
       settleTurn: vi.fn(),
       emitTurnFailureMessage: vi.fn(async () => undefined),
+      recordSubagentActivity,
     });
 
-    for (let index = 0; index <= 1000; index += 1) {
-      await handler.handleCodexNotification({
-        method: 'item/started',
+    const sendSubagentActivity = (
+      method: 'item/started' | 'item/completed',
+      index: number
+    ): Promise<void> =>
+      handler.handleCodexNotification({
+        method,
         params: {
           threadId: 'thread_1',
           turnId: 'turn_1',
@@ -743,22 +749,33 @@ describe('stream-event-handler', () => {
           },
         },
       });
+
+    await sendSubagentActivity('item/started', 0);
+    for (let index = 1; index <= 1001; index += 1) {
+      await sendSubagentActivity('item/started', index);
+      await sendSubagentActivity('item/completed', index);
     }
 
-    expect(session.syntheticallyCompletedToolItemIds.size).toBe(1000);
-    expect(session.syntheticallyCompletedToolItemIds.has('item_subagent_0')).toBe(false);
-    expect(session.syntheticallyCompletedToolItemIds.has('item_subagent_1000')).toBe(true);
+    expect(session.syntheticallyCompletedToolItemIds).toEqual(new Set(['item_subagent_0']));
+    const internalHandler = handler as unknown as {
+      completedSyntheticToolItemKeysBySession: WeakMap<AdapterSession, Set<string>>;
+    };
+    expect(internalHandler.completedSyntheticToolItemKeysBySession.get(session)?.size).toBe(1000);
+
+    await sendSubagentActivity('item/completed', 0);
+    await sendSubagentActivity('item/completed', 0);
 
     await handler.handleCodexNotification({
       method: 'item/commandExecution/outputDelta',
       params: {
         threadId: 'thread_1',
         turnId: 'turn_1',
-        itemId: 'item_subagent_1000',
+        itemId: 'item_subagent_0',
         delta: 'late progress',
       },
     });
 
+    expect(recordSubagentActivity).toHaveBeenCalledTimes(1);
     expect(reportShapeDrift).not.toHaveBeenCalled();
   });
 

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.test.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.test.ts
@@ -565,13 +565,14 @@ describe('stream-event-handler', () => {
     );
   });
 
-  it('retains tool metadata through started, progress, and completed updates', async () => {
+  it('completes sub-agent activity once while retaining tool metadata', async () => {
     const session = createSession();
     const updates: SessionUpdate[] = [];
     const emitSessionUpdate = vi.fn((_sessionId: string, update: SessionUpdate) => {
       updates.push(update);
       return Promise.resolve();
     });
+    const reportShapeDrift = vi.fn();
     const toolState: ToolCallState = {
       toolCallId: 'call_subagent_1',
       kind: 'other',
@@ -591,7 +592,7 @@ describe('stream-event-handler', () => {
       sessions: new Map([['sess_thread_1', session]]),
       requireSession: vi.fn(),
       emitSessionUpdate,
-      reportShapeDrift: vi.fn(),
+      reportShapeDrift,
       buildToolCallState: vi.fn(() => toolState),
       emitReasoningThoughtChunkFromItem: vi.fn(async () => undefined),
       shouldHoldTurnForPlanApproval: vi.fn(() => false),
@@ -636,27 +637,15 @@ describe('stream-event-handler', () => {
       },
     });
 
-    expect(updates).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          sessionUpdate: 'tool_call',
-          toolCallId: 'call_subagent_1',
-          _meta: toolState.meta,
-        }),
-        expect.objectContaining({
-          sessionUpdate: 'tool_call_update',
-          toolCallId: 'call_subagent_1',
-          status: 'in_progress',
-          _meta: toolState.meta,
-        }),
-        expect.objectContaining({
-          sessionUpdate: 'tool_call_update',
-          toolCallId: 'call_subagent_1',
-          status: 'completed',
-          _meta: toolState.meta,
-        }),
-      ])
-    );
+    expect(updates).toEqual([
+      expect.objectContaining({
+        sessionUpdate: 'tool_call',
+        toolCallId: 'call_subagent_1',
+        status: 'completed',
+        _meta: toolState.meta,
+      }),
+    ]);
+    expect(reportShapeDrift).not.toHaveBeenCalled();
   });
 
   it('correlates and invalidates a live sub-agent activity item exactly once', async () => {
@@ -696,6 +685,10 @@ describe('stream-event-handler', () => {
 
     await handler.handleCodexNotification({
       method: 'item/started',
+      params: { threadId: 'thread_1', turnId: 'turn_1', item },
+    });
+    await handler.handleCodexNotification({
+      method: 'item/completed',
       params: { threadId: 'thread_1', turnId: 'turn_1', item },
     });
     await handler.handleCodexNotification({

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.test.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.test.ts
@@ -700,6 +700,68 @@ describe('stream-event-handler', () => {
     expect(recordSubagentActivity).toHaveBeenCalledWith('sess_thread_1', ['child_1'], 'created');
   });
 
+  it('bounds synthetic completions while suppressing recent sub-agent progress', async () => {
+    const session = createSession();
+    const reportShapeDrift = vi.fn();
+    const handler = new CodexStreamEventHandler({
+      codex: { request: vi.fn() },
+      sessionIdByThreadId: new Map([['thread_1', 'sess_thread_1']]),
+      sessions: new Map([['sess_thread_1', session]]),
+      requireSession: vi.fn(),
+      emitSessionUpdate: vi.fn(async () => undefined),
+      reportShapeDrift,
+      buildToolCallState: vi.fn(
+        (_session, item) =>
+          ({
+            toolCallId: `call_${item.id}`,
+            kind: 'other',
+            title: 'Start subagent',
+            locations: [],
+          }) satisfies ToolCallState
+      ),
+      emitReasoningThoughtChunkFromItem: vi.fn(async () => undefined),
+      shouldHoldTurnForPlanApproval: vi.fn(() => false),
+      holdTurnUntilPlanApprovalResolves: vi.fn(),
+      maybeRequestPlanApproval: vi.fn(async () => undefined),
+      hasPendingPlanApprovals: vi.fn(() => false),
+      settleTurn: vi.fn(),
+      emitTurnFailureMessage: vi.fn(async () => undefined),
+    });
+
+    for (let index = 0; index <= 1000; index += 1) {
+      await handler.handleCodexNotification({
+        method: 'item/started',
+        params: {
+          threadId: 'thread_1',
+          turnId: 'turn_1',
+          item: {
+            type: 'subAgentActivity',
+            id: `item_subagent_${index}`,
+            agentThreadId: `child_${index}`,
+            agentPath: `review/${index}`,
+            kind: 'started',
+          },
+        },
+      });
+    }
+
+    expect(session.syntheticallyCompletedToolItemIds.size).toBe(1000);
+    expect(session.syntheticallyCompletedToolItemIds.has('item_subagent_0')).toBe(false);
+    expect(session.syntheticallyCompletedToolItemIds.has('item_subagent_1000')).toBe(true);
+
+    await handler.handleCodexNotification({
+      method: 'item/commandExecution/outputDelta',
+      params: {
+        threadId: 'thread_1',
+        turnId: 'turn_1',
+        itemId: 'item_subagent_1000',
+        delta: 'late progress',
+      },
+    });
+
+    expect(reportShapeDrift).not.toHaveBeenCalled();
+  });
+
   it('retains tool metadata when replaying history', async () => {
     const session = createSession();
     const emitSessionUpdate = vi.fn(async () => undefined);

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.ts
@@ -530,13 +530,12 @@ export class CodexStreamEventHandler {
     if (this.isReplayedTurnItem(session, turnId, itemId)) {
       return;
     }
+    if (session.syntheticallyCompletedToolItemIds.has(itemId)) {
+      return;
+    }
     const toolCall = session.toolCallsByItemId.get(itemId);
     if (!toolCall) {
       this.deps.reportShapeDrift('tool_progress_without_tool_call', { turnId, itemId });
-      return;
-    }
-
-    if (session.syntheticallyCompletedToolItemIds.has(itemId)) {
       return;
     }
 
@@ -694,6 +693,22 @@ export class CodexStreamEventHandler {
       return;
     }
 
+    if (item.type === 'subAgentActivity') {
+      session.syntheticallyCompletedToolItemIds.add(item.id);
+      await this.recordSubagentActivity(session, item, toolInfo);
+      await this.deps.emitSessionUpdate(session.sessionId, {
+        sessionUpdate: 'tool_call',
+        toolCallId: toolInfo.toolCallId,
+        title: toolInfo.title,
+        kind: toolInfo.kind,
+        status: 'completed',
+        ...metaUpdate(toolInfo.meta),
+        rawInput: item,
+        rawOutput: item,
+      });
+      return;
+    }
+
     session.syntheticallyCompletedToolItemIds.delete(item.id);
     session.toolCallsByItemId.set(item.id, toolInfo);
     await this.recordSubagentActivity(session, item, toolInfo);
@@ -726,6 +741,12 @@ export class CodexStreamEventHandler {
     turnId: string
   ): Promise<void> {
     if (this.isReplayedTurnItem(session, turnId, item.id)) {
+      return;
+    }
+    if (
+      item.type === 'subAgentActivity' &&
+      session.syntheticallyCompletedToolItemIds.has(item.id)
+    ) {
       return;
     }
 

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.ts
@@ -43,17 +43,6 @@ function metaUpdate(meta: ToolCallState['meta']): Record<string, unknown> {
   return meta ? { _meta: meta } : {};
 }
 
-function recordSyntheticCompletion(session: AdapterSession, itemId: string): void {
-  session.syntheticallyCompletedToolItemIds.add(itemId);
-  if (session.syntheticallyCompletedToolItemIds.size <= MAX_SYNTHETIC_COMPLETION_TOMBSTONES) {
-    return;
-  }
-  const oldestItemId = session.syntheticallyCompletedToolItemIds.values().next().value;
-  if (oldestItemId !== undefined) {
-    session.syntheticallyCompletedToolItemIds.delete(oldestItemId);
-  }
-}
-
 type StreamEventHandlerDeps = {
   codex: Pick<CodexClient, 'request'>;
   sessionIdByThreadId: Map<string, string>;
@@ -99,6 +88,10 @@ export class CodexStreamEventHandler {
   private readonly goalRefreshStateByThreadId = new Map<
     string,
     { notificationVersion: number; pendingRefreshCount: number }
+  >();
+  private readonly completedSyntheticToolItemKeysBySession = new WeakMap<
+    AdapterSession,
+    Set<string>
   >();
 
   constructor(private readonly deps: StreamEventHandlerDeps) {}
@@ -482,6 +475,37 @@ export class CodexStreamEventHandler {
     return session.replayedTurnItemKeys.has(toTurnItemKey(turnId, itemId));
   }
 
+  private hasSyntheticCompletion(session: AdapterSession, turnId: string, itemId: string): boolean {
+    return (
+      session.syntheticallyCompletedToolItemIds.has(itemId) ||
+      (this.completedSyntheticToolItemKeysBySession
+        .get(session)
+        ?.has(toTurnItemKey(turnId, itemId)) ??
+        false)
+    );
+  }
+
+  private finishSubagentSyntheticCompletion(
+    session: AdapterSession,
+    turnId: string,
+    itemId: string
+  ): void {
+    if (!session.syntheticallyCompletedToolItemIds.delete(itemId)) {
+      return;
+    }
+    const completedItemKeys =
+      this.completedSyntheticToolItemKeysBySession.get(session) ?? new Set<string>();
+    this.completedSyntheticToolItemKeysBySession.set(session, completedItemKeys);
+    completedItemKeys.add(toTurnItemKey(turnId, itemId));
+    if (completedItemKeys.size <= MAX_SYNTHETIC_COMPLETION_TOMBSTONES) {
+      return;
+    }
+    const oldestItemKey = completedItemKeys.values().next().value;
+    if (oldestItemKey !== undefined) {
+      completedItemKeys.delete(oldestItemKey);
+    }
+  }
+
   private async emitReasoningThoughtDelta(
     sessionId: string,
     session: AdapterSession,
@@ -543,7 +567,7 @@ export class CodexStreamEventHandler {
     if (this.isReplayedTurnItem(session, turnId, itemId)) {
       return;
     }
-    if (session.syntheticallyCompletedToolItemIds.has(itemId)) {
+    if (this.hasSyntheticCompletion(session, turnId, itemId)) {
       return;
     }
     const toolCall = session.toolCallsByItemId.get(itemId);
@@ -553,7 +577,7 @@ export class CodexStreamEventHandler {
     }
 
     if (source === 'commandExecution' && isCommandExecutionSessionHandoffOutput(output)) {
-      recordSyntheticCompletion(session, itemId);
+      session.syntheticallyCompletedToolItemIds.add(itemId);
       await this.deps.emitSessionUpdate(sessionId, {
         sessionUpdate: 'tool_call_update',
         toolCallId: toolCall.toolCallId,
@@ -707,7 +731,7 @@ export class CodexStreamEventHandler {
     }
 
     if (item.type === 'subAgentActivity') {
-      recordSyntheticCompletion(session, item.id);
+      session.syntheticallyCompletedToolItemIds.add(item.id);
       await this.recordSubagentActivity(session, item, toolInfo);
       await this.deps.emitSessionUpdate(session.sessionId, {
         sessionUpdate: 'tool_call',
@@ -756,10 +780,8 @@ export class CodexStreamEventHandler {
     if (this.isReplayedTurnItem(session, turnId, item.id)) {
       return;
     }
-    if (
-      item.type === 'subAgentActivity' &&
-      session.syntheticallyCompletedToolItemIds.has(item.id)
-    ) {
+    if (item.type === 'subAgentActivity' && this.hasSyntheticCompletion(session, turnId, item.id)) {
+      this.finishSubagentSyntheticCompletion(session, turnId, item.id);
       return;
     }
 

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.ts
@@ -37,8 +37,21 @@ type CodexNotificationPayload = {
 
 type KnownCodexNotification = ReturnType<typeof knownCodexNotificationSchema.parse>;
 
+const MAX_SYNTHETIC_COMPLETION_TOMBSTONES = 1000;
+
 function metaUpdate(meta: ToolCallState['meta']): Record<string, unknown> {
   return meta ? { _meta: meta } : {};
+}
+
+function recordSyntheticCompletion(session: AdapterSession, itemId: string): void {
+  session.syntheticallyCompletedToolItemIds.add(itemId);
+  if (session.syntheticallyCompletedToolItemIds.size <= MAX_SYNTHETIC_COMPLETION_TOMBSTONES) {
+    return;
+  }
+  const oldestItemId = session.syntheticallyCompletedToolItemIds.values().next().value;
+  if (oldestItemId !== undefined) {
+    session.syntheticallyCompletedToolItemIds.delete(oldestItemId);
+  }
 }
 
 type StreamEventHandlerDeps = {
@@ -540,7 +553,7 @@ export class CodexStreamEventHandler {
     }
 
     if (source === 'commandExecution' && isCommandExecutionSessionHandoffOutput(output)) {
-      session.syntheticallyCompletedToolItemIds.add(itemId);
+      recordSyntheticCompletion(session, itemId);
       await this.deps.emitSessionUpdate(sessionId, {
         sessionUpdate: 'tool_call_update',
         toolCallId: toolCall.toolCallId,
@@ -694,7 +707,7 @@ export class CodexStreamEventHandler {
     }
 
     if (item.type === 'subAgentActivity') {
-      session.syntheticallyCompletedToolItemIds.add(item.id);
+      recordSyntheticCompletion(session, item.id);
       await this.recordSubagentActivity(session, item, toolInfo);
       await this.deps.emitSessionUpdate(session.sessionId, {
         sessionUpdate: 'tool_call',


### PR DESCRIPTION
## Summary

- project Codex subagent activity as a one-shot completed ACP tool call
- ignore late progress and repeated completion events while child lifecycle updates continue through status notifications
- preserve pending-to-completed ordering coverage for genuinely long-running command tools

## Why

A completed `Start subagent` activity could remain pending in the ACP projection. After 60 minutes, the generic tool timeout canceled an otherwise active parent prompt, which is what stopped workspace `cmt1kcfvq0071hspzxsg5fwpf`.

## Verification

- `pnpm check:fix`
- `pnpm typecheck`
- `pnpm test` — 412 files passed, 1 skipped; 5,289 tests passed, 4 skipped
- `pnpm check`
- independent code review — no findings after follow-up fixes

`pnpm check` passed. Its local Codex schema drift step was skipped because the installed CLI is 0.148 while the repository pins 0.145; CI installs the pinned CLI and enforces that check.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ACP stream projection and turn-tool lifecycle for sub-agents; a miss here can still leave tools pending or drop late events, but the change is localized and covered by tests.
> 
> **Overview**
> Stops Codex `subAgentActivity` from lingering as a pending ACP tool call, which could hit the generic 60-minute tool timeout and cancel an otherwise live parent turn.
> 
> On `item/started`, sub-agent activity is now projected as a single completed `tool_call` (with metadata). Late progress and duplicate `item/completed` events are ignored via synthetic-completion tombstones (capped at 1000 per session) so in-flight items are not evicted. Real command tools still go pending → in_progress → completed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89d3b40bc652259a4488e562043ebf1a831a7bd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->