### PR TITLE
Extract authoritative ratchet projection worker

### DIFF
--- a/docs/architecture/pull-requests.md
+++ b/docs/architecture/pull-requests.md
@@ -39,6 +39,13 @@ observation (`prState`, `prReviewState`, `prCiStatus`, `hasMergeConflict`) via
 changes-requested review would not be visible until the separate PR-sync poller
 caught up.
 
+Live snapshot invalidations go through `RatchetProjectionWorker`, owned by the
+event collector for one start/stop lifetime. It re-reads when invalidations arrive
+during a read, retries failures at 1s and 2s with a three-attempt budget, and
+suppresses archived workspaces and results arriving after stop. The collector
+keeps the event subscriptions and coalesced snapshot writes; reconciliation is
+the safety net after the worker exhausts its retries.
+
 ### Dispatch tracking
 
 Each fixer dispatch is tracked via an explicit record on that row (snapshot key

--- a/scripts/file-length-baseline.json
+++ b/scripts/file-length-baseline.json
@@ -1,8 +1,7 @@
 {
   "src/backend/interceptors/branch-naming.interceptor.test.ts": 1112,
   "src/backend/orchestration/domain-bridges.orchestrator.test.ts": 1097,
-  "src/backend/orchestration/event-collector.orchestrator.test.ts": 1797,
-  "src/backend/orchestration/event-collector.orchestrator.ts": 1013,
+  "src/backend/orchestration/event-collector.orchestrator.test.ts": 1681,
   "src/backend/orchestration/workspace-init.orchestrator.test.ts": 1895,
   "src/backend/routers/websocket/terminal.handler.test.ts": 1012,
   "src/backend/services/github/service/github-cli.service.test.ts": 1912,

--- a/src/backend/orchestration/event-collector.orchestrator.test.ts
+++ b/src/backend/orchestration/event-collector.orchestrator.test.ts
@@ -988,160 +988,6 @@ describe('configureEventCollector', () => {
     );
   });
 
-  it('retries a failed authoritative projection without another invalidation', async () => {
-    vi.mocked(workspaceSnapshotStore.getByWorkspaceId).mockReturnValue({
-      projectId: 'proj-1',
-    } as ReturnType<typeof workspaceSnapshotStore.getByWorkspaceId>);
-    vi.mocked(workspaceDataService.findRatchetProjection)
-      .mockRejectedValueOnce(new Error('read failed'))
-      .mockResolvedValue({
-        status: 'READY',
-        ratchetEnabled: true,
-        ratchetState: 'CI_FAILED',
-        ratchetDispatchOutcome: 'DIED',
-        ratchetDispatchRetryCount: 3,
-      } as never);
-    configureEventCollector();
-    const handler = vi
-      .mocked(ratchetService.on)
-      .mock.calls.find((call) => call[0] === 'ratchet_dispatch_changed')![1] as (event: {
-      workspaceId: string;
-    }) => void;
-
-    handler({ workspaceId: 'ws-retry' });
-    await vi.waitFor(() =>
-      expect(workspaceDataService.findRatchetProjection).toHaveBeenCalledTimes(1)
-    );
-    await vi.advanceTimersByTimeAsync(1000);
-
-    await vi.waitFor(() =>
-      expect(workspaceDataService.findRatchetProjection).toHaveBeenCalledTimes(2)
-    );
-    expect(workspaceSnapshotStore.upsert).toHaveBeenCalledWith(
-      'ws-retry',
-      expect.objectContaining({ ratchetDispatchOutcome: 'DIED' }),
-      'projection:ratchet_authoritative',
-      expect.any(Number)
-    );
-  });
-
-  it('backs off materially after a persistent authoritative projection failure', async () => {
-    vi.mocked(workspaceSnapshotStore.getByWorkspaceId).mockReturnValue({
-      projectId: 'proj-1',
-    } as ReturnType<typeof workspaceSnapshotStore.getByWorkspaceId>);
-    vi.mocked(workspaceDataService.findRatchetProjection).mockRejectedValue(
-      new Error('read failed')
-    );
-    configureEventCollector();
-    const handler = vi
-      .mocked(ratchetService.on)
-      .mock.calls.find((call) => call[0] === 'ratchet_dispatch_changed')![1] as (event: {
-      workspaceId: string;
-    }) => void;
-
-    handler({ workspaceId: 'ws-persistent-failure' });
-    await vi.waitFor(() =>
-      expect(workspaceDataService.findRatchetProjection).toHaveBeenCalledTimes(1)
-    );
-    await vi.advanceTimersByTimeAsync(999);
-    expect(workspaceDataService.findRatchetProjection).toHaveBeenCalledTimes(1);
-    await vi.advanceTimersByTimeAsync(1);
-    expect(workspaceDataService.findRatchetProjection).toHaveBeenCalledTimes(2);
-    await vi.advanceTimersByTimeAsync(2000);
-    expect(workspaceDataService.findRatchetProjection).toHaveBeenCalledTimes(3);
-    await vi.advanceTimersByTimeAsync(120_000);
-    expect(workspaceDataService.findRatchetProjection).toHaveBeenCalledTimes(3);
-  });
-
-  it('backs off when an invalidation arrives during a failed projection read', async () => {
-    vi.mocked(workspaceSnapshotStore.getByWorkspaceId).mockReturnValue({
-      projectId: 'proj-1',
-    } as ReturnType<typeof workspaceSnapshotStore.getByWorkspaceId>);
-    const pendingRead = deferred<never>();
-    vi.mocked(workspaceDataService.findRatchetProjection)
-      .mockReturnValueOnce(pendingRead.promise)
-      .mockResolvedValue({
-        status: 'READY',
-        ratchetEnabled: true,
-        ratchetState: 'CI_FAILED',
-        ratchetDispatchOutcome: 'DIED',
-        ratchetDispatchRetryCount: 3,
-      } as never);
-    configureEventCollector();
-    const handler = vi
-      .mocked(ratchetService.on)
-      .mock.calls.find((call) => call[0] === 'ratchet_dispatch_changed')![1] as (event: {
-      workspaceId: string;
-    }) => void;
-
-    handler({ workspaceId: 'ws-concurrent-invalidation' });
-    await vi.waitFor(() =>
-      expect(workspaceDataService.findRatchetProjection).toHaveBeenCalledTimes(1)
-    );
-    handler({ workspaceId: 'ws-concurrent-invalidation' });
-    pendingRead.reject(new Error('read failed'));
-    await Promise.resolve();
-
-    await vi.advanceTimersByTimeAsync(999);
-    expect(workspaceDataService.findRatchetProjection).toHaveBeenCalledTimes(1);
-    await vi.advanceTimersByTimeAsync(1);
-    expect(workspaceDataService.findRatchetProjection).toHaveBeenCalledTimes(2);
-  });
-
-  it('does not reset the projection failure budget for repeated invalidations', async () => {
-    vi.mocked(workspaceSnapshotStore.getByWorkspaceId).mockReturnValue({
-      projectId: 'proj-1',
-    } as ReturnType<typeof workspaceSnapshotStore.getByWorkspaceId>);
-    vi.mocked(workspaceDataService.findRatchetProjection).mockRejectedValue(
-      new Error('read failed')
-    );
-    configureEventCollector();
-    const handler = vi
-      .mocked(ratchetService.on)
-      .mock.calls.find((call) => call[0] === 'ratchet_dispatch_changed')![1] as (event: {
-      workspaceId: string;
-    }) => void;
-
-    handler({ workspaceId: 'ws-invalidation-stream' });
-    await vi.waitFor(() =>
-      expect(workspaceDataService.findRatchetProjection).toHaveBeenCalledTimes(1)
-    );
-    handler({ workspaceId: 'ws-invalidation-stream' });
-    await vi.advanceTimersByTimeAsync(1000);
-    expect(workspaceDataService.findRatchetProjection).toHaveBeenCalledTimes(2);
-    handler({ workspaceId: 'ws-invalidation-stream' });
-    await vi.advanceTimersByTimeAsync(1999);
-    expect(workspaceDataService.findRatchetProjection).toHaveBeenCalledTimes(2);
-    await vi.advanceTimersByTimeAsync(1);
-    expect(workspaceDataService.findRatchetProjection).toHaveBeenCalledTimes(3);
-    await vi.advanceTimersByTimeAsync(120_000);
-    expect(workspaceDataService.findRatchetProjection).toHaveBeenCalledTimes(3);
-  });
-
-  it('cancels an authoritative projection retry when stopped', async () => {
-    vi.mocked(workspaceSnapshotStore.getByWorkspaceId).mockReturnValue({
-      projectId: 'proj-1',
-    } as ReturnType<typeof workspaceSnapshotStore.getByWorkspaceId>);
-    vi.mocked(workspaceDataService.findRatchetProjection).mockRejectedValue(
-      new Error('read failed')
-    );
-    configureEventCollector();
-    const handler = vi
-      .mocked(ratchetService.on)
-      .mock.calls.find((call) => call[0] === 'ratchet_dispatch_changed')![1] as (event: {
-      workspaceId: string;
-    }) => void;
-
-    handler({ workspaceId: 'ws-stop-retry' });
-    await vi.waitFor(() =>
-      expect(workspaceDataService.findRatchetProjection).toHaveBeenCalledTimes(1)
-    );
-    stopEventCollector();
-    await vi.advanceTimersByTimeAsync(100);
-
-    expect(workspaceDataService.findRatchetProjection).toHaveBeenCalledTimes(1);
-  });
-
   it('pr_snapshot_updated without prUrl does not overwrite existing prUrl in store', () => {
     vi.mocked(workspaceSnapshotStore.getByWorkspaceId).mockReturnValue({
       projectId: 'proj-1',
@@ -1772,6 +1618,44 @@ describe('per-graph event collector lifecycle', () => {
     expect(firstDependencies.workspaceActivityService.listenerCount('workspace_active')).toBe(0);
     expect(secondDependencies.workspaceActivityService.listenerCount('workspace_active')).toBe(1);
     second.stop();
+  });
+
+  it('drops a late projection from before stop while projecting new events after restart', async () => {
+    const store = createMockStore();
+    const pendingRead =
+      deferred<Awaited<ReturnType<typeof workspaceDataService.findRatchetProjection>>>();
+    const projection = {
+      status: 'READY',
+      ratchetEnabled: true,
+      ratchetState: 'CI_FAILED',
+      ratchetDispatchOutcome: 'DIED',
+      ratchetDispatchRetryCount: 3,
+      ratchetDispatchStalled: true,
+      prHasMergeConflict: false,
+    } as const;
+    const read = vi.fn().mockReturnValueOnce(pendingRead.promise).mockResolvedValue(projection);
+    const dependencies = {
+      ...createDependencies(store),
+      workspaceDataService: { findRatchetProjection: read },
+    };
+    const collector = createEventCollectorOrchestrator(dependencies as never);
+    collector.start();
+    dependencies.ratchetService.emit('ratchet_dispatch_changed', { workspaceId: 'ws' });
+    collector.stop();
+    collector.start();
+    dependencies.ratchetService.emit('ratchet_dispatch_changed', { workspaceId: 'ws' });
+    await vi.waitFor(() => expect(store.upsert).toHaveBeenCalledTimes(1));
+    pendingRead.resolve({ ...projection, ratchetState: 'CI_RUNNING' });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(store.upsert).toHaveBeenCalledTimes(1);
+    expect(store.upsert).toHaveBeenCalledWith(
+      'ws',
+      expect.objectContaining({ ratchetState: 'CI_FAILED' }),
+      'projection:ratchet_authoritative',
+      expect.any(Number)
+    );
+    collector.stop();
   });
 
   it('detaches every listener and can start-stop-restart without duplicates', () => {

--- a/src/backend/orchestration/event-collector.orchestrator.ts
+++ b/src/backend/orchestration/event-collector.orchestrator.ts
@@ -65,8 +65,9 @@ import {
   type workspaceSnapshotStore,
   type workspaceStateMachine,
 } from '@/backend/services/workspace';
-import { type CIStatus, type PRState, WorkspaceStatus } from '@/shared/core';
+import type { CIStatus, PRState } from '@/shared/core';
 import type { getWorkspaceLinearContext } from './linear-config.helper';
+import { RatchetProjectionWorker } from './ratchet-projection.worker';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -112,8 +113,6 @@ interface PendingRequestChangedEvent {
 
 const DEFAULT_WINDOW_MS = 150;
 const IDLE_PR_REFRESH_COOLDOWN_MS = 30_000;
-const PROJECTION_RETRY_BASE_MS = 1000;
-const MAX_PROJECTION_READ_ATTEMPTS = 3;
 let lastCoalescerTimestamp = 0;
 
 function nextCoalescerTimestamp(): number {
@@ -144,100 +143,6 @@ export type EventCollectorDependencies = {
   workspaceSnapshotStore: typeof workspaceSnapshotStore;
   workspaceStateMachine: typeof workspaceStateMachine;
 };
-
-async function projectAuthoritativeRatchetState(
-  state: EventCollectorState,
-  coalescer: EventCoalescer,
-  workspaceId: string,
-  isActive: () => boolean
-): Promise<boolean> {
-  try {
-    const workspace =
-      await state.dependencies.workspaceDataService.findRatchetProjection(workspaceId);
-    if (
-      !(workspace && isActive()) ||
-      workspace.status === WorkspaceStatus.ARCHIVING ||
-      workspace.status === WorkspaceStatus.ARCHIVED
-    ) {
-      return true;
-    }
-    coalescer.enqueue(
-      workspaceId,
-      {
-        ratchetEnabled: workspace.ratchetEnabled,
-        ratchetState: workspace.ratchetState,
-        ratchetDispatchOutcome: workspace.ratchetDispatchOutcome,
-        ratchetDispatchRetryCount: workspace.ratchetDispatchRetryCount,
-        ratchetDispatchStalled: workspace.ratchetDispatchStalled,
-        hasMergeConflict: workspace.prHasMergeConflict,
-      },
-      'projection:ratchet_authoritative',
-      { immediate: true }
-    );
-    return true;
-  } catch (error) {
-    state.logger.warn('Failed to refresh authoritative Ratchet snapshot projection', {
-      workspaceId,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return false;
-  }
-}
-
-function getNewerProjectionRevision(refresh: { revision: number }, target: number): number | null {
-  return refresh.revision > target ? refresh.revision : null;
-}
-
-async function runRatchetProjectionRefresh(params: {
-  state: EventCollectorState;
-  coalescer: EventCoalescer;
-  workspaceId: string;
-  refresh: { revision: number };
-  refreshes: Map<string, { revision: number }>;
-  isActive: () => boolean;
-  waitForRetry: (attempt: number) => Promise<void>;
-}): Promise<void> {
-  const { state, coalescer, workspaceId, refresh, refreshes, isActive, waitForRetry } = params;
-  let targetRevision = refresh.revision;
-  let failedAttempts = 0;
-  try {
-    while (isActive()) {
-      const succeeded = await projectAuthoritativeRatchetState(
-        state,
-        coalescer,
-        workspaceId,
-        isActive
-      );
-      const newerRevision = getNewerProjectionRevision(refresh, targetRevision);
-      if (succeeded) {
-        if (newerRevision === null) {
-          break;
-        }
-        targetRevision = newerRevision;
-        failedAttempts = 0;
-        continue;
-      }
-      failedAttempts += 1;
-      if (newerRevision !== null) {
-        targetRevision = newerRevision;
-      }
-      if (!isActive()) {
-        break;
-      }
-      // The 60-second snapshot reconciliation is the long-term safety net.
-      // Bound event-path retries so a database outage cannot leave one loop
-      // per workspace running indefinitely.
-      if (failedAttempts >= MAX_PROJECTION_READ_ATTEMPTS) {
-        break;
-      }
-      await waitForRetry(Math.max(failedAttempts - 1, 0));
-    }
-  } finally {
-    if (refreshes.get(workspaceId) === refresh) {
-      refreshes.delete(workspaceId);
-    }
-  }
-}
 
 function shouldRefreshRatchetForPrSwitch(
   previousSnapshot: ReturnType<StoreInterface['getByWorkspaceId']>,
@@ -393,7 +298,7 @@ class EventCollectorState {
   activeCoalescer: EventCoalescer | null = null;
   lastIdlePrRefreshByWorkspace = new Map<string, number>();
   teardownListeners: Array<() => void> = [];
-  stopRatchetProjection: (() => void) | null = null;
+  ratchetProjection: RatchetProjectionWorker | null = null;
 
   constructor(readonly dependencies: Readonly<EventCollectorDependencies>) {
     this.logger = dependencies.createLogger('event-collector');
@@ -583,68 +488,15 @@ function startEventCollectorWithState(state: EventCollectorState): void {
     state.logger
   );
   state.activeCoalescer = coalescer;
-  const ratchetProjectionRefreshes = new Map<string, { revision: number }>();
-  const archivedProjectionWorkspaceIds = new Set<string>();
-  let projectionActive = true;
-  const projectionRetryWaiters = new Set<{
-    timer: NodeJS.Timeout;
-    resolve: () => void;
-  }>();
-  state.stopRatchetProjection = () => {
-    projectionActive = false;
-    for (const waiter of projectionRetryWaiters) {
-      clearTimeout(waiter.timer);
-      waiter.resolve();
-    }
-    projectionRetryWaiters.clear();
-    ratchetProjectionRefreshes.clear();
-    archivedProjectionWorkspaceIds.clear();
-  };
-
-  const waitForProjectionRetry = (attempt: number): Promise<void> =>
-    new Promise((resolve) => {
-      if (!projectionActive || state.activeCoalescer !== coalescer) {
-        resolve();
-        return;
-      }
-      const waiter = {
-        timer: setTimeout(
-          () => {
-            projectionRetryWaiters.delete(waiter);
-            resolve();
-          },
-          PROJECTION_RETRY_BASE_MS * 2 ** attempt
-        ),
-        resolve,
-      };
-      projectionRetryWaiters.add(waiter);
-    });
-
-  const requestAuthoritativeRatchetProjection = (workspaceId: string): void => {
-    if (archivedProjectionWorkspaceIds.has(workspaceId)) {
-      return;
-    }
-    const existing = ratchetProjectionRefreshes.get(workspaceId);
-    if (existing) {
-      existing.revision += 1;
-      return;
-    }
-
-    const refresh = { revision: 1 };
-    ratchetProjectionRefreshes.set(workspaceId, refresh);
-    void runRatchetProjectionRefresh({
-      state,
-      coalescer,
-      workspaceId,
-      refresh,
-      refreshes: ratchetProjectionRefreshes,
-      isActive: () =>
-        projectionActive &&
-        state.activeCoalescer === coalescer &&
-        !archivedProjectionWorkspaceIds.has(workspaceId),
-      waitForRetry: waitForProjectionRetry,
-    });
-  };
+  const ratchetProjection = new RatchetProjectionWorker({
+    read: (workspaceId) => dependencies.workspaceDataService.findRatchetProjection(workspaceId),
+    publish: (workspaceId, fields) =>
+      coalescer.enqueue(workspaceId, fields, 'projection:ratchet_authoritative', {
+        immediate: true,
+      }),
+    logger: state.logger,
+  });
+  state.ratchetProjection = ratchetProjection;
   state.lastIdlePrRefreshByWorkspace.clear();
 
   const refreshPrSnapshotOnIdle = (workspaceId: string): void => {
@@ -686,8 +538,7 @@ function startEventCollectorWithState(state: EventCollectorState): void {
   // 1. Workspace state changes
   const workspaceStateChangedHandler = (event: WorkspaceStateChangedEvent) => {
     if (event.toStatus === 'ARCHIVED') {
-      archivedProjectionWorkspaceIds.add(event.workspaceId);
-      ratchetProjectionRefreshes.delete(event.workspaceId);
+      ratchetProjection.setArchived(event.workspaceId, true);
       // Immediate removal for UI feedback -- no coalescing delay
       removeWorkspaceWithState(state, event.workspaceId);
       void Promise.allSettled([
@@ -716,7 +567,7 @@ function startEventCollectorWithState(state: EventCollectorState): void {
       });
       return;
     }
-    archivedProjectionWorkspaceIds.delete(event.workspaceId);
+    ratchetProjection.setArchived(event.workspaceId, false);
     coalescer.enqueue(
       event.workspaceId,
       buildWorkspaceStateChangeFields(event),
@@ -751,7 +602,7 @@ function startEventCollectorWithState(state: EventCollectorState): void {
     // Before the projection this refresh was conditional on the dispatch record
     // moving, which is why a snapshot could show `prState: MERGED` next to a
     // `ratchetState` from the previous ratchet poll.
-    requestAuthoritativeRatchetProjection(event.workspaceId);
+    ratchetProjection.request(event.workspaceId);
 
     if (shouldRefreshRatchet) {
       // Bypass the PR-fetch cooldown: this event was emitted by a sync that
@@ -797,7 +648,7 @@ function startEventCollectorWithState(state: EventCollectorState): void {
         { immediate: true }
       );
     }
-    requestAuthoritativeRatchetProjection(event.workspaceId);
+    ratchetProjection.request(event.workspaceId);
   };
   dependencies.ratchetService.on(RATCHET_STATE_CHANGED, ratchetStateChangedHandler);
   state.teardownListeners.push(() =>
@@ -812,7 +663,7 @@ function startEventCollectorWithState(state: EventCollectorState): void {
       'event:ratchet_toggled',
       { immediate: true }
     );
-    requestAuthoritativeRatchetProjection(event.workspaceId);
+    ratchetProjection.request(event.workspaceId);
   };
   dependencies.ratchetService.on(RATCHET_TOGGLED, ratchetToggledHandler);
   state.teardownListeners.push(() =>
@@ -821,7 +672,7 @@ function startEventCollectorWithState(state: EventCollectorState): void {
 
   // 5. Ratchet dispatch ownership changes
   const ratchetDispatchChangedHandler = (event: RatchetDispatchChangedEvent) => {
-    requestAuthoritativeRatchetProjection(event.workspaceId);
+    ratchetProjection.request(event.workspaceId);
   };
   dependencies.ratchetService.on(RATCHET_DISPATCH_CHANGED, ratchetDispatchChangedHandler);
   state.teardownListeners.push(() =>
@@ -975,8 +826,8 @@ function stopEventCollectorWithState(state: EventCollectorState): void {
   for (const teardown of state.teardownListeners.splice(0).reverse()) {
     teardown();
   }
-  state.stopRatchetProjection?.();
-  state.stopRatchetProjection = null;
+  state.ratchetProjection?.stop();
+  state.ratchetProjection = null;
 
   if (state.activeCoalescer) {
     state.activeCoalescer.flushAll();

--- a/src/backend/orchestration/ratchet-projection.worker.test.ts
+++ b/src/backend/orchestration/ratchet-projection.worker.test.ts
@@ -1,0 +1,212 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { workspaceDataService } from '@/backend/services/workspace';
+import { RatchetProjectionWorker } from './ratchet-projection.worker';
+
+type Projection = Awaited<ReturnType<typeof workspaceDataService.findRatchetProjection>>;
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
+const readyProjection = {
+  status: 'READY',
+  ratchetEnabled: true,
+  ratchetState: 'CI_FAILED',
+  ratchetDispatchOutcome: 'DIED',
+  ratchetDispatchRetryCount: 3,
+  ratchetDispatchStalled: true,
+  prHasMergeConflict: false,
+} satisfies Projection;
+
+describe('RatchetProjectionWorker', () => {
+  const read = vi.fn<typeof workspaceDataService.findRatchetProjection>();
+  const publish = vi.fn();
+  let worker: RatchetProjectionWorker;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    read.mockReset().mockResolvedValue(readyProjection);
+    publish.mockReset();
+    worker = new RatchetProjectionWorker({ read, publish, logger: { warn: vi.fn() } });
+  });
+
+  afterEach(() => {
+    worker.stop();
+    vi.useRealTimers();
+  });
+
+  it('retries a failed authoritative projection without another invalidation', async () => {
+    read.mockRejectedValueOnce(new Error('read failed')).mockResolvedValue({
+      status: 'READY',
+      ratchetEnabled: true,
+      ratchetState: 'CI_FAILED',
+      ratchetDispatchOutcome: 'DIED',
+      ratchetDispatchRetryCount: 3,
+      ratchetDispatchStalled: false,
+      prHasMergeConflict: false,
+    });
+
+    worker.request('ws-retry');
+    await vi.waitFor(() => expect(read).toHaveBeenCalledTimes(1));
+    await vi.advanceTimersByTimeAsync(1000);
+
+    await vi.waitFor(() => expect(read).toHaveBeenCalledTimes(2));
+    expect(publish).toHaveBeenCalledWith(
+      'ws-retry',
+      expect.objectContaining({ ratchetDispatchOutcome: 'DIED' })
+    );
+  });
+
+  it('backs off materially after a persistent authoritative projection failure', async () => {
+    read.mockRejectedValue(new Error('read failed'));
+
+    worker.request('ws-persistent-failure');
+    await vi.waitFor(() => expect(read).toHaveBeenCalledTimes(1));
+    await vi.advanceTimersByTimeAsync(999);
+    expect(read).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(read).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(read).toHaveBeenCalledTimes(3);
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(read).toHaveBeenCalledTimes(3);
+  });
+
+  it('backs off when an invalidation arrives during a failed projection read', async () => {
+    const pendingRead = deferred<Projection>();
+    read.mockReturnValueOnce(pendingRead.promise).mockResolvedValue({
+      status: 'READY',
+      ratchetEnabled: true,
+      ratchetState: 'CI_FAILED',
+      ratchetDispatchOutcome: 'DIED',
+      ratchetDispatchRetryCount: 3,
+      ratchetDispatchStalled: false,
+      prHasMergeConflict: false,
+    });
+
+    worker.request('ws-concurrent-invalidation');
+    await vi.waitFor(() => expect(read).toHaveBeenCalledTimes(1));
+    worker.request('ws-concurrent-invalidation');
+    pendingRead.reject(new Error('read failed'));
+    await Promise.resolve();
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(read).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(read).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not reset the projection failure budget for repeated invalidations', async () => {
+    read.mockRejectedValue(new Error('read failed'));
+
+    worker.request('ws-invalidation-stream');
+    await vi.waitFor(() => expect(read).toHaveBeenCalledTimes(1));
+    worker.request('ws-invalidation-stream');
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(read).toHaveBeenCalledTimes(2);
+    worker.request('ws-invalidation-stream');
+    await vi.advanceTimersByTimeAsync(1999);
+    expect(read).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(read).toHaveBeenCalledTimes(3);
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(read).toHaveBeenCalledTimes(3);
+  });
+
+  it('cancels an authoritative projection retry when stopped', async () => {
+    read.mockRejectedValue(new Error('read failed'));
+
+    worker.request('ws-stop-retry');
+    await vi.waitFor(() => expect(read).toHaveBeenCalledTimes(1));
+    worker.stop();
+    await vi.advanceTimersByTimeAsync(120_000);
+
+    expect(read).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-reads invalidations during a successful read and accepts a later request', async () => {
+    const pendingRead = deferred<Projection>();
+    read.mockReturnValueOnce(pendingRead.promise);
+    worker.request('ws');
+    worker.request('ws');
+    worker.request('ws');
+    expect(read).toHaveBeenCalledTimes(1);
+
+    pendingRead.resolve({ ...readyProjection, ratchetState: 'CI_RUNNING' });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(read).toHaveBeenCalledTimes(2);
+    expect(publish).toHaveBeenLastCalledWith('ws', {
+      ratchetEnabled: true,
+      ratchetState: 'CI_FAILED',
+      ratchetDispatchOutcome: 'DIED',
+      ratchetDispatchRetryCount: 3,
+      ratchetDispatchStalled: true,
+      hasMergeConflict: false,
+    });
+    worker.request('ws');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(read).toHaveBeenCalledTimes(3);
+  });
+
+  it.each(['ARCHIVING', 'ARCHIVED'] as const)('does not publish a %s row', async (status) => {
+    read.mockResolvedValue({ ...readyProjection, status });
+    worker.request('ws');
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(publish).not.toHaveBeenCalled();
+    expect(read).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry a missing workspace', async () => {
+    read.mockResolvedValue(null);
+    worker.request('ws');
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(publish).not.toHaveBeenCalled();
+    expect(read).toHaveBeenCalledTimes(1);
+  });
+
+  it('suppresses retries and requests while archived and allows requests when restored', async () => {
+    read.mockRejectedValueOnce(new Error('read failed'));
+    worker.request('ws');
+    await vi.advanceTimersByTimeAsync(0);
+    worker.setArchived('ws', true);
+    worker.request('ws');
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(read).toHaveBeenCalledTimes(1);
+    expect(publish).not.toHaveBeenCalled();
+
+    worker.setArchived('ws', false);
+    worker.request('ws');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(publish).toHaveBeenCalledWith(
+      'ws',
+      expect.objectContaining({ ratchetState: 'CI_FAILED' })
+    );
+  });
+
+  it("discards a stopped lifetime's in-flight read when a new worker has started", async () => {
+    const pendingRead = deferred<Projection>();
+    read.mockReturnValueOnce(pendingRead.promise);
+    worker.request('ws');
+    worker.stop();
+    worker.request('ws');
+    expect(read).toHaveBeenCalledTimes(1);
+
+    worker = new RatchetProjectionWorker({ read, publish, logger: { warn: vi.fn() } });
+    worker.request('ws');
+    await vi.advanceTimersByTimeAsync(0);
+    pendingRead.resolve({ ...readyProjection, ratchetState: 'CI_RUNNING' });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(publish).toHaveBeenCalledWith(
+      'ws',
+      expect.objectContaining({ ratchetState: 'CI_FAILED' })
+    );
+  });
+});

--- a/src/backend/orchestration/ratchet-projection.worker.ts
+++ b/src/backend/orchestration/ratchet-projection.worker.ts
@@ -1,0 +1,163 @@
+import type { createLogger } from '@/backend/services/logger.service';
+import type { SnapshotUpdateInput, workspaceDataService } from '@/backend/services/workspace';
+import { WorkspaceStatus } from '@/shared/core';
+
+const PROJECTION_RETRY_BASE_MS = 1000;
+const MAX_PROJECTION_READ_ATTEMPTS = 3;
+
+interface ProjectionRefresh {
+  revision: number;
+}
+
+function getNewerRevision(refresh: ProjectionRefresh, target: number): number | null {
+  return refresh.revision > target ? refresh.revision : null;
+}
+
+interface RetryWaiter {
+  timer: NodeJS.Timeout;
+  resolve: () => void;
+}
+
+interface RatchetProjectionDependencies {
+  read: typeof workspaceDataService.findRatchetProjection;
+  publish(workspaceId: string, fields: SnapshotUpdateInput): void;
+  logger: Pick<ReturnType<typeof createLogger>, 'warn'>;
+}
+
+/**
+ * One collector lifetime's authoritative Ratchet reads. Requests arriving during
+ * a read advance its revision so the latest observation is eventually published.
+ * Create a new worker on restart; a stopped worker never publishes again.
+ */
+export class RatchetProjectionWorker {
+  private active = true;
+  private readonly refreshes = new Map<string, ProjectionRefresh>();
+  private readonly archivedWorkspaceIds = new Set<string>();
+  private readonly retryWaiters = new Set<RetryWaiter>();
+
+  constructor(private readonly dependencies: RatchetProjectionDependencies) {}
+
+  request(workspaceId: string): void {
+    if (!this.isActive(workspaceId)) {
+      return;
+    }
+    const existing = this.refreshes.get(workspaceId);
+    if (existing) {
+      existing.revision += 1;
+      return;
+    }
+
+    const refresh = { revision: 1 };
+    this.refreshes.set(workspaceId, refresh);
+    void this.refresh(workspaceId, refresh);
+  }
+
+  setArchived(workspaceId: string, archived: boolean): void {
+    if (archived) {
+      this.archivedWorkspaceIds.add(workspaceId);
+      this.refreshes.delete(workspaceId);
+    } else {
+      this.archivedWorkspaceIds.delete(workspaceId);
+    }
+  }
+
+  stop(): void {
+    this.active = false;
+    for (const waiter of this.retryWaiters) {
+      clearTimeout(waiter.timer);
+      waiter.resolve();
+    }
+    this.retryWaiters.clear();
+    this.refreshes.clear();
+    this.archivedWorkspaceIds.clear();
+  }
+
+  private isActive(workspaceId: string): boolean {
+    return this.active && !this.archivedWorkspaceIds.has(workspaceId);
+  }
+
+  private async project(workspaceId: string): Promise<boolean> {
+    try {
+      const workspace = await this.dependencies.read(workspaceId);
+      if (
+        !(workspace && this.isActive(workspaceId)) ||
+        workspace.status === WorkspaceStatus.ARCHIVING ||
+        workspace.status === WorkspaceStatus.ARCHIVED
+      ) {
+        return true;
+      }
+      this.dependencies.publish(workspaceId, {
+        ratchetEnabled: workspace.ratchetEnabled,
+        ratchetState: workspace.ratchetState,
+        ratchetDispatchOutcome: workspace.ratchetDispatchOutcome,
+        ratchetDispatchRetryCount: workspace.ratchetDispatchRetryCount,
+        ratchetDispatchStalled: workspace.ratchetDispatchStalled,
+        hasMergeConflict: workspace.prHasMergeConflict,
+      });
+      return true;
+    } catch (error) {
+      this.dependencies.logger.warn('Failed to refresh authoritative Ratchet snapshot projection', {
+        workspaceId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return false;
+    }
+  }
+
+  private async refresh(workspaceId: string, refresh: ProjectionRefresh): Promise<void> {
+    let targetRevision = refresh.revision;
+    let failedAttempts = 0;
+    try {
+      while (this.isActive(workspaceId)) {
+        const succeeded = await this.project(workspaceId);
+        const newerRevision = getNewerRevision(refresh, targetRevision);
+        if (succeeded) {
+          if (newerRevision === null) {
+            break;
+          }
+          targetRevision = newerRevision;
+          failedAttempts = 0;
+          continue;
+        }
+        failedAttempts += 1;
+        if (newerRevision !== null) {
+          targetRevision = newerRevision;
+        }
+        if (!this.isActive(workspaceId)) {
+          break;
+        }
+        // The 60-second snapshot reconciliation is the long-term safety net.
+        // Bound event-path retries so a database outage cannot leave one loop
+        // per workspace running indefinitely, even with repeated invalidations.
+        if (failedAttempts >= MAX_PROJECTION_READ_ATTEMPTS) {
+          break;
+        }
+        await this.waitForRetry(Math.max(failedAttempts - 1, 0));
+      }
+    } finally {
+      if (this.refreshes.get(workspaceId) === refresh) {
+        this.refreshes.delete(workspaceId);
+      }
+    }
+  }
+
+  private waitForRetry(attempt: number): Promise<void> {
+    return new Promise((resolve) => {
+      if (!this.active) {
+        resolve();
+        return;
+      }
+      const waiter = {
+        timer: setTimeout(
+          () => {
+            this.retryWaiters.delete(waiter);
+            resolve();
+          },
+          PROJECTION_RETRY_BASE_MS * 2 ** attempt
+        ),
+        resolve,
+      };
+      this.retryWaiters.add(waiter);
+    });
+  }
+}


### PR DESCRIPTION
The event collector mixed domain subscriptions with authoritative Ratchet reads, revision coalescing, retries, archive filtering, and shutdown cancellation. Extract that lifecycle into a focused worker, reducing the collector from 1,013 to 864 lines while preserving publication timing and retry semantics. Move retry tests beside the worker and add coverage for requests during reads and late reads across collector restart.

Validation: Node 24.13.0; `pnpm check:fix`, `pnpm typecheck`, full suite (5,351 passed; 4 skipped), `pnpm check` including Codex schema, `pnpm knip`, and Prisma migration-drift check passed. Independently reviewed.

Full suite command: `GIT_TRACE2_EVENT=0 pnpm test --maxWorkers=4`. Earlier runs hit unrelated `ENOTEMPTY` cleanup races in temporary Git fixtures containing background AI notes; process-local tracing isolation avoided those failures without source or assertion changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

