### PR TITLE
Upgrade ACP SDK to 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Upgrade the ACP SDK from 0.15.0 to 1.4.0, matching Claude ACP, migrate model switching to the supported config API, and handle the expanded config and MCP transport types
 - Upgrade Knip from 5.88.1 to 6.35.0, include CSS, MDX, and Prisma in its project analysis, and remove redundant entry points and dependency ignores
 - Upgrade Biome from 2.4.4 to 2.5.12, migrate its configuration, and apply the updated lint and formatting rules
 - Refresh compatible runtime and development dependencies, including Claude ACP 0.75.1, Prisma 7.10.0, Electron 41.10.7, Storybook 10.6.0, and pnpm 10.34.5

--- a/docs/architecture/agent-runtime.md
+++ b/docs/architecture/agent-runtime.md
@@ -5,7 +5,13 @@
 All agent sessions use the Agent Client Protocol (ACP) via
 `@agentclientprotocol/sdk`. CLAUDE sessions spawn `claude-agent-acp`; CODEX
 sessions spawn Factory Factory's internal `codex-app-server-acp` adapter, both
-over stdio JSON-RPC.
+over stdio JSON-RPC. The direct SDK dependency matches Claude ACP's SDK 1.4.
+Model changes use `session/set_config_option`. Legacy model/mode response
+fallbacks remain supported; model and mode controls require select options.
+Boolean options are retained in backend configuration but omitted from the
+current select-only chat controls. The internal Codex adapter accepts string
+configuration values and stdio/HTTP/SSE MCP servers; it rejects ACP-tunneled MCP
+servers, which it does not advertise support for.
 
 Session init/load is fail-fast and requires provider `configOptions` with
 model/mode categories. Permission requests present multi-option selection

--- a/docs/architecture/agent-runtime.md
+++ b/docs/architecture/agent-runtime.md
@@ -13,8 +13,9 @@ current select-only chat controls. The internal Codex adapter accepts string
 configuration values and stdio/HTTP/SSE MCP servers; it rejects ACP-tunneled MCP
 servers, which it does not advertise support for.
 
-Session init/load is fail-fast and requires provider `configOptions` with
-model/mode categories. Permission requests present multi-option selection
+Session init/load fails unless model/mode select options can be obtained from
+provider `configOptions` or legacy model/mode response fields. Permission requests
+present multi-option selection
 (`allow_once`, `allow_always`, `deny_once`, `deny_always`) and are bridged
 through ACP permission response handlers.
 

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   },
   "dependencies": {
     "@agentclientprotocol/claude-agent-acp": "^0.75.1",
-    "@agentclientprotocol/sdk": "0.15.0",
+    "@agentclientprotocol/sdk": "1.4.0",
     "@linear/sdk": "^76.0.0",
     "@phosphor-icons/react": "^2.1.10",
     "@prisma/adapter-better-sqlite3": "7.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,8 +61,8 @@ importers:
         specifier: ^0.75.1
         version: 0.75.1(@anthropic-ai/sdk@0.124.0(zod@4.5.4))(@modelcontextprotocol/sdk@1.29.0(zod@4.5.4))
       '@agentclientprotocol/sdk':
-        specifier: 0.15.0
-        version: 0.15.0(zod@4.5.4)
+        specifier: 1.4.0
+        version: 1.4.0(zod@4.5.4)
       '@linear/sdk':
         specifier: ^76.0.0
         version: 76.0.0(graphql@16.12.0)
@@ -434,11 +434,6 @@ packages:
     resolution: {integrity: sha512-Un6I4BRkhpCFS3I7kr5C/lkAm8Nc3VuGZU2YQ3xIpJAIxV94iWO0Q2CH2QABxMERpONRu4Le6XC9V+5PImQZ2A==}
     engines: {node: '>=22'}
     hasBin: true
-
-  '@agentclientprotocol/sdk@0.15.0':
-    resolution: {integrity: sha512-TH4utu23Ix8ec34srBHmDD4p3HI0cYleS1jN9lghRczPfhFlMBNrQgZWeBBe12DWy27L11eIrtciY2MXFSEiDg==}
-    peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
 
   '@agentclientprotocol/sdk@1.4.0':
     resolution: {integrity: sha512-/eufudw+aFY1LKLolT6yFE6UMmYRl7fMJ/DEONSIyR6wI3slHWITBsANRGqXEY8FRzqUxwh7QEaGiZHcJPVThg==}
@@ -6706,10 +6701,6 @@ snapshots:
     transitivePeerDependencies:
       - '@anthropic-ai/sdk'
       - '@modelcontextprotocol/sdk'
-
-  '@agentclientprotocol/sdk@0.15.0(zod@4.5.4)':
-    dependencies:
-      zod: 4.5.4
 
   '@agentclientprotocol/sdk@1.4.0(zod@4.5.4)':
     dependencies:

--- a/src/backend/services/session/service/acp/acp-runtime-config-controller.test.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-config-controller.test.ts
@@ -104,100 +104,39 @@ describe('AcpRuntimeConfigController', () => {
     );
   });
 
