### PR TITLE
Remove transitional ACP runtime callbacks

### DIFF
--- a/docs/architecture/agent-runtime.md
+++ b/docs/architecture/agent-runtime.md
@@ -41,6 +41,10 @@ subprocess handles, pending creation, incarnation filtering, exits, stops, and
 quiescence. `AcpRuntimeManager` is the stable compatibility facade over the
 supervisor and stateless ACP collaborators. Lifecycle coordinators continue to
 own durable reconciliation and never manipulate runtime registries directly.
+Runtime callbacks use `onRuntimeExit` and `onRuntimeError` events carrying the
+supervisor's incarnation identity and current purpose. Exit events also carry
+whether the stop was managed; coordinators consume this metadata directly,
+including after a browsing runtime is promoted to active use.
 
 Startup, termination, runtime exit, notifications, context, and workflow
 finalization each have one coordinator or service.

--- a/scripts/file-length-baseline.json
+++ b/scripts/file-length-baseline.json
@@ -16,7 +16,7 @@
   "src/backend/services/session/service/chat/chat-message-handlers/handlers/load-session.handler.test.ts": 1576,
   "src/backend/services/session/service/lifecycle/session.config.service.test.ts": 1159,
   "src/backend/services/session/service/lifecycle/session.config.service.ts": 1080,
-  "src/backend/services/session/service/lifecycle/session.service.test.ts": 2777,
+  "src/backend/services/session/service/lifecycle/session.service.test.ts": 2774,
   "src/backend/services/workspace/resources/workspace.accessor.ts": 1040,
   "src/backend/services/workspace/service/lifecycle/state-machine.service.test.ts": 1115,
   "src/backend/services/workspace/service/snapshot/workspace-snapshot-store.service.test.ts": 1008,

