### PR TITLE
Fix stale running tool calls after session crashes

### DIFF
--- a/src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.recovery.test.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.recovery.test.ts
@@ -1,0 +1,220 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ChatMessage } from '@/shared/acp-protocol';
+
+const mocks = vi.hoisted(() => ({
+  findById: vi.fn(),
+  hydrateLifecycleEvents: vi.fn(),
+  getRuntimeSnapshot: vi.fn(),
+  getChatBarCapabilities: vi.fn(),
+  getSessionConfigOptionsWithFallback: vi.fn(),
+  subscribe: vi.fn(),
+  emitDelta: vi.fn(),
+  getTranscriptSnapshot: vi.fn(),
+  isHistoryHydrated: vi.fn(),
+  getHistoryHydrationSource: vi.fn(),
+  canAttemptHistoryHydration: vi.fn(),
+  setHistoryRetryAt: vi.fn(),
+  clearHistoryRetryCooldown: vi.fn(),
+  markHistoryHydrated: vi.fn(),
+  replaceTranscript: vi.fn(),
+  consumeInitialMessage: vi.fn(),
+  enqueue: vi.fn(),
+  getCachedCommands: vi.fn(),
+  loadClaudeSessionHistory: vi.fn(),
+  loadCodexSessionHistory: vi.fn(),
+  tryDispatchNextMessage: vi.fn(),
+}));
+
+vi.mock('@/backend/services/session/resources/agent-session.accessor', () => ({
+  agentSessionAccessor: { findById: mocks.findById },
+}));
+
+vi.mock('@/backend/services/session/service/data/session-history-loader.service', () => ({
+  claudeSessionHistoryLoaderService: { loadSessionHistory: mocks.loadClaudeSessionHistory },
+}));
+
+vi.mock('@/backend/services/session/service/data/codex-session-history-loader.service', () => ({
+  codexSessionHistoryLoaderService: { loadSessionHistory: mocks.loadCodexSessionHistory },
+}));
+
+vi.mock('@/backend/services/session/service/lifecycle/session-core-services', () => ({
+  sessionLifecycleService: { getRuntimeSnapshot: mocks.getRuntimeSnapshot },
+  sessionLifecycleEventService: { hydrate: mocks.hydrateLifecycleEvents },
+  sessionConfigService: {
+    getChatBarCapabilities: mocks.getChatBarCapabilities,
+    getSessionConfigOptionsWithFallback: mocks.getSessionConfigOptionsWithFallback,
+  },
+}));
+
+vi.mock('@/backend/services/session/service/session-domain.service', () => ({
+  sessionDomainService: {
+    subscribe: mocks.subscribe,
+    emitDelta: mocks.emitDelta,
+    getTranscriptSnapshot: mocks.getTranscriptSnapshot,
+    isHistoryHydrated: mocks.isHistoryHydrated,
+    getHistoryHydrationSource: mocks.getHistoryHydrationSource,
+    canAttemptHistoryHydration: mocks.canAttemptHistoryHydration,
+    setHistoryRetryAt: mocks.setHistoryRetryAt,
+    clearHistoryRetryCooldown: mocks.clearHistoryRetryCooldown,
+    markHistoryHydrated: mocks.markHistoryHydrated,
+    replaceTranscript: mocks.replaceTranscript,
+    consumeInitialMessage: mocks.consumeInitialMessage,
+    enqueue: mocks.enqueue,
+  },
+}));
+
+vi.mock('@/backend/services/session/service/store/slash-command-cache.service', () => ({
+  slashCommandCacheService: { getCachedCommands: mocks.getCachedCommands },
+}));
+
+vi.mock('@/backend/services/logger.service', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+import { createLoadSessionHandler } from './load-session.handler';
+
+function unmatchedToolCall(): ChatMessage {
+  return {
+    id: 'history-tool-1',
+    source: 'agent',
+    timestamp: '2026-08-20T10:00:00.000Z',
+    order: 0,
+    message: {
+      type: 'stream_event',
+      event: {
+        type: 'content_block_start',
+        index: 0,
+        content_block: {
+          type: 'tool_use',
+          id: 'call-interrupted',
+          name: 'exec_command',
+          input: { cmd: 'pnpm test' },
+        },
+      },
+    },
+  };
+}
+
+function matchingToolResult(): ChatMessage {
+  return {
+    id: 'history-tool-result-1',
+    source: 'agent',
+    timestamp: '2026-08-20T10:00:01.000Z',
+    order: 1,
+    message: {
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'call-interrupted',
+            content: 'tests passed',
+          },
+        ],
+      },
+    },
+  };
+}
+
+async function loadSession(): Promise<void> {
+  const handler = createLoadSessionHandler({
+    tryDispatchNextMessage: mocks.tryDispatchNextMessage,
+    setManualDispatchResume: vi.fn(),
+  });
+
+  await handler({
+    ws: { send: vi.fn() } as never,
+    sessionId: 'session-crashed',
+    workingDir: '/tmp/worktree',
+    message: { type: 'load_session' } as never,
+  });
+}
+
+describe('load session tool-call recovery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findById.mockResolvedValue({
+      provider: 'CODEX',
+      status: 'IDLE',
+      model: 'gpt-5.3-codex',
+      providerSessionId: 'provider-session-1',
+      providerMetadata: null,
+      workspace: { status: 'READY', worktreePath: '/tmp/worktree' },
+    });
+    mocks.isHistoryHydrated.mockReturnValue(true);
+    mocks.getHistoryHydrationSource.mockReturnValue('jsonl');
+    mocks.getTranscriptSnapshot.mockReturnValue([unmatchedToolCall()]);
+    mocks.getRuntimeSnapshot.mockReturnValue({
+      phase: 'idle',
+      processState: 'stopped',
+      activity: 'IDLE',
+      updatedAt: '2026-08-20T10:01:00.000Z',
+    });
+    mocks.getChatBarCapabilities.mockResolvedValue({
+      provider: 'CODEX',
+      model: { enabled: false, options: [] },
+      reasoning: { enabled: false, options: [] },
+      thinking: { enabled: false },
+      planMode: { enabled: true },
+      attachments: { enabled: true, kinds: ['image', 'text'] },
+      slashCommands: { enabled: false },
+      usageStats: { enabled: false, contextWindow: false },
+      rewind: { enabled: false },
+    });
+    mocks.getSessionConfigOptionsWithFallback.mockResolvedValue([]);
+    mocks.getCachedCommands.mockResolvedValue([]);
+    mocks.consumeInitialMessage.mockReturnValue(null);
+  });
+
+  it('finalizes an unmatched historical tool call when loading a stopped session', async () => {
+    await loadSession();
+
+    expect(mocks.replaceTranscript).toHaveBeenCalledWith(
+      'session-crashed',
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: 'agent',
+          message: expect.objectContaining({
+            type: 'user',
+            message: expect.objectContaining({
+              content: [
+                expect.objectContaining({
+                  type: 'tool_result',
+                  tool_use_id: 'call-interrupted',
+                  is_error: true,
+                }),
+              ],
+            }),
+          }),
+        }),
+      ])
+    );
+  });
+
+  it('keeps an unmatched tool call pending while the session is running', async () => {
+    mocks.getRuntimeSnapshot.mockReturnValue({
+      phase: 'running',
+      processState: 'alive',
+      activity: 'WORKING',
+      updatedAt: '2026-08-20T10:01:00.000Z',
+    });
+
+    await loadSession();
+
+    expect(mocks.replaceTranscript).not.toHaveBeenCalled();
+  });
+
+  it('does not alter a stopped transcript whose tool call already completed', async () => {
+    mocks.getTranscriptSnapshot.mockReturnValue([unmatchedToolCall(), matchingToolResult()]);
+
+    await loadSession();
+
+    expect(mocks.replaceTranscript).not.toHaveBeenCalled();
+  });
+});

