### PR TITLE
Reuse chat groups during streaming updates

### DIFF
--- a/src/client/features/chat/incremental-chat-grouping.bench.ts
+++ b/src/client/features/chat/incremental-chat-grouping.bench.ts
@@ -1,0 +1,91 @@
+import { bench, describe } from 'vitest';
+import type { AgentMessage, ChatMessage } from '@/lib/chat-protocol';
+import { groupAdjacentToolCalls } from '@/lib/chat-protocol';
+import { createIncrementalChatGrouper } from './incremental-chat-grouping';
+
+const timestamp = '2026-09-08T00:00:00.000Z';
+
+function toolUse(index: number): ChatMessage {
+  const message: AgentMessage = {
+    type: 'stream_event',
+    event: {
+      type: 'content_block_start',
+      index: 0,
+      content_block: {
+        type: 'tool_use',
+        id: `call-${index}`,
+        name: 'Read',
+        input: { file_path: `src/file-${index}.ts` },
+      },
+    },
+  };
+  return {
+    id: `tool-use-${index}`,
+    source: 'agent',
+    message,
+    timestamp,
+    order: index * 3,
+  };
+}
+
+function toolResult(index: number): ChatMessage {
+  const message: AgentMessage = {
+    type: 'user',
+    message: {
+      role: 'user',
+      content: [
+        {
+          type: 'tool_result',
+          tool_use_id: `call-${index}`,
+          content: `result-${index}`,
+          is_error: false,
+        },
+      ],
+    },
+  };
+  return {
+    id: `tool-result-${index}`,
+    source: 'agent',
+    message,
+    timestamp,
+    order: index * 3 + 1,
+  };
+}
+
+function assistant(index: number, text: string): ChatMessage {
+  return {
+    id: `assistant-${index}`,
+    source: 'agent',
+    message: {
+      type: 'assistant',
+      message: { role: 'assistant', content: [{ type: 'text', text }] },
+    },
+    timestamp,
+    order: index * 3 + 2,
+  };
+}
+
+function createHistory(toolGroupCount: number): ChatMessage[] {
+  return Array.from({ length: toolGroupCount }, (_, index) => [
+    toolUse(index),
+    toolResult(index),
+    assistant(index, `completed-${index}`),
+  ]).flat();
+}
+
+describe('streaming a tail after 500 completed tool groups', () => {
+  const history = createHistory(500);
+  let pureUpdate = 0;
+  bench('pure full regroup', () => {
+    pureUpdate += 1;
+    groupAdjacentToolCalls([...history, assistant(500, `stream-${pureUpdate}`)]);
+  });
+
+  const grouper = createIncrementalChatGrouper();
+  let incrementalUpdate = 0;
+  grouper.group([...history, assistant(500, 'stream-0')]);
+  bench('incremental tail regroup', () => {
+    incrementalUpdate += 1;
+    grouper.group([...history, assistant(500, `stream-${incrementalUpdate}`)]);
+  });
+});

