### PR TITLE
Fix #2181: Serialize ACP turn completion notifications

### DIFF
--- a/src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.notification-ordering.test.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.notification-ordering.test.ts
@@ -49,7 +49,10 @@ async function initializeAdapter(
     },
   });
   request.mockResolvedValueOnce({
-    data: [{ name: 'Default', mode: 'default' }],
+    data: [
+      { name: 'Default', mode: 'default' },
+      { name: 'Plan', mode: 'plan' },
+    ],
     nextCursor: null,
   });
   request.mockResolvedValueOnce({
@@ -165,5 +168,180 @@ describe('CodexAppServerAcpAdapter notification ordering', () => {
       'in_progress',
       'completed',
     ]);
+  });
+
+  it('finishes an item before turn completion clears its tool call state', async () => {
+    const connection = createMockConnection();
+    const { client, request } = createMockCodexClient();
+    const adapter = new CodexAppServerAcpAdapter(connection as AgentSideConnection, client);
+    await initializeAdapter(adapter, request);
+
+    request.mockResolvedValueOnce({
+      thread: { id: 'thread_turn_completion_order', cwd: '/tmp/workspace' },
+      approvalPolicy: 'on-failure',
+      reasoningEffort: 'medium',
+    });
+    const session = await adapter.newSession({ cwd: '/tmp/workspace', mcpServers: [] });
+    request.mockResolvedValueOnce({
+      turn: { id: 'turn_completion_order', status: 'inProgress' },
+    });
+    const prompt = adapter.prompt({
+      sessionId: session.sessionId,
+      prompt: [{ type: 'text', text: 'run a command' }],
+    });
+    await vi.waitFor(() =>
+      expect(request).toHaveBeenCalledWith(
+        'turn/start',
+        expect.objectContaining({ threadId: 'thread_turn_completion_order' })
+      )
+    );
+
+    const sessionUpdate = connection.sessionUpdate as ReturnType<typeof vi.fn>;
+    sessionUpdate.mockClear();
+    let releaseFirstUpdate: () => void = () => undefined;
+    const firstUpdateBlocked = new Promise<void>((resolve) => {
+      releaseFirstUpdate = resolve;
+    });
+    sessionUpdate
+      .mockImplementationOnce(async () => await firstUpdateBlocked)
+      .mockResolvedValue(undefined);
+
+    const handleCodexNotification = (
+      adapter as unknown as {
+        handleCodexNotification: (method: string, params: unknown) => Promise<void>;
+      }
+    ).handleCodexNotification.bind(adapter);
+    const item = {
+      type: 'commandExecution',
+      id: 'item_turn_completion_order',
+      status: 'inProgress',
+      command: 'echo ordered',
+    };
+    const started = handleCodexNotification('item/started', {
+      threadId: 'thread_turn_completion_order',
+      turnId: 'turn_completion_order',
+      item,
+    });
+    await vi.waitFor(() => expect(sessionUpdate).toHaveBeenCalledTimes(1));
+
+    const completed = handleCodexNotification('item/completed', {
+      threadId: 'thread_turn_completion_order',
+      turnId: 'turn_completion_order',
+      item: { ...item, status: 'completed' },
+    });
+    const turnCompleted = handleCodexNotification('turn/completed', {
+      threadId: 'thread_turn_completion_order',
+      turn: { id: 'turn_completion_order', status: 'completed', error: null, items: [] },
+    });
+
+    releaseFirstUpdate();
+    await Promise.all([started, completed, turnCompleted]);
+    await expect(prompt).resolves.toEqual({ stopReason: 'end_turn' });
+
+    expect(sessionUpdate.mock.calls.map((call) => call[0].update.sessionUpdate)).toEqual([
+      'tool_call',
+      'tool_call_update',
+      'tool_call_update',
+    ]);
+  });
+
+  it('waits for a plan hold before processing turn completion', async () => {
+    let resolvePlanApproval: (value: RequestPermissionResponse) => void = () => {
+      throw new Error('expected plan approval request callback');
+    };
+    const connection = createMockConnection();
+    (connection.requestPermission as ReturnType<typeof vi.fn>).mockImplementation(
+      () =>
+        new Promise<RequestPermissionResponse>((resolve) => {
+          resolvePlanApproval = resolve;
+        })
+    );
+    const { client, request } = createMockCodexClient();
+    const adapter = new CodexAppServerAcpAdapter(connection as AgentSideConnection, client);
+    await initializeAdapter(adapter, request);
+
+    request.mockResolvedValueOnce({
+      thread: { id: 'thread_plan_hold_order', cwd: '/tmp/workspace' },
+      approvalPolicy: 'on-failure',
+      reasoningEffort: 'medium',
+    });
+    const session = await adapter.newSession({ cwd: '/tmp/workspace', mcpServers: [] });
+    await adapter.setSessionMode({ sessionId: session.sessionId, modeId: 'plan' });
+    request.mockResolvedValueOnce({
+      turn: { id: 'turn_plan_hold_order', status: 'inProgress' },
+    });
+    const prompt = adapter.prompt({
+      sessionId: session.sessionId,
+      prompt: [{ type: 'text', text: 'make a plan' }],
+    });
+    await vi.waitFor(() =>
+      expect(request).toHaveBeenCalledWith(
+        'turn/start',
+        expect.objectContaining({ threadId: 'thread_plan_hold_order' })
+      )
+    );
+
+    const handleCodexNotification = (
+      adapter as unknown as {
+        handleCodexNotification: (method: string, params: unknown) => Promise<void>;
+      }
+    ).handleCodexNotification.bind(adapter);
+    await handleCodexNotification('item/started', {
+      threadId: 'thread_plan_hold_order',
+      turnId: 'turn_plan_hold_order',
+      item: { type: 'plan', id: 'item_plan_hold_order', status: 'inProgress' },
+    });
+    await handleCodexNotification('item/plan/delta', {
+      threadId: 'thread_plan_hold_order',
+      turnId: 'turn_plan_hold_order',
+      itemId: 'item_plan_hold_order',
+      delta: '# Plan\n- implement it',
+    });
+
+    let releaseTranscriptActivity: () => void = () => undefined;
+    const transcriptActivityBlocked = new Promise<void>((resolve) => {
+      releaseTranscriptActivity = resolve;
+    });
+    const subagentController = (
+      adapter as unknown as {
+        subagentController: { handleTranscriptActivity: (threadId: string) => Promise<void> };
+      }
+    ).subagentController;
+    const handleTranscriptActivity = vi
+      .spyOn(subagentController, 'handleTranscriptActivity')
+      .mockImplementationOnce(async () => await transcriptActivityBlocked)
+      .mockResolvedValue(undefined);
+
+    const itemCompleted = handleCodexNotification('item/completed', {
+      threadId: 'thread_plan_hold_order',
+      turnId: 'turn_plan_hold_order',
+      item: { type: 'plan', id: 'item_plan_hold_order', status: 'completed' },
+    });
+    await vi.waitFor(() => expect(handleTranscriptActivity).toHaveBeenCalledTimes(1));
+
+    let turnCompletionProcessed = false;
+    const turnCompleted = handleCodexNotification('turn/completed', {
+      threadId: 'thread_plan_hold_order',
+      turn: { id: 'turn_plan_hold_order', status: 'completed', error: null, items: [] },
+    });
+    void turnCompleted.then(() => {
+      turnCompletionProcessed = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(turnCompletionProcessed).toBe(false);
+
+    releaseTranscriptActivity();
+    await turnCompleted;
+
+    let promptSettled = false;
+    void prompt.then(() => {
+      promptSettled = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(promptSettled).toBe(false);
+
+    resolvePlanApproval({ outcome: { outcome: 'selected', optionId: 'default' } });
+    await itemCompleted;
+    await expect(prompt).resolves.toEqual({ stopReason: 'end_turn' });
   });
 });

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.ts
@@ -747,11 +747,12 @@ export class CodexAppServerAcpAdapter implements Agent {
     }
     return session;
   }
-
   private handleCodexNotification(method: string, params: unknown): Promise<void> {
     return this.codexNotificationQueue.enqueue(
+      method,
       params,
-      () => this.streamEventHandler.handleCodexNotification({ method, params }),
+      (releaseTurnBarrier) =>
+        this.streamEventHandler.handleCodexNotification({ method, params }, releaseTurnBarrier),
       (error) => {
         this.reportShapeDrift('notification_handler_error', {
           method,

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/codex-notification-queue.test.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/codex-notification-queue.test.ts
@@ -13,11 +13,13 @@ describe('CodexNotificationQueue', () => {
     const processed: string[] = [];
 
     const rejected = queue.enqueue(
+      'item/started',
       ITEM_PARAMS,
       () => Promise.reject(new Error('malformed notification')),
       onError
     );
     const continued = queue.enqueue(
+      'item/completed',
       ITEM_PARAMS,
       () => {
         processed.push('continued');
@@ -38,17 +40,177 @@ describe('CodexNotificationQueue', () => {
     const processed: string[] = [];
 
     await queue.enqueue(
+      'item/started',
       ITEM_PARAMS,
       () => Promise.reject(new Error('malformed notification')),
       () => {
         throw new Error('reporting unavailable');
       }
     );
-    await queue.enqueue(ITEM_PARAMS, () => {
+    await queue.enqueue('item/completed', ITEM_PARAMS, () => {
       processed.push('continued');
       return Promise.resolve();
     });
 
     expect(processed).toEqual(['continued']);
+  });
+
+  it('processes turn completion after earlier item notifications on the same thread', async () => {
+    const queue = new CodexNotificationQueue();
+    const processed: string[] = [];
+    let releaseStarted: () => void = () => undefined;
+    const startedBlocked = new Promise<void>((resolve) => {
+      releaseStarted = resolve;
+    });
+
+    const started = queue.enqueue('item/started', ITEM_PARAMS, async () => {
+      processed.push('started');
+      await startedBlocked;
+    });
+    await vi.waitFor(() => expect(processed).toEqual(['started']));
+
+    const completed = queue.enqueue('item/completed', ITEM_PARAMS, () => {
+      processed.push('completed');
+      return Promise.resolve();
+    });
+    const turnCompleted = queue.enqueue(
+      'turn/completed',
+      {
+        threadId: ITEM_PARAMS.threadId,
+        turn: { id: 'turn-1', status: 'completed' },
+      },
+      () => {
+        processed.push('turn-completed');
+        return Promise.resolve();
+      }
+    );
+
+    expect(processed).toEqual(['started']);
+    releaseStarted();
+    await Promise.all([started, completed, turnCompleted]);
+
+    expect(processed).toEqual(['started', 'completed', 'turn-completed']);
+  });
+
+  it('waits for every earlier item on the completed turn thread', async () => {
+    const queue = new CodexNotificationQueue();
+    const processed: string[] = [];
+    let releaseFirstItem: () => void = () => undefined;
+    const firstItemBlocked = new Promise<void>((resolve) => {
+      releaseFirstItem = resolve;
+    });
+
+    const firstItem = queue.enqueue(
+      'item/started',
+      { threadId: ITEM_PARAMS.threadId, itemId: 'item-1' },
+      async () => {
+        await firstItemBlocked;
+        processed.push('item-1');
+      }
+    );
+    const secondItem = queue.enqueue(
+      'item/started',
+      { threadId: ITEM_PARAMS.threadId, itemId: 'item-2' },
+      () => {
+        processed.push('item-2');
+        return Promise.resolve();
+      }
+    );
+    const turnCompleted = queue.enqueue(
+      'turn/completed',
+      {
+        threadId: ITEM_PARAMS.threadId,
+        turn: { id: 'turn-1', status: 'completed' },
+      },
+      () => {
+        processed.push('turn-completed');
+        return Promise.resolve();
+      }
+    );
+
+    await secondItem;
+    expect(processed).toEqual(['item-2']);
+    releaseFirstItem();
+    await Promise.all([firstItem, turnCompleted]);
+
+    expect(processed).toEqual(['item-2', 'item-1', 'turn-completed']);
+  });
+
+  it('does not make turn completion wait for items on another thread', async () => {
+    const queue = new CodexNotificationQueue();
+    const processed: string[] = [];
+    let releaseItem: () => void = () => undefined;
+    const itemBlocked = new Promise<void>((resolve) => {
+      releaseItem = resolve;
+    });
+
+    const item = queue.enqueue('item/started', ITEM_PARAMS, async () => {
+      await itemBlocked;
+      processed.push('item');
+    });
+    await queue.enqueue(
+      'turn/completed',
+      {
+        threadId: 'thread-2',
+        turn: { id: 'turn-2', status: 'completed' },
+      },
+      () => {
+        processed.push('turn-completed');
+        return Promise.resolve();
+      }
+    );
+
+    expect(processed).toEqual(['turn-completed']);
+    releaseItem();
+    await item;
+  });
+
+  it('releases a completed plan barrier only after the handler marks the turn safe', async () => {
+    const queue = new CodexNotificationQueue();
+    const processed: string[] = [];
+    let releasePreDispatch: () => void = () => undefined;
+    const preDispatchBlocked = new Promise<void>((resolve) => {
+      releasePreDispatch = resolve;
+    });
+    let releaseApproval: () => void = () => undefined;
+    const approvalBlocked = new Promise<void>((resolve) => {
+      releaseApproval = resolve;
+    });
+
+    const planCompleted = queue.enqueue(
+      'item/completed',
+      {
+        threadId: ITEM_PARAMS.threadId,
+        item: { id: ITEM_PARAMS.itemId, type: 'plan', status: 'completed' },
+      },
+      async (releaseTurnBarrier?: () => void) => {
+        processed.push('plan-started');
+        await preDispatchBlocked;
+        processed.push('plan-held');
+        releaseTurnBarrier?.();
+        await approvalBlocked;
+      }
+    );
+    const turnCompleted = queue.enqueue(
+      'turn/completed',
+      {
+        threadId: ITEM_PARAMS.threadId,
+        turn: { id: 'turn-1', status: 'completed' },
+      },
+      () => {
+        processed.push('turn-completed');
+        return Promise.resolve();
+      }
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(processed).toEqual(['plan-started']);
+
+    releasePreDispatch();
+    await turnCompleted;
+    expect(processed).toEqual(['plan-started', 'plan-held', 'turn-completed']);
+
+    releaseApproval();
+    await planCompleted;
   });
 });

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/codex-notification-queue.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/codex-notification-queue.ts
@@ -13,17 +13,33 @@ function getNotificationItemKey(params: unknown): string | null {
   return itemId ? `${params.threadId}:${itemId}` : null;
 }
 
+function getNotificationThreadId(params: unknown): string | null {
+  return isRecord(params) && typeof params.threadId === 'string' ? params.threadId : null;
+}
+
+function releasesTurnBarrierWhenSignaled(method: string, params: unknown): boolean {
+  return (
+    method === 'item/completed' &&
+    isRecord(params) &&
+    isRecord(params.item) &&
+    params.item.type === 'plan'
+  );
+}
+
 export class CodexNotificationQueue {
   private readonly chainsByItemKey = new Map<string, Promise<void>>();
+  private readonly itemBarriersByThreadId = new Map<string, Set<Promise<void>>>();
+  private readonly turnBarriersByThreadId = new Map<string, Promise<void>>();
 
   enqueue(
+    method: string,
     params: unknown,
-    processNotification: () => Promise<void>,
+    processNotification: (releaseTurnBarrier?: () => void) => Promise<void>,
     onError?: (error: unknown) => void
   ): Promise<void> {
-    const processSafely = async (): Promise<void> => {
+    const processSafely = async (releaseTurnBarrier?: () => void): Promise<void> => {
       try {
-        await processNotification();
+        await processNotification(releaseTurnBarrier);
       } catch (error) {
         try {
           onError?.(error);
@@ -32,19 +48,69 @@ export class CodexNotificationQueue {
         }
       }
     };
-    const itemKey = getNotificationItemKey(params);
-    if (!itemKey) {
+    const threadId = getNotificationThreadId(params);
+    if (!threadId) {
       return processSafely();
     }
 
+    const itemKey = getNotificationItemKey(params);
+    if (!itemKey && method !== 'turn/completed') {
+      return processSafely();
+    }
+
+    if (!itemKey) {
+      const previousTurnBarrier = this.turnBarriersByThreadId.get(threadId);
+      const itemBarriers = [...(this.itemBarriersByThreadId.get(threadId) ?? [])];
+      const dependencies = previousTurnBarrier
+        ? [previousTurnBarrier, ...itemBarriers]
+        : itemBarriers;
+      const turnBarrier =
+        dependencies.length > 0
+          ? Promise.all(dependencies).then(() => processSafely())
+          : processSafely();
+      this.turnBarriersByThreadId.set(threadId, turnBarrier);
+      void turnBarrier.then(() => {
+        if (this.turnBarriersByThreadId.get(threadId) === turnBarrier) {
+          this.turnBarriersByThreadId.delete(threadId);
+        }
+      });
+      return turnBarrier;
+    }
+
     const previousNotification = this.chainsByItemKey.get(itemKey);
-    const notificationChain = previousNotification
-      ? previousNotification.then(processSafely)
-      : processSafely();
+    const previousTurnBarrier = this.turnBarriersByThreadId.get(threadId);
+    const dependencies = [previousNotification, previousTurnBarrier].filter(
+      (dependency): dependency is Promise<void> => dependency !== undefined
+    );
+    const releasesWhenSignaled = releasesTurnBarrierWhenSignaled(method, params);
+    let releaseTurnBarrier: () => void = () => undefined;
+    const signaledTurnBarrier = releasesWhenSignaled
+      ? new Promise<void>((resolve) => {
+          releaseTurnBarrier = resolve;
+        })
+      : null;
+    const processQueued = async (): Promise<void> => {
+      await processSafely(releasesWhenSignaled ? releaseTurnBarrier : undefined);
+      releaseTurnBarrier();
+    };
+    const notificationChain =
+      dependencies.length > 0 ? Promise.all(dependencies).then(processQueued) : processQueued();
     this.chainsByItemKey.set(itemKey, notificationChain);
     void notificationChain.then(() => {
       if (this.chainsByItemKey.get(itemKey) === notificationChain) {
         this.chainsByItemKey.delete(itemKey);
+      }
+    });
+
+    const itemBarrier = signaledTurnBarrier ?? notificationChain;
+    const threadItemBarriers =
+      this.itemBarriersByThreadId.get(threadId) ?? new Set<Promise<void>>();
+    threadItemBarriers.add(itemBarrier);
+    this.itemBarriersByThreadId.set(threadId, threadItemBarriers);
+    void itemBarrier.then(() => {
+      threadItemBarriers.delete(itemBarrier);
+      if (threadItemBarriers.size === 0) {
+        this.itemBarriersByThreadId.delete(threadId);
       }
     });
     return notificationChain;

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.test.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.test.ts
@@ -909,8 +909,17 @@ describe('stream-event-handler', () => {
 
     const emitSessionUpdate = vi.fn(async () => undefined);
     const shouldHoldTurnForPlanApproval = vi.fn(() => true);
-    const holdTurnUntilPlanApprovalResolves = vi.fn();
-    const maybeRequestPlanApproval = vi.fn(async () => undefined);
+    const approvalEvents: string[] = [];
+    const holdTurnUntilPlanApprovalResolves = vi.fn(() => {
+      approvalEvents.push('hold');
+    });
+    const maybeRequestPlanApproval = vi.fn(() => {
+      approvalEvents.push('request');
+      return Promise.resolve();
+    });
+    const releaseTurnBarrier = vi.fn(() => {
+      approvalEvents.push('release');
+    });
     const toolState: ToolCallState = {
       toolCallId: 'call_plan',
       kind: 'think',
@@ -941,17 +950,21 @@ describe('stream-event-handler', () => {
       status: 'completed',
     };
 
-    await handler.handleCodexNotification({
-      method: 'item/completed',
-      params: {
-        threadId: 'thread_1',
-        turnId: 'turn_1',
-        item,
+    await handler.handleCodexNotification(
+      {
+        method: 'item/completed',
+        params: {
+          threadId: 'thread_1',
+          turnId: 'turn_1',
+          item,
+        },
       },
-    });
+      releaseTurnBarrier
+    );
 
     expect(shouldHoldTurnForPlanApproval).toHaveBeenCalledWith(session, item, 'turn_1');
     expect(holdTurnUntilPlanApprovalResolves).toHaveBeenCalledWith(session, 'turn_1');
+    expect(approvalEvents).toEqual(['hold', 'release', 'request']);
     expect(emitSessionUpdate).toHaveBeenCalledWith(
       'sess_thread_1',
       expect.objectContaining({

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.test.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.test.ts
@@ -907,9 +907,12 @@ describe('stream-event-handler', () => {
     session.defaults.collaborationMode = 'plan';
     session.planTextByItemId.set('item_plan', '## Proposed Plan\n1. Fix recovery approval');
 
-    const emitSessionUpdate = vi.fn(async () => undefined);
-    const shouldHoldTurnForPlanApproval = vi.fn(() => true);
     const approvalEvents: string[] = [];
+    const emitSessionUpdate = vi.fn(() => {
+      approvalEvents.push('update');
+      return Promise.resolve();
+    });
+    const shouldHoldTurnForPlanApproval = vi.fn(() => true);
     const holdTurnUntilPlanApprovalResolves = vi.fn(() => {
       approvalEvents.push('hold');
     });
@@ -964,7 +967,7 @@ describe('stream-event-handler', () => {
 
     expect(shouldHoldTurnForPlanApproval).toHaveBeenCalledWith(session, item, 'turn_1');
     expect(holdTurnUntilPlanApprovalResolves).toHaveBeenCalledWith(session, 'turn_1');
-    expect(approvalEvents).toEqual(['hold', 'release', 'request']);
+    expect(approvalEvents).toEqual(['hold', 'update', 'release', 'request']);
     expect(emitSessionUpdate).toHaveBeenCalledWith(
       'sess_thread_1',
       expect.objectContaining({

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.ts
@@ -831,7 +831,7 @@ export class CodexStreamEventHandler {
 
     const existing = session.toolCallsByItemId.get(item.id);
     if (!existing) {
-      await this.handleCompletedItemWithoutStartedState(session, item, turnId);
+      await this.handleCompletedItemWithoutStartedState(session, item, turnId, releaseTurnBarrier);
       return;
     }
 
@@ -866,12 +866,14 @@ export class CodexStreamEventHandler {
   private async handleCompletedItemWithoutStartedState(
     session: AdapterSession,
     item: { type: string; id: string } & Record<string, unknown>,
-    turnId: string
+    turnId: string,
+    releaseTurnBarrier?: () => void
   ): Promise<void> {
     const recovered = this.deps.buildToolCallState(session, item, turnId);
     if (recovered) {
       if (this.deps.shouldHoldTurnForPlanApproval(session, item, turnId)) {
         this.deps.holdTurnUntilPlanApprovalResolves(session, turnId);
+        releaseTurnBarrier?.();
       }
 
       await this.recordSubagentActivity(session, item, recovered);

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.ts
@@ -168,7 +168,10 @@ export class CodexStreamEventHandler {
     return updates;
   }
 
-  async handleCodexNotification(notification: CodexNotificationPayload): Promise<void> {
+  async handleCodexNotification(
+    notification: CodexNotificationPayload,
+    releaseTurnBarrier?: () => void
+  ): Promise<void> {
     const parsed = knownCodexNotificationSchema.safeParse(notification);
     if (!parsed.success) {
       this.deps.reportShapeDrift('malformed_notification', {
@@ -280,7 +283,8 @@ export class CodexStreamEventHandler {
       await this.handleItemCompleted(
         session,
         typedNotification.params.item as { type: string; id: string } & Record<string, unknown>,
-        typedNotification.params.turnId
+        typedNotification.params.turnId,
+        releaseTurnBarrier
       );
       return;
     }
@@ -723,7 +727,8 @@ export class CodexStreamEventHandler {
   private async handleItemCompleted(
     session: AdapterSession,
     item: { type: string; id: string } & Record<string, unknown>,
-    turnId: string
+    turnId: string,
+    releaseTurnBarrier?: () => void
   ): Promise<void> {
     if (this.isReplayedTurnItem(session, turnId, item.id)) {
       return;
@@ -776,6 +781,8 @@ export class CodexStreamEventHandler {
 
     if (this.deps.shouldHoldTurnForPlanApproval(session, item, turnId)) {
       this.deps.holdTurnUntilPlanApprovalResolves(session, turnId);
+      // Turn completion can now observe the hold while permission remains pending.
+      releaseTurnBarrier?.();
     }
 
     const statusFromItem = toToolStatus(item.status);

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.ts
@@ -835,11 +835,12 @@ export class CodexStreamEventHandler {
       return;
     }
 
-    if (this.deps.shouldHoldTurnForPlanApproval(session, item, turnId)) {
-      this.deps.holdTurnUntilPlanApprovalResolves(session, turnId);
-      // Turn completion can now observe the hold while permission remains pending.
-      releaseTurnBarrier?.();
-    }
+    const releaseHeldTurnBarrier = this.holdTurnForPlanApproval(
+      session,
+      item,
+      turnId,
+      releaseTurnBarrier
+    );
 
     const statusFromItem = toToolStatus(item.status);
     const status = statusFromItem ?? 'completed';
@@ -860,6 +861,9 @@ export class CodexStreamEventHandler {
     session.toolCallsByItemId.delete(item.id);
     session.syntheticallyCompletedToolItemIds.delete(item.id);
 
+    // Turn completion can now observe the hold after item completion is fully projected.
+    releaseHeldTurnBarrier?.();
+
     await this.deps.maybeRequestPlanApproval(session, item, turnId, existing);
   }
 
@@ -871,10 +875,12 @@ export class CodexStreamEventHandler {
   ): Promise<void> {
     const recovered = this.deps.buildToolCallState(session, item, turnId);
     if (recovered) {
-      if (this.deps.shouldHoldTurnForPlanApproval(session, item, turnId)) {
-        this.deps.holdTurnUntilPlanApprovalResolves(session, turnId);
-        releaseTurnBarrier?.();
-      }
+      const releaseHeldTurnBarrier = this.holdTurnForPlanApproval(
+        session,
+        item,
+        turnId,
+        releaseTurnBarrier
+      );
 
       await this.recordSubagentActivity(session, item, recovered);
 
@@ -890,6 +896,8 @@ export class CodexStreamEventHandler {
         rawOutput: item,
       });
 
+      releaseHeldTurnBarrier?.();
+
       await this.deps.maybeRequestPlanApproval(session, item, turnId, recovered);
       return;
     }
@@ -899,6 +907,19 @@ export class CodexStreamEventHandler {
       itemType: item.type,
       itemId: item.id,
     });
+  }
+
+  private holdTurnForPlanApproval(
+    session: AdapterSession,
+    item: { type: string; id: string } & Record<string, unknown>,
+    turnId: string,
+    releaseTurnBarrier?: () => void
+  ): (() => void) | undefined {
+    if (!this.deps.shouldHoldTurnForPlanApproval(session, item, turnId)) {
+      return undefined;
+    }
+    this.deps.holdTurnUntilPlanApprovalResolves(session, turnId);
+    return releaseTurnBarrier;
   }
 
   private async recordSubagentActivity(


### PR DESCRIPTION
## Summary
- Serialize `turn/completed` behind earlier same-thread item notifications.
- Prevent ACP recovery from emitting a duplicate `tool_call` when turn settlement races item completion.
- Preserve plan-approval deferral with an explicit barrier release after the approval hold is installed.

## Changes
- **Notification queue**: Add same-thread item and turn barriers while preserving per-item ordering and cross-thread concurrency.
- **Plan approval**: Release the turn barrier only when plan completion has made turn settlement safe, with completion/error fallback to prevent deadlocks.
- **Regression coverage**: Exercise the duplicate ACP event race, multi-item/thread boundaries, failure isolation, and blocked plan pre-dispatch flow.

## Testing
- [x] Tests pass (`pnpm test --maxWorkers=4` — 5,295 passed)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Repository guardrails pass (`pnpm check`)
- [ ] Manual testing: Not applicable; this asynchronous protocol race is covered deterministically by adapter and queue tests.

Closes #2181

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches ACP notification ordering and turn settlement, which can stall or duplicate session updates if barriers are wrong. Coverage is strong, but the queue is concurrency-sensitive.
> 
> **Overview**
> Fixes a race where `turn/completed` could run before same-thread item events, clearing tool-call state and emitting duplicate ACP updates.
> 
> `CodexNotificationQueue` now waits on per-thread item (and prior turn) barriers before processing `turn/completed`, while keeping per-item order and allowing other threads to proceed. Completed **plan** items expose an explicit `releaseTurnBarrier` so the hold is installed and the completion is projected *before* turn settlement, then plan approval can still wait.
> 
> Stream handling releases that barrier after the hold and session update, then requests plan approval. Tests cover multi-item waits, cross-thread independence, the duplicate `tool_call` race, and blocked plan pre-dispatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12a7bce48e3dc22a95caaa8a85482b89e2db740c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->