--- a/src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.ts
+++ b/src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.ts
@@ -15,6 +15,7 @@ import {
 } from '@/backend/services/session/service/lifecycle/session-core-services';
 import { hydrateProviderHistoryIfNeeded } from '@/backend/services/session/service/lifecycle/session-provider-history-hydrator';
 import { sessionDomainService } from '@/backend/services/session/service/session-domain.service';
+import { finalizeInterruptedTranscriptToolCalls } from '@/backend/services/session/service/store/session-tool-call-recovery';
 import { slashCommandCacheService } from '@/backend/services/session/service/store/slash-command-cache.service';
 import {
   commandNameKey,
@@ -40,6 +41,16 @@ export function createLoadSessionHandler(
     await sessionLifecycleEventService.hydrate(sessionId);
 
     const sessionRuntime = sessionLifecycleService.getRuntimeSnapshot(sessionId);
+    if (sessionRuntime.processState === 'stopped') {
+      const transcript = sessionDomainService.getTranscriptSnapshot(sessionId);
+      const recoveredTranscript = finalizeInterruptedTranscriptToolCalls(
+        transcript,
+        sessionRuntime.updatedAt
+      );
+      if (recoveredTranscript !== transcript) {
+        sessionDomainService.replaceTranscript(sessionId, recoveredTranscript);
+      }
+    }
     await sessionDomainService.subscribe({
       sessionId,
       sessionRuntime,

--- a/src/backend/services/session/service/store/session-tool-call-recovery.test.ts
+++ b/src/backend/services/session/service/store/session-tool-call-recovery.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { groupAdjacentToolCalls, isToolSequence } from '@/lib/chat-protocol';
+import type { ChatMessage } from '@/shared/acp-protocol';
+import { finalizeInterruptedTranscriptToolCalls } from './session-tool-call-recovery';
+
+function toolUse(messageId: string, order: number): ChatMessage {
+  return {
+    id: messageId,
+    source: 'agent',
+    timestamp: `2026-08-20T10:00:0${order}.000Z`,
+    order,
+    message: {
+      type: 'stream_event',
+      event: {
+        type: 'content_block_start',
+        index: 0,
+        content_block: {
+          type: 'tool_use',
+          id: 'reused-call-id',
+          name: 'exec_command',
+          input: { cmd: `command-${order}` },
+        },
+      },
+    },
+  };
+}
+
+function assistantMessage(order: number): ChatMessage {
+  return {
+    id: `assistant-${order}`,
+    source: 'agent',
+    timestamp: `2026-08-20T10:00:0${order}.000Z`,
+    order,
+    message: {
+      type: 'assistant',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'Continuing.' }] },
+    },
+  };
+}
+
+function toolResult(order: number): ChatMessage {
+  return {
+    id: `tool-result-${order}`,
+    source: 'agent',
+    timestamp: `2026-08-20T10:00:0${order}.000Z`,
+    order,
+    message: {
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'reused-call-id', content: 'done' }],
+      },
+    },
+  };
+}
+
+describe('finalizeInterruptedTranscriptToolCalls', () => {
+  it('finalizes every unmatched occurrence when a tool ID was reused', () => {
+    const recovered = finalizeInterruptedTranscriptToolCalls(
+      [toolUse('tool-use-1', 0), toolUse('tool-use-2', 1)],
+      '2026-08-20T10:01:00.000Z'
+    );
+
+    const toolSequences = groupAdjacentToolCalls(recovered).filter(isToolSequence);
+    expect(toolSequences).toHaveLength(1);
+    expect(toolSequences[0]?.pairedCalls.map((call) => call.status)).toEqual(['error', 'error']);
+  });
+
+  it('matches a real result to the earlier occurrence of a reused tool ID', () => {
+    const recovered = finalizeInterruptedTranscriptToolCalls(
+      [toolUse('tool-use-1', 0), toolResult(1), assistantMessage(2), toolUse('tool-use-2', 3)],
+      '2026-08-20T10:01:00.000Z'
+    );
+
+    const toolSequences = groupAdjacentToolCalls(recovered).filter(isToolSequence);
+    expect(toolSequences.map((sequence) => sequence.pairedCalls[0]?.status)).toEqual([
+      'success',
+      'error',
+    ]);
+  });
+
+  it('keeps a real result on the earlier occurrence when recovering the later one', () => {
+    const recovered = finalizeInterruptedTranscriptToolCalls(
+      [toolUse('tool-use-1', 0), assistantMessage(1), toolUse('tool-use-2', 2), toolResult(3)],
+      '2026-08-20T10:01:00.000Z'
+    );
+
+    const toolSequences = groupAdjacentToolCalls(recovered).filter(isToolSequence);
+    expect(toolSequences.map((sequence) => sequence.pairedCalls[0]?.status)).toEqual([
+      'success',
+      'error',
+    ]);
+  });
+
+  it('does not add another result when recovery is applied twice', () => {
+    const firstRecovery = finalizeInterruptedTranscriptToolCalls(
+      [toolUse('tool-use-1', 0)],
+      '2026-08-20T10:01:00.000Z'
+    );
+
+    const secondRecovery = finalizeInterruptedTranscriptToolCalls(
+      firstRecovery,
+      '2026-08-20T10:02:00.000Z'
+    );
+
+    expect(secondRecovery).toBe(firstRecovery);
+  });
+});

