### PR TITLE
Scope Git cache watcher invalidation

### DIFF
--- a/docs/architecture/workspace-state.md
+++ b/docs/architecture/workspace-state.md
@@ -111,10 +111,10 @@ diff badge for a moment rather than the board being missing entirely.
 
 Each cache entry watches its worktree and private Git directory, while linked
 worktrees share one reference-counted watcher for the repo's common `.git`
-directory. Worktree files and private metadata such as `HEAD` and `index`
-invalidate only their owning worktree. Common metadata changes invalidate every
-dependent entry, including refs, config, info attributes and excludes, and
-reftable state. Object and reflog writes are ignored because the associated ref
-event performs the invalidation. If the shared watcher fails, all of its
-dependents switch to the five-minute fallback expiry; removing the last
-dependent closes it.
+directory. Worktree files and private metadata such as `HEAD`, `index`, and
+`config.worktree` invalidate only their owning worktree. Common metadata changes
+invalidate every dependent entry, including shared config, refs, info attributes
+and excludes, and reftable state. Object and reflog writes are ignored because
+the associated ref event performs the invalidation. If the shared watcher fails,
+all of its dependents switch to the five-minute fallback expiry; removing the
+last dependent closes it.

--- a/docs/architecture/workspace-state.md
+++ b/docs/architecture/workspace-state.md
@@ -112,7 +112,9 @@ diff badge for a moment rather than the board being missing entirely.
 Each cache entry watches its worktree and private Git directory, while linked
 worktrees share one reference-counted watcher for the repo's common `.git`
 directory. Worktree files and private metadata such as `HEAD` and `index`
-invalidate only their owning worktree. Shared refs, packed refs, shallow state,
-and config changes invalidate every dependent entry. If the shared watcher
-fails, all of its dependents switch to the five-minute fallback expiry; removing
-the last dependent closes it.
+invalidate only their owning worktree. Common metadata changes invalidate every
+dependent entry, including refs, config, info attributes and excludes, and
+reftable state. Object and reflog writes are ignored because the associated ref
+event performs the invalidation. If the shared watcher fails, all of its
+dependents switch to the five-minute fallback expiry; removing the last
+dependent closes it.

--- a/docs/architecture/workspace-state.md
+++ b/docs/architecture/workspace-state.md
@@ -109,7 +109,10 @@ reconciliation field, so the snapshot poll recomputes it for every live
 workspace each minute and streams it into the same cache; a card is missing its
 diff badge for a moment rather than the board being missing entirely.
 
-Note that each worktree's cache entry is watched via the repo's *shared* `.git`
-common dir, so git activity in any one worktree invalidates the others' entries
-— the cache is cold more often than a per-worktree watcher would suggest, which
-is exactly why the response path must not depend on it being warm.
+Each cache entry watches its worktree and private Git directory, while linked
+worktrees share one reference-counted watcher for the repo's common `.git`
+directory. Worktree files and private metadata such as `HEAD` and `index`
+invalidate only their owning worktree. Shared refs, packed refs, shallow state,
+and config changes invalidate every dependent entry. If the shared watcher
+fails, all of its dependents switch to the five-minute fallback expiry; removing
+the last dependent closes it.

