### PR TITLE
Fix #2160: Respect deliberate Ratchet stops

### DIFF
--- a/src/backend/services/session/service/lifecycle/session-workflow-finalizer.test.ts
+++ b/src/backend/services/session/service/lifecycle/session-workflow-finalizer.test.ts
@@ -192,7 +192,9 @@ describe('SessionWorkflowFinalizer', () => {
     [0, false, 'COMPLETED'],
     [1, false, 'DIED'],
     [null, false, 'DIED'],
-  ] as const)('settles ratchet runtime exit code %s as %s', async (exitCode, deliberate, outcome) => {
+    [1, true, 'COMPLETED'],
+    [null, true, 'COMPLETED'],
+  ] as const)('settles ratchet runtime exit code %s with deliberate=%s as %s', async (exitCode, deliberate, outcome) => {
     const harness = createFinalizerHarness({
       session: createLifecycleTestSession({ workflow: 'ratchet' }),
     });
@@ -211,7 +213,7 @@ describe('SessionWorkflowFinalizer', () => {
     );
   });
 
-  it('settles a runtime-managed ratchet stop as completed without a lifecycle stop', async () => {
+  it('uses the captured deliberate-stop state when settling a ratchet exit', async () => {
     const harness = createFinalizerHarness({
       session: createLifecycleTestSession({ workflow: 'ratchet' }),
     });
@@ -227,7 +229,7 @@ describe('SessionWorkflowFinalizer', () => {
     expect(harness.workspaceBridge.recordRatchetSessionEnd).toHaveBeenCalledWith(
       'workspace-1',
       'session-1',
-      'COMPLETED'
+      'DIED'
     );
   });
 

--- a/src/backend/services/session/service/lifecycle/session-workflow-finalizer.ts
+++ b/src/backend/services/session/service/lifecycle/session-workflow-finalizer.ts
@@ -33,7 +33,7 @@ type WorkflowFinalizerDependencies = {
   };
   lifecycleEventService: Pick<SessionLifecycleEventService, 'hydrate'>;
   hydrateProviderHistory: HydrateProviderHistory;
-  runtimeManager: Pick<AcpRuntimeManager, 'isSessionRunning' | 'isStopInProgress'>;
+  runtimeManager: Pick<AcpRuntimeManager, 'isSessionRunning'>;
   countViewers(sessionId: string): number;
 };
 
@@ -88,10 +88,7 @@ export class SessionWorkflowFinalizer {
   }): Promise<void> {
     const { session, sessionId, exitCode, deliberate } = input;
     if (session.workflow === 'ratchet') {
-      const outcome: RatchetSessionEndOutcome =
-        exitCode === 0 || deliberate || this.dependencies.runtimeManager.isStopInProgress(sessionId)
-          ? 'COMPLETED'
-          : 'DIED';
+      const outcome: RatchetSessionEndOutcome = exitCode === 0 || deliberate ? 'COMPLETED' : 'DIED';
       try {
         await this.recordRatchetSessionEnd(session.workspaceId, sessionId, outcome);
       } catch (error) {


### PR DESCRIPTION
## Summary
- make the captured deliberate-stop state authoritative for Ratchet exit settlement
- prevent deliberately stopped fixers from being classified as `DIED` after non-zero or signal exits
- expand regression coverage across clean, unexpected, and deliberate exit outcomes

## Changes
- **Session lifecycle**: remove the mutable `isStopInProgress` re-read from workflow finalization and narrow the finalizer's runtime dependency
- **Tests**: cover deliberate non-zero and signal exits as `COMPLETED`, unexpected exits as `DIED`, and stale runtime stop state not overriding the captured classification

## Testing
- [x] Tests pass (`pnpm test`)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Repository guardrails pass (`pnpm check`)
- [x] Focused regression mutation verified the deliberate-stop cases fail without the fix

Closes #2160

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session lifecycle classification for Ratchet COMPLETED vs DIED, which can change how stopped vs crashed sessions are recorded. Scope is a small, well-tested condition change.
> 
> **Overview**
> Ratchet runtime-exit settlement now treats the captured `deliberate` flag (plus exit code 0) as the only COMPLETED vs DIED signal, instead of also re-reading `runtimeManager.isStopInProgress`.
> 
> That stops a stale in-progress stop from marking unexpected non-zero/signal exits as `COMPLETED`, and keeps user-initiated stops `COMPLETED` even after the runtime stop flag has cleared. Tests cover clean, unexpected, and deliberate non-zero/null exits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec95139473a476c791dd1eacba7e5c91df0570a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->