### PR TITLE
Lazy-load application routes and Mermaid diagrams

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -14,6 +14,7 @@ the one that matches your change before you touch it.
 | [workspace-state.md](./workspace-state.md) | Run script, auto-iteration state, the Kanban column projection |
 | [agent-runtime.md](./agent-runtime.md) | ACP runtime, provider sub-agents, child workspaces, quick actions |
 | [integrations.md](./integrations.md) | GitHub, Linear, periodic tasks |
+| [client-loading.md](./client-loading.md) | Route chunks, diagram loading, startup bundle measurement |
 
 Keep these current. When behaviour changes, update the note in the same PR — a
 stale rationale is worse than no rationale, because it is believed.

--- a/docs/architecture/client-loading.md
+++ b/docs/architecture/client-loading.md
@@ -1,0 +1,17 @@
+# Client Loading
+
+Page components in `src/client/router.tsx` are React lazy imports. The app shell
+stays mounted while the outlet's Suspense boundary shows the existing Loading
+component. Keep page imports at these split points: an eager import through
+another module can pull a page's dependencies back into the startup bundle.
+
+Markdown loads independently of Mermaid. Only a Mermaid code block renders the
+lazy `mermaid-diagram.tsx` component and initializes the diagram engine, with
+strict security enabled. While that chunk loads, the block displays its source.
+Ordinary Markdown and workspace file links do not wait for it.
+
+Use `pnpm exec vite build --manifest` to inspect the production chunks. The
+initial JavaScript cost includes the entry and its transitive static imports in
+`dist/client/.vite/manifest.json`; dynamic imports load when needed. Compare both
+raw and gzip sizes, and smoke-test direct page navigation after changing split
+points. Markdown's Storybook stories cover plain text, diagrams, and render errors.

--- a/src/client/root.tsx
+++ b/src/client/root.tsx
@@ -1,6 +1,7 @@
-import { useEffect } from 'react';
+import { Suspense, useEffect } from 'react';
 import { Outlet, useLocation, useNavigate } from 'react-router';
 import { CLIHealthBanner } from '@/client/components/cli-health-banner';
+import { Loading } from '@/client/components/loading';
 import { AppLayout } from '@/client/components/resizable-layout';
 import { ThemeProvider } from '@/client/components/theme-provider';
 import { WorkspaceNotificationManager } from '@/client/features/workspace/WorkspaceNotificationManager';
@@ -37,7 +38,9 @@ function RootLayout() {
     >
       <CLIHealthBanner />
       <AppLayout className="flex-1 overflow-hidden">
-        <Outlet />
+        <Suspense fallback={<Loading message="Loading page..." />}>
+          <Outlet />
+        </Suspense>
       </AppLayout>
     </div>
   );

--- a/src/client/router.tsx
+++ b/src/client/router.tsx
@@ -5,17 +5,18 @@ import { TRPCProvider } from '@/client/lib/providers';
 import { ErrorBoundary } from './error-boundary';
 import { ProjectLayout } from './layouts/project-layout';
 import { Root } from './root';
-import AdminPage from './routes/admin-page';
-// Route components
-import HomePage from './routes/home';
-import LogsPage from './routes/logs';
-import ProjectsListPage from './routes/projects/list';
-import NewProjectPage from './routes/projects/new';
-import ProjectRedirectPage from './routes/projects/redirect';
-import WorkspaceDetailPage from './routes/projects/workspaces/detail';
-import WorkspacesListPage from './routes/projects/workspaces/list';
-import NewWorkspacePage from './routes/projects/workspaces/new';
-import ReviewsPage from './routes/reviews';
+
+// Route modules load only when their page is rendered.
+const AdminPage = lazy(() => import('./routes/admin-page'));
+const HomePage = lazy(() => import('./routes/home'));
+const LogsPage = lazy(() => import('./routes/logs'));
+const ProjectsListPage = lazy(() => import('./routes/projects/list'));
+const NewProjectPage = lazy(() => import('./routes/projects/new'));
+const ProjectRedirectPage = lazy(() => import('./routes/projects/redirect'));
+const WorkspaceDetailPage = lazy(() => import('./routes/projects/workspaces/detail'));
+const WorkspacesListPage = lazy(() => import('./routes/projects/workspaces/list'));
+const NewWorkspacePage = lazy(() => import('./routes/projects/workspaces/new'));
+const ReviewsPage = lazy(() => import('./routes/reviews'));
 
 const MobileBaselinePage = lazy(() => import('./routes/mobile-baseline'));
 const isDevelopmentMode = import.meta.env.MODE === 'development';

