### PR TITLE
Stream workspace snapshots before Git refresh completes

### DIFF
--- a/docs/architecture/background-jobs.md
+++ b/docs/architecture/background-jobs.md
@@ -39,8 +39,10 @@ list first. A service whose guard is also reachable outside a run
 in `start()`, or a restart would inherit the previous stop's aborted signal.
 
 `waitForCurrentRun(name)` resolves on the run already in flight, not the next
-one; the `/snapshots` WebSocket handler uses it to hold the first
-`snapshot_full` until the startup reconciliation has seeded the store.
+one. Snapshot reconciliation has a narrower `waitForSeed()` barrier: the
+`/snapshots` WebSocket handler waits only until database/runtime fields are in
+the store and stale entries are removed. Git stats continue streaming while the
+job remains in flight, so `stop()` still waits for every Git task to settle.
 
 There is deliberately no "run this job now" API. The two loops with a
 cancellable sleep only ever cancelled it from their own `stop()`, so

--- a/docs/architecture/workspace-state.md
+++ b/docs/architecture/workspace-state.md
@@ -110,12 +110,14 @@ of them behind the one query (~20s at 68 worktrees).
 database and runtime fields, retaining any cached Git stats, then releases the
 startup snapshot barrier. It recomputes Git stats with bounded concurrency and
 publishes each workspace as soon as its Git commands finish; one slow worktree
-cannot hold the rest of the board. Git stats have their own optional timestamp
-group, so the seed's `lastActivityAt` and the later Git update can carry the same
-poll-start timestamp without weakening either field's stale-update protection.
-The optional timestamp keeps older snapshot payloads valid during upgrades. A
-card can be missing its diff badge for a moment rather than the board being
-missing entirely.
+cannot hold the rest of the board. A failed Git refresh retains a non-null
+cached value, while a workspace that no longer has a worktree is explicitly
+cleared to null. Git stats have their own optional timestamp group, so the
+seed's `lastActivityAt` and the later Git update can carry the same poll-start
+timestamp without weakening either field's stale-update protection. The
+optional timestamp keeps older snapshot payloads valid during upgrades. A card
+can be missing its diff badge for a moment rather than the board being missing
+entirely.
 
 Note that each worktree's cache entry is watched via the repo's *shared* `.git`
 common dir, so git activity in any one worktree invalidates the others' entries

--- a/docs/architecture/workspace-state.md
+++ b/docs/architecture/workspace-state.md
@@ -104,10 +104,18 @@ That endpoint never spawns `git` on its response path: `gitStats` is served from
 returns null while a background warm recomputes it. Awaiting those recomputes is
 what used to hold the board on its loading state — a worktree's stats cost
 several `git` spawns and a project with dozens of live workspaces serialized all
-of them behind the one query (~20s at 68 worktrees). `gitStats` is a
-reconciliation field, so the snapshot poll recomputes it for every live
-workspace each minute and streams it into the same cache; a card is missing its
-diff badge for a moment rather than the board being missing entirely.
+of them behind the one query (~20s at 68 worktrees).
+
+`gitStats` is a reconciliation field. Each snapshot poll first seeds all
+database and runtime fields, retaining any cached Git stats, then releases the
+startup snapshot barrier. It recomputes Git stats with bounded concurrency and
+publishes each workspace as soon as its Git commands finish; one slow worktree
+cannot hold the rest of the board. Git stats have their own optional timestamp
+group, so the seed's `lastActivityAt` and the later Git update can carry the same
+poll-start timestamp without weakening either field's stale-update protection.
+The optional timestamp keeps older snapshot payloads valid during upgrades. A
+card can be missing its diff badge for a moment rather than the board being
+missing entirely.
 
 Note that each worktree's cache entry is watched via the repo's *shared* `.git`
 common dir, so git activity in any one worktree invalidates the others' entries