--- a/src/backend/services/session/service/store/session-tool-call-recovery.ts
+++ b/src/backend/services/session/service/store/session-tool-call-recovery.ts
@@ -1,0 +1,116 @@
+import type { ChatMessage } from '@/shared/acp-protocol';
+
+type OpenToolCall = {
+  hasResult: boolean;
+  messageId: string;
+  occurrence: number;
+  toolUseId: string;
+};
+
+function getToolUseIds(message: ChatMessage): string[] {
+  if (message.source !== 'agent' || !message.message) {
+    return [];
+  }
+
+  const agentMessage = message.message;
+  if (
+    agentMessage.type === 'stream_event' &&
+    agentMessage.event?.type === 'content_block_start' &&
+    agentMessage.event.content_block.type === 'tool_use'
+  ) {
+    return [agentMessage.event.content_block.id];
+  }
+
+  const content = agentMessage.message?.content;
+  if (!Array.isArray(content)) {
+    return [];
+  }
+  return content.flatMap((item) => (item.type === 'tool_use' ? [item.id] : []));
+}
+
+function getToolResultIds(message: ChatMessage): string[] {
+  if (message.source !== 'agent' || !message.message) {
+    return [];
+  }
+
+  const agentMessage = message.message;
+  if (
+    agentMessage.type === 'stream_event' &&
+    agentMessage.event?.type === 'content_block_start' &&
+    agentMessage.event.content_block.type === 'tool_result'
+  ) {
+    return [agentMessage.event.content_block.tool_use_id];
+  }
+
+  const content = agentMessage.message?.content;
+  if (!Array.isArray(content)) {
+    return [];
+  }
+  return content.flatMap((item) => (item.type === 'tool_result' ? [item.tool_use_id] : []));
+}
+
+export function finalizeInterruptedTranscriptToolCalls(
+  transcript: ChatMessage[],
+  timestamp: string
+): ChatMessage[] {
+  const openToolCallsById = new Map<string, OpenToolCall[]>();
+  const toolCalls: OpenToolCall[] = [];
+  for (const message of transcript) {
+    for (const toolUseId of getToolUseIds(message)) {
+      const toolCall = {
+        hasResult: false,
+        messageId: message.id,
+        occurrence: toolCalls.length,
+        toolUseId,
+      };
+      toolCalls.push(toolCall);
+      const occurrences = openToolCallsById.get(toolUseId) ?? [];
+      occurrences.push(toolCall);
+      openToolCallsById.set(toolUseId, occurrences);
+    }
+    for (const toolResultId of getToolResultIds(message)) {
+      const occurrences = openToolCallsById.get(toolResultId);
+      const completedToolCall = occurrences?.shift();
+      if (completedToolCall) {
+        completedToolCall.hasResult = true;
+      }
+      if (occurrences?.length === 0) {
+        openToolCallsById.delete(toolResultId);
+      }
+    }
+  }
+
+  if (openToolCallsById.size === 0) {
+    return transcript;
+  }
+
+  let nextOrder = transcript.reduce((maximum, message) => Math.max(maximum, message.order), -1) + 1;
+  const recoveredResults = toolCalls
+    .filter((toolCall) => !toolCall.hasResult)
+    .map((toolCall): ChatMessage => {
+      const recoveredResult: ChatMessage = {
+        id: `recovered-tool-result:${toolCall.messageId}:${toolCall.toolUseId}:${toolCall.occurrence}`,
+        source: 'agent',
+        timestamp,
+        order: nextOrder,
+        message: {
+          type: 'user',
+          message: {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: toolCall.toolUseId,
+                content: 'Tool call was interrupted before it returned a result.',
+                is_error: true,
+              },
+            ],
+          },
+        },
+      };
+      nextOrder += 1;
+      return recoveredResult;
+    });
+
+  return [...transcript, ...recoveredResults];
+}

