### PR TITLE
Fix npm postinstall deadlock and refresh 0.4.7 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,20 @@ All notable changes to Factory Factory will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.7] - 2026-08-24
+## [0.4.7] - 2026-09-08
 
 ### Changed
 
+- Publish npm releases through OIDC-authenticated staging, require maintainer approval on npm, and finalize the GitHub release from the original staging run's commit (#2199)
 - Modularize session lifecycle and ACP runtime management into focused services for context, notification delivery, startup, termination, runtime exits, workflow finalization, configuration, prompting, sub-agent browsing, and supervision, with smaller compatibility facades and focused contract suites (#2165, #2170, #2173, #2174, #2175, #2176, #2177, #2179, #2180, #2184)
 - Keep workspaces in Working while Codex goals remain active, including between prompts and after session resume (#2182)
 - Enforce a 1,000-line ceiling for new JavaScript and TypeScript files, ratchet oversized legacy files downward, and reject dangling symlinks from file-length checks (#2155, #2156)
 - Remove obsolete lifecycle test stubs, Electron preload APIs, Git and shell helpers, file traversal utilities, decision-log accessors, GitHub schemas, and issue-closing code (#2178, #2188, #2189, #2190, #2191, #2192, #2193, #2194)
+- Remove unused file-lock and provider-runtime abstractions, session and permission helpers, project and workspace accessors, workspace re-exports, PR review procedures, and file-reference parsing code (#2204, #2205, #2206, #2207, #2210, #2211, #2212, #2213, #2214)
 
 ### Fixed
 
+- Prevent npm package installation and release smoke tests from deadlocking by running the installed Prisma CLI directly during postinstall
 - Preserve Codex notification ordering, serialize turn completion behind earlier item events, reject empty sub-agent receiver IDs, and validate permission request options before rendering (#2157, #2166, #2167, #2187)
 - Prevent disconnected terminal creation, stale sub-agent tabs after refetch failures, stale voice worklet callbacks, and orphaned Git worktrees after workspace deletion (#2168, #2169, #2171, #2172)
 - Stop sub-agent activity events from canceling long turns and prevent command handoffs from emitting duplicate tool completions (#2186, #2196)

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -8,20 +8,24 @@
  * 2. node-pty spawn-helper permissions
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
 import { existsSync, chmodSync, readdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = join(__dirname, '..');
+const require = createRequire(import.meta.url);
 
 // Generate Prisma client if schema exists
 const schemaPath = join(projectRoot, 'prisma', 'schema.prisma');
 if (existsSync(schemaPath)) {
 	try {
 		console.log('Generating Prisma client...');
-		execSync(`npx prisma generate --schema="${schemaPath}"`, {
+		// Nested npx can wait on the installation lock held by the outer npm exec.
+		const prismaCliPath = require.resolve('prisma/build/index.js');
+		execFileSync(process.execPath, [prismaCliPath, 'generate', '--schema', schemaPath], {
 			stdio: 'inherit',
 			cwd: projectRoot,
 		});

--- a/scripts/postinstall.test.ts
+++ b/scripts/postinstall.test.ts
@@ -1,0 +1,83 @@
+import { spawnSync } from 'node:child_process';
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const temporaryDirectories: string[] = [];
+const postinstallPath = fileURLToPath(new URL('./postinstall.mjs', import.meta.url));
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function createInstalledPackage(prismaCli: string) {
+  const directory = mkdtempSync(join(tmpdir(), 'postinstall with spaces '));
+  temporaryDirectories.push(directory);
+  const packageRoot = join(directory, 'node_modules', 'factory-factory');
+  const prismaRoot = join(directory, 'node_modules', 'prisma');
+  mkdirSync(join(packageRoot, 'scripts'), { recursive: true });
+  mkdirSync(join(packageRoot, 'prisma'), { recursive: true });
+  mkdirSync(join(prismaRoot, 'build'), { recursive: true });
+  copyFileSync(postinstallPath, join(packageRoot, 'scripts', 'postinstall.mjs'));
+  writeFileSync(join(packageRoot, 'prisma', 'schema.prisma'), '// fixture schema');
+  // Match Prisma's CLI export: its root export is not the CLI entry point.
+  writeFileSync(
+    join(prismaRoot, 'package.json'),
+    JSON.stringify({
+      name: 'prisma',
+      type: 'module',
+      exports: { '.': './build/types.js', './build/index.js': './build/index.js' },
+      bin: { prisma: './build/index.js' },
+    })
+  );
+  writeFileSync(join(prismaRoot, 'build', 'index.js'), prismaCli);
+  return packageRoot;
+}
+
+function runPostinstall(packageRoot: string) {
+  return spawnSync(process.execPath, [join(packageRoot, 'scripts', 'postinstall.mjs')], {
+    cwd: tmpdir(),
+    // A nested npm/npx invocation must not be needed during installation.
+    env: { PATH: '' },
+    encoding: 'utf8',
+    timeout: 5000,
+  });
+}
+
+describe('postinstall Prisma generation', () => {
+  it('runs the installed Prisma CLI without npm or npx on PATH', () => {
+    const packageRoot = createInstalledPackage(`
+import { strict as assert } from 'node:assert';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+assert.deepEqual(process.argv.slice(2), ['generate', '--schema', join(process.cwd(), 'prisma', 'schema.prisma')]);
+assert.equal(readFileSync(process.argv[4], 'utf8'), '// fixture schema');
+writeFileSync(join(process.cwd(), 'prisma', 'generated.txt'), 'generated');
+`);
+
+    const result = runPostinstall(packageRoot);
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(readFileSync(join(packageRoot, 'prisma', 'generated.txt'), 'utf8')).toBe('generated');
+  });
+
+  it('reports Prisma generation failures without failing installation', () => {
+    const packageRoot = createInstalledPackage(`
+console.error('fixture Prisma generation failed');
+process.exitCode = 1;
+`);
+
+    const result = runPostinstall(packageRoot);
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain('fixture Prisma generation failed');
+    expect(result.stderr).toContain('Failed to generate Prisma client:');
+  });
+});


### PR DESCRIPTION
The 0.4.7 release smoke test hangs while installing the packed package: the outer `npm exec` holds a cache installation lock, and postinstall's nested `npx prisma generate` waits for that same lock. Resolve the installed Prisma CLI and launch it with the current Node executable so generation completes without starting another package-manager process. Existing nonfatal generation-error handling is preserved.

Add executable regression tests for generation without npm/npx on PATH, paths containing spaces, and generation failures. Refresh the existing 0.4.7 changelog with all ten commits merged since release preparation (#2198), plus this fix; keep the package version at 0.4.7 because it has not been published.

Validation:
- `pnpm check:fix`
- `pnpm typecheck`
- `pnpm test` — 5,336 passed; 4 skipped
- `pnpm check` — passed; Codex schema check skipped locally because the installed CLI differs from the pinned version (CI enforces it)
- `pnpm build`
- Packed-artifact smoke tests on macOS with Node 22.22.0 and npm 11.19.0: Prisma generation, `serve --help`, and migrations against a fresh temporary database
- Regression tests failed with the original postinstall script and passed after the fix


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