--- a/src/backend/orchestration/snapshot-reconciliation.orchestrator.test.ts
+++ b/src/backend/orchestration/snapshot-reconciliation.orchestrator.test.ts
@@ -397,7 +397,7 @@ describe('SnapshotReconciliationService', () => {
 
       await service.reconcile();
 
-      expect(mockUpsert).toHaveBeenCalledTimes(2);
+      expect(mockUpsert).toHaveBeenCalledTimes(3);
 
       // Verify first workspace's upsert contains correct fields
       const firstCall = mockUpsert.mock.calls[0]!;
@@ -516,7 +516,7 @@ describe('SnapshotReconciliationService', () => {
 
       // Should not throw, gitStats should be null
       expect(result.gitStatsComputed).toBe(0);
-      const upsertFields = mockUpsert.mock.calls[0]![1] as SnapshotUpdateInput;
+      const upsertFields = mockUpsert.mock.calls[1]![1] as SnapshotUpdateInput;
       expect(upsertFields.gitStats).toBeNull();
     });
 
@@ -836,7 +836,7 @@ describe('SnapshotReconciliationService', () => {
 
       expect(result.workspacesScanned).toBe(2);
       expect(result.workspacesChanged).toBe(2);
-      expect(result.deltasEmitted).toBe(3);
+      expect(result.deltasEmitted).toBe(4);
       expect(result.workspacesReconciled).toBe(2);
       expect(result.driftsDetected).toBeGreaterThan(0);
       expect(result.staleEntriesRemoved).toBe(1);
@@ -847,7 +847,7 @@ describe('SnapshotReconciliationService', () => {
         expect.objectContaining({
           workspacesScanned: 2,
           workspacesChanged: 2,
-          deltasEmitted: 3,
+          deltasEmitted: 4,
         })
       );
     });

--- a/src/backend/orchestration/snapshot-reconciliation.orchestrator.ts
+++ b/src/backend/orchestration/snapshot-reconciliation.orchestrator.ts
@@ -7,7 +7,7 @@
  * and is the only path for expensive git stats computation.
  *
  * Key behaviors:
- * - RCNL-02: Git stats computed with p-limit(3) concurrency
+ * - RCNL-02: Git stats computed with bounded p-limit concurrency
  * - RCNL-03: pollStartTs passed to every upsert for field-timestamp safety
  * - RCNL-04: Drift detection compares existing snapshot against authoritative values
  *
@@ -181,6 +181,7 @@ export class SnapshotReconciliationService {
     'debug' | 'error' | 'info' | 'warn'
   >;
   private readonly jobRunner: JobRunner;
+  private seedInProgress: Promise<void> | null = null;
 
   constructor(private readonly dependencies: Readonly<SnapshotReconciliationDependencies>) {
     this.logger = dependencies.createLogger('snapshot-reconciliation');
@@ -188,7 +189,7 @@ export class SnapshotReconciliationService {
     this.jobRunner.register({
       name: SNAPSHOT_RECONCILIATION_JOB,
       intervalMs: SERVICE_INTERVAL_MS.snapshotReconciliation,
-      // Seeds the snapshot store; the /snapshots handler waits on this run.
+      // Seeds the snapshot store; the /snapshots handler waits on the seed phase.
       runImmediately: true,
       run: () => this.reconcile(),
     });
@@ -203,12 +204,11 @@ export class SnapshotReconciliationService {
   }
 
   /**
-   * If a reconciliation is currently in progress, waits for it to finish.
-   * Used by the /snapshots WebSocket handler to defer the initial snapshot_full
-   * message until the store is populated on startup.
+   * Wait for the database/runtime seed phase of the active reconciliation.
+   * Git stats continue streaming after this resolves.
    */
-  waitForInProgress(): Promise<void> {
-    return this.jobRunner.waitForCurrentRun(SNAPSHOT_RECONCILIATION_JOB);
+  waitForSeed(): Promise<void> {
+    return this.seedInProgress ?? Promise.resolve();
   }
 
   /**
@@ -220,11 +220,7 @@ export class SnapshotReconciliationService {
         SnapshotReconciliationDependencies['workspaceMaintenanceService']['findActiveWithSessionsAndProject']
       >
     >[number],
-    allPendingRequests: Map<string, { toolName: string; input?: Record<string, unknown> }>,
-    gitStatsMap: Map<
-      string,
-      { total: number; additions: number; deletions: number; hasUncommitted: boolean } | null
-    >
+    allPendingRequests: Map<string, { toolName: string; input?: Record<string, unknown> }>
   ): SnapshotUpdateInput {
     const sessionIds = [...(ws.agentSessions?.map((s) => s.id) ?? [])];
     const sessionSummaries = buildWorkspaceSessionSummaries(ws.agentSessions ?? [], (sessionId) =>
@@ -268,7 +264,6 @@ export class SnapshotReconciliationService {
       isWorking,
       pendingRequestType,
       sessionSummaries,
-      gitStats: gitStatsMap.get(ws.id) ?? null,
       lastActivityAt,
     };
   }
@@ -298,120 +293,152 @@ export class SnapshotReconciliationService {
 
   async reconcile(): Promise<ReconciliationResult> {
     const pollStartTs = Date.now();
+    let resolveSeed!: () => void;
+    const seedInProgress = new Promise<void>((resolve) => {
+      resolveSeed = resolve;
+    });
+    this.seedInProgress = seedInProgress;
 
-    // 1. Fetch all non-archived workspaces from DB
-    const workspaces =
-      await this.dependencies.workspaceMaintenanceService.findActiveWithSessionsAndProject();
+    try {
+      // 1. Fetch all non-archived workspaces from DB
+      const workspaces =
+        await this.dependencies.workspaceMaintenanceService.findActiveWithSessionsAndProject();
 
-    // 2. Get pending requests from bridges
-    const allPendingRequests = this.dependencies.session.getAllPendingRequests();
+      // 2. Get pending requests from bridges
+      const allPendingRequests = this.dependencies.session.getAllPendingRequests();
 
-    // 3. Compute git stats with concurrency limit (RCNL-02)
-    const gitLimit = pLimit(GIT_CONCURRENCY);
-    const gitStatsMap = new Map<
-      string,
-      { total: number; additions: number; deletions: number; hasUncommitted: boolean } | null
-    >();
+      let driftsDetected = 0;
+      let deltasEmitted = 0;
+      let staleEntriesRemoved = 0;
+      let gitStatsComputed = 0;
+      const changedWorkspaceIds = new Set<string>();
 
-    await Promise.all(
-      workspaces.map((ws) =>
-        gitLimit(async () => {
-          if (!ws.worktreePath) {
-            gitStatsMap.set(ws.id, null);
-            return;
-          }
-          const defaultBranch = ws.project?.defaultBranch ?? 'main';
-          try {
-            const stats = await this.dependencies.gitOpsService.getWorkspaceGitStats(
-              ws.worktreePath,
-              defaultBranch
-            );
-            gitStatsMap.set(ws.id, stats);
-          } catch {
-            gitStatsMap.set(ws.id, null);
-          }
-        })
-      )
-    );
-
-    // 4. Reconcile each workspace
-    let driftsDetected = 0;
-    let gitStatsComputed = 0;
-    let workspacesChanged = 0;
-    let deltasEmitted = 0;
-
-    for (const ws of workspaces) {
-      const authoritativeFields = this.buildAuthoritativeFields(
-        ws,
-        allPendingRequests,
-        gitStatsMap
-      );
-
-      if (authoritativeFields.gitStats) {
-        gitStatsComputed++;
-      }
-
-      // Drift detection (RCNL-04)
-      const existing = this.dependencies.workspaceSnapshotStore.getByWorkspaceId(ws.id);
-      if (existing) {
-        const drifts = detectDrift(existing, authoritativeFields);
-        if (drifts.length > 0) {
-          driftsDetected += drifts.length;
-          this.logger.warn('Snapshot drift detected', {
-            workspaceId: ws.id,
-            driftCount: drifts.length,
-            drifts: drifts.map((d) => ({
-              field: d.field,
-              group: d.group,
-              snapshot: d.snapshotValue,
-              authoritative: d.authoritativeValue,
-            })),
-          });
+      const recordUpsert = (
+        workspaceId: string,
+        result: { changed: boolean; emitted: boolean }
+      ) => {
+        if (result.changed) {
+          changedWorkspaceIds.add(workspaceId);
         }
+        if (result.emitted) {
+          deltasEmitted++;
+        }
+      };
+
+      // 3. Seed DB and runtime fields without waiting for git. Omitting gitStats
+      // preserves an existing cached value until this pass computes a replacement.
+      for (const ws of workspaces) {
+        const authoritativeFields = this.buildAuthoritativeFields(ws, allPendingRequests);
+        if (!ws.worktreePath) {
+          authoritativeFields.gitStats = null;
+        }
+
+        // Drift detection (RCNL-04)
+        const existing = this.dependencies.workspaceSnapshotStore.getByWorkspaceId(ws.id);
+        if (existing) {
+          const drifts = detectDrift(existing, authoritativeFields);
+          if (drifts.length > 0) {
+            driftsDetected += drifts.length;
+            this.logger.warn('Snapshot drift detected', {
+              workspaceId: ws.id,
+              driftCount: drifts.length,
+              drifts: drifts.map((d) => ({
+                field: d.field,
+                group: d.group,
+                snapshot: d.snapshotValue,
+                authoritative: d.authoritativeValue,
+              })),
+            });
+          }
+        }
+
+        recordUpsert(
+          ws.id,
+          this.dependencies.workspaceSnapshotStore.upsert(
+            ws.id,
+            authoritativeFields,
+            'reconciliation',
+            pollStartTs
+          )
+        );
       }
 
-      // Upsert with pollStartTs (RCNL-03)
-      const upsertResult = this.dependencies.workspaceSnapshotStore.upsert(
-        ws.id,
-        authoritativeFields,
-        'reconciliation',
-        pollStartTs
+      // Stale entries are part of the authoritative seed and must be removed
+      // before a client receives its initial snapshot_full baseline.
+      const staleCleanup = this.removeStaleEntries(new Set(workspaces.map((w) => w.id)));
+      staleEntriesRemoved = staleCleanup.staleEntriesRemoved;
+      deltasEmitted += staleCleanup.deltasEmitted;
+      resolveSeed();
+
+      // 4. Compute and publish git stats independently with bounded concurrency.
+      const gitLimit = pLimit(GIT_CONCURRENCY);
+      await Promise.all(
+        workspaces.map((ws) => {
+          const worktreePath = ws.worktreePath;
+          if (!worktreePath) {
+            return Promise.resolve();
+          }
+          return gitLimit(async () => {
+            const defaultBranch = ws.project?.defaultBranch ?? 'main';
+            let gitStats: Awaited<
+              ReturnType<
+                SnapshotReconciliationDependencies['gitOpsService']['getWorkspaceGitStats']
+              >
+            > | null = null;
+            try {
+              gitStats = await this.dependencies.gitOpsService.getWorkspaceGitStats(
+                worktreePath,
+                defaultBranch
+              );
+            } catch {
+              gitStats = null;
+            }
+            if (gitStats) {
+              gitStatsComputed++;
+            }
+            recordUpsert(
+              ws.id,
+              this.dependencies.workspaceSnapshotStore.upsert(
+                ws.id,
+                { gitStats },
+                'reconciliation',
+                pollStartTs
+              )
+            );
+          });
+        })
       );
-      if (upsertResult.changed) {
-        workspacesChanged++;
-      }
-      if (upsertResult.emitted) {
-        deltasEmitted++;
+
+      // 5. Log summary after every streamed git update has settled.
+      const durationMs = Date.now() - pollStartTs;
+      const workspacesChanged = changedWorkspaceIds.size;
+      this.logger.info('Reconciliation complete', {
+        workspacesScanned: workspaces.length,
+        workspacesChanged,
+        deltasEmitted,
+        workspacesReconciled: workspaces.length,
+        driftsDetected,
+        staleEntriesRemoved,
+        gitStatsComputed,
+        durationMs,
+      });
+
+      return {
+        workspacesScanned: workspaces.length,
+        workspacesChanged,
+        deltasEmitted,
+        workspacesReconciled: workspaces.length,
+        driftsDetected,
+        staleEntriesRemoved,
+        gitStatsComputed,
+        durationMs,
+      };
+    } finally {
+      resolveSeed();
+      if (this.seedInProgress === seedInProgress) {
+        this.seedInProgress = null;
       }
     }
-
-    // 5. Stale entry cleanup
-    const staleCleanup = this.removeStaleEntries(new Set(workspaces.map((w) => w.id)));
-    deltasEmitted += staleCleanup.deltasEmitted;
-
-    // 6. Log summary
-    const durationMs = Date.now() - pollStartTs;
-    this.logger.info('Reconciliation complete', {
-      workspacesScanned: workspaces.length,
-      workspacesChanged,
-      deltasEmitted,
-      workspacesReconciled: workspaces.length,
-      driftsDetected,
-      staleEntriesRemoved: staleCleanup.staleEntriesRemoved,
-      gitStatsComputed,
-      durationMs,
-    });
-
-    return {
-      workspacesScanned: workspaces.length,
-      workspacesChanged,
-      deltasEmitted,
-      workspacesReconciled: workspaces.length,
-      driftsDetected,
-      staleEntriesRemoved: staleCleanup.staleEntriesRemoved,
-      gitStatsComputed,
-      durationMs,
-    };
   }
 }
 
@@ -420,5 +447,5 @@ export class SnapshotReconciliationService {
 // read-only startup wait port. Runtime composition creates a fully injected
 // SnapshotReconciliationService in app-context.ts.
 export const snapshotReconciliationService = Object.freeze({
-  waitForInProgress: () => Promise.resolve(),
+  waitForSeed: () => Promise.resolve(),
 });

--- a/src/backend/orchestration/snapshot-reconciliation.orchestrator.ts
+++ b/src/backend/orchestration/snapshot-reconciliation.orchestrator.ts
@@ -393,6 +393,12 @@ export class SnapshotReconciliationService {
             } catch {
               gitStats = null;
             }
+            const cachedGitStats = this.dependencies.workspaceSnapshotStore.getByWorkspaceId(
+              ws.id
+            )?.gitStats;
+            if (gitStats === null && cachedGitStats != null) {
+              return;
+            }
             if (gitStats) {
               gitStatsComputed++;
             }

--- a/src/backend/orchestration/snapshot-reconciliation.streaming.test.ts
+++ b/src/backend/orchestration/snapshot-reconciliation.streaming.test.ts
@@ -1,0 +1,260 @@
+import { expect, it, vi } from 'vitest';
+import {
+  deriveWorkspaceFlowState,
+  type SnapshotUpdateInput,
+  WorkspaceSnapshotStore,
+} from '@/backend/services/workspace';
+import { deriveWorkspaceSidebarStatus } from '@/shared/core';
+import { SnapshotReconciliationService } from './snapshot-reconciliation.orchestrator';
+
+type GitStats = NonNullable<SnapshotUpdateInput['gitStats']>;
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function makeWorkspace(id: string, worktreePath: string) {
+  return {
+    id,
+    projectId: 'project-1',
+    name: `Workspace ${id}`,
+    status: 'READY',
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    branchName: `feature/${id}`,
+    hasHadSessions: false,
+    worktreePath,
+    prUrl: null,
+    prNumber: null,
+    prState: 'NONE',
+    prCiStatus: 'UNKNOWN',
+    prUpdatedAt: null,
+    ratchetEnabled: false,
+    ratchetState: 'IDLE',
+    ratchetDispatchOutcome: null,
+    ratchetDispatchRetryCount: 0,
+    ratchetDispatchStalled: false,
+    prHasMergeConflict: false,
+    mode: 'STANDARD',
+    autoIterationStatus: null,
+    runScriptStatus: 'IDLE',
+    agentSessions: [],
+    terminalSessions: [],
+    project: { defaultBranch: 'main' },
+  };
+}
+
+function makeService(
+  workspaces: ReturnType<typeof makeWorkspace>[],
+  getWorkspaceGitStats: (path: string) => Promise<GitStats>,
+  workspaceSnapshotStore: {
+    getAllWorkspaceIds(): string[];
+    getByWorkspaceId(id: string): unknown;
+    remove(id: string): boolean;
+    upsert(
+      id: string,
+      update: SnapshotUpdateInput,
+      source: string,
+      timestamp: number
+    ): {
+      accepted: boolean;
+      changed: boolean;
+      emitted: boolean;
+    };
+  }
+) {
+  return new SnapshotReconciliationService({
+    createLogger: () => ({ debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() }),
+    gitOpsService: { getWorkspaceGitStats },
+    session: {
+      getAllPendingRequests: () => new Map(),
+      getRuntimeSnapshot: () => ({
+        phase: 'idle',
+        processState: 'stopped',
+        activity: 'IDLE',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      }),
+    },
+    workspaceMaintenanceService: {
+      findActiveWithSessionsAndProject: vi.fn().mockResolvedValue(workspaces),
+    },
+    workspaceSnapshotStore,
+  } as never);
+}
+
+function createStore() {
+  const store = new WorkspaceSnapshotStore();
+  store.configure({
+    deriveFlowState: (input) =>
+      deriveWorkspaceFlowState({
+        ...input,
+        prUpdatedAt: input.prUpdatedAt ? new Date(input.prUpdatedAt) : null,
+      }),
+    deriveSidebarStatus: deriveWorkspaceSidebarStatus,
+  });
+  return store;
+}
+
+it('makes the database seed available while preserving cached git stats', async () => {
+  const cachedGitStats = { total: 2, additions: 1, deletions: 1, hasUncommitted: false };
+  const freshGitStats = { total: 4, additions: 3, deletions: 1, hasUncommitted: true };
+  const pendingGitStats = deferred<GitStats>();
+  const store = createStore();
+  store.upsert('ws-1', { projectId: 'project-1', gitStats: cachedGitStats }, 'seed', 100);
+  const service = makeService(
+    [makeWorkspace('ws-1', '/path/1')],
+    () => pendingGitStats.promise,
+    store
+  );
+
+  service.start();
+  try {
+    await service.waitForSeed();
+    expect(store.getByWorkspaceId('ws-1')).toMatchObject({
+      name: 'Workspace ws-1',
+      gitStats: cachedGitStats,
+    });
+  } finally {
+    pendingGitStats.resolve(freshGitStats);
+    await service.stop();
+  }
+
+  expect(store.getByWorkspaceId('ws-1')?.gitStats).toEqual(freshGitStats);
+});
+
+it('releases the seed barrier when there are no workspaces', async () => {
+  const upsert = vi.fn();
+  const service = makeService([], vi.fn(), {
+    getAllWorkspaceIds: () => [],
+    getByWorkspaceId: () => undefined,
+    remove: () => false,
+    upsert,
+  });
+
+  service.start();
+  await service.waitForSeed();
+  await service.stop();
+
+  expect(upsert).not.toHaveBeenCalled();
+});
+
+it('keeps shutdown pending until streamed git work settles', async () => {
+  const pendingGitStats = deferred<GitStats>();
+  const service = makeService([makeWorkspace('ws-1', '/path/1')], () => pendingGitStats.promise, {
+    getAllWorkspaceIds: () => [],
+    getByWorkspaceId: () => undefined,
+    remove: () => false,
+    upsert: () => ({ accepted: true, changed: true, emitted: true }),
+  });
+  service.start();
+  await service.waitForSeed();
+
+  let stopped = false;
+  const stopping = service.stop().then(() => {
+    stopped = true;
+  });
+  await Promise.resolve();
+  expect(stopped).toBe(false);
+
+  pendingGitStats.resolve({ total: 2, additions: 1, deletions: 1, hasUncommitted: false });
+  await stopping;
+  expect(stopped).toBe(true);
+});
+
+it('publishes each git result as it settles and keeps accurate accounting', async () => {
+  const first = deferred<GitStats>();
+  const second = deferred<GitStats>();
+  const upsert = vi.fn<
+    (
+      id: string,
+      update: SnapshotUpdateInput,
+      source: string,
+      timestamp: number
+    ) => { accepted: boolean; changed: boolean; emitted: boolean }
+  >(() => ({ accepted: true, changed: true, emitted: true }));
+  const store = {
+    getAllWorkspaceIds: () => [],
+    getByWorkspaceId: () => undefined,
+    remove: () => false,
+    upsert,
+  };
+  const service = makeService(
+    [makeWorkspace('ws-1', '/path/1'), makeWorkspace('ws-2', '/path/2')],
+    (path) => (path === '/path/1' ? first.promise : second.promise),
+    store
+  );
+
+  const reconciliation = service.reconcile();
+  await vi.waitFor(() => expect(upsert).toHaveBeenCalledTimes(2));
+  second.resolve({ total: 4, additions: 3, deletions: 1, hasUncommitted: true });
+  await vi.waitFor(() =>
+    expect(upsert).toHaveBeenCalledWith(
+      'ws-2',
+      { gitStats: { total: 4, additions: 3, deletions: 1, hasUncommitted: true } },
+      'reconciliation',
+      expect.any(Number)
+    )
+  );
+  expect(upsert).toHaveBeenCalledTimes(3);
+
+  first.resolve({ total: 2, additions: 1, deletions: 1, hasUncommitted: false });
+  const result = await reconciliation;
+  expect(result).toMatchObject({ workspacesChanged: 2, deltasEmitted: 4, gitStatsComputed: 2 });
+  expect(new Set(upsert.mock.calls.map((call) => call[3]))).toHaveLength(1);
+});
+
+it('accepts git stats at the same timestamp as the activity seed', () => {
+  const store = createStore();
+  store.upsert(
+    'ws-1',
+    {
+      projectId: 'project-1',
+      gitStats: { total: 2, additions: 1, deletions: 1, hasUncommitted: false },
+      lastActivityAt: '2026-01-01T00:00:00.000Z',
+    },
+    'seed',
+    100
+  );
+  store.upsert('ws-1', { lastActivityAt: '2026-01-02T00:00:00.000Z' }, 'reconciliation', 200);
+
+  const result = store.upsert(
+    'ws-1',
+    { gitStats: { total: 5, additions: 4, deletions: 1, hasUncommitted: true } },
+    'reconciliation',
+    200
+  );
+
+  expect(result).toEqual({ accepted: true, changed: true, emitted: true });
+  expect(store.getByWorkspaceId('ws-1')).toMatchObject({
+    gitStats: { total: 5, additions: 4, deletions: 1, hasUncommitted: true },
+    lastActivityAt: '2026-01-02T00:00:00.000Z',
+    fieldTimestamps: { git: 200, reconciliation: 200 },
+  });
+});
+
+it('does not let a newer session-only event suppress an activity seed', () => {
+  const store = createStore();
+  store.upsert(
+    'ws-1',
+    { projectId: 'project-1', lastActivityAt: '2026-01-01T00:00:00.000Z' },
+    'seed',
+    100
+  );
+  store.upsert('ws-1', { isWorking: true }, 'session-event', 300);
+
+  const result = store.upsert(
+    'ws-1',
+    { lastActivityAt: '2026-01-02T00:00:00.000Z' },
+    'reconciliation',
+    200
+  );
+
+  expect(result).toEqual({ accepted: true, changed: true, emitted: true });
+  expect(store.getByWorkspaceId('ws-1')).toMatchObject({
+    lastActivityAt: '2026-01-02T00:00:00.000Z',
+    fieldTimestamps: { session: 300, reconciliation: 200 },
+  });
+});

--- a/src/backend/orchestration/snapshot-reconciliation.streaming.test.ts
+++ b/src/backend/orchestration/snapshot-reconciliation.streaming.test.ts
@@ -17,7 +17,7 @@ function deferred<T>() {
   return { promise, resolve };
 }
 
-function makeWorkspace(id: string, worktreePath: string) {
+function makeWorkspace(id: string, worktreePath: string | null) {
   return {
     id,
     projectId: 'project-1',
@@ -49,7 +49,7 @@ function makeWorkspace(id: string, worktreePath: string) {
 
 function makeService(
   workspaces: ReturnType<typeof makeWorkspace>[],
-  getWorkspaceGitStats: (path: string) => Promise<GitStats>,
+  getWorkspaceGitStats: (path: string) => Promise<GitStats | null>,
   workspaceSnapshotStore: {
     getAllWorkspaceIds(): string[];
     getByWorkspaceId(id: string): unknown;
@@ -123,6 +123,52 @@ it('makes the database seed available while preserving cached git stats', async 
   }
 
   expect(store.getByWorkspaceId('ws-1')?.gitStats).toEqual(freshGitStats);
+});
+
+it.each([
+  {
+    failure: 'a null result',
+    readGitStats: () => Promise.resolve(null),
+  },
+  {
+    failure: 'a rejected read',
+    readGitStats: () => Promise.reject(new Error('git unavailable')),
+  },
+])('preserves cached git stats after $failure', async ({ readGitStats }) => {
+  const cachedGitStats = { total: 6, additions: 4, deletions: 2, hasUncommitted: true };
+  const store = createStore();
+  store.upsert('ws-1', { projectId: 'project-1', gitStats: cachedGitStats }, 'seed', 100);
+  const service = makeService([makeWorkspace('ws-1', '/path/1')], readGitStats, store);
+
+  await service.reconcile();
+
+  expect(store.getByWorkspaceId('ws-1')?.gitStats).toEqual(cachedGitStats);
+});
+
+it('keeps null git stats when a first read fails without a cached value', async () => {
+  const store = createStore();
+  const service = makeService(
+    [makeWorkspace('ws-1', '/path/1')],
+    () => Promise.resolve(null),
+    store
+  );
+
+  await service.reconcile();
+
+  expect(store.getByWorkspaceId('ws-1')?.gitStats).toBeNull();
+});
+
+it('clears cached git stats when the workspace no longer has a worktree', async () => {
+  const cachedGitStats = { total: 6, additions: 4, deletions: 2, hasUncommitted: true };
+  const store = createStore();
+  store.upsert('ws-1', { projectId: 'project-1', gitStats: cachedGitStats }, 'seed', 100);
+  const readGitStats = vi.fn<() => Promise<GitStats>>();
+  const service = makeService([makeWorkspace('ws-1', null)], readGitStats, store);
+
+  await service.reconcile();
+
+  expect(store.getByWorkspaceId('ws-1')?.gitStats).toBeNull();
+  expect(readGitStats).not.toHaveBeenCalled();
 });
 
 it('releases the seed barrier when there are no workspaces', async () => {

--- a/src/backend/routers/websocket/snapshots.handler.test.ts
+++ b/src/backend/routers/websocket/snapshots.handler.test.ts
@@ -32,13 +32,13 @@ const {
   mockGetByProjectId,
   mockGetCachedReviewCount,
   mockRefreshReviewCountIfStale,
-  mockWaitForInProgress,
+  mockWaitForSeed,
 } = vi.hoisted(() => ({
   storeListeners: new Map<string, (event: unknown) => unknown>(),
   mockGetByProjectId: vi.fn(() => []),
   mockGetCachedReviewCount: vi.fn<() => number | undefined>(() => 5),
   mockRefreshReviewCountIfStale: vi.fn(),
-  mockWaitForInProgress: vi.fn<() => Promise<void>>(() => Promise.resolve()),
+  mockWaitForSeed: vi.fn<() => Promise<void>>(() => Promise.resolve()),
 }));
 
 const snapshotStoreEmitter = new EventEmitter();
@@ -81,7 +81,7 @@ function createAppContextMock(
     },
     lifecycle: {
       snapshotReconciliation: {
-        waitForInProgress: mockWaitForInProgress,
+        waitForSeed: mockWaitForSeed,
       },
     },
   } as unknown as AppContext;
@@ -145,7 +145,7 @@ describe('createSnapshotsUpgradeHandler', () => {
     }
     testApplications.clear();
     storeListeners.clear();
-    mockWaitForInProgress.mockImplementation(() => Promise.resolve());
+    mockWaitForSeed.mockImplementation(() => Promise.resolve());
   });
 
   it('sends full snapshot with review count on connect', async () => {
@@ -466,7 +466,7 @@ describe('createSnapshotsUpgradeHandler', () => {
 
   it('buffers deltas emitted before snapshot_full and flushes them after it', async () => {
     let resolveWait: (() => void) | undefined;
-    mockWaitForInProgress.mockReturnValueOnce(
+    mockWaitForSeed.mockReturnValueOnce(
       new Promise<void>((resolve) => {
         resolveWait = resolve;
       })

--- a/src/backend/routers/websocket/snapshots.handler.ts
+++ b/src/backend/routers/websocket/snapshots.handler.ts
@@ -284,7 +284,7 @@ export function createSnapshotsUpgradeHandler(
         void sendSnapshot();
       } else {
         snapshotReconciliation
-          .waitForInProgress()
+          .waitForSeed()
           .then(sendSnapshot)
           .catch(() => void sendSnapshot());
       }

--- a/src/backend/services/job-runner.service.ts
+++ b/src/backend/services/job-runner.service.ts
@@ -196,9 +196,7 @@ export class JobRunner {
    * immediately if the job is between runs.
    *
    * This does not wait for a *next* run: a caller that needs the job's output
-   * wants the work already underway, not another cycle of it. The /snapshots
-   * WebSocket handler uses it to hold the first `snapshot_full` until the
-   * startup reconciliation has populated the store.
+   * wants the work already underway, not another cycle of it.
    */
   waitForCurrentRun(name: string): Promise<void> {
     return this.get(name).currentRun ?? Promise.resolve();

--- a/src/backend/services/workspace/service/snapshot/workspace-snapshot-store.service.test.ts
+++ b/src/backend/services/workspace/service/snapshot/workspace-snapshot-store.service.test.ts
@@ -450,7 +450,7 @@ describe('WorkspaceSnapshotStore', () => {
       expect(store.getByWorkspaceId('ws-1')!.name).toBe('authoritative');
     });
 
-    it('treats equal structured reconciliation and session fields as no-ops', () => {
+    it('treats equal structured git and session fields as no-ops', () => {
       const handler = vi.fn();
       store.on(SNAPSHOT_CHANGED, handler);
       const gitStats = { total: 3, additions: 2, deletions: 1, hasUncommitted: true };
@@ -472,7 +472,7 @@ describe('WorkspaceSnapshotStore', () => {
       const entry = store.getByWorkspaceId('ws-1')!;
       expect(result).toEqual({ accepted: true, changed: false, emitted: false });
       expect(entry.version).toBe(1);
-      expect(entry.fieldTimestamps.reconciliation).toBe(200);
+      expect(entry.fieldTimestamps.git).toBe(200);
       expect(entry.fieldTimestamps.session).toBe(200);
       expect(handler).toHaveBeenCalledTimes(1);
     });

--- a/src/backend/services/workspace/service/snapshot/workspace-snapshot-store.service.ts
+++ b/src/backend/services/workspace/service/snapshot/workspace-snapshot-store.service.ts
@@ -182,7 +182,8 @@ const RATCHET_FIELDS = [
   'ratchetDispatchStalled',
 ] as const;
 const RUN_SCRIPT_FIELDS = ['runScriptStatus'] as const;
-const RECONCILIATION_FIELDS = ['gitStats', 'lastActivityAt'] as const;
+const RECONCILIATION_FIELDS = ['lastActivityAt'] as const;
+const GIT_FIELDS = ['gitStats'] as const;
 
 type SnapshotField = keyof SnapshotUpdateInput & keyof WorkspaceSnapshotEntry;
 
@@ -200,6 +201,7 @@ const FIELD_GROUP_MAPPINGS: FieldGroupMapping[] = [
   { group: 'ratchet', fields: RATCHET_FIELDS },
   { group: 'runScript', fields: RUN_SCRIPT_FIELDS },
   { group: 'reconciliation', fields: RECONCILIATION_FIELDS },
+  { group: 'git', fields: GIT_FIELDS },
 ];
 
 // ---------------------------------------------------------------------------
@@ -220,6 +222,7 @@ function createDefaultFieldTimestamps(): Record<SnapshotFieldGroup, number> {
     ratchet: 0,
     runScript: 0,
     reconciliation: 0,
+    git: 0,
   };
 }
 
@@ -423,7 +426,7 @@ export class WorkspaceSnapshotStore extends EventEmitter {
     let rawChanged = false;
     for (const mapping of FIELD_GROUP_MAPPINGS) {
       const hasFieldsInGroup = mapping.fields.some((field) => update[field] !== undefined);
-      if (!hasFieldsInGroup || ts <= entry.fieldTimestamps[mapping.group]) {
+      if (!hasFieldsInGroup || ts <= (entry.fieldTimestamps[mapping.group] ?? 0)) {
         continue;
       }
       accepted = true;

--- a/src/backend/services/workspace/service/snapshot/workspace-snapshot-store.service.ts
+++ b/src/backend/services/workspace/service/snapshot/workspace-snapshot-store.service.ts
@@ -88,13 +88,15 @@ export interface SnapshotUpdateInput {
   // Run-script fields (group: 'runScript')
   runScriptStatus?: RunScriptStatus;
 
-  // Reconciliation fields (group: 'reconciliation')
+  // Git fields (group: 'git')
   gitStats?: {
     total: number;
     additions: number;
     deletions: number;
     hasUncommitted: boolean;
   } | null;
+
+  // Reconciliation fields (group: 'reconciliation')
   lastActivityAt?: string | null;
 }
 

--- a/src/shared/workspace-snapshot.test.ts
+++ b/src/shared/workspace-snapshot.test.ts
@@ -131,6 +131,18 @@ describe('workspace snapshot transport contract', () => {
     expect(() => WorkspaceSnapshotEntrySchema.parse({ ...entry, fieldTimestamps })).toThrow();
   });
 
+  it('accepts legacy timestamps and carries a dedicated git timestamp', () => {
+    const legacyEntry = makeCompleteSnapshot();
+
+    expect(WorkspaceSnapshotEntrySchema.parse(legacyEntry).fieldTimestamps.git).toBeUndefined();
+    expect(
+      WorkspaceSnapshotEntrySchema.parse({
+        ...legacyEntry,
+        fieldTimestamps: { ...legacyEntry.fieldTimestamps, git: 7 },
+      }).fieldTimestamps.git
+    ).toBe(7);
+  });
+
   it('carries merge conflict, mode, auto-iteration status, and dispatch stall', () => {
     const parsed = WorkspaceSnapshotEntrySchema.parse({
       ...makeCompleteSnapshot(),

--- a/src/shared/workspace-snapshot.ts
+++ b/src/shared/workspace-snapshot.ts
@@ -32,6 +32,7 @@ const SnapshotFieldGroupSchema = z.enum([
   'ratchet',
   'runScript',
   'reconciliation',
+  'git',
 ]);
 
 export type SnapshotFieldGroup = z.infer<typeof SnapshotFieldGroupSchema>;
@@ -121,6 +122,7 @@ export const WorkspaceSnapshotEntrySchema = z.object({
     ratchet: z.number(),
     runScript: z.number(),
     reconciliation: z.number(),
+    git: z.number().optional(),
   }),
 });
 


### PR DESCRIPTION
A slow workspace Git query previously delayed all snapshot updates and initial WebSocket delivery. Seed database/runtime fields for every workspace first, deliver the initial snapshot after that phase, and publish each Git result as it settles with the existing concurrency limit. Cached Git stats remain visible during refresh and survive transient null or rejected reads. Removing a worktree still clears its cached stats.

Keep the original poll timestamp for late-write protection and separate Git freshness from reconciliation/activity freshness. The new Git timestamp is optional when parsing older snapshot payloads. Shutdown still awaits the complete job; accounting distinguishes unique updated workspaces from emitted deltas.

Validation:
- Regression coverage for seed-before-Git delivery, independent Git settlement, stale writes, cached stats, removals, accounting, shutdown, and legacy payloads
- `pnpm check:fix`, `pnpm typecheck`, `pnpm check`
- Focused suites: 124 tests passed
- `NODE_OPTIONS=--no-experimental-webstorage pnpm test --maxWorkers=2`: 5,355 passed, 4 skipped
- Commit hooks passed, including Prisma drift, dependency checks, and Knip
- Independent review completed

The test-only Node option prevents Node 26's global web storage from overriding jsdom storage; the unchanged baseline passes with the same setting.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


