### PR TITLE
Fix recovery of reordered tool results (#2200)

### DIFF
--- a/docs/architecture/agent-runtime.md
+++ b/docs/architecture/agent-runtime.md
@@ -23,6 +23,11 @@ Session stop history is durable: `SessionLifecycleEvent` rows are append-only,
 deduplicated by session/attempt key, merged chronologically with provider
 history, and rendered as structured chat rows after reconnect or restart.
 
+When reloading a stopped session, transcript recovery matches tool results to
+call occurrences across the full transcript before synthesizing interruption
+results. Provider history backfill can timestamp-sort a result before its call;
+that existing result still completes exactly one occurrence of the tool ID.
+
 Normal user turns have a fixed four-hour deadline; auto-iteration keeps its
 separate configured deadline. Explicit stops, closes, workspace archives,
 provider failures, prompt timeouts, and unexpected process exits record distinct

--- a/src/backend/services/session/service/store/session-tool-call-recovery.test.ts
+++ b/src/backend/services/session/service/store/session-tool-call-recovery.test.ts
@@ -55,6 +55,28 @@ function toolResult(order: number): ChatMessage {
 }
 
 describe('finalizeInterruptedTranscriptToolCalls', () => {
+  it('preserves a real result sorted before its tool call', () => {
+    const transcript = [toolResult(0), toolUse('tool-use-1', 1)];
+
+    expect(finalizeInterruptedTranscriptToolCalls(transcript, '2026-08-20T10:01:00.000Z')).toBe(
+      transcript
+    );
+  });
+
+  it('uses each reordered result for only one occurrence of a reused tool ID', () => {
+    const transcript = [toolResult(0), toolUse('tool-use-1', 1), toolUse('tool-use-2', 2)];
+    const recovered = finalizeInterruptedTranscriptToolCalls(
+      transcript,
+      '2026-08-20T10:01:00.000Z'
+    );
+
+    expect(recovered).toHaveLength(4);
+    expect(recovered[3]?.id).toBe('recovered-tool-result:tool-use-2:reused-call-id:1');
+    expect(finalizeInterruptedTranscriptToolCalls(recovered, '2026-08-20T10:02:00.000Z')).toBe(
+      recovered
+    );
+  });
+
   it('finalizes every unmatched occurrence when a tool ID was reused', () => {
     const recovered = finalizeInterruptedTranscriptToolCalls(
       [toolUse('tool-use-1', 0), toolUse('tool-use-2', 1)],

--- a/src/backend/services/session/service/store/session-tool-call-recovery.ts
+++ b/src/backend/services/session/service/store/session-tool-call-recovery.ts
@@ -68,6 +68,11 @@ export function finalizeInterruptedTranscriptToolCalls(
       occurrences.push(toolCall);
       openToolCallsById.set(toolUseId, occurrences);
     }
+  }
+
+  // History backfill can sort a result before its call. Register every call
+  // first, then consume results once each in occurrence order.
+  for (const message of transcript) {
     for (const toolResultId of getToolResultIds(message)) {
       const occurrences = openToolCallsById.get(toolResultId);
       const completedToolCall = occurrences?.shift();


### PR DESCRIPTION
When provider history timestamps sort a completed tool result before its tool call, reloading a stopped session could append a conflicting synthetic interruption result. Register all tool-call occurrences before matching results so each existing result completes one occurrence, regardless of message order.

Adds regressions for reordered results, reused tool IDs, and repeat recovery. Documents the recovery ordering contract.

Validation: `pnpm check:fix`, `pnpm typecheck`, affected recovery/session-load tests, and `pnpm check`.

Fixes #2200.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

