### PR TITLE
Upgrade pnpm to 12.3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install pnpm
-        uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0: native pnpm 12 support
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install pnpm
-        uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0: native pnpm 12 support
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -101,7 +101,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install pnpm
-        uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0: native pnpm 12 support
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -130,7 +130,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install pnpm
-        uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0: native pnpm 12 support
 
       - name: Setup Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install pnpm
-        uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0: native pnpm 12 support
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install pnpm
-        uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0: native pnpm 12 support
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -110,7 +110,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install pnpm
-        uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0: native pnpm 12 support
 
       - name: Setup Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
 
       - name: Install pnpm
-        uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0: native pnpm 12 support
 
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Upgrade pnpm to 12.3.4, migrate dependency build permissions, and update the verified Docker bootstrap
 - Require Node.js 26.8.1 or newer, update development and release environments, and align Node.js types
 - Upgrade the ACP SDK from 0.15.0 to 1.4.0, matching Claude ACP, migrate model switching to the supported config API, and handle the expanded config and MCP transport types
 - Upgrade Knip from 5.88.1 to 6.35.0, include CSS, MDX, and Prisma in its project analysis, and remove redundant entry points and dependency ignores

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade the ACP SDK from 0.15.0 to 1.4.0, matching Claude ACP, migrate model switching to the supported config API, and handle the expanded config and MCP transport types
 - Upgrade Knip from 5.88.1 to 6.35.0, include CSS, MDX, and Prisma in its project analysis, and remove redundant entry points and dependency ignores
 - Upgrade Biome from 2.4.4 to 2.5.12, migrate its configuration, and apply the updated lint and formatting rules
-- Refresh compatible runtime and development dependencies, including Claude ACP 0.75.1, Prisma 7.10.0, Electron 41.10.7, Storybook 10.6.0, and pnpm 10.34.5
+- Refresh compatible runtime and development dependencies, including Claude ACP 0.75.1, Prisma 7.10.0, Electron 41.10.7, and Storybook 10.6.0
 - Update the Codex CLI compatibility baseline from 0.145.0 to 0.153.4 and regenerate the app-server method snapshot
 
 ### Security

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,19 +6,20 @@ ARG NODE_VERSION=26.8.1
 # Node 26 does not bundle Corepack. Share one pinned pnpm installation across stages.
 FROM node:${NODE_VERSION}-alpine AS base
 ENV PNPM_HOME=/pnpm
-ENV PATH="${PNPM_HOME}:${PATH}"
+ENV PATH="${PNPM_HOME}/bin:${PNPM_HOME}:${PATH}"
 # Keep the pnpm version and release asset SHA-256 digests pinned together.
-# Use static binaries on Alpine and verify before making the download executable.
-RUN PNPM_VERSION=10.34.5 \
+# Use musl release archives on Alpine and verify before extraction.
+RUN PNPM_VERSION=12.3.4 \
   && case "$(uname -m)" in \
-       x86_64) PNPM_ARCH=x64; PNPM_SHA256=8e744e9720cd31a727cfc3059955fdec6433bbe7383360a9e08a9ae833cb06e3 ;; \
-       aarch64) PNPM_ARCH=arm64; PNPM_SHA256=d0e2a99ad2e4d427967f98b3aa8fb5e0bab548a8fd39c6c0aa293b27b740906b ;; \
+       x86_64) PNPM_ARCH=x64; PNPM_SHA256=e4c4f54599627cc0646fbb2ea8103bd6c88634533fbd6c6f5ca0f6fe7d6f5d9c ;; \
+       aarch64) PNPM_ARCH=arm64; PNPM_SHA256=75c0b268cedbf9b57b69dcef576b9b307dd5b7650c1f967ac1b8f8d6afc1ca25 ;; \
        *) echo "Unsupported pnpm architecture: $(uname -m)" >&2; exit 1 ;; \
      esac \
   && mkdir -p "${PNPM_HOME}" \
-  && wget -qO "${PNPM_HOME}/pnpm" "https://github.com/pnpm/pnpm/releases/download/v${PNPM_VERSION}/pnpm-linuxstatic-${PNPM_ARCH}" \
-  && echo "${PNPM_SHA256}  ${PNPM_HOME}/pnpm" | sha256sum -c - \
-  && chmod +x "${PNPM_HOME}/pnpm"
+  && wget -qO /tmp/pnpm.tar.gz "https://github.com/pnpm/pnpm/releases/download/v${PNPM_VERSION}/pnpm-linux-${PNPM_ARCH}-musl.tar.gz" \
+  && echo "${PNPM_SHA256}  /tmp/pnpm.tar.gz" | sha256sum -c - \
+  && tar -xzf /tmp/pnpm.tar.gz -C "${PNPM_HOME}" \
+  && rm /tmp/pnpm.tar.gz
 
 # ============================================================================
 # Stage 1: Install dependencies

