### PR TITLE
Fix #2183: Prevent duplicate handoff tool completions

### DIFF
--- a/scripts/file-length-baseline.json
+++ b/scripts/file-length-baseline.json
@@ -12,7 +12,7 @@
   "src/backend/services/ratchet/service/ratchet.service.ts": 1035,
   "src/backend/services/run-script/service/run-script.service.test.ts": 2332,
   "src/backend/services/run-script/service/run-script.service.ts": 1026,
-  "src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.test.ts": 3422,
+  "src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.test.ts": 3415,
   "src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.test.ts": 1576,
   "src/backend/services/session/service/lifecycle/session.config.service.test.ts": 1159,
   "src/backend/services/session/service/lifecycle/session.config.service.ts": 1080,

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.test.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.test.ts
@@ -81,6 +81,18 @@ function getCodexRequestCalls(
   );
 }
 
+function sendCodexNotification(
+  adapter: CodexAppServerAcpAdapter,
+  method: string,
+  params: unknown
+): Promise<void> {
+  return (
+    adapter as unknown as {
+      handleCodexNotification: (method: string, params: unknown) => Promise<void>;
+    }
+  ).handleCodexNotification(method, params);
+}
+
 const DEFAULT_APPROVAL_POLICY = 'on-failure';
 const DEFAULT_ALLOWED_APPROVAL_POLICIES = [DEFAULT_APPROVAL_POLICY, 'on-request', 'never'];
 const DEFAULT_ALLOWED_SANDBOX_MODES = ['read-only', 'workspace-write', 'danger-full-access'];
@@ -762,11 +774,7 @@ describe('CodexAppServerAcpAdapter', () => {
     });
     (connection.sessionUpdate as ReturnType<typeof vi.fn>).mockClear();
 