--- a/src/client/features/chat/incremental-chat-grouping.test.ts
+++ b/src/client/features/chat/incremental-chat-grouping.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentMessage, ChatMessage } from '@/lib/chat-protocol';
+import {
+  filterDuplicateResultMessages,
+  groupAdjacentToolCalls,
+  isToolSequence,
+} from '@/lib/chat-protocol';
+import { createIncrementalChatGrouper } from './incremental-chat-grouping';
+
+const timestamp = '2026-09-08T00:00:00.000Z';
+
+function user(id: string, order: number): ChatMessage {
+  return { id, source: 'user', text: id, timestamp, order };
+}
+
+function assistant(id: string, text: string, order: number): ChatMessage {
+  return {
+    id,
+    source: 'agent',
+    message: {
+      type: 'assistant',
+      message: { role: 'assistant', content: [{ type: 'text', text }] },
+    },
+    timestamp,
+    order,
+  };
+}
+
+function toolUse(messageId: string, toolUseId: string, order: number): ChatMessage {
+  const message: AgentMessage = {
+    type: 'stream_event',
+    event: {
+      type: 'content_block_start',
+      index: 0,
+      content_block: {
+        type: 'tool_use',
+        id: toolUseId,
+        name: 'Read',
+        input: { file_path: `${messageId}.ts` },
+      },
+    },
+  };
+  return { id: messageId, source: 'agent', message, timestamp, order };
+}
+
+function toolResult(
+  messageId: string,
+  toolUseId: string,
+  order: number,
+  content = `${messageId} result`
+): ChatMessage {
+  const message: AgentMessage = {
+    type: 'user',
+    message: {
+      role: 'user',
+      content: [{ type: 'tool_result', tool_use_id: toolUseId, content, is_error: false }],
+    },
+  };
+  return { id: messageId, source: 'agent', message, timestamp, order };
+}
+
+function result(id: string, text: string, order: number): ChatMessage {
+  return {
+    id,
+    source: 'agent',
+    message: { type: 'result', result: text },
+    timestamp,
+    order,
+  };
+}
+
+function oracle(messages: ChatMessage[], filterDuplicateResults = false) {
+  return groupAdjacentToolCalls(
+    filterDuplicateResults ? filterDuplicateResultMessages(messages) : messages
+  );
+}
+
+function toolSequences(messages: ReturnType<typeof oracle>) {
+  return messages.filter(isToolSequence);
+}
+
+describe('createIncrementalChatGrouper', () => {
+  it('keeps completed historical tool groups stable while the final text streams', () => {
+    const grouper = createIncrementalChatGrouper();
+    const history = [
+      user('user', 0),
+      toolUse('tool-use', 'call', 1),
+      toolResult('tool-result', 'call', 2),
+    ];
+    const first = grouper.group([...history, assistant('answer', 'hel', 3)]);
+    const secondMessages = [...history, assistant('answer', 'hello', 3)];
+    const second = grouper.group(secondMessages);
+
+    expect(second).toEqual(oracle(secondMessages));
+    expect(toolSequences(second)[0]).toBe(toolSequences(first)[0]);
+    expect(second.at(-1)).toBe(secondMessages.at(-1));
+  });
+
+  it('recomputes a pending group when its result arrives after assistant text', () => {
+    const grouper = createIncrementalChatGrouper();
+    const completed = [
+      toolUse('completed-use', 'completed', 0),
+      toolResult('completed-result', 'completed', 1),
+      assistant('between', 'between', 2),
+    ];
+    const pending = toolUse('pending-use', 'pending', 3);
+    const trailingText = assistant('trailing', 'working', 4);
+    const first = grouper.group([...completed, pending, trailingText]);
+    const nextMessages = [
+      ...completed,
+      pending,
+      trailingText,
+      toolResult('late-result', 'pending', 5),
+    ];
+    const second = grouper.group(nextMessages);
+
+    expect(second).toEqual(oracle(nextMessages));
+    expect(toolSequences(second)[0]).toBe(toolSequences(first)[0]);
+    expect(toolSequences(second)[1]).not.toBe(toolSequences(first)[1]);
+    expect(toolSequences(second)[1]?.pairedCalls[0]?.status).toBe('success');
+  });
+
+  it('pairs late results in occurrence order when tool IDs are reused', () => {
+    const grouper = createIncrementalChatGrouper();
+    const firstUse = toolUse('use-1', 'reused', 0);
+    const firstText = assistant('text-1', 'one', 1);
+    const secondUse = toolUse('use-2', 'reused', 2);
+    const secondText = assistant('text-2', 'two', 3);
+
+    grouper.group([firstUse, firstText, secondUse, secondText]);
+    const afterFirstMessages = [
+      firstUse,
+      firstText,
+      secondUse,
+      secondText,
+      toolResult('result-1', 'reused', 4, 'first'),
+    ];
+    const afterFirst = grouper.group(afterFirstMessages);
+    const afterSecondMessages = [
+      ...afterFirstMessages,
+      toolResult('result-2', 'reused', 5, 'second'),
+    ];
+    const afterSecond = grouper.group(afterSecondMessages);
+
+    expect(afterFirst).toEqual(oracle(afterFirstMessages));
+    expect(afterSecond).toEqual(oracle(afterSecondMessages));
+    expect(toolSequences(afterSecond)[0]).toBe(toolSequences(afterFirst)[0]);
+    expect(
+      toolSequences(afterSecond).map((sequence) => sequence.pairedCalls[0]?.result?.content)
+    ).toEqual(['first', 'second']);
+  });
+
+  it('does not regroup a consumed late result into a following orphan-result sequence', () => {
+    const grouper = createIncrementalChatGrouper();
+    const initialMessages = [
+      toolUse('use-a', 'call-a', 0),
+      assistant('boundary', 'working', 1),
+      toolResult('late-a', 'call-a', 2),
+      toolResult('orphan-b', 'call-b', 3),
+    ];
+    const initial = grouper.group(initialMessages);
+    const initialCopy = structuredClone(initial);
+    const nextMessages = [...initialMessages, toolUse('use-c', 'call-c', 4)];
+    const next = grouper.group(nextMessages);
+
+    expect(next).toEqual(oracle(nextMessages));
+    expect(toolSequences(next).at(-1)?.id).toBe('tool-seq-orphan-b');
+    expect(initial).toEqual(initialCopy);
+  });
+
+  it('falls back when a reused ID rewind crosses another call late result', () => {
+    const grouper = createIncrementalChatGrouper();
+    const initialMessages = [
+      toolUse('use-b', 'call-b', 0),
+      assistant('boundary-b', 'working', 1),
+      toolUse('use-a-1', 'call-a', 2),
+      assistant('boundary-a-1', 'working', 3),
+      toolResult('late-b', 'call-b', 4),
+      toolUse('use-a-2', 'call-a', 5),
+      assistant('boundary-a-2', 'working', 6),
+      toolResult('result-a-1', 'call-a', 7),
+      assistant('after-a-1', 'still working', 8),
+    ];
+    grouper.group(initialMessages);
+    const nextMessages = [...initialMessages, toolResult('result-a-2', 'call-a', 9)];
+
+    expect(grouper.group(nextMessages)).toEqual(oracle(nextMessages));
+  });
+
+  it('stays equivalent through prepend, window trim, replay, reset, and reorder updates', () => {
+    const grouper = createIncrementalChatGrouper();
+    const stableToolUse = toolUse('stable-use', 'stable', 2);
+    const stableToolResult = toolResult('stable-result', 'stable', 3);
+    const stableText = assistant('stable-text', 'done', 4);
+    const window = [stableToolUse, stableToolResult, stableText];
+    const initial = grouper.group(window);
+    const initialToolGroup = toolSequences(initial)[0];
+
+    const prepended = [user('older-0', 0), user('older-1', 1), ...window];
+    const afterPrepend = grouper.group(prepended);
+    expect(afterPrepend).toEqual(oracle(prepended));
+    expect(toolSequences(afterPrepend)[0]).toBe(initialToolGroup);
+
+    const trimmed = prepended.slice(1);
+    const afterTrim = grouper.group(trimmed);
+    expect(afterTrim).toEqual(oracle(trimmed));
+    expect(toolSequences(afterTrim)[0]).toBe(initialToolGroup);
+
+    const replayed = trimmed.map((message) => ({ ...message }));
+    expect(grouper.group(replayed)).toEqual(oracle(replayed));
+    expect(grouper.group([])).toEqual([]);
+    expect(grouper.group([replayed[2]!, replayed[0]!, replayed[1]!])).toEqual(
+      oracle([replayed[2]!, replayed[0]!, replayed[1]!])
+    );
+  });
+
+  it('optionally preserves main-chat duplicate result filtering', () => {
+    const messages = [assistant('answer', 'same', 0), result('result', 'same', 1)];
+
+    expect(createIncrementalChatGrouper().group(messages)).toEqual(oracle(messages));
+    expect(createIncrementalChatGrouper({ filterDuplicateResults: true }).group(messages)).toEqual(
+      oracle(messages, true)
+    );
+  });
+});