-  it('uses Claude unstable_setSessionModel and replaces the cached model value', async () => {
-    const unstableSetSessionModel = vi.fn().mockResolvedValue({});
-    const handle = createTestProcessHandle({
-      provider: 'CLAUDE',
-      connection: { unstable_setSessionModel: unstableSetSessionModel },
-    });
-    handle.configOptions = configOptions();
-
-    await expect(controller.setSessionModel(handle, 'opus', LOGICAL_SESSION_ID)).resolves.toEqual([
-      { ...configOptions()[0], currentValue: 'opus' },
-      configOptions()[1],
-    ]);
-    expect(unstableSetSessionModel).toHaveBeenCalledWith({
-      sessionId: handle.providerSessionId,
-      modelId: 'opus',
-    });
-  });
-
-  it('falls back to generic model configuration when Claude unstable model is unavailable', async () => {
-    const unstableSetSessionModel = vi
-      .fn()
-      .mockRejectedValue({ code: -32_601, message: 'Method not found' });
-    const setSessionConfigOption = vi.fn().mockResolvedValue({
-      configOptions: configOptions().map((option) =>
+  it.each(['CLAUDE', 'CODEX'] as const)(
+    'sets %s models through session config and caches the complete response',
+    async (provider) => {
+      const nextOptions = configOptions().map((option) =>
         option.id === 'model' ? { ...option, currentValue: 'opus' } : option
-      ),
-    });
-    const handle = createTestProcessHandle({
-      provider: 'CLAUDE',
-      connection: { unstable_setSessionModel: unstableSetSessionModel, setSessionConfigOption },
-    });
-    handle.configOptions = configOptions();
+      );
+      const setSessionConfigOption = vi.fn().mockResolvedValue({ configOptions: nextOptions });
+      const handle = createTestProcessHandle({ provider, connection: { setSessionConfigOption } });
+      handle.configOptions = configOptions();
+      await expect(controller.setSessionModel(handle, 'opus', LOGICAL_SESSION_ID)).resolves.toEqual(
+        nextOptions
+      );
+      expect(setSessionConfigOption).toHaveBeenCalledWith({
+        sessionId: handle.providerSessionId,
+        configId: 'model',
+        value: 'opus',
+      });
+      expect(handle.configOptions).toEqual(nextOptions);
+    }
+  );
 
-    await controller.setSessionModel(handle, 'opus', LOGICAL_SESSION_ID);
-
-    expect(setSessionConfigOption).toHaveBeenCalledWith({
-      sessionId: handle.providerSessionId,
-      configId: 'model',
-      value: 'opus',
-    });
-    expect(handle.configOptions.find((option) => option.category === 'model')?.currentValue).toBe(
-      'opus'
-    );
-    expectManagerWarning(
-      'unstable_setSessionModel unavailable, falling back to setSessionConfigOption',
-      {
-        sessionId: LOGICAL_SESSION_ID,
-        modelId: 'opus',
-        provider: 'CLAUDE',
-      }
-    );
-  });
-
-  it('propagates a Claude model error that is not method-not-found', async () => {
+  it('propagates Claude model configuration errors without changing the cache', async () => {
     const error = new Error('Model rejected');
-    const unstableSetSessionModel = vi.fn().mockRejectedValue(error);
+    const setSessionConfigOption = vi.fn().mockRejectedValue(error);
     const handle = createTestProcessHandle({
       provider: 'CLAUDE',
-      connection: { unstable_setSessionModel: unstableSetSessionModel },
+      connection: { setSessionConfigOption },
     });
     handle.configOptions = configOptions();
-
     await expect(controller.setSessionModel(handle, 'opus', LOGICAL_SESSION_ID)).rejects.toBe(
       error
     );
-    expectManagerWarning('setSessionModel failed', {
-      sessionId: LOGICAL_SESSION_ID,
-      modelId: 'opus',
-      provider: 'CLAUDE',
-      error: 'Model rejected',
-    });
-  });
-
-  it('uses generic model configuration for Codex', async () => {
-    const setSessionConfigOption = vi.fn().mockResolvedValue({
-      configOptions: configOptions().map((option) =>
-        option.id === 'model' ? { ...option, currentValue: 'gpt-5.2-codex' } : option
-      ),
-    });
-    const unstableSetSessionModel = vi.fn();
-    const handle = createTestProcessHandle({
-      provider: 'CODEX',
-      connection: { setSessionConfigOption, unstable_setSessionModel: unstableSetSessionModel },
-    });
-    handle.configOptions = configOptions();
-
-    await controller.setSessionModel(handle, 'gpt-5.2-codex', LOGICAL_SESSION_ID);
-
-    expect(unstableSetSessionModel).not.toHaveBeenCalled();
-    expect(setSessionConfigOption).toHaveBeenCalledWith({
-      sessionId: handle.providerSessionId,
-      configId: 'model',
-      value: 'gpt-5.2-codex',
-    });
+    expect(handle.configOptions).toEqual(configOptions());
   });
 
   it('rejects a generic response missing required config categories', async () => {

--- a/src/backend/services/session/service/acp/acp-runtime-config-controller.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-config-controller.ts
@@ -1,7 +1,6 @@
 import type { SessionConfigOption } from '@agentclientprotocol/sdk';
 import { createLogger } from '@/backend/services/logger.service';
 import type { AcpProcessHandle } from './acp-process-handle';
-import { isMethodNotFoundError } from './acp-runtime-errors';
 import { requireSessionConfigOptions } from './acp-session-config-options';
 
 const logger = createLogger('acp-runtime-manager');
@@ -48,7 +47,9 @@ export class AcpRuntimeConfigController {
       });
 
       handle.configOptions = handle.configOptions.map((option) =>
-        option.category === 'mode' ? { ...option, currentValue: modeId } : option
+        option.type === 'select' && option.category === 'mode'
+          ? { ...option, currentValue: modeId }
+          : option
       );
 
       return [...handle.configOptions];
@@ -68,41 +69,6 @@ export class AcpRuntimeConfigController {
     modelId: string,
     sessionId: string
   ): Promise<SessionConfigOption[]> {
-    const applyModelToCache = (): SessionConfigOption[] => {
-      handle.configOptions = handle.configOptions.map((option) =>
-        option.category === 'model' ? { ...option, currentValue: modelId } : option
-      );
-      return [...handle.configOptions];
-    };
-
-    if (handle.provider === 'CLAUDE') {
-      try {
-        await handle.connection.unstable_setSessionModel({
-          sessionId: handle.providerSessionId,
-          modelId,
-        });
-        return applyModelToCache();
-      } catch (error) {
-        if (!isMethodNotFoundError(error)) {
-          logger.warn('setSessionModel failed', {
-            sessionId,
-            modelId,
-            provider: handle.provider,
-            error: error instanceof Error ? error.message : String(error),
-          });
-          throw error;
-        }
-        logger.warn(
-          'unstable_setSessionModel unavailable, falling back to setSessionConfigOption',
-          {
-            sessionId,
-            modelId,
-            provider: handle.provider,
-          }
-        );
-      }
-    }
-
     return await this.setConfigOption(handle, 'model', modelId, sessionId);
   }
 }

--- a/src/backend/services/session/service/acp/acp-runtime-manager.config.test.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-manager.config.test.ts
@@ -4,7 +4,6 @@ import {
   createManagerTestHarness,
   mockSetSessionConfigOption,
   mockSetSessionMode,
-  mockSetSessionModel,
   setupSuccessfulSpawn,
 } from './acp-runtime-manager.test-harness';
 import {
@@ -68,6 +67,7 @@ describe('AcpRuntimeManager', () => {
       await manager.setConfigOption('session-1', 'mode', 'plan');
 
       const defaultModelOption = handle.configOptions
+        .filter((option) => option.type === 'select')
         .find((option) => option.id === 'model')
         ?.options.find((option) => 'value' in option && option.value === 'default');
       expect(defaultModelOption).toMatchObject({
@@ -159,30 +159,8 @@ describe('AcpRuntimeManager', () => {
   });
 
   describe('setSessionModel', () => {
-    it('uses unstable_setSessionModel for CLAUDE and updates cached model currentValue', async () => {
+    it('uses setSessionConfigOption for CLAUDE and caches the returned model', async () => {
       setupSuccessfulSpawn();
-      const handle = await manager.getOrCreateClient(
-        'session-1',
-        defaultOptions(),
-        defaultHandlers(),
-        defaultContext()
-      );
-
-      await manager.setSessionModel('session-1', 'opus');
-
-      expect(mockSetSessionModel).toHaveBeenCalledWith({
-        sessionId: 'provider-session-123',
-        modelId: 'opus',
-      });
-      expect(mockSetSessionConfigOption).not.toHaveBeenCalled();
-      expect(handle.configOptions.find((option) => option.id === 'model')?.currentValue).toBe(
-        'opus'
-      );
-    });
-
-    it('falls back to setSessionConfigOption when unstable_setSessionModel is unavailable', async () => {
-      setupSuccessfulSpawn();
-      mockSetSessionModel.mockRejectedValueOnce({ code: -32_601, message: 'Method not found' });
       mockSetSessionConfigOption.mockResolvedValueOnce({
         configOptions: [
           {
@@ -215,18 +193,16 @@ describe('AcpRuntimeManager', () => {
 
       await manager.setSessionModel('session-1', 'opus');
 
-      expect(mockSetSessionModel).toHaveBeenCalledWith({
-        sessionId: 'provider-session-123',
-        modelId: 'opus',
-      });
       expect(mockSetSessionConfigOption).toHaveBeenCalledWith({
         sessionId: 'provider-session-123',
         configId: 'model',
         value: 'opus',
       });
-      expect(handle.configOptions.find((option) => option.id === 'model')?.currentValue).toBe(
-        'opus'
-      );
+      expect(
+        handle.configOptions
+          .filter((option) => option.type === 'select')
+          .find((option) => option.id === 'model')?.currentValue
+      ).toBe('opus');
     });
 
     it('uses setSessionConfigOption path for CODEX model updates', async () => {
@@ -240,7 +216,6 @@ describe('AcpRuntimeManager', () => {
 
       await manager.setSessionModel('session-1', 'gpt-5.2-codex');
 
-      expect(mockSetSessionModel).not.toHaveBeenCalled();
       expect(mockSetSessionConfigOption).toHaveBeenCalledWith({
         sessionId: 'provider-session-123',
         configId: 'model',

--- a/src/backend/services/session/service/acp/acp-runtime-manager.creation.test.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-manager.creation.test.ts
@@ -469,8 +469,12 @@ describe('AcpRuntimeManager', () => {
 
       const handle = await createTestClient(manager);
 
-      const modelOption = handle.configOptions.find((option) => option.category === 'model');
-      const modeOption = handle.configOptions.find((option) => option.category === 'mode');
+      const modelOption = handle.configOptions
+        .filter((option) => option.type === 'select')
+        .find((option) => option.category === 'model');
+      const modeOption = handle.configOptions
+        .filter((option) => option.type === 'select')
+        .find((option) => option.category === 'mode');
 
       expect(modelOption).toMatchObject({
         id: 'model',
@@ -551,7 +555,9 @@ describe('AcpRuntimeManager', () => {
       });
 
       const handle = await createTestClient(manager);
-      const modelOption = handle.configOptions.find((option) => option.id === 'model');
+      const modelOption = handle.configOptions
+        .filter((option) => option.type === 'select')
+        .find((option) => option.id === 'model');
       const defaultEntry = modelOption?.options.find(
         (option) => 'value' in option && option.value === 'default'
       );

--- a/src/backend/services/session/service/acp/acp-runtime-manager.test-harness.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-manager.test-harness.ts
@@ -18,7 +18,6 @@ const mocks = vi.hoisted(() => ({
   mockCancel: vi.fn(),
   mockSetSessionConfigOption: vi.fn(),
   mockSetSessionMode: vi.fn(),
-  mockSetSessionModel: vi.fn(),
   mockExtMethod: vi.fn(),
   mockNdJsonStream: vi
     .fn()
@@ -36,7 +35,6 @@ export const mockCancel: ReturnType<typeof vi.fn> = mocks.mockCancel;
 export const mockSetSessionConfigOption: ReturnType<typeof vi.fn> =
   mocks.mockSetSessionConfigOption;
 export const mockSetSessionMode: ReturnType<typeof vi.fn> = mocks.mockSetSessionMode;
-export const mockSetSessionModel: ReturnType<typeof vi.fn> = mocks.mockSetSessionModel;
 export const mockExtMethod: ReturnType<typeof vi.fn> = mocks.mockExtMethod;
 export const mockNdJsonStream: ReturnType<typeof vi.fn> = mocks.mockNdJsonStream;
 export const mockLoggerWarn: ReturnType<typeof vi.fn> = mocks.mockLoggerWarn;
@@ -56,7 +54,6 @@ vi.mock('@agentclientprotocol/sdk', () => {
     cancel = mockCancel;
     setSessionConfigOption = mockSetSessionConfigOption;
     setSessionMode = mockSetSessionMode;
-    unstable_setSessionModel = mockSetSessionModel;
     extMethod = mockExtMethod;
 
     constructor(toClient: (agent: unknown) => unknown, _stream: unknown) {
@@ -110,7 +107,6 @@ export function setupSuccessfulSpawn(
     configOptions: defaultConfigOptions(),
   });
   mockSetSessionMode.mockResolvedValue({});
-  mockSetSessionModel.mockResolvedValue({});
   return child;
 }
 

--- a/src/backend/services/session/service/acp/acp-session-config-options.test.ts
+++ b/src/backend/services/session/service/acp/acp-session-config-options.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from 'vitest';
-import { requireSessionConfigOptions } from './acp-session-config-options';
+import { assert, describe, expect, it } from 'vitest';
+import {
+  normalizeSessionConfigOptions,
+  requireSessionConfigOptions,
+} from './acp-session-config-options';
 
 describe('requireSessionConfigOptions Claude labels', () => {
   it('normalizes flat Claude model names and preserves option values', () => {
@@ -35,10 +38,12 @@ describe('requireSessionConfigOptions Claude labels', () => {
       ],
     });
 
+    assert(configOptions[0]?.type === 'select');
     expect(configOptions[0]?.options).toEqual([
       expect.objectContaining({ value: 'default', name: 'Default — Opus 4.8 (1M)' }),
       expect.objectContaining({ value: 'sonnet', name: 'Sonnet 5' }),
     ]);
+    assert(configOptions[1]?.type === 'select');
     expect(configOptions[1]?.options).toEqual([{ value: 'default', name: 'Default' }]);
   });
 
@@ -81,6 +86,7 @@ describe('requireSessionConfigOptions Claude labels', () => {
       ],
     });
 
+    assert(configOptions[0]?.type === 'select');
     expect(configOptions[0]?.options).toEqual([
       expect.objectContaining({
         name: 'Latest models',
@@ -119,8 +125,26 @@ describe('requireSessionConfigOptions Claude labels', () => {
     });
 
     expect(configOptions[0]).toMatchObject({ category: 'model' });
+    assert(configOptions[0]?.type === 'select');
     expect(configOptions[0]?.options).toEqual([
       expect.objectContaining({ value: 'sonnet', name: 'Sonnet 5' }),
     ]);
+  });
+});
+
+describe('boolean ACP config options', () => {
+  it('preserves boolean values without treating them as model selects', () => {
+    const option = { id: 'model', name: 'Toggle', type: 'boolean' as const, currentValue: false };
+    expect(normalizeSessionConfigOptions('CLAUDE', [option])).toEqual([option]);
+  });
+  it('requires select options for the model and mode categories', () => {
+    expect(() =>
+      requireSessionConfigOptions('CLAUDE', 'newSession', {
+        configOptions: [
+          { id: 'model', name: 'Model', type: 'boolean', category: 'model', currentValue: false },
+          { id: 'mode', name: 'Mode', type: 'boolean', category: 'mode', currentValue: true },
+        ],
+      })
+    ).toThrow('missing required config option categories: model, mode');
   });
 });

--- a/src/backend/services/session/service/acp/acp-session-config-options.ts
+++ b/src/backend/services/session/service/acp/acp-session-config-options.ts
@@ -1,8 +1,8 @@
 import type {
   SessionConfigOption,
+  SessionConfigSelect,
   SessionConfigSelectGroup,
   SessionConfigSelectOption,
-  SessionModelState,
   SessionModeState,
 } from '@agentclientprotocol/sdk';
 import { createLogger } from '@/backend/services/logger.service';
@@ -11,9 +11,15 @@ import { formatClaudeModelOptionName } from './claude-model-options';
 const logger = createLogger('acp-session-config-options');
 const REQUIRED_CONFIG_CATEGORIES = ['model', 'mode'] as const;
 
+// Older providers may still send the retired model-state response alongside modes.
+type LegacySessionModelState = {
+  currentModelId: string;
+  availableModels: Array<{ modelId: string; name: string; description?: string | null }>;
+};
+
 type SessionResultWithFallbackState = {
   configOptions?: SessionConfigOption[] | null;
-  models?: SessionModelState | null;
+  models?: LegacySessionModelState | null;
   modes?: SessionModeState | null;
 };
 
@@ -35,7 +41,7 @@ function isOptionGroup(
 }
 
 function isOptionGroupArray(
-  options: SessionConfigOption['options']
+  options: SessionConfigSelect['options']
 ): options is SessionConfigSelectGroup[] {
   const [firstOption] = options;
   return firstOption ? isOptionGroup(firstOption) : false;
@@ -43,7 +49,10 @@ function isOptionGroupArray(
 
 function normalizeClaudeConfigOptions(configOptions: SessionConfigOption[]): SessionConfigOption[] {
   return configOptions.map((configOption) => {
-    if (configOption.category !== 'model' && configOption.id !== 'model') {
+    if (
+      configOption.type !== 'select' ||
+      (configOption.category !== 'model' && configOption.id !== 'model')
+    ) {
       return configOption;
     }
 
@@ -75,7 +84,11 @@ export function normalizeSessionConfigOptions(
   const providerNormalized =
     provider === 'CLAUDE' ? normalizeClaudeConfigOptions(configOptions) : configOptions;
   return providerNormalized.map((configOption) => {
-    if (configOption.category || (configOption.id !== 'model' && configOption.id !== 'mode')) {
+    if (
+      configOption.type !== 'select' ||
+      configOption.category ||
+      (configOption.id !== 'model' && configOption.id !== 'mode')
+    ) {
       return configOption;
     }
     return {
@@ -86,7 +99,7 @@ export function normalizeSessionConfigOptions(
 }
 
 function resolveModelConfigOption(
-  models: SessionModelState | null | undefined
+  models: LegacySessionModelState | null | undefined
 ): SessionConfigOption | null {
   if (!(models && Array.isArray(models.availableModels))) {
     return null;
@@ -200,7 +213,10 @@ export function requireSessionConfigOptions(
 
   const normalizedConfigOptions = normalizeSessionConfigOptions(provider, configOptions);
   const missingCategories = REQUIRED_CONFIG_CATEGORIES.filter(
-    (category) => !normalizedConfigOptions.some((option) => option.category === category)
+    (category) =>
+      !normalizedConfigOptions.some(
+        (option) => option.type === 'select' && option.category === category
+      )
   );
   if (missingCategories.length > 0) {
     throw new Error(

--- a/src/backend/services/session/service/acp/acp-session-negotiation.integration.test.ts
+++ b/src/backend/services/session/service/acp/acp-session-negotiation.integration.test.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { SessionConfigOption } from '@agentclientprotocol/sdk';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AcpRuntimeManager } from './acp-runtime-manager';
 import type { AcpClientOptions } from './types';
@@ -181,8 +182,8 @@ function defaultContext() {
   return { workspaceId: 'workspace-1', workingDir: process.cwd() };
 }
 
-function getOptionValues(option: { options?: unknown[] } | undefined): string[] {
-  if (!(option && Array.isArray(option.options))) {
+function getOptionValues(option: SessionConfigOption | undefined): string[] {
+  if (!(option?.type === 'select' && Array.isArray(option.options))) {
     return [];
   }
 
@@ -205,10 +206,10 @@ function getOptionValues(option: { options?: unknown[] } | undefined): string[] 
 }
 
 function getOptionByValue(
-  option: { options?: unknown[] } | undefined,
+  option: SessionConfigOption | undefined,
   value: string
 ): { value: string; name?: string } | null {
-  if (!(option && Array.isArray(option.options))) {
+  if (!(option?.type === 'select' && Array.isArray(option.options))) {
     return null;
   }
 
@@ -328,5 +329,34 @@ describe('ACP session negotiation integration', () => {
       name: 'Medium',
     });
     expect(getOptionByValue(reasoningOption, 'high')).toEqual({ value: 'high', name: 'High' });
+  });
+  it('preserves model and mode fallback for legacy provider responses over stdio', async () => {
+    const binaryPath = createFakeAcpBinary(tempDir, 'legacy-acp', {
+      sessionId: 'legacy-session',
+      models: {
+        availableModels: [{ modelId: 'old-model', name: 'Old model' }],
+        currentModelId: 'old-model',
+      },
+      modes: { availableModes: [{ id: 'default', name: 'Default' }], currentModeId: 'default' },
+    });
+    await expect(
+      manager.getOrCreateClient(
+        'legacy-session',
+        {
+          provider: 'CLAUDE',
+          sessionId: 'legacy-session',
+          workingDir: process.cwd(),
+          adapterBinaryPath: binaryPath,
+        },
+        {},
+        defaultContext()
+      )
+    ).resolves.toMatchObject({
+      providerSessionId: 'legacy-session',
+      configOptions: [
+        expect.objectContaining({ type: 'select', category: 'model', currentValue: 'old-model' }),
+        expect.objectContaining({ type: 'select', category: 'mode', currentValue: 'default' }),
+      ],
+    });
   });
 });

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/codex-adapter-parsing.test.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/codex-adapter-parsing.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { toCodexMcpConfigMap } from './codex-adapter-parsing';
+
+describe('toCodexMcpConfigMap', () => {
+  it('rejects the unsupported ACP transport with an actionable protocol error', () => {
+    expect(() =>
+      toCodexMcpConfigMap([{ type: 'acp', name: 'tools', serverId: 'tools-1' }])
+    ).toThrow('ACP MCP transport is not supported');
+  });
+});

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/codex-adapter-parsing.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/codex-adapter-parsing.ts
@@ -1,4 +1,4 @@
-import type { McpServer, PromptRequest } from '@agentclientprotocol/sdk';
+import { type McpServer, type PromptRequest, RequestError } from '@agentclientprotocol/sdk';
 import { dedupeStrings, isRecord } from './acp-adapter-utils';
 import type { CodexMcpServerConfig } from './adapter-state';
 
@@ -142,6 +142,9 @@ function toCodexMcpServerConfig(server: McpServer): CodexMcpServerConfig {
     };
   }
 
+  if (server.type === 'acp') {
+    throw RequestError.invalidParams({ name: server.name }, 'ACP MCP transport is not supported');
+  }
   const httpHeaders = toMcpHeadersRecord(server.headers);
   return {
     enabled: true,

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.test.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.test.ts
@@ -1202,7 +1202,7 @@ describe('CodexAppServerAcpAdapter', () => {
     ]);
   });
 
-  it('rejects invalid thought level values', async () => {
+  it.each(['turbo', true, false])('rejects invalid thought level value %s', async (value) => {
     const { connection } = createMockConnection();
     const { client: codexClient, mocks: codex } = createMockCodexClient();
     const adapter = new CodexAppServerAcpAdapter(connection as AgentSideConnection, codexClient);
@@ -1223,7 +1223,7 @@ describe('CodexAppServerAcpAdapter', () => {
       adapter.setSessionConfigOption({
         sessionId: session.sessionId,
         configId: 'reasoning_effort',
-        value: 'turbo',
+        ...(typeof value === 'boolean' ? { type: 'boolean' as const, value } : { value }),
       })
     ).rejects.toBeInstanceOf(Error);
   });

--- a/src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.ts
+++ b/src/backend/services/session/service/acp/codex-app-server-adapter/codex-app-server-acp-adapter.ts
@@ -384,14 +384,16 @@ export class CodexAppServerAcpAdapter implements Agent {
     await Promise.resolve();
     const session = this.requireSession(params.sessionId);
 
+    const invalidValue = () =>
+      RequestError.invalidParams({ configId: params.configId, value: params.value });
+    if (typeof params.value !== 'string') {
+      throw invalidValue();
+    }
     switch (params.configId) {
       case 'mode': {
         const availableModes = this.getCollaborationModeValues(session.defaults.collaborationMode);
         if (!availableModes.includes(params.value)) {
-          throw RequestError.invalidParams({
-            configId: params.configId,
-            value: params.value,
-          });
+          throw invalidValue();
         }
         session.defaults.collaborationMode = params.value;
         break;
@@ -400,10 +402,7 @@ export class CodexAppServerAcpAdapter implements Agent {
         const presets = this.getExecutionPresets(session);
         const selectedPreset = presets.find((preset) => preset.id === params.value);
         if (!selectedPreset) {
-          throw RequestError.invalidParams({
-            configId: params.configId,
-            value: params.value,
-          });
+          throw invalidValue();
         }
         session.defaults.approvalPolicy = selectedPreset.approvalPolicy;
         session.defaults.sandboxPolicy = createSandboxPolicyFromMode(
@@ -414,10 +413,7 @@ export class CodexAppServerAcpAdapter implements Agent {
       }
       case 'model': {
         if (!isKnownModel(this.modelCatalog, params.value)) {
-          throw RequestError.invalidParams({
-            configId: params.configId,
-            value: params.value,
-          });
+          throw invalidValue();
         }
         session.defaults.model = params.value;
         session.defaults.reasoningEffort = this.resolveReasoningEffortForModel(
@@ -435,10 +431,7 @@ export class CodexAppServerAcpAdapter implements Agent {
             params.value
           )
         ) {
-          throw RequestError.invalidParams({
-            configId: params.configId,
-            value: params.value,
-          });
+          throw invalidValue();
         }
         session.defaults.reasoningEffort = params.value;
         break;

--- a/src/backend/services/session/service/lifecycle/session-config-option-helpers.test.ts
+++ b/src/backend/services/session/service/lifecycle/session-config-option-helpers.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { getSelectOptions } from './session-config-option-helpers';
+
+describe('getSelectOptions', () => {
+  it('returns no select choices for a boolean config option', () => {
+    expect(
+      getSelectOptions({ id: 'fast', name: 'Fast', type: 'boolean', currentValue: false })
+    ).toEqual([]);
+  });
+});

--- a/src/backend/services/session/service/lifecycle/session-config-option-helpers.ts
+++ b/src/backend/services/session/service/lifecycle/session-config-option-helpers.ts
@@ -16,6 +16,9 @@ export type CodexModelCatalogEntry = {
 };
 
 export function getSelectOptions(option: SessionConfigOption): SessionConfigSelectOption[] {
+  if (option.type !== 'select') {
+    return [];
+  }
   return option.options.flatMap((entry) => {
     if (typeof entry !== 'object' || entry === null) {
       return [];

--- a/src/backend/services/session/service/lifecycle/session.config.service.cached-options.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.config.service.cached-options.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest';
+import { unsafeCoerce } from '@/test-utils/unsafe-coerce';
+import { SessionConfigService } from './session.config.service';
+
+vi.mock('@/backend/services/logger.service', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+vi.mock('@/backend/services/settings', () => ({ userSettingsService: {} }));
+vi.mock('@/backend/services/session/service/acp', () => ({
+  fetchCodexModelCatalogFromAppServer: vi.fn(),
+}));
+
+describe('inactive session config errors', () => {
+  it.each([
+    ['fast', 'Cannot set config option "fast" on an inactive session: unsupported type "boolean"'],
+    ['missing', 'Unknown config option: missing'],
+  ])(
+    'reports the reason for rejecting %s without changing the cached snapshot',
+    async (configId, message) => {
+      const option = { id: 'fast', name: 'Fast', type: 'boolean', currentValue: false };
+      const repository = {
+        getSessionById: vi.fn().mockResolvedValue({
+          id: 'session-1',
+          provider: 'CODEX',
+          providerMetadata: {
+            acpConfigSnapshot: {
+              provider: 'CODEX',
+              providerSessionId: 'thread-1',
+              configOptions: [option],
+            },
+          },
+        }),
+        updateSession: vi.fn(),
+      };
+      const sessionDomainService = { emitDelta: vi.fn() };
+      const service = new SessionConfigService({
+        repository: unsafeCoerce(repository),
+        runtimeManager: unsafeCoerce({ getClient: vi.fn().mockReturnValue(undefined) }),
+        sessionDomainService: unsafeCoerce(sessionDomainService),
+      });
+
+      await expect(service.setSessionConfigOption('session-1', configId, 'true')).rejects.toThrow(
+        message
+      );
+      expect(option.currentValue).toBe(false);
+      expect(repository.updateSession).not.toHaveBeenCalled();
+      expect(sessionDomainService.emitDelta).not.toHaveBeenCalled();
+    }
+  );
+});

--- a/src/backend/services/session/service/lifecycle/session.config.service.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.config.service.test.ts
@@ -105,7 +105,7 @@ describe('SessionConfigService', () => {
 
     service.applyConfigOptionsUpdateDelta('session-1', handle, unsafeCoerce(incoming));
 
-    expect(handle.configOptions[0]?.options).toEqual([
+    expect(handle.configOptions.filter((option) => option.type === 'select')[0]?.options).toEqual([
       expect.objectContaining({ value: 'sonnet', name: 'Sonnet 5' }),
     ]);
     expect(sessionDomain.emitDelta).toHaveBeenCalledWith(
@@ -407,7 +407,7 @@ describe('SessionConfigService', () => {
 
     expect(fetchCodexModelCatalogFromAppServer).toHaveBeenCalledTimes(1);
     expect(modelOption?.currentValue).toBe('gpt-5.3-codex');
-    expect(modelOption?.options).toEqual(
+    expect(modelOption?.type === 'select' ? modelOption.options : undefined).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ value: 'gpt-5.4-codex', name: 'GPT-5.4 Codex' }),
         expect.objectContaining({ value: 'gpt-5.3-codex', name: 'GPT-5.3 Codex' }),

--- a/src/backend/services/session/service/lifecycle/session.config.service.ts
+++ b/src/backend/services/session/service/lifecycle/session.config.service.ts
@@ -882,10 +882,17 @@ export class SessionConfigService {
     configId: string,
     value: string
   ): SessionConfigOption[] {
-    let didUpdate = false;
-    const nextConfigOptions = configOptions.map((option) => {
-      if (option.id !== configId || option.type !== 'select') {
+    if (!configOptions.some((option) => option.id === configId)) {
+      throw new Error(`Unknown config option: ${configId}`);
+    }
+    return configOptions.map((option) => {
+      if (option.id !== configId) {
         return option;
+      }
+      if (option.type !== 'select') {
+        throw new Error(
+          `Cannot set config option "${configId}" on an inactive session: unsupported type "${option.type}"`
+        );
       }
 
       const allowedValues = getConfigOptionValues(option);
@@ -896,18 +903,11 @@ export class SessionConfigService {
         );
       }
 
-      didUpdate = true;
       return {
         ...option,
         currentValue: value,
       };
     });
-
-    if (!didUpdate) {
-      throw new Error(`Unknown config option: ${configId}`);
-    }
-
-    return nextConfigOptions;
   }
 
   private async refreshCodexFallbackConfigOptionsFromAppServer(params: {

--- a/src/backend/services/session/service/lifecycle/session.config.service.ts
+++ b/src/backend/services/session/service/lifecycle/session.config.service.ts
@@ -884,7 +884,7 @@ export class SessionConfigService {
   ): SessionConfigOption[] {
     let didUpdate = false;
     const nextConfigOptions = configOptions.map((option) => {
-      if (option.id !== configId) {
+      if (option.id !== configId || option.type !== 'select') {
         return option;
       }
 

--- a/src/client/features/chat/reducer/config-options.test.ts
+++ b/src/client/features/chat/reducer/config-options.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { createActionFromWebSocketMessage } from './index';
+
+describe('config option updates', () => {
+  it('keeps select controls when an update also includes boolean config options', () => {
+    const select = {
+      id: 'model',
+      name: 'Model',
+      type: 'select',
+      currentValue: 'sonnet',
+      options: [{ value: 'sonnet', name: 'Sonnet' }],
+    };
+    const action = createActionFromWebSocketMessage({
+      type: 'config_options_update',
+      configOptions: [select, { id: 'fast', name: 'Fast', type: 'boolean', currentValue: false }],
+    });
+    expect(action).toEqual({ type: 'CONFIG_OPTIONS_UPDATE', payload: { configOptions: [select] } });
+  });
+});

--- a/src/client/features/chat/reducer/index.ts
+++ b/src/client/features/chat/reducer/index.ts
@@ -440,7 +440,12 @@ function handleConfigOptionsUpdateMessage(data: WebSocketMessage): ChatAction | 
   }
   return {
     type: 'CONFIG_OPTIONS_UPDATE',
-    payload: { configOptions },
+    payload: {
+      configOptions: configOptions.filter(
+        (option) =>
+          option && typeof option.currentValue === 'string' && Array.isArray(option.options)
+      ),
+    },
   };
 }
 

--- a/src/shared/acp-protocol/protocol/websocket.ts
+++ b/src/shared/acp-protocol/protocol/websocket.ts
@@ -242,8 +242,8 @@ interface WebSocketMessagePayloadByType {
       description?: string | null;
       type: string;
       category?: string | null;
-      currentValue: string;
-      options: unknown[];
+      currentValue: string | boolean;
+      options?: unknown[];
     }>;
   };
 }


### PR DESCRIPTION
Upgrade the direct ACP SDK from 0.15.0 to 1.4.0, aligning it with Claude ACP 0.75.1 and removing the duplicate older SDK from the lockfile.

The SDK removed the experimental model setter and added boolean configuration options and an ACP MCP transport. Model switching now uses `session/set_config_option` for both providers and caches the complete returned configuration. Select-only paths guard the new boolean variant; the chat controls omit boolean options, and the internal Codex adapter returns a protocol error for unsupported boolean settings and ACP-tunneled MCP servers. Existing model/mode fallback responses remain supported and are covered over real stdio. Cached boolean settings report that their type is unsupported for inactive sessions; missing option IDs retain the unknown-option error.

Updated the runtime architecture note and Unreleased changelog. This is the first upgrade after #2222; Node 26 and the other major updates will follow separately after this merges.

Validation:
- `pnpm check:fix`, `pnpm typecheck`, full `pnpm test` (5,352 passed, four manual tests skipped).
- Focused ACP, lifecycle, and reducer tests after final edits.
- `CODEX_SCHEMA_CHECK=strict pnpm check`, `pnpm build`, and normal pre-commit checks.
- `pnpm audit`: zero vulnerabilities.
- Regression cases reproduced the model setter and boolean/transport failures before the fixes; read-only code review completed.