--- a/src/components/ui/markdown-loading.test.tsx
+++ b/src/components/ui/markdown-loading.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { expect, it, vi } from 'vitest';
+import { MarkdownRenderer } from './markdown';
+
+const engine = vi.hoisted(() => ({ loaded: false }));
+
+Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
+  configurable: true,
+  value: true,
+});
+
+vi.mock('mermaid', () => {
+  engine.loaded = true;
+  return {
+    default: {
+      initialize: vi.fn(),
+      render: vi.fn(() => Promise.resolve({ svg: '<svg aria-label="Flow diagram"></svg>' })),
+    },
+  };
+});
+
+it('loads the diagram engine only when markdown contains a Mermaid diagram', async () => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  try {
+    await act(() => {
+      root.render(<MarkdownRenderer content="# Plain markdown" />);
+    });
+    expect(container.querySelector('h1')?.textContent).toBe('Plain markdown');
+    expect(engine.loaded).toBe(false);
+
+    await act(() => {
+      root.render(<MarkdownRenderer content={'```mermaid\ngraph TD; A-->B\n```'} />);
+    });
+    await vi.waitFor(() => {
+      expect(container.querySelector('svg')?.getAttribute('aria-label')).toBe('Flow diagram');
+    });
+    expect(engine.loaded).toBe(true);
+  } finally {
+    await act(() => root.unmount());
+    container.remove();
+  }
+});

--- a/src/components/ui/markdown.stories.tsx
+++ b/src/components/ui/markdown.stories.tsx
@@ -1,4 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { Button } from './button';
 import { MarkdownRenderer } from './markdown';
 
 const meta = {
@@ -20,4 +22,25 @@ export const Mermaid: Story = {
 
 export const InvalidMermaid: Story = {
   args: { content: '```mermaid\nthis is not a diagram\n```' },
+};
+
+export const MermaidRecovery: Story = {
+  args: { content: '' },
+  render: function Recovery() {
+    const [complete, setComplete] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setComplete((value) => !value)}>
+          {complete ? 'Show incomplete diagram' : 'Complete diagram'}
+        </Button>
+        <MarkdownRenderer
+          content={
+            complete
+              ? '```mermaid\ngraph LR\n  Workspace --> Session\n```'
+              : '```mermaid\ngraph LR\n  Workspace -->\n```'
+          }
+        />
+      </>
+    );
+  },
 };