--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ Use Factory Factory only with repositories and agent instructions you trust. Rev
 
 ## Development
 
+Use pnpm 12.3.4, pinned in `package.json`. Dependency build permissions live in
+`pnpm-workspace.yaml` under `allowBuilds`; review new build scripts with
+`pnpm approve-builds` when adding or updating dependencies.
+
 ```bash
 git clone https://github.com/purplefish-ai/factory-factory.git
 cd factory-factory

--- a/docs/superpowers/plans/2026-09-08-pnpm-12.md
+++ b/docs/superpowers/plans/2026-09-08-pnpm-12.md
@@ -1,0 +1,60 @@
+# pnpm 12 Upgrade Implementation Plan
+
+> **For agentic workers:** Use superpowers:executing-plans to implement this plan task by task. Keep upgrades sequential.
+
+**Goal:** Upgrade repository and Docker pnpm from 10.34.5 to 12.3.4 with working native builds and release packaging.
+
+**Architecture:** Preserve the dependency graph, existing build approvals, and pnpm 10 release-age policy (`minimumReleaseAge: 0`). Move legacy build settings to `allowBuilds`; install checksum-verified pnpm 12 musl release archives in Docker and expose the new global bin directory. CI inherits the package manager pin through pnpm/action-setup v6.1.0, which adds pnpm 12 native bootstrap support.
+
+**Tech Stack:** Node 26.8.1, pnpm 12.3.4, Alpine Docker, Prisma, Vitest.
+
+**Spec:** User-approved dependency upgrade queue, following merged Node 26 PR #2230. Official migration sources: https://github.com/pnpm/pnpm.io/blob/main/docs/migration.md and https://github.com/pnpm/pnpm.io/blob/main/blog/releases/12.0.md.
+
+## Global Constraints
+
+- Keep unrelated dependency versions unchanged and retain Node 26.8.1.
+- Use pnpm for repository commands; preserve the existing npm publication workflow.
+- Never execute a Docker bootstrap download before verifying its pinned digest.
+- Open one PR and wait for its merge before TypeScript or other dependency upgrades.
+
+## Task 1: Package manager and build configuration
+
+**Files:** `.github/workflows/{ci,npm-publish,electron-release}.yml`, `package.json`, `pnpm-workspace.yaml`, `pnpm-lock.yaml` if pnpm requires metadata migration, `README.md`, `CHANGELOG.md`.
+
+- [x] Install the baseline with `pnpm install --frozen-lockfile` under pnpm 10.34.5.
+- [x] Run baseline postinstall and release-workflow tests: `GIT_TRACE2_EVENT=0 pnpm test scripts/postinstall.test.ts src/backend/testing/npm-publish-workflow.test.ts`.
+- [x] Change `packageManager` to `pnpm@12.3.4`.
+- [x] Replace the eight `onlyBuiltDependencies` entries with the same keys set to `true` in `allowBuilds`; set `electron-winstaller: false` in that map and remove `ignoredBuiltDependencies`.
+- [x] Run a fresh frozen install. If lock metadata requires migration, regenerate through pnpm and verify package versions remain unchanged before repeating the frozen install.
+- [x] Document the pnpm 12 pin and `pnpm approve-builds` review workflow, and add an Unreleased changelog entry.
+
+## Task 2: Docker bootstrap
+
+**Files:** `Dockerfile`.
+
+- [x] Set the shell-local pnpm pin to 12.3.4 and use `pnpm-linux-${PNPM_ARCH}-musl.tar.gz` from its versioned GitHub release.
+- [x] Pin SHA-256 `e4c4f54599627cc0646fbb2ea8103bd6c88634533fbd6c6f5ca0f6fe7d6f5d9c` for x64 and `75c0b268cedbf9b57b69dcef576b9b307dd5b7650c1f967ac1b8f8d6afc1ca25` for arm64, verify the archive before extraction, and install pnpm in `/pnpm`.
+- [x] Add `/pnpm/bin` to PATH for pnpm 12 global package commands, retaining `/pnpm` for the bootstrap binary.
+- [x] Build the ARM64 full image and AMD64 base; verify pnpm and agent CLI versions, application CLI help, migrations, SQLite, and PTY operation.
+- [x] Build a temporary Dockerfile with an incorrect checksum and verify failure before extraction.
+
+## Task 3: Verification and PR
+
+- [x] Run `pnpm check:fix`, `pnpm typecheck`, `GIT_TRACE2_EVENT=0 pnpm test`, and strict `pnpm check` with the pinned Codex CLI on PATH.
+- [x] Run `pnpm build`, `pnpm build:storybook`, and `pnpm audit`.
+- [x] Pack with `pnpm pack --pack-destination /tmp/ff-pnpm12-package`; install the artifact in an isolated pnpm 12 consumer with explicit build permissions and verify postinstall, CLI help, and database migration.
+- [ ] Get a read-only code review; commit with normal hooks and open a PR using `gh pr create --body-file`.
+- [ ] Wait for merge before the TypeScript upgrade.
+
+## Verification notes
+
+- Baseline: 11 postinstall/release tests passed under pnpm 10.34.5.
+- pnpm 12 adds a separate package-manager lockfile document. Compared parsed documents and confirmed the application lockfile is unchanged. Fresh frozen install ran native build scripts and generated Prisma successfully.
+- The new default 24-hour release delay rejected three already-merged dependency versions. Explicit `minimumReleaseAge: 0` retains the previous policy, including same-day security updates.
+- AMD64 base executes pnpm 12.3.4; an incorrect archive checksum fails before extraction.
+
+- Updated all pnpm/action-setup pins to v6.1.0 (`ea17c68df8912ef543352723c149a84f56e3d413`), the pnpm 12 native bootstrap support release (upstream PR #288).
+- Full suite: 5,364 passed, four manual skips; typecheck, strict guardrails, application and Storybook builds passed. Audit: zero vulnerabilities.
+- Packed artifact: exact local-tarball build selector approved in an isolated pnpm 12 consumer; postinstall generated Prisma, CLI help and migrations passed.
+- Docker full ARM64 image: pnpm/Node/agent CLI versions, help, migrations, SQLite, and PTY smoke passed.
+- Electron dependency collection and unsigned ARM64 directory packaging succeeded with a temporary `extraMetadata.main=electron/dist/electron/main/index.js` CLI override. The unchanged base configuration points `main` at the CLI entry but excludes that file from its package; normal packaging fails this existing sanity check. Follow up during the queued Electron upgrade. Node 26 native modules restored; 11 focused tests passed afterward.

--- a/docs/superpowers/plans/2026-09-08-pnpm-12.md
+++ b/docs/superpowers/plans/2026-09-08-pnpm-12.md
@@ -14,7 +14,7 @@
 
 - Keep unrelated dependency versions unchanged and retain Node 26.8.1.
 - Use pnpm for repository commands; preserve the existing npm publication workflow.
-- Never execute a Docker bootstrap download before verifying its pinned digest.
+- Never extract or execute a Docker bootstrap archive before verifying its pinned digest.
 - Open one PR and wait for its merge before TypeScript or other dependency upgrades.
 
 ## Task 1: Package manager and build configuration

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "author": "Purplefish",
   "type": "module",
   "main": "dist/src/cli/index.js",
-  "packageManager": "pnpm@10.34.5",
+  "packageManager": "pnpm@12.3.4",
   "bin": {
     "ff": "./dist/src/cli/index.js",
     "factory-factory": "./dist/src/cli/index.js"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,104 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.3.4
+        version: 12.3.4
+
+packages:
+
+  '@pnpm/exe.darwin-arm64@12.3.4':
+    resolution: {integrity: sha512-PAyUol8T1+/+ViOiXAt51ECA+QnfXCqz6foL4bW+LsoX0NcVd5XVEM2mRQu+LV4oc7uRz9zf9U0P+XFfuQeDAw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.3.4':
+    resolution: {integrity: sha512-fxP9JCk0Cdye+ePuj+GJJLMUMTqHGWRdb1dtv4How876uQ2ehxvenpgiYAir/ceO9PsYUZkFTtyZdx+rRu5QOA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.linux-arm64-musl@12.3.4':
+    resolution: {integrity: sha512-FBOt0/7ye6O6q4AllVV5QMviB6qE6fqkeczV/+MDWQsmo+QJrlfsh6X7CpH/tClVpBZEyIbjpUoT8bNhCYBxEg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.3.4':
+    resolution: {integrity: sha512-t71AVA7LRqiKTyZ5xMYaZc2n5DfdpMbfokZuiIOXHBOM03ECnF0t4iYwaBDqJgVjlKYUOwaF/bRQajGNA4cJ4w==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.3.4':
+    resolution: {integrity: sha512-RPmk7Jb/aYaFvL2iyDN/AtMY+hUEsue732WmXpcuQ9tBpMnGyA5py7Z3+e+qmQaJ0zY/4ni9jJiyPBQHujmv6w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.3.4':
+    resolution: {integrity: sha512-2ZqOlSPkfwX1h5cR+FPiWf8+F+2hZT/3TvhUK5sigHqwaQCIiq8R7CGxhndKs63JtcLi2a1Qpo+wX/EoyfjyJQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.3.4':
+    resolution: {integrity: sha512-ANyrHqyqco6SXBysUTRF74itDyyraea7IbFsKFdNXTjcFnfycTDx37EwuhdpPYFNSIh2JhUG4fByclsRfiHX7w==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.3.4':
+    resolution: {integrity: sha512-WH/KqBPY/hq2Tb7SgQltEZytimcjgKRaCRL/aM9CI0c67iKc5TVmHUhIiL3Ux9FB4bWn36i6XewUcScQI+zG8w==}
+    cpu: [x64]
+    os: [win32]
+
+  pnpm@12.3.4:
+    resolution: {integrity: sha512-lhqkH7B32joEpEHZ+OFevAyW2o73ELLrZ7+e58sGEOq9SPH9hfUc/+c4RnhfoPh8VqOocqHYk/hEZ0G1zORUVw==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe.darwin-arm64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.3.4':
+    optional: true
+
+  pnpm@12.3.4:
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.3.4
+      '@pnpm/exe.darwin-x64': 12.3.4
+      '@pnpm/exe.linux-arm64': 12.3.4
+      '@pnpm/exe.linux-arm64-musl': 12.3.4
+      '@pnpm/exe.linux-x64': 12.3.4
+      '@pnpm/exe.linux-x64-musl': 12.3.4
+      '@pnpm/exe.win32-arm64': 12.3.4
+      '@pnpm/exe.win32-x64': 12.3.4
+
+---
 lockfileVersion: '9.0'
 
 settings:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,18 +1,19 @@
 publicHoistPattern:
   - '@types/*'
 
-onlyBuiltDependencies:
-  - '@prisma/engines'
-  - better-sqlite3
-  - electron
-  - esbuild
-  - node-pty
-  - prisma
-  - protobufjs
-  - sharp
+# Preserve pnpm 10's release-age policy, including same-day security updates.
+minimumReleaseAge: 0
 
-ignoredBuiltDependencies:
-  - electron-winstaller
+allowBuilds:
+  '@prisma/engines': true
+  better-sqlite3: true
+  electron: true
+  esbuild: true
+  node-pty: true
+  prisma: true
+  protobufjs: true
+  sharp: true
+  electron-winstaller: false
 
 packageExtensions:
   'electron-builder@26.16.1':


### PR DESCRIPTION
Upgrade pnpm from 10.34.5 to 12.3.4 for development, CI, and Docker. Convert the existing dependency build permissions to `allowBuilds`, add pnpm's package-manager lockfile metadata, and use pnpm/action-setup v6.1.0 for native pnpm 12 support. The application dependency lockfile document is unchanged.

Docker installs versioned musl release archives with pinned ARM64/AMD64 SHA-256 verification before extraction, and includes pnpm's new global bin directory on PATH. Explicit `minimumReleaseAge: 0` preserves pnpm 10's existing policy: the new 24-hour default rejected three dependency versions already merged into main, including same-day security updates. README and Unreleased changelog are updated.

Validation:
- Fresh pnpm 12 frozen install, including native build scripts and Prisma postinstall generation.
- `pnpm check:fix`, `pnpm typecheck`, full `pnpm test` (5,364 passed, four manual skips), strict `pnpm check`, application and Storybook builds, dependency audit (zero vulnerabilities).
- ARM64 Docker image build and Node/pnpm/agent CLI versions, CLI help, migrations, SQLite, and PTY smoke; AMD64 base build and pnpm version check. An incorrect archive checksum fails before extraction.
- `pnpm pack` artifact installed in an isolated pnpm 12 consumer with explicit approval for its local-tarball build script; Prisma generation, CLI help, and migrations passed.
- Electron dependency collection and unsigned ARM64 directory packaging passed with a temporary CLI entry override. Normal packaging exposes an existing configuration mismatch: `package.json` points `main` at the CLI file, but `electron-builder.yml` excludes it. This is recorded for the separate Electron upgrade. Node 26 native modules were restored, then 11 focused tests passed.
- Read-only review: clean.

Follows merged #2230. Wait for this PR to merge before the TypeScript upgrade.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

