### PR TITLE
Clarify duplicate list key stability

### DIFF
--- a/src/client/lib/list-keys.ts
+++ b/src/client/lib/list-keys.ts
@@ -1,4 +1,8 @@
-/** Keep identities stable across reordering, disambiguating duplicates by occurrence. */
+/**
+ * Keep keys stable across reordering for distinct identities.
+ * Duplicate identities are distinguished by occurrence, so their keys depend on
+ * their relative order. Use unique identities when individual rows must retain state.
+ */
 export function withOccurrenceKeys<T>(
   items: readonly T[],
   getIdentity: (item: T) => string


### PR DESCRIPTION
Clarify that `withOccurrenceKeys` preserves keys across reordering for distinct identities, while duplicate identities depend on their relative occurrence order. Document that callers needing row-specific state preservation should provide unique identities.

Addresses [Cubic's docstring comment on #2220](https://github.com/purplefish-ai/factory-factory/pull/2220#discussion_r3961725422), following that PR's merge. Only the docstring changes; runtime behavior is unchanged.

Validation: `pnpm check:fix`, `pnpm typecheck`, the existing list-key and file-change renderer tests, `CODEX_SCHEMA_CHECK=strict pnpm check`, and normal pre-commit checks.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