--- a/src/components/ui/markdown.stories.tsx
+++ b/src/components/ui/markdown.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { MarkdownRenderer } from './markdown';
+
+const meta = {
+  title: 'UI/Markdown',
+  component: MarkdownRenderer,
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof MarkdownRenderer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const PlainMarkdown: Story = {
+  args: { content: '# Workspace notes\n\nPlain **Markdown** loads without the diagram engine.' },
+};
+
+export const Mermaid: Story = {
+  args: { content: '```mermaid\ngraph LR\n  Workspace --> Session\n  Session --> Result\n```' },
+};
+
+export const InvalidMermaid: Story = {
+  args: { content: '```mermaid\nthis is not a diagram\n```' },
+};

--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -1,69 +1,23 @@
 import { ArrowSquareOutIcon, FileCodeIcon } from '@phosphor-icons/react';
-import mermaid from 'mermaid';
 import {
   type ComponentPropsWithoutRef,
   isValidElement,
+  lazy,
   memo,
-  useEffect,
+  Suspense,
   useMemo,
-  useRef,
-  useState,
 } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { cn } from '@/lib/utils';
 
-// Initialize mermaid with strict security
-if (typeof window !== 'undefined') {
-  mermaid.initialize({
-    startOnLoad: false,
-    theme: 'default',
-    securityLevel: 'strict',
-  });
-}
+const MermaidDiagram = lazy(() => import('./mermaid-diagram'));
 
-interface MarkdownRendererProps {
+export interface MarkdownRendererProps {
   content: string;
   className?: string;
   resolveWorkspaceFileLink?: (href: string) => string | null;
   onWorkspaceFileLink?: (path: string) => void;
-}
-
-// Component to render Mermaid diagrams
-function MermaidDiagram({ chart }: { chart: string }) {
-  const ref = useRef<HTMLDivElement>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (ref.current && chart) {
-      const renderDiagram = async () => {
-        try {
-          setError(null);
-          const id = `mermaid-${Math.random().toString(36).substr(2, 9)}`;
-          const { svg } = await mermaid.render(id, chart);
-          if (ref.current) {
-            ref.current.innerHTML = svg;
-          }
-        } catch (err) {
-          // Capture the actual error message for debugging
-          const errorMessage = err instanceof Error ? err.message : String(err);
-          setError(errorMessage);
-        }
-      };
-      void renderDiagram();
-    }
-  }, [chart]);
-
-  if (error) {
-    return (
-      <div className="my-4 p-3 bg-destructive/10 border border-destructive/20 rounded-md">
-        <div className="text-destructive text-sm font-medium mb-2">Error rendering diagram:</div>
-        <pre className="text-destructive text-xs overflow-x-auto whitespace-pre-wrap">{error}</pre>
-      </div>
-    );
-  }
-
-  return <div ref={ref} className="my-4" />;
 }
 
 export const MarkdownRenderer = memo(function MarkdownRenderer({
@@ -84,7 +38,11 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
         if (hasLanguage) {
           // Check if it's a Mermaid diagram
           if (language === 'mermaid') {
-            return <MermaidDiagram chart={String(children).trim()} />;
+            return (
+              <Suspense fallback={<pre className="my-4 overflow-x-auto">{children}</pre>}>
+                <MermaidDiagram chart={String(children).trim()} />
+              </Suspense>
+            );
           }
           return (
             <code className={className} {...props}>

--- a/src/components/ui/mermaid-diagram.test.tsx
+++ b/src/components/ui/mermaid-diagram.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+
+import mermaid from 'mermaid';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import MermaidDiagram from './mermaid-diagram';
+
+vi.mock('mermaid', () => ({ default: { initialize: vi.fn(), render: vi.fn() } }));
+
+function deferredRender() {
+  let resolve!: (value: { svg: string }) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<{ svg: string }>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+let container: HTMLDivElement;
+let root: ReturnType<typeof createRoot>;
+
+beforeEach(() => {
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  vi.mocked(mermaid.render).mockReset();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(() => root.unmount());
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+it('recovers when an invalid chart becomes valid', async () => {
+  vi.mocked(mermaid.render).mockRejectedValueOnce(new Error('Incomplete diagram'));
+  await act(() => root.render(<MermaidDiagram chart="graph" />));
+  expect(container.textContent).toContain('Incomplete diagram');
+
+  vi.mocked(mermaid.render).mockResolvedValueOnce({
+    svg: '<svg aria-label="Complete diagram"></svg>',
+    diagramType: 'flowchart',
+  });
+  await act(() => root.render(<MermaidDiagram chart="graph TD; A-->B" />));
+  expect(container.querySelector('svg')?.getAttribute('aria-label')).toBe('Complete diagram');
+  expect(container.textContent).not.toContain('Incomplete diagram');
+});
+
+it.each(['success', 'error'] as const)(
+  'ignores a stale render %s after the chart changes',
+  async (outcome) => {
+    const oldRender = deferredRender();
+    const latestRender = deferredRender();
+    vi.mocked(mermaid.render)
+      .mockImplementationOnce(() =>
+        oldRender.promise.then((result) => ({ ...result, diagramType: 'flowchart' }))
+      )
+      .mockImplementationOnce(() =>
+        latestRender.promise.then((result) => ({ ...result, diagramType: 'flowchart' }))
+      );
+    await act(() => root.render(<MermaidDiagram chart="graph TD; A-->B" />));
+    await act(() => root.render(<MermaidDiagram chart="graph TD; A-->C" />));
+    await act(() => latestRender.resolve({ svg: '<svg aria-label="Latest diagram"></svg>' }));
+
+    await act(() => {
+      if (outcome === 'success') {
+        oldRender.resolve({ svg: '<svg aria-label="Old diagram"></svg>' });
+      } else {
+        oldRender.reject(new Error('Stale render error'));
+      }
+    });
+    expect(container.querySelector('svg')?.getAttribute('aria-label')).toBe('Latest diagram');
+    expect(container.textContent).not.toContain('Stale render error');
+  }
+);

--- a/src/components/ui/mermaid-diagram.tsx
+++ b/src/components/ui/mermaid-diagram.tsx
@@ -1,0 +1,48 @@
+import mermaid from 'mermaid';
+import { useEffect, useRef, useState } from 'react';
+
+// Initialize mermaid with strict security
+if (typeof window !== 'undefined') {
+  mermaid.initialize({
+    startOnLoad: false,
+    theme: 'default',
+    securityLevel: 'strict',
+  });
+}
+
+// Component to render Mermaid diagrams
+export default function MermaidDiagram({ chart }: { chart: string }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (ref.current && chart) {
+      const renderDiagram = async () => {
+        try {
+          setError(null);
+          const id = `mermaid-${Math.random().toString(36).substr(2, 9)}`;
+          const { svg } = await mermaid.render(id, chart);
+          if (ref.current) {
+            ref.current.innerHTML = svg;
+          }
+        } catch (err) {
+          // Capture the actual error message for debugging
+          const errorMessage = err instanceof Error ? err.message : String(err);
+          setError(errorMessage);
+        }
+      };
+      void renderDiagram();
+    }
+  }, [chart]);
+
+  if (error) {
+    return (
+      <div className="my-4 p-3 bg-destructive/10 border border-destructive/20 rounded-md">
+        <div className="text-destructive text-sm font-medium mb-2">Error rendering diagram:</div>
+        <pre className="text-destructive text-xs overflow-x-auto whitespace-pre-wrap">{error}</pre>
+      </div>
+    );
+  }
+
+  return <div ref={ref} className="my-4" />;
+}

--- a/src/components/ui/mermaid-diagram.tsx
+++ b/src/components/ui/mermaid-diagram.tsx
@@ -7,6 +7,7 @@ if (typeof window !== 'undefined') {
     startOnLoad: false,
     theme: 'default',
     securityLevel: 'strict',
+    suppressErrorRendering: true,
   });
 }
 
@@ -16,33 +17,44 @@ export default function MermaidDiagram({ chart }: { chart: string }) {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (ref.current && chart) {
-      const renderDiagram = async () => {
-        try {
-          setError(null);
-          const id = `mermaid-${Math.random().toString(36).substr(2, 9)}`;
-          const { svg } = await mermaid.render(id, chart);
-          if (ref.current) {
-            ref.current.innerHTML = svg;
-          }
-        } catch (err) {
-          // Capture the actual error message for debugging
-          const errorMessage = err instanceof Error ? err.message : String(err);
-          setError(errorMessage);
-        }
-      };
-      void renderDiagram();
+    if (!(ref.current && chart)) {
+      return;
     }
+    let cancelled = false;
+    const renderDiagram = async () => {
+      try {
+        setError(null);
+        const id = `mermaid-${Math.random().toString(36).substr(2, 9)}`;
+        const { svg } = await mermaid.render(id, chart);
+        if (!cancelled && ref.current) {
+          ref.current.innerHTML = svg;
+        }
+      } catch (err) {
+        if (cancelled) {
+          return;
+        }
+        // Capture the actual error message for debugging
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        setError(errorMessage);
+      }
+    };
+    void renderDiagram();
+    return () => {
+      cancelled = true;
+    };
   }, [chart]);
 
-  if (error) {
-    return (
-      <div className="my-4 p-3 bg-destructive/10 border border-destructive/20 rounded-md">
-        <div className="text-destructive text-sm font-medium mb-2">Error rendering diagram:</div>
-        <pre className="text-destructive text-xs overflow-x-auto whitespace-pre-wrap">{error}</pre>
-      </div>
-    );
-  }
-
-  return <div ref={ref} className="my-4" />;
+  return (
+    <>
+      <div ref={ref} className="my-4" hidden={Boolean(error)} />
+      {error && (
+        <div className="my-4 p-3 bg-destructive/10 border border-destructive/20 rounded-md">
+          <div className="text-destructive text-sm font-medium mb-2">Error rendering diagram:</div>
+          <pre className="text-destructive text-xs overflow-x-auto whitespace-pre-wrap">
+            {error}
+          </pre>
+        </div>
+      )}
+    </>
+  );
 }


### PR DESCRIPTION
The client previously loaded every application page and initialized Mermaid before either was needed. Load page modules on navigation, keep the app shell visible with a loading state, and load Mermaid only for diagram code blocks. Preserve workspace links and diagram error rendering. Also fix streamed Mermaid diagrams failing to recover after invalid syntax or accepting stale asynchronous results, and keep Mermaid from injecting a second global error graphic.

The production entry JavaScript shrinks from 3,483,311 to 1,461,172 bytes; gzip shrinks from 1,006,519 to 430,725 bytes (57%). These measurements cover the entry and its static imports; each destination page still loads its own chunk.

Validation:
- `pnpm check:fix`, `pnpm typecheck`, `pnpm check`, `pnpm knip`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm test --maxWorkers=2`: 5,348 passed, 4 skipped
- `pnpm exec prisma migrate diff --from-schema prisma/schema.prisma --to-migrations prisma/migrations --exit-code`: no drift
- `pnpm exec vite build --manifest`
- Storybook browser checks for plain Markdown, valid Mermaid, invalid Mermaid, and recovery after an incomplete streamed diagram
- Production browser smoke checks for direct navigation to projects, logs, settings, reviews, and new project; no uncaught errors (API calls intercepted)

The test-only Node option prevents Node 26's global web storage from overriding jsdom storage; the unchanged baseline passes with the same setting.
