### PR TITLE
Fix npm staging tarball path resolution

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -116,7 +116,8 @@ jobs:
         run: npm install --global npm@11.19.0
 
       - name: Stage package on npm
-        run: npm stage publish npm-package/factory-factory-*.tgz --access public
+        # The ./ prefix prevents npm from treating the path as GitHub owner/repo shorthand.
+        run: npm stage publish ./npm-package/factory-factory-*.tgz --access public
 
       - name: Record finalization details
         if: ${{ github.event_name == 'workflow_dispatch' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Resolve the staged npm tarball as a local file instead of a GitHub repository during release publishing
 - Prevent npm package installation and release smoke tests from deadlocking by running the installed Prisma CLI directly during postinstall
 - Preserve Codex notification ordering, serialize turn completion behind earlier item events, reject empty sub-agent receiver IDs, and validate permission request options before rendering (#2157, #2166, #2167, #2187)
 - Prevent disconnected terminal creation, stale sub-agent tabs after refetch failures, stale voice worklet callbacks, and orphaned Git worktrees after workspace deletion (#2168, #2169, #2171, #2172)

--- a/src/backend/testing/npm-publish-workflow.test.ts
+++ b/src/backend/testing/npm-publish-workflow.test.ts
@@ -123,7 +123,7 @@ describe('npm publish workflow', () => {
     expectSecureNodeSetup(stageJob);
     expect(getStep(stageJob, 'Install npm CLI').run).toBe('npm install --global npm@11.19.0');
     expect(getStep(stageJob, 'Stage package on npm').run).toBe(
-      'npm stage publish npm-package/factory-factory-*.tgz --access public'
+      'npm stage publish ./npm-package/factory-factory-*.tgz --access public'
     );
 
     const oidcJobs = Object.entries(workflow.jobs)


### PR DESCRIPTION
The release staging command passed `npm-package/factory-factory-0.4.7.tgz` to npm, which interpreted it as GitHub `owner/repo` shorthand and attempted an SSH Git fetch. This caused the [0.4.7 staging run](https://github.com/purplefish-ai/factory-factory/actions/runs/34261147968/job/102180770535) to fail before uploading the package.

Prefix the tarball path with `./` so npm resolves the downloaded local artifact. Update the workflow regression assertion and the existing 0.4.7 changelog. This release fix is independent of the dependency refresh in #2218.

Validation:
- The workflow regression test failed with the old command and passes with the fix (8 tests).
- npm 11.19.0 successfully ran `stage publish ./npm-package/factory-factory-*.tgz --access public --dry-run --ignore-scripts --json` against the exact artifact from the failed run, identifying `factory-factory@0.4.7`. No package was uploaded.
- `pnpm check:fix`, `pnpm typecheck`, `pnpm test`, and `CODEX_SCHEMA_CHECK=strict pnpm check`.

After merging, start a fresh staging workflow on main so it uses the updated command; rerunning the failed run uses its original workflow revision. Actual registry staging remains to be verified by that run.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