--- a/src/client/features/chat/incremental-chat-grouping.test.ts
+++ b/src/client/features/chat/incremental-chat-grouping.test.ts
@@ -88,12 +88,14 @@ describe('createIncrementalChatGrouper', () => {
       toolResult('tool-result', 'call', 2),
     ];
     const first = grouper.group([...history, assistant('answer', 'hel', 3)]);
+    const firstCopy = structuredClone(first);
     const secondMessages = [...history, assistant('answer', 'hello', 3)];
     const second = grouper.group(secondMessages);
 
     expect(second).toEqual(oracle(secondMessages));
     expect(toolSequences(second)[0]).toBe(toolSequences(first)[0]);
     expect(second.at(-1)).toBe(secondMessages.at(-1));
+    expect(first).toEqual(firstCopy);
   });
 
   it('recomputes a pending group when its result arrives after assistant text', () => {
@@ -136,6 +138,7 @@ describe('createIncrementalChatGrouper', () => {
       toolResult('result-1', 'reused', 4, 'first'),
     ];
     const afterFirst = grouper.group(afterFirstMessages);
+    const afterFirstCopy = structuredClone(afterFirst);
     const afterSecondMessages = [
       ...afterFirstMessages,
       toolResult('result-2', 'reused', 5, 'second'),
@@ -148,6 +151,29 @@ describe('createIncrementalChatGrouper', () => {
     expect(
       toolSequences(afterSecond).map((sequence) => sequence.pairedCalls[0]?.result?.content)
     ).toEqual(['first', 'second']);
+    expect(afterFirst).toEqual(afterFirstCopy);
+  });
+
+  it('detects repeated in-place appends without aliasing either snapshot input', () => {
+    const grouper = createIncrementalChatGrouper();
+    const messages = [
+      toolUse('stable-use', 'stable', 0),
+      toolResult('stable-result', 'stable', 1),
+      assistant('first-text', 'first', 2),
+    ];
+    const first = grouper.group(messages);
+    const stableGroup = toolSequences(first)[0];
+
+    messages.push(assistant('second-text', 'second', 3));
+    const second = grouper.group(messages);
+    expect(second).toEqual(oracle(messages));
+    expect(toolSequences(second)[0]).toBe(stableGroup);
+
+    messages.push(assistant('third-text', 'third', 4));
+    const third = grouper.group(messages);
+    expect(third).toEqual(oracle(messages));
+    expect(toolSequences(third)[0]).toBe(stableGroup);
+    expect(third.at(-1)).toBe(messages.at(-1));
   });
 
   it('does not regroup a consumed late result into a following orphan-result sequence', () => {

--- a/src/client/features/chat/incremental-chat-grouping.ts
+++ b/src/client/features/chat/incremental-chat-grouping.ts
@@ -1,0 +1,335 @@
+import type { ChatMessage, GroupedMessageItem, ToolSequence } from '@/lib/chat-protocol';
+import {
+  extractToolResultInfo,
+  filterDuplicateResultMessages,
+  groupAdjacentToolCalls,
+  isToolResultMessage,
+  isToolSequence,
+  isToolUseMessage,
+} from '@/lib/chat-protocol';
+
+export interface IncrementalChatGroupingOptions {
+  filterDuplicateResults?: boolean;
+}
+
+interface GroupedSegment {
+  item: GroupedMessageItem;
+  start: number;
+}
+
+interface GroupingSnapshot {
+  messages: ChatMessage[];
+  grouped: GroupedMessageItem[];
+  segments: GroupedSegment[];
+}
+
+export interface IncrementalChatGrouper {
+  group: (messages: ChatMessage[]) => GroupedMessageItem[];
+}
+
+function isRenderableMessage(message: ChatMessage): boolean {
+  return (
+    message.source !== 'agent' ||
+    message.message?.type !== 'result' ||
+    (typeof message.message.result === 'string' && message.message.result.trim().length > 0)
+  );
+}
+
+function isToolMessage(message: ChatMessage | undefined): boolean {
+  return Boolean(
+    message?.message && (isToolUseMessage(message.message) || isToolResultMessage(message.message))
+  );
+}
+
+function commonPrefixLength(previous: ChatMessage[], next: ChatMessage[]): number {
+  const limit = Math.min(previous.length, next.length);
+  let index = 0;
+  while (index < limit && previous[index] === next[index]) {
+    index += 1;
+  }
+  return index;
+}
+
+function rewindToolRun(messages: ChatMessage[], index: number): number {
+  if (!isToolMessage(messages[index])) {
+    return index;
+  }
+  let start = index;
+  while (start > 0 && isToolMessage(messages[start - 1])) {
+    start -= 1;
+  }
+  return start;
+}
+
+function findMessageIndex(
+  messages: ChatMessage[],
+  item: GroupedMessageItem,
+  fromIndex: number
+): number {
+  if (!isToolSequence(item)) {
+    for (let index = fromIndex; index < messages.length; index += 1) {
+      if (messages[index] === item) {
+        return index;
+      }
+    }
+    return -1;
+  }
+  for (let index = fromIndex; index < messages.length; index += 1) {
+    const message = messages[index];
+    if (message && isToolMessage(message) && `tool-seq-${message.id}` === item.id) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function deriveSegments(messages: ChatMessage[], grouped: GroupedMessageItem[]): GroupedSegment[] {
+  const segments: GroupedSegment[] = [];
+  let cursor = 0;
+  for (const item of grouped) {
+    const start = findMessageIndex(messages, item, cursor);
+    if (start < 0) {
+      return [];
+    }
+    segments.push({ item, start });
+    cursor = start + 1;
+  }
+  return segments;
+}
+
+function sameToolSequence(left: ToolSequence, right: ToolSequence): boolean {
+  if (left.id !== right.id || left.pairedCalls.length !== right.pairedCalls.length) {
+    return false;
+  }
+  return left.pairedCalls.every((call, index) => {
+    const other = right.pairedCalls[index];
+    return (
+      other !== undefined &&
+      call.id === other.id &&
+      call.name === other.name &&
+      call.input === other.input &&
+      call.status === other.status &&
+      call.result?.content === other.result?.content &&
+      call.result?.isError === other.result?.isError
+    );
+  });
+}
+
+function reuseToolSequencesByAnchor(
+  previous: GroupingSnapshot,
+  messages: ChatMessage[],
+  grouped: GroupedMessageItem[],
+  nextSegments: GroupedSegment[],
+  previousSegments = previous.segments
+): GroupedMessageItem[] {
+  const previousByAnchor = new Map<ChatMessage, ToolSequence>();
+  for (const segment of previousSegments) {
+    if (isToolSequence(segment.item)) {
+      const anchor = previous.messages[segment.start];
+      if (anchor) {
+        previousByAnchor.set(anchor, segment.item);
+      }
+    }
+  }
+
+  return grouped.map((item, index) => {
+    if (!isToolSequence(item)) {
+      return item;
+    }
+    const segment = nextSegments[index];
+    const anchor = segment ? messages[segment.start] : undefined;
+    const previousItem = anchor ? previousByAnchor.get(anchor) : undefined;
+    return previousItem && sameToolSequence(previousItem, item) ? previousItem : item;
+  });
+}
+
+function hasChangedHistoricalToolResult(
+  previous: ChatMessage[],
+  next: ChatMessage[],
+  commonPrefix: number
+): boolean {
+  const oldChanged = previous.slice(commonPrefix).some(isToolMessageResult);
+  const nextChangedBeforeOldEnd = next
+    .slice(commonPrefix, previous.length)
+    .some(isToolMessageResult);
+  return oldChanged || nextChangedBeforeOldEnd;
+}
+
+function rewindCrossesHistoricalToolResult(
+  previous: ChatMessage[],
+  next: ChatMessage[],
+  commonPrefix: number
+): boolean {
+  const recomputeStart = Math.min(
+    rewindToolRun(previous, commonPrefix),
+    rewindToolRun(next, commonPrefix)
+  );
+  return (
+    rangeContainsToolResult(previous, recomputeStart, commonPrefix) ||
+    rangeContainsToolResult(next, recomputeStart, commonPrefix)
+  );
+}
+
+function rangeContainsToolResult(messages: ChatMessage[], start: number, end: number): boolean {
+  for (let index = start; index < end; index += 1) {
+    const message = messages[index];
+    if (message && isToolMessageResult(message)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isToolMessageResult(message: ChatMessage): boolean {
+  return Boolean(message.message && isToolResultMessage(message.message));
+}
+
+function prepareMessages(messages: ChatMessage[], filterDuplicateResults: boolean): ChatMessage[] {
+  const deduplicated = filterDuplicateResults ? filterDuplicateResultMessages(messages) : messages;
+  return deduplicated.filter(isRenderableMessage);
+}
+
+function createFullSnapshot(
+  messages: ChatMessage[],
+  previous?: GroupingSnapshot
+): GroupingSnapshot {
+  const freshlyGrouped = groupAdjacentToolCalls(messages);
+  const freshSegments = deriveSegments(messages, freshlyGrouped);
+  const grouped = previous
+    ? reuseToolSequencesByAnchor(previous, messages, freshlyGrouped, freshSegments)
+    : freshlyGrouped;
+  const segments = freshSegments.map((segment, index) => ({
+    ...segment,
+    item: grouped[index] ?? segment.item,
+  }));
+  return { messages, grouped, segments };
+}
+
+function collectToolResultIds(messages: ChatMessage[], fromIndex: number): Set<string> {
+  const resultIds = new Set<string>();
+  for (let index = fromIndex; index < messages.length; index += 1) {
+    const agentMessage = messages[index]?.message;
+    const result = agentMessage ? extractToolResultInfo(agentMessage) : null;
+    if (result) {
+      resultIds.add(result.toolUseId);
+    }
+  }
+  return resultIds;
+}
+
+function collectAffectedPendingIds(
+  snapshot: GroupingSnapshot,
+  resultIds: Set<string>
+): Set<string> {
+  const affectedIds = new Set<string>();
+  for (const segment of snapshot.segments) {
+    if (!isToolSequence(segment.item)) {
+      continue;
+    }
+    for (const call of segment.item.pairedCalls) {
+      if (call.status === 'pending' && resultIds.has(call.id)) {
+        affectedIds.add(call.id);
+      }
+    }
+  }
+  return affectedIds;
+}
+
+function findEarliestSequenceStart(
+  snapshot: GroupingSnapshot,
+  affectedIds: Set<string>
+): number | undefined {
+  for (const segment of snapshot.segments) {
+    if (
+      isToolSequence(segment.item) &&
+      segment.item.pairedCalls.some((call) => affectedIds.has(call.id))
+    ) {
+      return segment.start;
+    }
+  }
+  return undefined;
+}
+
+function findLateResultRecomputeStart(
+  snapshot: GroupingSnapshot,
+  messages: ChatMessage[],
+  fromIndex: number
+): number | undefined {
+  const resultIds = collectToolResultIds(messages, fromIndex);
+  const affectedIds = collectAffectedPendingIds(snapshot, resultIds);
+  return findEarliestSequenceStart(snapshot, affectedIds);
+}
+
+function createIncrementalSnapshot(
+  previous: GroupingSnapshot,
+  messages: ChatMessage[],
+  commonPrefix: number
+): GroupingSnapshot {
+  let recomputeStart = Math.min(
+    rewindToolRun(previous.messages, commonPrefix),
+    rewindToolRun(messages, commonPrefix)
+  );
+  const lateResultStart = findLateResultRecomputeStart(previous, messages, recomputeStart);
+  if (lateResultStart !== undefined) {
+    recomputeStart = Math.min(recomputeStart, lateResultStart);
+  }
+  if (
+    rangeContainsToolResult(previous.messages, recomputeStart, commonPrefix) ||
+    rangeContainsToolResult(messages, recomputeStart, commonPrefix)
+  ) {
+    return createFullSnapshot(messages, previous);
+  }
+
+  const reusable = previous.segments.filter((segment) => segment.start < recomputeStart);
+  const suffixMessages = messages.slice(recomputeStart);
+  const freshlyGroupedSuffix = groupAdjacentToolCalls(suffixMessages);
+  const freshSuffixSegments = deriveSegments(suffixMessages, freshlyGroupedSuffix).map(
+    (segment) => ({ ...segment, start: segment.start + recomputeStart })
+  );
+  const previousSuffix = previous.segments.slice(reusable.length);
+  const groupedSuffix = reuseToolSequencesByAnchor(
+    previous,
+    messages,
+    freshlyGroupedSuffix,
+    freshSuffixSegments,
+    previousSuffix
+  );
+  const suffixSegments = freshSuffixSegments.map((segment, index) => ({
+    ...segment,
+    item: groupedSuffix[index] ?? segment.item,
+  }));
+  const grouped = [...reusable.map((segment) => segment.item), ...groupedSuffix];
+  return { messages, grouped, segments: [...reusable, ...suffixSegments] };
+}
+
+export function createIncrementalChatGrouper(
+  options: IncrementalChatGroupingOptions = {}
+): IncrementalChatGrouper {
+  const filterDuplicateResults = options.filterDuplicateResults ?? false;
+  let snapshot: GroupingSnapshot | undefined;
+
+  return {
+    group(messages) {
+      const prepared = prepareMessages(messages, filterDuplicateResults);
+      if (!snapshot) {
+        snapshot = createFullSnapshot(prepared);
+        return snapshot.grouped;
+      }
+
+      const commonPrefix = commonPrefixLength(snapshot.messages, prepared);
+      if (commonPrefix === snapshot.messages.length && commonPrefix === prepared.length) {
+        return snapshot.grouped;
+      }
+
+      const canReusePrefix =
+        commonPrefix > 0 &&
+        snapshot.segments.length === snapshot.grouped.length &&
+        !hasChangedHistoricalToolResult(snapshot.messages, prepared, commonPrefix) &&
+        !rewindCrossesHistoricalToolResult(snapshot.messages, prepared, commonPrefix);
+      snapshot = canReusePrefix
+        ? createIncrementalSnapshot(snapshot, prepared, commonPrefix)
+        : createFullSnapshot(prepared, snapshot);
+      return snapshot.grouped;
+    },
+  };
+}

--- a/src/client/features/chat/index.ts
+++ b/src/client/features/chat/index.ts
@@ -23,6 +23,7 @@ export { TodoPanel } from './todo-panel';
 // Hooks
 export type { UseChatWebSocketOptions, UseChatWebSocketReturn } from './use-chat-websocket';
 export { useChatWebSocket } from './use-chat-websocket';
+export { useGroupedChatMessages } from './use-grouped-chat-messages';
 export type { Todo, TodoState } from './use-todo-tracker';
 export { useTodoTracker } from './use-todo-tracker';
 export { VirtualizedMessageList } from './virtualized-message-list';

--- a/src/client/features/chat/use-grouped-chat-messages.ts
+++ b/src/client/features/chat/use-grouped-chat-messages.ts
@@ -1,0 +1,25 @@
+import { useRef } from 'react';
+import type { ChatMessage, GroupedMessageItem } from '@/lib/chat-protocol';
+import {
+  createIncrementalChatGrouper,
+  type IncrementalChatGrouper,
+  type IncrementalChatGroupingOptions,
+} from './incremental-chat-grouping';
+
+export function useGroupedChatMessages(
+  messages: ChatMessage[],
+  options: IncrementalChatGroupingOptions = {}
+): GroupedMessageItem[] {
+  const filterDuplicateResults = options.filterDuplicateResults ?? false;
+  const cacheRef = useRef<{
+    filterDuplicateResults: boolean;
+    grouper: IncrementalChatGrouper;
+  } | null>(null);
+  if (!cacheRef.current || cacheRef.current.filterDuplicateResults !== filterDuplicateResults) {
+    cacheRef.current = {
+      filterDuplicateResults,
+      grouper: createIncrementalChatGrouper({ filterDuplicateResults }),
+    };
+  }
+  return cacheRef.current.grouper.group(messages);
+}

--- a/src/client/features/kanban/quick-chat-content.tsx
+++ b/src/client/features/kanban/quick-chat-content.tsx
@@ -1,14 +1,14 @@
 import { ArrowDownIcon } from '@phosphor-icons/react';
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 import {
   ChatInput,
   PermissionPrompt,
   QuestionPrompt,
   type UseChatWebSocketReturn,
+  useGroupedChatMessages,
   VirtualizedMessageList,
 } from '@/client/features/chat';
 import { Button } from '@/components/ui/button';
-import { groupAdjacentToolCalls } from '@/lib/chat-protocol';
 
 interface QuickChatContentProps {
   workspaceId: string;
@@ -27,10 +27,7 @@ export function QuickChatContent({
   isNearBottom,
   scrollToBottom,
 }: QuickChatContentProps) {
-  const groupedMessages = useMemo(
-    () => groupAdjacentToolCalls(chatState.messages),
-    [chatState.messages]
-  );
+  const groupedMessages = useGroupedChatMessages(chatState.messages);
 
   const running = chatState.sessionStatus.phase === 'running';
   const stopping = chatState.sessionStatus.phase === 'stopping';

--- a/src/client/routes/projects/workspaces/workspace-detail-chat-content.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-chat-content.tsx
@@ -12,13 +12,13 @@ import {
   PermissionPrompt,
   QuestionPrompt,
   RewindConfirmationDialog,
+  useGroupedChatMessages,
   VirtualizedMessageList,
 } from '@/client/features/chat';
 import { VoiceModeToggle } from '@/client/features/voice';
 import { getStatusBannerClassName } from '@/client/lib/status-banner-styles';
 import { Button } from '@/components/ui/button';
 import type { CommandInfo, TokenStats } from '@/lib/chat-protocol';
-import { filterDuplicateResultMessages, groupAdjacentToolCalls } from '@/lib/chat-protocol';
 import { getSessionRuntimeErrorMessage, type SessionRuntimeState } from '@/shared/session-runtime';
 import type { WorkspaceInitBanner } from '@/shared/workspace-init';
 import { useRetryWorkspaceInit } from './use-retry-workspace-init';
@@ -176,10 +176,9 @@ export const ChatContent = memo(function ChatContent(props: ChatContentProps) {
   const autoStartPending = props.autoStartPending ?? false;
 
   const { retry, retryInit } = useRetryWorkspaceInit(props.workspaceId);
-  const groupedMessages = useMemo(
-    () => groupAdjacentToolCalls(filterDuplicateResultMessages(props.messages)),
-    [props.messages]
-  );
+  const groupedMessages = useGroupedChatMessages(props.messages, {
+    filterDuplicateResults: true,
+  });
   const queuedMessageIds = useMemo(
     () => new Set(props.queuedMessages.map((msg) => msg.id)),
     [props.queuedMessages]


### PR DESCRIPTION
Streaming text previously regrouped the complete chat transcript and replaced historical tool-group objects on every update. Cache grouping per mounted chat view, reuse unchanged groups, and recompute the affected suffix for ordinary streaming and appended messages. Both workspace chat and quick chat use the shared hook while preserving their existing duplicate-result settings.

Fall back to the pure grouping implementation for history resets, reordering, and late-result cases that cannot safely reuse a prefix. Retain only the current transcript and leave previous outputs immutable.

A synthetic benchmark with 500 completed tool groups measured 9,897 grouping updates/second versus 1,262 for full regrouping (7.84×). This measures grouping throughput, not end-to-end UI latency.

Validation:
- Focused suites: 70 tests passed, including historical results and reused tool IDs
- Independent 6,000-update comparison including in-place array mutations against the pure implementation, including prior-output immutability
- `pnpm check:fix`, `pnpm typecheck`, `pnpm check`, and commit hooks passed
- GitHub CI full suite, lint/type/dependency checks, production build, and Storybook build passed
- Final local full suite: 5,352 passed, 4 skipped
- Independent review completed

Tests use `NODE_OPTIONS=--no-experimental-webstorage pnpm test --maxWorkers=2` to prevent Node 26's global web storage from overriding jsdom storage; the unchanged baseline passes with the same setting.

Benchmark reproduction: `NODE_OPTIONS=--no-experimental-webstorage pnpm exec vitest bench src/client/features/chat/incremental-chat-grouping.bench.ts --run`.