--- a/src/backend/services/workspace-git-state.service.test.ts
+++ b/src/backend/services/workspace-git-state.service.test.ts
@@ -71,6 +71,9 @@ describe('WorkspaceGitStateService', () => {
     now = 1234;
     runGit = vi.fn<RunGit>((args) => Promise.resolve(defaultGitResult(args)));
     readFile = vi.fn((filePath) => {
+      if (filePath === '/repo/.git') {
+        return Promise.reject(Object.assign(new Error('directory'), { code: 'EISDIR' }));
+      }
       const worktreeMatch = filePath.match(/^\/repo\/(w[12])\/\.git$/);
       if (worktreeMatch?.[1]) {
         return Promise.resolve(`gitdir: /repo/.git/worktrees/${worktreeMatch[1]}\n`);
@@ -307,7 +310,7 @@ describe('WorkspaceGitStateService', () => {
     expect(watchPath.mock.calls.every(([, options]) => options.recursive)).toBe(true);
   });
 
-  it.each(['index', 'HEAD'])(
+  it.each(['index', 'HEAD', 'config.worktree', 'config.worktree.lock'])(
     'keeps sibling caches warm when one worktree %s changes',
     async (metadataFile) => {
       vi.useFakeTimers();
@@ -328,10 +331,35 @@ describe('WorkspaceGitStateService', () => {
     }
   );
 
+  it.each(['config.worktree', 'config.worktree.lock'])(
+    'keeps linked caches warm when primary worktree metadata %s changes',
+    async (metadataFile) => {
+      vi.useFakeTimers();
+      try {
+        const primaryInput = { worktreePath: '/repo', defaultBranch: 'main' };
+        const siblingInput = { worktreePath: '/repo/w2', defaultBranch: 'main' };
+        const primary = await service.getSnapshot(primaryInput);
+        const first = await service.getSnapshot(input);
+        const sibling = await service.getSnapshot(siblingInput);
+
+        emitWatchEvent('/repo', 'change', `.git/${metadataFile}`);
+        emitWatchEvent('/repo/.git', 'change', metadataFile);
+        await vi.advanceTimersByTimeAsync(100);
+
+        expect(await service.getSnapshot(primaryInput)).not.toBe(primary);
+        expect(await service.getSnapshot(input)).toBe(first);
+        expect(await service.getSnapshot(siblingInput)).toBe(sibling);
+      } finally {
+        vi.useRealTimers();
+      }
+    }
+  );
+
   it.each([
     'refs/remotes/origin/main',
     'refs',
     'config',
+    'config.lock',
     'info/exclude',
     'reftable',
     'reftable/tables.list',

--- a/src/backend/services/workspace-git-state.service.test.ts
+++ b/src/backend/services/workspace-git-state.service.test.ts
@@ -328,25 +328,30 @@ describe('WorkspaceGitStateService', () => {
     }
   );
 
-  it.each(['refs/remotes/origin/main', 'refs', 'config'])(
-    'invalidates every dependent cache when shared Git metadata %s changes',
-    async (filename) => {
-      vi.useFakeTimers();
-      try {
-        const siblingInput = { worktreePath: '/repo/w2', defaultBranch: 'main' };
-        const first = await service.getSnapshot(input);
-        const sibling = await service.getSnapshot(siblingInput);
+  it.each([
+    'refs/remotes/origin/main',
+    'refs',
+    'config',
+    'info/exclude',
+    'reftable',
+    'reftable/tables.list',
+    'future-ref-storage/state',
+  ])('invalidates every dependent cache when shared Git metadata %s changes', async (filename) => {
+    vi.useFakeTimers();
+    try {
+      const siblingInput = { worktreePath: '/repo/w2', defaultBranch: 'main' };
+      const first = await service.getSnapshot(input);
+      const sibling = await service.getSnapshot(siblingInput);
 
-        emitWatchEvent('/repo/.git', 'change', filename);
-        await vi.advanceTimersByTimeAsync(100);
+      emitWatchEvent('/repo/.git', 'change', filename);
+      await vi.advanceTimersByTimeAsync(100);
 
-        expect(await service.getSnapshot(input)).not.toBe(first);
-        expect(await service.getSnapshot(siblingInput)).not.toBe(sibling);
-      } finally {
-        vi.useRealTimers();
-      }
+      expect(await service.getSnapshot(input)).not.toBe(first);
+      expect(await service.getSnapshot(siblingInput)).not.toBe(sibling);
+    } finally {
+      vi.useRealTimers();
     }
-  );
+  });
 
   it('shares and reference-counts a common Git metadata watcher', async () => {
     const siblingInput = { worktreePath: '/repo/w2', defaultBranch: 'main' };

--- a/src/backend/services/workspace-git-state.service.test.ts
+++ b/src/backend/services/workspace-git-state.service.test.ts
@@ -63,21 +63,25 @@ describe('WorkspaceGitStateService', () => {
     >
   >;
   let watchers: Map<string, TestWatcher>;
+  let watcherHistory: Array<{ filePath: string; watcher: TestWatcher }>;
+  let emitWatchEvent: (filePath: string, eventType: string, filename: string | null) => void;
   let service: WorkspaceGitStateService;
 
   beforeEach(() => {
     now = 1234;
     runGit = vi.fn<RunGit>((args) => Promise.resolve(defaultGitResult(args)));
     readFile = vi.fn((filePath) => {
-      if (filePath === '/repo/w1/.git') {
-        return Promise.resolve('gitdir: /repo/.git/worktrees/w1\n');
+      const worktreeMatch = filePath.match(/^\/repo\/(w[12])\/\.git$/);
+      if (worktreeMatch?.[1]) {
+        return Promise.resolve(`gitdir: /repo/.git/worktrees/${worktreeMatch[1]}\n`);
       }
-      if (filePath === '/repo/.git/worktrees/w1/commondir') {
+      if (/^\/repo\/\.git\/worktrees\/w[12]\/commondir$/.test(filePath)) {
         return Promise.resolve('../..\n');
       }
       return Promise.reject(Object.assign(new Error('missing'), { code: 'ENOENT' }));
     });
     watchers = new Map();
+    watcherHistory = [];
     watchPath = vi.fn((filePath, _options, listener) => {
       const closeMock = vi.fn<() => void>();
       const watcher: TestWatcher = {
@@ -90,8 +94,16 @@ describe('WorkspaceGitStateService', () => {
         },
       };
       watchers.set(filePath, watcher);
+      watcherHistory.push({ filePath, watcher });
       return watcher;
     });
+    emitWatchEvent = (filePath, eventType, filename) => {
+      for (const entry of watcherHistory) {
+        if (entry.filePath === filePath) {
+          entry.watcher.listener(eventType, filename);
+        }
+      }
+    };
     service = new WorkspaceGitStateService({ runGit, now: () => now, readFile, watchPath });
   });
 
@@ -293,6 +305,74 @@ describe('WorkspaceGitStateService', () => {
     expect([...watchers.keys()]).toEqual(['/repo/w1', '/repo/.git/worktrees/w1', '/repo/.git']);
     expect(watchPath).toHaveBeenCalledTimes(3);
     expect(watchPath.mock.calls.every(([, options]) => options.recursive)).toBe(true);
+  });
+
+  it.each(['index', 'HEAD'])(
+    'keeps sibling caches warm when one worktree %s changes',
+    async (metadataFile) => {
+      vi.useFakeTimers();
+      try {
+        const siblingInput = { worktreePath: '/repo/w2', defaultBranch: 'main' };
+        const first = await service.getSnapshot(input);
+        const sibling = await service.getSnapshot(siblingInput);
+
+        emitWatchEvent('/repo/.git/worktrees/w1', 'change', metadataFile);
+        emitWatchEvent('/repo/.git', 'change', `worktrees/w1/${metadataFile}`);
+        await vi.advanceTimersByTimeAsync(100);
+
+        expect(await service.getSnapshot(input)).not.toBe(first);
+        expect(await service.getSnapshot(siblingInput)).toBe(sibling);
+      } finally {
+        vi.useRealTimers();
+      }
+    }
+  );
+
+  it.each(['refs/remotes/origin/main', 'refs', 'config'])(
+    'invalidates every dependent cache when shared Git metadata %s changes',
+    async (filename) => {
+      vi.useFakeTimers();
+      try {
+        const siblingInput = { worktreePath: '/repo/w2', defaultBranch: 'main' };
+        const first = await service.getSnapshot(input);
+        const sibling = await service.getSnapshot(siblingInput);
+
+        emitWatchEvent('/repo/.git', 'change', filename);
+        await vi.advanceTimersByTimeAsync(100);
+
+        expect(await service.getSnapshot(input)).not.toBe(first);
+        expect(await service.getSnapshot(siblingInput)).not.toBe(sibling);
+      } finally {
+        vi.useRealTimers();
+      }
+    }
+  );
+
+  it('shares and reference-counts a common Git metadata watcher', async () => {
+    const siblingInput = { worktreePath: '/repo/w2', defaultBranch: 'main' };
+    await service.getSnapshot(input);
+    await service.getSnapshot(siblingInput);
+    const sharedWatchers = watcherHistory.filter(({ filePath }) => filePath === '/repo/.git');
+
+    expect(sharedWatchers).toHaveLength(1);
+    service.remove(input.worktreePath);
+    expect(sharedWatchers[0]?.watcher.closeMock).not.toHaveBeenCalled();
+    service.remove(siblingInput.worktreePath);
+    expect(sharedWatchers[0]?.watcher.closeMock).toHaveBeenCalledOnce();
+  });
+
+  it('moves every dependent to fallback expiry when a shared watcher fails', async () => {
+    const siblingInput = { worktreePath: '/repo/w2', defaultBranch: 'main' };
+    const first = await service.getSnapshot(input);
+    const sibling = await service.getSnapshot(siblingInput);
+    const sharedWatcher = watcherHistory.find(({ filePath }) => filePath === '/repo/.git');
+
+    sharedWatcher?.watcher.errorListener?.(new Error('shared watcher failed'));
+    now += 300_000;
+
+    expect(await service.getSnapshot(input)).not.toBe(first);
+    expect(await service.getSnapshot(siblingInput)).not.toBe(sibling);
+    expect(sharedWatcher?.watcher.closeMock).toHaveBeenCalledOnce();
   });
 
   it('invalidates all base variants 100 ms after a watched file event', async () => {

--- a/src/backend/services/workspace-git-state.service.ts
+++ b/src/backend/services/workspace-git-state.service.ts
@@ -73,10 +73,23 @@ interface CacheEntry {
 }
 
 interface WatcherRecord {
+  worktreePath: string;
   mode: 'healthy' | 'fallback';
   handles: WatchHandle[];
   setup: Promise<void>;
+  sharedDirectory?: string;
   debounceTimer?: ReturnType<typeof setTimeout>;
+}
+
+interface SharedWatcherRecord {
+  handle: WatchHandle;
+  dependents: Set<string>;
+  debounceTimer?: ReturnType<typeof setTimeout>;
+}
+
+interface WatchRoots {
+  local: string[];
+  shared?: string;
 }
 
 const WATCH_DEBOUNCE_MS = 100;
@@ -121,6 +134,26 @@ function shouldIgnoreWorktreeWatchEvent(filename: string | null): boolean {
 
   const [topLevelDirectory] = filename.split(/[\\/]+/);
   return IGNORED_WORKTREE_WATCH_DIRECTORIES.has(topLevelDirectory ?? '');
+}
+
+function shouldInvalidateForSharedGitEvent(filename: string | null): boolean {
+  if (!filename) {
+    return true;
+  }
+
+  const normalized = filename.replaceAll('\\', '/').replace(/^\.\//, '');
+  // HEAD, index, and worktrees/* belong to one worktree and are covered by its
+  // private Git-directory watcher. Only the shared paths below fan out.
+  return (
+    normalized === 'config' ||
+    normalized.startsWith('config.') ||
+    normalized === 'packed-refs' ||
+    normalized.startsWith('packed-refs.') ||
+    normalized === 'shallow' ||
+    normalized.startsWith('shallow.') ||
+    normalized === 'refs' ||
+    normalized.startsWith('refs/')
+  );
 }
 
 function parseNameStatus(
@@ -181,6 +214,7 @@ export class WorkspaceGitStateService {
   private readonly generations = new Map<string, number>();
   private readonly activeCalculations = new Map<string, number>();
   private readonly watchers = new Map<string, WatcherRecord>();
+  private readonly sharedWatchers = new Map<string, SharedWatcherRecord>();
 
   constructor(options: WorkspaceGitStateServiceOptions = {}) {
     this.runGit = options.runGit ?? gitCommand;
@@ -339,6 +373,7 @@ export class WorkspaceGitStateService {
     }
 
     const record: WatcherRecord = {
+      worktreePath,
       mode: 'healthy',
       handles: [],
       setup: Promise.resolve(),
@@ -352,7 +387,7 @@ export class WorkspaceGitStateService {
 
   private async installWatchers(worktreePath: string, record: WatcherRecord): Promise<void> {
     const roots = await this.resolveWatchRoots(worktreePath);
-    for (const root of roots) {
+    for (const root of roots.local) {
       if (record.mode !== 'healthy' || this.watchers.get(worktreePath) !== record) {
         return;
       }
@@ -367,17 +402,20 @@ export class WorkspaceGitStateService {
         this.activateFallback(record);
       });
     }
+    if (roots.shared && record.mode === 'healthy' && this.watchers.get(worktreePath) === record) {
+      this.attachSharedWatcher(roots.shared, record);
+    }
   }
 
-  private async resolveWatchRoots(worktreePath: string): Promise<string[]> {
-    const roots = [worktreePath];
+  private async resolveWatchRoots(worktreePath: string): Promise<WatchRoots> {
+    const local = [worktreePath];
     const dotGitPath = path.join(worktreePath, '.git');
     let dotGitContents: string;
     try {
       dotGitContents = await this.readFile(dotGitPath);
     } catch (error) {
       if (hasErrorCode(error, 'EISDIR')) {
-        return roots;
+        return { local };
       }
       throw error;
     }
@@ -387,13 +425,13 @@ export class WorkspaceGitStateService {
       throw new Error(`Invalid Git worktree metadata: ${dotGitPath}`);
     }
     const gitDir = path.resolve(path.dirname(dotGitPath), gitDirMatch[1].trim());
-    roots.push(gitDir);
+    local.push(gitDir);
 
     try {
       const commonDirContents = await this.readFile(path.join(gitDir, 'commondir'));
       const commonDir = commonDirContents.trim();
       if (commonDir) {
-        roots.push(path.resolve(gitDir, commonDir));
+        return { local: [...new Set(local)], shared: path.resolve(gitDir, commonDir) };
       }
     } catch (error) {
       if (!hasErrorCode(error, 'ENOENT')) {
@@ -401,7 +439,32 @@ export class WorkspaceGitStateService {
       }
     }
 
-    return [...new Set(roots)];
+    return { local: [...new Set(local)] };
+  }
+
+  private attachSharedWatcher(commonDirectory: string, record: WatcherRecord): void {
+    let shared = this.sharedWatchers.get(commonDirectory);
+    if (!shared) {
+      let created!: SharedWatcherRecord;
+      const handle = this.watchPath(
+        commonDirectory,
+        { recursive: true },
+        (_eventType, filename) => {
+          if (shouldInvalidateForSharedGitEvent(filename)) {
+            this.scheduleSharedInvalidation(commonDirectory, created);
+          }
+        }
+      );
+      created = { handle, dependents: new Set() };
+      shared = created;
+      this.sharedWatchers.set(commonDirectory, shared);
+      handle.on('error', () => {
+        this.activateSharedFallback(commonDirectory, created);
+      });
+    }
+
+    shared.dependents.add(record.worktreePath);
+    record.sharedDirectory = commonDirectory;
   }
 
   private scheduleInvalidation(worktreePath: string, record: WatcherRecord): void {
@@ -419,6 +482,23 @@ export class WorkspaceGitStateService {
     }, WATCH_DEBOUNCE_MS);
   }
 
+  private scheduleSharedInvalidation(commonDirectory: string, record: SharedWatcherRecord): void {
+    if (this.sharedWatchers.get(commonDirectory) !== record) {
+      return;
+    }
+    if (record.debounceTimer) {
+      clearTimeout(record.debounceTimer);
+    }
+    record.debounceTimer = setTimeout(() => {
+      record.debounceTimer = undefined;
+      if (this.sharedWatchers.get(commonDirectory) === record) {
+        for (const worktreePath of record.dependents) {
+          this.invalidate(worktreePath);
+        }
+      }
+    }, WATCH_DEBOUNCE_MS);
+  }
+
   private activateFallback(record: WatcherRecord): void {
     record.mode = 'fallback';
     if (record.debounceTimer) {
@@ -431,6 +511,53 @@ export class WorkspaceGitStateService {
       } catch {
         // Watcher cleanup is best effort; fallback freshness still protects callers.
       }
+    }
+    this.detachSharedWatcher(record);
+  }
+
+  private detachSharedWatcher(record: WatcherRecord): void {
+    const commonDirectory = record.sharedDirectory;
+    record.sharedDirectory = undefined;
+    if (!commonDirectory) {
+      return;
+    }
+    const shared = this.sharedWatchers.get(commonDirectory);
+    if (!shared) {
+      return;
+    }
+    shared.dependents.delete(record.worktreePath);
+    if (shared.dependents.size === 0) {
+      this.closeSharedWatcher(commonDirectory, shared);
+    }
+  }
+
+  private activateSharedFallback(commonDirectory: string, record: SharedWatcherRecord): void {
+    if (this.sharedWatchers.get(commonDirectory) !== record) {
+      return;
+    }
+    this.closeSharedWatcher(commonDirectory, record);
+    for (const worktreePath of record.dependents) {
+      const watcher = this.watchers.get(worktreePath);
+      if (watcher?.sharedDirectory === commonDirectory) {
+        watcher.sharedDirectory = undefined;
+        this.activateFallback(watcher);
+      }
+    }
+    record.dependents.clear();
+  }
+
+  private closeSharedWatcher(commonDirectory: string, record: SharedWatcherRecord): void {
+    if (this.sharedWatchers.get(commonDirectory) === record) {
+      this.sharedWatchers.delete(commonDirectory);
+    }
+    if (record.debounceTimer) {
+      clearTimeout(record.debounceTimer);
+      record.debounceTimer = undefined;
+    }
+    try {
+      record.handle.close();
+    } catch {
+      // Watcher cleanup is best effort; dependents still use fallback freshness.
     }
   }
 

--- a/src/backend/services/workspace-git-state.service.ts
+++ b/src/backend/services/workspace-git-state.service.ts
@@ -142,17 +142,20 @@ function shouldInvalidateForSharedGitEvent(filename: string | null): boolean {
   }
 
   const normalized = filename.replaceAll('\\', '/').replace(/^\.\//, '');
-  // HEAD, index, and worktrees/* belong to one worktree and are covered by its
-  // private Git-directory watcher. Only the shared paths below fan out.
-  return (
-    normalized === 'config' ||
-    normalized.startsWith('config.') ||
-    normalized === 'packed-refs' ||
-    normalized.startsWith('packed-refs.') ||
-    normalized === 'shallow' ||
-    normalized.startsWith('shallow.') ||
-    normalized === 'refs' ||
-    normalized.startsWith('refs/')
+  // Worktree metadata is covered by its private watcher. Object and reflog
+  // writes are high-volume side effects of ref changes, which arrive through
+  // the remaining shared metadata paths.
+  return !(
+    normalized === 'HEAD' ||
+    normalized.startsWith('HEAD.') ||
+    normalized === 'index' ||
+    normalized.startsWith('index.') ||
+    normalized === 'worktrees' ||
+    normalized.startsWith('worktrees/') ||
+    normalized === 'objects' ||
+    normalized.startsWith('objects/') ||
+    normalized === 'logs' ||
+    normalized.startsWith('logs/')
   );
 }
 

--- a/src/backend/services/workspace-git-state.service.ts
+++ b/src/backend/services/workspace-git-state.service.ts
@@ -150,6 +150,8 @@ function shouldInvalidateForSharedGitEvent(filename: string | null): boolean {
     normalized.startsWith('HEAD.') ||
     normalized === 'index' ||
     normalized.startsWith('index.') ||
+    normalized === 'config.worktree' ||
+    normalized.startsWith('config.worktree.') ||
     normalized === 'worktrees' ||
     normalized.startsWith('worktrees/') ||
     normalized === 'objects' ||


### PR DESCRIPTION
Git index or HEAD activity in one linked worktree previously invalidated every sibling cache because each workspace recursively watched the same common Git directory. Share one common-directory watcher per repository and keep worktree-local events scoped to their own cache. Preserve conservative invalidation for shared refs/configuration, fallback freshness after watcher errors, and cleanup when the final dependent is removed.

An isolated reproduction using the real service with mocked Git/watch boundaries and 50 worktrees now retains 49 sibling caches after one index change. Refreshing them requires 6 additional Git calls instead of 300, with 1 shared watcher instead of 50. Shared ref changes intentionally still invalidate all dependents to protect merge-base and upstream calculations.

Validation:
- Regression tests for private index/HEAD/worktree-config events, shared refs (including directory events), info/exclude, reftable, unknown shared metadata, watcher sharing, cleanup, and failure propagation
- `pnpm check:fix`, `pnpm typecheck`, `pnpm check`
- Affected suites: 232 tests passed
- `NODE_OPTIONS=--no-experimental-webstorage pnpm test --maxWorkers=2`: 5,360 passed, 4 skipped
- Independent 50-worktree operation-count reproduction

The test-only Node option prevents Node 26's global web storage from overriding jsdom storage; the unchanged baseline passes with the same setting.