-    await (
-      adapter as unknown as {
-        handleCodexNotification: (method: string, params: unknown) => Promise<void>;
-      }
-    ).handleCodexNotification('item/started', {
+    await sendCodexNotification(adapter, 'item/started', {
       threadId: 'thread_replay_dedupe',
       turnId: 'turn_replay_dedupe',
       item: {
@@ -792,22 +800,14 @@ describe('CodexAppServerAcpAdapter', () => {
       },
     });
 
-    await (
-      adapter as unknown as {
-        handleCodexNotification: (method: string, params: unknown) => Promise<void>;
-      }
-    ).handleCodexNotification('item/reasoning/summaryTextDelta', {
+    await sendCodexNotification(adapter, 'item/reasoning/summaryTextDelta', {
       threadId: 'thread_replay_dedupe',
       turnId: 'turn_replay_dedupe',
       itemId: 'item_replayed_reasoning',
       delta: '**From live**',
     });
 
-    await (
-      adapter as unknown as {
-        handleCodexNotification: (method: string, params: unknown) => Promise<void>;
-      }
-    ).handleCodexNotification('item/completed', {
+    await sendCodexNotification(adapter, 'item/completed', {
       threadId: 'thread_replay_dedupe',
       turnId: 'turn_replay_dedupe',
       item: {
@@ -914,11 +914,7 @@ describe('CodexAppServerAcpAdapter', () => {
       mcpServers: [],
     });
 
-    await (
-      adapter as unknown as {
-        handleCodexNotification: (method: string, params: unknown) => Promise<void>;
-      }
-    ).handleCodexNotification('item/started', {
+    await sendCodexNotification(adapter, 'item/started', {
       threadId: 'thread_command_handoff',
       turnId: 'turn_command_handoff',
       item: {
@@ -930,27 +926,34 @@ describe('CodexAppServerAcpAdapter', () => {
       },
     });
 
-    await (
-      adapter as unknown as {
-        handleCodexNotification: (method: string, params: unknown) => Promise<void>;
-      }
-    ).handleCodexNotification('item/commandExecution/outputDelta', {
+    await sendCodexNotification(adapter, 'item/commandExecution/outputDelta', {
       threadId: 'thread_command_handoff',
       turnId: 'turn_command_handoff',
       itemId: 'item_command_handoff',
       delta: 'Process running with session ID 96081',
     });
 
-    await (
-      adapter as unknown as {
-        handleCodexNotification: (method: string, params: unknown) => Promise<void>;
-      }
-    ).handleCodexNotification('item/commandExecution/outputDelta', {
+    await sendCodexNotification(adapter, 'item/commandExecution/outputDelta', {
       threadId: 'thread_command_handoff',
       turnId: 'turn_command_handoff',
       itemId: 'item_command_handoff',
       delta: 'still running',
     });
+
+    const completedItem = {
+      type: 'commandExecution',
+      id: 'item_command_handoff',
+      status: 'completed',
+      aggregatedOutput: 'Process exited with code 0',
+      exitCode: 0,
+    };
+    for (let count = 0; count < 2; count += 1) {
+      await sendCodexNotification(adapter, 'item/completed', {
+        threadId: 'thread_command_handoff',
+        turnId: 'turn_command_handoff',
+        item: completedItem,
+      });
+    }
 
     const updates = (connection.sessionUpdate as ReturnType<typeof vi.fn>).mock.calls.map(
       (call) => call[0].update
@@ -962,16 +965,18 @@ describe('CodexAppServerAcpAdapter', () => {
         update.status === 'in_progress'
     );
     expect(inProgressUpdates).toHaveLength(1);
-    expect(updates).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          sessionUpdate: 'tool_call_update',
-          toolCallId: 'call_command_handoff',
-          status: 'completed',
-          rawOutput: 'Process running with session ID 96081',
-        }),
-      ])
+    const completedUpdates = updates.filter(
+      (update) =>
+        (update.sessionUpdate === 'tool_call' || update.sessionUpdate === 'tool_call_update') &&
+        update.toolCallId === 'call_command_handoff' &&
+        update.status === 'completed'
     );
+    expect(completedUpdates).toEqual([
+      expect.objectContaining({
+        sessionUpdate: 'tool_call_update',
+        rawOutput: 'Process running with session ID 96081',
+      }),
+    ]);
   });
 
   it('does not synthesize completion for normal output that mentions session handoff text', async () => {
@@ -991,11 +996,7 @@ describe('CodexAppServerAcpAdapter', () => {
       mcpServers: [],
     });
 
-    await (
-      adapter as unknown as {
-        handleCodexNotification: (method: string, params: unknown) => Promise<void>;
-      }
-    ).handleCodexNotification('item/started', {
+    await sendCodexNotification(adapter, 'item/started', {
       threadId: 'thread_command_log_output',
       turnId: 'turn_command_log_output',
       item: {
@@ -1007,22 +1008,14 @@ describe('CodexAppServerAcpAdapter', () => {
       },
     });
 
-    await (
-      adapter as unknown as {
-        handleCodexNotification: (method: string, params: unknown) => Promise<void>;
-      }
-    ).handleCodexNotification('item/commandExecution/outputDelta', {
+    await sendCodexNotification(adapter, 'item/commandExecution/outputDelta', {
       threadId: 'thread_command_log_output',
       turnId: 'turn_command_log_output',
       itemId: 'item_command_log_output',
       delta: 'worker log: process running with session ID 96081 and waiting',
     });
 
-    await (
-      adapter as unknown as {
-        handleCodexNotification: (method: string, params: unknown) => Promise<void>;
-      }
-    ).handleCodexNotification('item/commandExecution/outputDelta', {
+    await sendCodexNotification(adapter, 'item/commandExecution/outputDelta', {
       threadId: 'thread_command_log_output',
       turnId: 'turn_command_log_output',
       itemId: 'item_command_log_output',

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/stream-event-handler.ts
@@ -489,14 +489,11 @@ export class CodexStreamEventHandler {
     );
   }
 
-  private finishSubagentSyntheticCompletion(
-    session: AdapterSession,
-    turnId: string,
-    itemId: string
-  ): void {
+  private finishSyntheticCompletion(session: AdapterSession, turnId: string, itemId: string): void {
     if (!session.syntheticallyCompletedToolItemIds.delete(itemId)) {
       return;
     }
+    session.toolCallsByItemId.delete(itemId);
     const completedItemKeys =
       this.completedSyntheticToolItemKeysBySession.get(session) ?? new Set<string>();
     this.completedSyntheticToolItemKeysBySession.set(session, completedItemKeys);
@@ -785,8 +782,12 @@ export class CodexStreamEventHandler {
     if (this.isReplayedTurnItem(session, turnId, item.id)) {
       return;
     }
-    if (item.type === 'subAgentActivity' && this.hasSyntheticCompletion(session, turnId, item.id)) {
-      this.finishSubagentSyntheticCompletion(session, turnId, item.id);
+    if (this.hasSyntheticCompletion(session, turnId, item.id)) {
+      const existing = session.toolCallsByItemId.get(item.id);
+      this.finishSyntheticCompletion(session, turnId, item.id);
+      if (existing) {
+        await this.deps.maybeRequestPlanApproval(session, item, turnId, existing);
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary
- Prevent command handoff tool calls from emitting duplicate terminal completions.
- Retain bounded completion tombstones so repeated authoritative notifications cannot recover and re-emit the tool.
- Add regression coverage for authoritative and repeated completion notifications after a synthetic handoff completion.

## Changes
- **Codex ACP stream handling**: Generalize synthetic completion cleanup to remove live tool state and suppress later completion notifications by turn and item ID.
- **Adapter tests**: Verify a session handoff produces exactly one terminal tool event even when `item/completed` arrives more than once.
- **Guardrails**: Consolidate notification test setup and lower the legacy file-length baseline.

## Testing
- [x] Tests pass (`pnpm test` — 5,367 passed, 4 skipped)
- [x] Types pass (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Repository checks pass (`pnpm check`)
- [ ] Manual testing: Not required; the adapter notification sequence is covered by an automated regression test.

Closes #2183

---
🏭 Forged in [Factory Factory](https://factoryfactory.ai)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Codex ACP stream completion and tool-call lifecycle, so a mistake could drop real completions or still duplicate UI events. Scope is small and covered by a regression test.
> 
> **Overview**
> Stops Codex ACP command-handoff tools from emitting a second terminal completion when a later `item/completed` arrives.
> 
> Synthetic completion cleanup now applies to **all** item types, not just subagents. It drops live `toolCallsByItemId` state and keeps a bounded turn/item tombstone so repeated completions cannot recover and re-emit the tool. Plan-approval is still requested if a tool call existed.
> 
> Tests assert a session-handoff command produces **exactly one** completed tool event even when `item/completed` is sent twice. Notification helpers are consolidated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9692cfc375a2691ab36d87a7ad3ff049102376f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->