--- a/src/lib/chat-protocol.test.ts
+++ b/src/lib/chat-protocol.test.ts
@@ -189,7 +189,11 @@ function createToolUseMessage(params: {
   };
 }
 
-function createToolResultMessage(toolUseId: string, order: number): ChatMessage {
+function createToolResultMessage(
+  toolUseId: string,
+  order: number,
+  options: { content?: string; isError?: boolean } = {}
+): ChatMessage {
   const agentMessage: AgentMessage = {
     type: 'user',
     message: {
@@ -198,7 +202,8 @@ function createToolResultMessage(toolUseId: string, order: number): ChatMessage 
         {
           type: 'tool_result',
           tool_use_id: toolUseId,
-          content: 'ok',
+          content: options.content ?? 'ok',
+          is_error: options.isError ?? false,
         },
       ],
     },
@@ -365,14 +370,19 @@ describe('groupAdjacentToolCalls', () => {
       createAssistantTextMessage(1),
       createToolUseMessage({ id: 'call-reused', name: 'Read', input: {}, order: 2 }),
       createAssistantTextMessage(3),
-      createToolResultMessage('call-reused', 4),
-      createToolResultMessage('call-reused', 5),
+      createToolResultMessage('call-reused', 4, { content: 'first result' }),
+      createToolResultMessage('call-reused', 5, { content: 'second result', isError: true }),
     ]);
 
     const toolSequences = grouped.filter(isToolSequence);
-    expect(toolSequences.map((sequence) => sequence.pairedCalls[0]?.status)).toEqual([
-      'success',
-      'success',
+    expect(
+      toolSequences.map((sequence) => {
+        const call = sequence.pairedCalls[0];
+        return { status: call?.status, result: call?.result };
+      })
+    ).toEqual([
+      { status: 'success', result: { content: 'first result', isError: false } },
+      { status: 'error', result: { content: 'second result', isError: true } },
     ]);
   });
 });

