### PR TITLE
Prepare 0.4.7 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to Factory Factory will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.7] - 2026-08-24
+
+### Changed
+
+- Modularize session lifecycle and ACP runtime management into focused services for context, notification delivery, startup, termination, runtime exits, workflow finalization, configuration, prompting, sub-agent browsing, and supervision, with smaller compatibility facades and focused contract suites (#2165, #2170, #2173, #2174, #2175, #2176, #2177, #2179, #2180, #2184)
+- Keep workspaces in Working while Codex goals remain active, including between prompts and after session resume (#2182)
+- Enforce a 1,000-line ceiling for new JavaScript and TypeScript files, ratchet oversized legacy files downward, and reject dangling symlinks from file-length checks (#2155, #2156)
+- Remove obsolete lifecycle test stubs, Electron preload APIs, Git and shell helpers, file traversal utilities, decision-log accessors, GitHub schemas, and issue-closing code (#2178, #2188, #2189, #2190, #2191, #2192, #2193, #2194)
+
+### Fixed
+
+- Preserve Codex notification ordering, serialize turn completion behind earlier item events, reject empty sub-agent receiver IDs, and validate permission request options before rendering (#2157, #2166, #2167, #2187)
+- Prevent disconnected terminal creation, stale sub-agent tabs after refetch failures, stale voice worklet callbacks, and orphaned Git worktrees after workspace deletion (#2168, #2169, #2171, #2172)
+- Stop sub-agent activity events from canceling long turns and prevent command handoffs from emitting duplicate tool completions (#2186, #2196)
+- Respect deliberate Ratchet stops when settling fixer exits (#2195)
+- Finalize unmatched running tool calls when loading sessions that stopped or crashed (#2197)
+
+### Documentation
+
+- Refresh the agent guide for current Claude and Codex workflows, move subsystem detail into focused architecture notes, and add scoped backend and client guidance (#2154)
+
 ## [0.4.6] - 2026-08-11
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "factory-factory",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Workspace-based coding environment for running multiple Claude Code and Codex sessions in parallel",
   "private": false,
   "license": "MIT",


### PR DESCRIPTION
## Summary

- bump the package version from 0.4.6 to 0.4.7
- add the 0.4.7 changelog entry covering all 34 changes merged since v0.4.6
- group the release notes by changed, fixed, and documentation impact, highlighting lifecycle/runtime modularization, active-goal workspace state, new file-length guardrails, session and tool-call reliability fixes, and dead-code cleanup

## Why

Prepare the next patch release with an accurate user-facing record of the reliability, maintainability, guardrail, and documentation work shipped after 0.4.6.

## Impact

Publishing this release will expose version 0.4.7 and its release notes. There are no runtime code changes in this PR.

## Validation

- `pnpm install --frozen-lockfile`
- `git diff --check`
- `pnpm check:fix`
- `pnpm typecheck`
- `pnpm check`
- `pnpm build`
- `pnpm test` — 425 files passed, 1 skipped, and 1 failed; 5,376 tests passed, 4 skipped, with 2 teardown failures in `git-ops.integration.test.ts`

The full suite hits a pre-existing local teardown race in which another process writes inside a temporary repository's `.git` directory while `afterEach` removes it, producing `ENOTEMPTY`. The same test failed on the untouched baseline before this metadata-only change (425 files passed, 1 skipped, and 1 failed; 5,377 tests passed, 4 skipped, with 1 teardown failure). Test assertions pass; only temporary-directory cleanup fails.

The local Codex schema sub-check skipped as designed because the installed CLI is 0.149.1 while the repository pins 0.145.0; CI installs the pinned CLI and enforces the check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version and changelog updates with no application or runtime code changes.
> 
> **Overview**
> Prepares **0.4.7** by bumping `package.json` from **0.4.6** to **0.4.7** and adding a **2026-08-24** changelog section that records everything merged since the last release.
> 
> The new notes are grouped under **Changed**, **Fixed**, and **Documentation**: lifecycle/ACP modularization, Codex active-goal workspace state, JS/TS file-length guardrails, dead-code removal, session/Codex/sub-agent/tool-call reliability fixes, and refreshed agent/architecture docs. **This PR does not ship those behaviors**—it only updates release metadata and user-facing release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e48cf3099fde555a85b9ff463f198412c16a408. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->