--- a/src/backend/services/session/service/acp/acp-runtime-error-handler.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-error-handler.ts
@@ -18,7 +18,7 @@ export function wireAcpRuntimeErrorHandler(
     if (!shouldDispatch()) {
       return;
     }
-    if (!(handlers.onRuntimeError || handlers.onError)) {
+    if (!handlers.onRuntimeError) {
       logger.warn('ACP child process error (no handler provided)', {
         sessionId,
         error: normalizedError.message,
@@ -27,16 +27,12 @@ export function wireAcpRuntimeErrorHandler(
     }
 
     try {
-      if (handlers.onRuntimeError) {
-        await handlers.onRuntimeError({
-          sessionId,
-          error: normalizedError,
-          incarnationId: runtime.incarnationId,
-          purpose: runtime.purpose,
-        });
-      } else {
-        await handlers.onError?.(sessionId, normalizedError);
-      }
+      await handlers.onRuntimeError({
+        sessionId,
+        error: normalizedError,
+        incarnationId: runtime.incarnationId,
+        purpose: runtime.purpose,
+      });
     } catch (handlerError) {
       logger.warn('Failed to handle ACP error event', {
         sessionId,

--- a/src/backend/services/session/service/acp/acp-runtime-events.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-events.ts
@@ -23,9 +23,6 @@ export type AcpRuntimeEventHandlers = {
   onSessionId?: (sessionId: string, providerSessionId: string) => Promise<void>;
   onRuntimeExit?: (event: AcpRuntimeExitEvent) => Promise<void>;
   onRuntimeError?: (event: AcpRuntimeErrorEvent) => Promise<void> | void;
-  /** @deprecated Transitional adapter for callers that have not migrated to onRuntimeExit. */
-  onExit?: (sessionId: string, code: number | null) => Promise<void>;
-  onError?: (sessionId: string, error: Error) => Promise<void> | void;
   onAcpEvent?: (sessionId: string, event: AcpRuntimeEvent) => void;
   onAcpLog?: (sessionId: string, payload: Record<string, unknown>) => void;
   /** Permission bridge to inject into AcpClientHandler for suspending requestPermission */

--- a/src/backend/services/session/service/acp/acp-runtime-exit-handler.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-exit-handler.ts
@@ -27,11 +27,7 @@ export function dispatchAcpRuntimeExit(
 ): Promise<void> {
   return exitHandlerSession.run(event.sessionId, async () => {
     try {
-      if (handlers.onRuntimeExit) {
-        await handlers.onRuntimeExit(event);
-      } else if (!event.managed && handlers.onExit) {
-        await handlers.onExit(event.sessionId, event.exitCode);
-      }
+      await handlers.onRuntimeExit?.(event);
     } catch (error) {
       logger.warn('Failed to handle ACP exit event', {
         sessionId: event.sessionId,

--- a/src/backend/services/session/service/acp/acp-runtime-manager.creation.test.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-manager.creation.test.ts
@@ -216,7 +216,12 @@ describe('AcpRuntimeManager', () => {
           },
         });
         expect(child.kill).not.toHaveBeenCalledWith('SIGKILL');
-        expect(handlers.onError).toHaveBeenCalledWith('session-1', expect.any(Error));
+        expect(handlers.onRuntimeError).toHaveBeenCalledWith({
+          sessionId: 'session-1',
+          error: spawnError,
+          incarnationId: expect.any(String),
+          purpose: 'active',
+        });
       } finally {
         await vi.advanceTimersByTimeAsync(5000);
         vi.useRealTimers();

--- a/src/backend/services/session/service/acp/acp-runtime-manager.manual.integration.test.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-manager.manual.integration.test.ts
@@ -19,8 +19,8 @@ describeIfRealCodex('AcpRuntimeManager (manual real codex app-server)', () => {
         },
         {
           onSessionId: async () => Promise.resolve(),
-          onExit: async () => Promise.resolve(),
-          onError: (_message) => undefined,
+          onRuntimeExit: async () => Promise.resolve(),
+          onRuntimeError: (_message) => undefined,
           onAcpEvent: (_event) => undefined,
         },
         {

--- a/src/backend/services/session/service/acp/acp-runtime-manager.termination.test.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-manager.termination.test.ts
@@ -242,12 +242,12 @@ describe('AcpRuntimeManager', () => {
         vi.useRealTimers();
       }
 
-      (handlers.onExit as ReturnType<typeof vi.fn>).mockClear();
+      (handlers.onRuntimeExit as ReturnType<typeof vi.fn>).mockClear();
       child.exitCode = 137;
       child.emit('exit', 137, 'SIGKILL');
       await new Promise((resolve) => setTimeout(resolve, 0));
 
-      expect(handlers.onExit).not.toHaveBeenCalled();
+      expect(handlers.onRuntimeExit).not.toHaveBeenCalled();
     });
 
     it('omits stale runtime error and exit events without affecting its replacement', async () => {
@@ -378,7 +378,6 @@ describe('AcpRuntimeManager', () => {
       expect(mockSpawn).toHaveBeenCalledOnce();
       expect(firstChild.kill).toHaveBeenCalledOnce();
       expect(onRuntimeError).not.toHaveBeenCalled();
-      expect(handlers.onError).not.toHaveBeenCalled();
 
       firstChild.exitCode = 0;
       firstChild.emit('exit', 0, null);

--- a/src/backend/services/session/service/acp/acp-runtime-manager.test-helpers.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-manager.test-helpers.ts
@@ -94,8 +94,8 @@ export function createTestProcessHandle(params?: {
 export function defaultHandlers(): AcpRuntimeEventHandlers {
   return {
     onSessionId: vi.fn().mockResolvedValue(undefined),
-    onExit: vi.fn().mockResolvedValue(undefined),
-    onError: vi.fn(),
+    onRuntimeExit: vi.fn().mockResolvedValue(undefined),
+    onRuntimeError: vi.fn(),
     onAcpEvent: vi.fn(),
   };
 }

--- a/src/backend/services/session/service/lifecycle/session-runtime-exit.coordinator.test.ts
+++ b/src/backend/services/session/service/lifecycle/session-runtime-exit.coordinator.test.ts
@@ -81,10 +81,8 @@ function createExitCoordinatorHarness(options?: {
     workflowFinalizer,
     onSessionExit,
   });
-  const purpose = options?.browse ? ('browse' as const) : ('active' as const);
   const handlers = coordinator.createHandlers({
     sessionId: 'session-1',
-    purpose,
     persistProviderSessionId: !options?.browse,
   });
 
@@ -168,8 +166,18 @@ describe('SessionRuntimeExitCoordinator', () => {
     const browse = createExitCoordinatorHarness({ browse: true });
     const runtimeError = new Error('provider transport failed');
 
-    await active.handlers.onError?.('session-1', runtimeError);
-    await browse.handlers.onError?.('session-1', runtimeError);
+    await active.handlers.onRuntimeError!({
+      sessionId: 'session-1',
+      error: runtimeError,
+      incarnationId: '11111111-1111-4111-8111-111111111111',
+      purpose: 'active',
+    });
+    await browse.handlers.onRuntimeError!({
+      sessionId: 'session-1',
+      error: runtimeError,
+      incarnationId: '22222222-2222-4222-8222-222222222222',
+      purpose: 'browse',
+    });
 
     expect(active.domain.markError).toHaveBeenCalledWith('session-1', 'provider transport failed');
     expect(browse.domain.markError).not.toHaveBeenCalled();
@@ -180,7 +188,7 @@ describe('SessionRuntimeExitCoordinator', () => {
     );
   });
 
-  it('uses typed runtime error purpose instead of handler creation purpose', async () => {
+  it('uses the promoted runtime purpose for handlers created while browsing', async () => {
     const harness = createExitCoordinatorHarness({ browse: true });
     const runtimeError = new Error('promoted runtime failed');
 
@@ -232,7 +240,7 @@ describe('SessionRuntimeExitCoordinator', () => {
     async (exitCode, message, dedupeSuffix) => {
       const harness = createExitCoordinatorHarness();
 
-      await harness.coordinator.handleExit(runtimeExit({ exitCode }));
+      await harness.handlers.onRuntimeExit!(runtimeExit({ exitCode }));
 
       expect(harness.lifecycleEvents.record).toHaveBeenCalledWith({
         workspaceId: 'workspace-1',
@@ -251,7 +259,7 @@ describe('SessionRuntimeExitCoordinator', () => {
       explicitStopReserved: true,
     });
 
-    await harness.coordinator.handleExit(runtimeExit({ managed: true, exitCode: null }));
+    await harness.handlers.onRuntimeExit!(runtimeExit({ managed: true, exitCode: null }));
 
     expect(harness.repository.updateSession).not.toHaveBeenCalled();
     expect(harness.lifecycleEvents.record).not.toHaveBeenCalled();
@@ -268,7 +276,7 @@ describe('SessionRuntimeExitCoordinator', () => {
     async (_caseName, lifecycleStopping) => {
       const harness = createExitCoordinatorHarness({ lifecycleStopping });
 
-      await harness.coordinator.handleExit(runtimeExit({ managed: true, exitCode: null }));
+      await harness.handlers.onRuntimeExit!(runtimeExit({ managed: true, exitCode: null }));
 
       expect(harness.repository.updateSession).toHaveBeenCalledWith('session-1', {
         status: SessionStatus.FAILED,

--- a/src/backend/services/session/service/lifecycle/session-runtime-exit.coordinator.ts
+++ b/src/backend/services/session/service/lifecycle/session-runtime-exit.coordinator.ts
@@ -1,11 +1,9 @@
-import { randomUUID } from 'node:crypto';
 import { createLogger } from '@/backend/services/logger.service';
 import type { AgentSessionRecord } from '@/backend/services/session/resources/agent-session.accessor';
 import type {
   AcpRuntimeErrorEvent,
   AcpRuntimeEventHandlers,
   AcpRuntimeExitEvent,
-  AcpRuntimePurpose,
 } from '@/backend/services/session/service/acp';
 import { acpTraceLogger } from '@/backend/services/session/service/logging/acp-trace-logger.service';
 import type { SessionDomainService } from '@/backend/services/session/service/session-domain.service';
@@ -55,13 +53,11 @@ export class SessionRuntimeExitCoordinator {
 
   createHandlers(input: {
     sessionId: string;
-    purpose: AcpRuntimePurpose;
     persistProviderSessionId: boolean;
   }): AcpRuntimeEventHandlers {
     const runtimeEventHandler = this.dependencies.acpEventProcessor.createRuntimeEventHandler(
       input.sessionId
     );
-    const legacyIncarnationId = randomUUID();
 
     return {
       ...runtimeEventHandler,
@@ -71,23 +67,6 @@ export class SessionRuntimeExitCoordinator {
       onRuntimeExit: (event) => this.handleExit(event),
       onRuntimeError: (event) => {
         this.handleRuntimeError(event);
-      },
-      onExit: async (sessionId, exitCode) => {
-        await this.handleExit({
-          sessionId,
-          exitCode,
-          incarnationId: legacyIncarnationId,
-          purpose: input.purpose,
-          managed: this.dependencies.lifecycleGate.isSessionStopping(sessionId),
-        });
-      },
-      onError: (sessionId, error) => {
-        this.handleRuntimeError({
-          sessionId,
-          error,
-          incarnationId: legacyIncarnationId,
-          purpose: input.purpose,
-        });
       },
       onAcpLog: (sessionId, payload) => {
         this.dependencies.acpEventProcessor.handleAcpLog(sessionId, payload);

--- a/src/backend/services/session/service/lifecycle/session-startup.coordinator.ts
+++ b/src/backend/services/session/service/lifecycle/session-startup.coordinator.ts
@@ -352,7 +352,6 @@ export class SessionStartupCoordinator {
 
     const handlers = this.dependencies.runtimeExitCoordinator.createHandlers({
       sessionId,
-      purpose: browseOnly ? 'browse' : 'active',
       persistProviderSessionId: !browseOnly,
     });
     this.dependencies.acpEventProcessor.setReplaySuppression(

--- a/src/backend/services/session/service/lifecycle/session.service.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.service.test.ts
@@ -111,6 +111,12 @@ import {
   sessionService,
 } from './session-services';
 
+const activeRuntime = {
+  incarnationId: '11111111-1111-4111-8111-111111111111',
+  purpose: 'active',
+  managed: false,
+} as const;
+
 const getAcpProcessorState = () => acpEventProcessor;
 function mockCreatedAcpClient(acpHandle: AcpProcessHandle): void {
   vi.mocked(acpRuntimeManager.getOrCreateClient).mockImplementation(() => {
@@ -813,10 +819,13 @@ describe('SessionService', () => {
     const stopPromise = sessionLifecycleService.stopSession('session-race-test');
     await Promise.resolve();
 
-    const acpHandlers = vi.mocked(acpRuntimeManager.getOrCreateClient).mock.calls[0]![2] as {
-      onExit: (id: string, exitCode: number | null) => Promise<void>;
-    };
-    await acpHandlers.onExit('session-race-test', 0);
+    const acpHandlers = vi.mocked(acpRuntimeManager.getOrCreateClient).mock.calls[0]![2];
+    await acpHandlers.onRuntimeExit!({
+      ...activeRuntime,
+      sessionId: 'session-race-test',
+      exitCode: 0,
+      managed: true,
+    });
 
     expect(sessionRepository.updateSession).toHaveBeenCalledWith('session-race-test', {
       status: SessionStatus.COMPLETED,
@@ -1109,9 +1118,7 @@ describe('SessionService', () => {
     mockCreatedAcpClient(acpHandle);
     await sessionLifecycleService.getOrCreateSessionClient('session-runtime-exit');
 
-    const acpHandlers = vi.mocked(acpRuntimeManager.getOrCreateClient).mock.calls[0]![2] as {
-      onExit: (id: string, exitCode: number | null) => Promise<void>;
-    };
+    const acpHandlers = vi.mocked(acpRuntimeManager.getOrCreateClient).mock.calls[0]![2];
 
     const firstPrompt = createDeferred<{ stopReason: string }>();
     vi.mocked(acpRuntimeManager.sendPrompt).mockReturnValueOnce(firstPrompt.promise as never);
@@ -1129,7 +1136,7 @@ describe('SessionService', () => {
     await Promise.resolve();
     expect(acpRuntimeManager.sendPrompt).toHaveBeenCalledTimes(1);
 
-    await acpHandlers.onExit('session-runtime-exit', 1);
+    await acpHandlers.onRuntimeExit!({ ...activeRuntime, sessionId: session.id, exitCode: 1 });
     await secondRejection;
     expect(acpRuntimeManager.sendPrompt).toHaveBeenCalledTimes(1);
 
@@ -1210,11 +1217,9 @@ describe('SessionService', () => {
     const appendClaudeEventSpy = vi
       .spyOn(sessionDomainService, 'appendClaudeEvent')
       .mockReturnValue(77);
-    const acpHandlers = vi.mocked(acpRuntimeManager.getOrCreateClient).mock.calls[0]![2] as {
-      onExit: (id: string, exitCode: number | null) => Promise<void>;
-    };
+    const acpHandlers = vi.mocked(acpRuntimeManager.getOrCreateClient).mock.calls[0]![2];
 
-    await acpHandlers.onExit('session-runtime-exit', 1);
+    await acpHandlers.onRuntimeExit!({ ...activeRuntime, sessionId: session.id, exitCode: 1 });
 
     expect(emitDeltaSpy).toHaveBeenCalledWith(
       'session-runtime-exit',
@@ -1804,11 +1809,9 @@ describe('SessionService', () => {
 
     await sessionLifecycleService.startSession('session-1');
 
-    // Extract the onExit handler from the ACP event handlers passed to acpRuntimeManager
-    const acpHandlers = vi.mocked(acpRuntimeManager.getOrCreateClient).mock.calls[0]![2] as {
-      onExit: (id: string, exitCode: number | null) => Promise<void>;
-    };
-    await acpHandlers.onExit('session-1', 0);
+    // Dispatch the exit of the active runtime created for this session.
+    const acpHandlers = vi.mocked(acpRuntimeManager.getOrCreateClient).mock.calls[0]![2];
+    await acpHandlers.onRuntimeExit!({ ...activeRuntime, sessionId: 'session-1', exitCode: 0 });
 
     expect(sessionRepository.updateSession).toHaveBeenCalledWith('session-1', {
       status: SessionStatus.COMPLETED,
@@ -1885,10 +1888,10 @@ describe('SessionService', () => {
 
     await sessionLifecycleService.startSession('session-1');
 
-    const acpHandlers = vi.mocked(acpRuntimeManager.getOrCreateClient).mock.calls[0]![2] as {
-      onExit: (id: string, exitCode: number | null) => Promise<void>;
-    };
-    await expect(acpHandlers.onExit('session-1', 0)).resolves.toBeUndefined();
+    const acpHandlers = vi.mocked(acpRuntimeManager.getOrCreateClient).mock.calls[0]![2];
+    await expect(
+      acpHandlers.onRuntimeExit!({ ...activeRuntime, sessionId: 'session-1', exitCode: 0 })
+    ).resolves.toBeUndefined();
 
     expect(sessionRepository.updateSession).toHaveBeenCalledWith('session-1', {
       status: SessionStatus.COMPLETED,
@@ -1943,10 +1946,8 @@ describe('SessionService', () => {
 
     await sessionLifecycleService.startSession('session-2');
 
-    const acpHandlers = vi.mocked(acpRuntimeManager.getOrCreateClient).mock.calls[0]![2] as {
-      onExit: (id: string, exitCode: number | null) => Promise<void>;
-    };
-    await acpHandlers.onExit('session-2', 0);
+    const acpHandlers = vi.mocked(acpRuntimeManager.getOrCreateClient).mock.calls[0]![2];
+    await acpHandlers.onRuntimeExit!({ ...activeRuntime, sessionId: 'session-2', exitCode: 0 });
 
     expect(sessionRepository.updateSession).toHaveBeenCalledWith('session-2', {
       status: SessionStatus.COMPLETED,
@@ -1997,13 +1998,11 @@ describe('SessionService', () => {
 
     await sessionLifecycleService.getOrCreateSessionClientFromRecord(session);
 
-    const acpHandlers = vi.mocked(acpRuntimeManager.getOrCreateClient).mock.calls[0]![2] as {
-      onExit: (id: string, exitCode: number | null) => Promise<void>;
-    };
+    const acpHandlers = vi.mocked(acpRuntimeManager.getOrCreateClient).mock.calls[0]![2];
     vi.mocked(sessionRepository.updateSession).mockReset();
     vi.mocked(sessionRepository.updateSession).mockReturnValueOnce(exitUpdate.promise);
 
-    const exitPromise = acpHandlers.onExit(sessionId, 1);
+    const exitPromise = acpHandlers.onRuntimeExit!({ ...activeRuntime, sessionId, exitCode: 1 });
     await vi.waitFor(() => {
       expect(sessionRepository.updateSession).toHaveBeenCalledWith(sessionId, {
         status: SessionStatus.FAILED,
@@ -2116,10 +2115,8 @@ describe('SessionService', () => {
 
       await sessionLifecycleService.startSession('session-2');
 
-      const acpHandlers = vi.mocked(acpRuntimeManager.getOrCreateClient).mock.calls[0]![2] as {
-        onExit: (id: string, exitCode: number | null) => Promise<void>;
-      };
-      await acpHandlers.onExit('session-2', exitCode);
+      const acpHandlers = vi.mocked(acpRuntimeManager.getOrCreateClient).mock.calls[0]![2];
+      await acpHandlers.onRuntimeExit!({ ...activeRuntime, sessionId: 'session-2', exitCode });
 
       expect(sessionRepository.updateSession).toHaveBeenCalledWith('session-2', {
         status: expectedStatus,
@@ -2193,15 +2190,15 @@ describe('SessionService', () => {
 
     await sessionLifecycleService.startSession('session-2');
 
-    const acpHandlers = vi.mocked(acpRuntimeManager.getOrCreateClient).mock.calls[0]![2] as {
-      onExit: (id: string, exitCode: number | null) => Promise<void>;
-    };
+    const acpHandlers = vi.mocked(acpRuntimeManager.getOrCreateClient).mock.calls[0]![2];
 
     vi.mocked(acpRuntimeManager.isSessionRunning).mockImplementation(() => {
       throw new Error('isSessionRunning failed');
     });
 
-    await expect(acpHandlers.onExit('session-2', 0)).rejects.toThrow('isSessionRunning failed');
+    await expect(
+      acpHandlers.onRuntimeExit!({ ...activeRuntime, sessionId: 'session-2', exitCode: 0 })
+    ).rejects.toThrow('isSessionRunning failed');
 
     expect(mockAcpTraceLoggerCloseSession).toHaveBeenCalledWith('session-2');
   });


### PR DESCRIPTION
ACP lifecycle tests still exercised deprecated exit/error callbacks while production dispatched structured runtime events. Migrate those tests to the production event interface and remove the compatibility callbacks, dispatcher fallbacks, and synthetic incarnation ID. Runtime purpose, managed-stop classification, incarnation identity, and stale-event filtering remain owned by the supervisor.

Validation: Node 24.13.0; `pnpm check:fix`, `pnpm typecheck`, `pnpm test --maxWorkers=4` (5,344 passed; 4 skipped), `pnpm check` including Codex schema, `pnpm knip`, and Prisma migration-drift check passed. A managed-event mutation was verified to fail the lifecycle regression. Independently reviewed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