--- a/src/lib/chat-protocol.test.ts
+++ b/src/lib/chat-protocol.test.ts
@@ -343,6 +343,38 @@ describe('groupAdjacentToolCalls', () => {
       expect(grouped[0].pairedCalls[0]?.status).toBe('success');
     }
   });
+
+  it('pairs contiguous calls and results in occurrence order when a tool ID is reused', () => {
+    const grouped = groupAdjacentToolCalls([
+      createToolUseMessage({ id: 'call-reused', name: 'Read', input: {}, order: 0 }),
+      createToolUseMessage({ id: 'call-reused', name: 'Read', input: {}, order: 1 }),
+      createToolResultMessage('call-reused', 2),
+      createToolResultMessage('call-reused', 3),
+    ]);
+
+    expect(grouped).toHaveLength(1);
+    expect(isToolSequence(grouped[0]!)).toBe(true);
+    if (isToolSequence(grouped[0]!)) {
+      expect(grouped[0].pairedCalls.map((call) => call.status)).toEqual(['success', 'success']);
+    }
+  });
+
+  it('reconciles delayed results in occurrence order when a tool ID is reused', () => {
+    const grouped = groupAdjacentToolCalls([
+      createToolUseMessage({ id: 'call-reused', name: 'Read', input: {}, order: 0 }),
+      createAssistantTextMessage(1),
+      createToolUseMessage({ id: 'call-reused', name: 'Read', input: {}, order: 2 }),
+      createAssistantTextMessage(3),
+      createToolResultMessage('call-reused', 4),
+      createToolResultMessage('call-reused', 5),
+    ]);
+
+    const toolSequences = grouped.filter(isToolSequence);
+    expect(toolSequences.map((sequence) => sequence.pairedCalls[0]?.status)).toEqual([
+      'success',
+      'success',
+    ]);
+  });
 });
 
 describe('isReasoningToolCall', () => {

--- a/src/lib/chat-protocol.ts
+++ b/src/lib/chat-protocol.ts
@@ -589,7 +589,7 @@ export function isReasoningToolCall(name: unknown, input: unknown): boolean {
 function applyToolResultToCall(
   msg: ChatMessage,
   pairedCalls: PairedToolCall[],
-  toolUseIdToIndex: Map<string, number>
+  toolUseIdToIndexes: Map<string, number[]>
 ): void {
   if (!(msg.message && isToolResultMessage(msg.message))) {
     return;
@@ -598,9 +598,16 @@ function applyToolResultToCall(
   if (!resultInfo) {
     return;
   }
-  const callIndex = toolUseIdToIndex.get(resultInfo.toolUseId);
+  const callIndexes = toolUseIdToIndexes.get(resultInfo.toolUseId);
+  if (!callIndexes) {
+    return;
+  }
+  const callIndex = callIndexes.shift();
   if (callIndex === undefined) {
     return;
+  }
+  if (callIndexes.length === 0) {
+    toolUseIdToIndexes.delete(resultInfo.toolUseId);
   }
   const call = pairedCalls[callIndex];
   if (!call) {
@@ -623,20 +630,22 @@ function applyToolResultToPairedCall(call: PairedToolCall, resultInfo: ToolResul
  */
 function extractPairedToolCalls(toolMessages: ChatMessage[]): PairedToolCall[] {
   const pairedCalls: PairedToolCall[] = [];
-  const toolUseIdToIndex = new Map<string, number>();
+  const toolUseIdToIndexes = new Map<string, number[]>();
 
   // First pass: collect all tool_use messages
   for (const msg of toolMessages) {
     const pairedCall = tryCreatePairedToolCall(msg);
     if (pairedCall) {
-      toolUseIdToIndex.set(pairedCall.id, pairedCalls.length);
+      const callIndexes = toolUseIdToIndexes.get(pairedCall.id) ?? [];
+      callIndexes.push(pairedCalls.length);
+      toolUseIdToIndexes.set(pairedCall.id, callIndexes);
       pairedCalls.push(pairedCall);
     }
   }
 
   // Second pass: match tool_result messages to their tool_use
   for (const msg of toolMessages) {
-    applyToolResultToCall(msg, pairedCalls, toolUseIdToIndex);
+    applyToolResultToCall(msg, pairedCalls, toolUseIdToIndexes);
   }
 
   return pairedCalls;
@@ -695,6 +704,40 @@ function isRenderableGroupedMessage(message: ChatMessage): boolean {
   );
 }
 
+function trackOpenPairedCalls(
+  pairedCalls: PairedToolCall[],
+  openPairedCallsById: Map<string, PairedToolCall[]>
+): void {
+  for (const call of pairedCalls) {
+    if (call.status !== 'pending') {
+      continue;
+    }
+    const openCalls = openPairedCallsById.get(call.id) ?? [];
+    openCalls.push(call);
+    openPairedCallsById.set(call.id, openCalls);
+  }
+}
+
+function applyLateToolResult(
+  resultInfo: ToolResultInfo,
+  openPairedCallsById: Map<string, PairedToolCall[]>
+): boolean {
+  const pendingCalls = openPairedCallsById.get(resultInfo.toolUseId);
+  if (!pendingCalls) {
+    return false;
+  }
+  const pendingCall = pendingCalls.shift();
+  if (!pendingCall) {
+    return false;
+  }
+
+  applyToolResultToPairedCall(pendingCall, resultInfo);
+  if (pendingCalls.length === 0) {
+    openPairedCallsById.delete(resultInfo.toolUseId);
+  }
+  return true;
+}
+
 /**
  * Groups adjacent tool_use and tool_result messages together.
  * Returns a mixed array of regular messages and tool sequences.
@@ -703,7 +746,7 @@ function isRenderableGroupedMessage(message: ChatMessage): boolean {
 export function groupAdjacentToolCalls(messages: ChatMessage[]): GroupedMessageItem[] {
   const result: GroupedMessageItem[] = [];
   let currentToolSequence: ChatMessage[] = [];
-  const openPairedCallsById = new Map<string, PairedToolCall>();
+  const openPairedCallsById = new Map<string, PairedToolCall[]>();
 
   const flushToolSequence = () => {
     if (currentToolSequence.length === 0) {
@@ -724,13 +767,7 @@ export function groupAdjacentToolCalls(messages: ChatMessage[]): GroupedMessageI
     };
     if (sequence.pairedCalls.length > 0) {
       result.push(sequence);
-      for (const call of sequence.pairedCalls) {
-        if (call.status === 'pending') {
-          openPairedCallsById.set(call.id, call);
-        } else {
-          openPairedCallsById.delete(call.id);
-        }
-      }
+      trackOpenPairedCalls(sequence.pairedCalls, openPairedCallsById);
     }
     currentToolSequence = [];
   };
@@ -740,13 +777,8 @@ export function groupAdjacentToolCalls(messages: ChatMessage[]): GroupedMessageI
       message.message && isToolResultMessage(message.message)
         ? extractToolResultInfo(message.message)
         : null;
-    if (lateToolResultInfo) {
-      const pendingCall = openPairedCallsById.get(lateToolResultInfo.toolUseId);
-      if (pendingCall) {
-        applyToolResultToPairedCall(pendingCall, lateToolResultInfo);
-        openPairedCallsById.delete(lateToolResultInfo.toolUseId);
-        continue;
-      }
+    if (lateToolResultInfo && applyLateToolResult(lateToolResultInfo, openPairedCallsById)) {
+      continue;
     }
 
     const isToolMessage =


### PR DESCRIPTION
## Summary

- finalize unmatched historical tool calls when loading a stopped session
- leave active and already-completed calls unchanged, with idempotent recovery
- pair reused tool-call IDs in occurrence order, including delayed results

## Why

A backend or app crash loses the in-memory pending-call map. When provider history later restores a `tool_use` without its corresponding `tool_result`, the client interprets that old call as still pending and renders it as running indefinitely.

## Testing

- `pnpm check:fix`
- `pnpm typecheck`
- `pnpm test` — 5,376 passed, 4 skipped
- `pnpm check`

## Notes

The local Codex schema check was skipped because the installed CLI version differs from the repository-pinned version; CI runs it with the pinned CLI.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mutates session transcripts on load and changes how tool_use/tool_result pairs are matched, which can affect chat history rendering if pairing is wrong.
> 
> **Overview**
> After a crash, unmatched historical `tool_use` events no longer stay pending forever. On **stopped** session load, `finalizeInterruptedTranscriptToolCalls` appends error `tool_result`s for open calls, then replaces the transcript. Running sessions and already-completed calls are left alone; recovery is idempotent.
> 
> `groupAdjacentToolCalls` now tracks **queues** of pending calls per ID so reused tool IDs pair with results in occurrence order, including delayed results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c2d6581a0de9183dc480e88b2dc67e93edc408b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->