### PR TITLE
Fix worktree cleanup under symlinked bases

### DIFF
--- a/docs/architecture/workspace-state.md
+++ b/docs/architecture/workspace-state.md
@@ -5,6 +5,10 @@ tables. They share a shape: one accessor is the sole writer, and reads flatten
 the row back onto the workspace under the field's original name, so the snapshot
 wire, the v4 export format and the client are unchanged.
 
+Worktree cleanup matches Git's registered paths against the real worktree base
+directory, so a symlinked base still removes Git metadata. It resolves the base
+separately from the worktree so cleanup also works after the worktree is deleted.
+
 ## Run script
 
 The workspace's dev server lives in a 1:1 `WorkspaceRunScript` row (`command`,

--- a/docs/architecture/workspace-state.md
+++ b/docs/architecture/workspace-state.md
@@ -8,6 +8,10 @@ wire, the v4 export format and the client are unchanged.
 Worktree cleanup matches Git's registered paths against the real worktree base
 directory, so a symlinked base still removes Git metadata. It resolves the base
 separately from the worktree so cleanup also works after the worktree is deleted.
+If the base symlink itself no longer resolves, cleanup logs a warning and matches
+only the exact configured path. Restore the original base symlink and retry to
+remove a canonical registration; guessing from a basename or pruning unrelated
+registrations could remove another workspace.
 
 ## Run script
 

--- a/src/backend/services/workspace/service/worktree/git-ops.service.test.ts
+++ b/src/backend/services/workspace/service/worktree/git-ops.service.test.ts
@@ -6,6 +6,7 @@ const mockGetSnapshot = vi.hoisted(() => vi.fn());
 const mockGetStats = vi.hoisted(() => vi.fn());
 const mockPathExists = vi.hoisted(() => vi.fn());
 const mockRm = vi.hoisted(() => vi.fn());
+const mockRealpath = vi.hoisted(() => vi.fn());
 const mockGitStateInvalidate = vi.hoisted(() => vi.fn());
 const mockGitStateRemove = vi.hoisted(() => vi.fn());
 
@@ -29,6 +30,7 @@ vi.mock('@/backend/lib/file-helpers', () => ({
 
 vi.mock('node:fs/promises', () => ({
   rm: (...args: unknown[]) => mockRm(...args),
+  realpath: (...args: unknown[]) => mockRealpath(...args),
 }));
 
 vi.mock('@/backend/clients/git.client', () => ({
@@ -56,6 +58,7 @@ const project = {
 describe('gitOpsService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockRealpath.mockImplementation(async (target: string) => target);
     mockGitClient.getWorktreePath.mockImplementation((name: string) => `/repo/worktrees/${name}`);
   });
 
@@ -313,6 +316,29 @@ describe('gitOpsService', () => {
       'Refusing to remove worktree because requested path does not match project'
     );
     expect(mockGitClient.listWorktreesWithBranches).not.toHaveBeenCalled();
+    expect(mockGitClient.deleteWorktree).not.toHaveBeenCalled();
+    expect(mockRm).not.toHaveBeenCalled();
+  });
+
+  it('removes a registered worktree when its base directory is already missing', async () => {
+    mockRealpath.mockRejectedValueOnce(Object.assign(new Error('missing'), { code: 'ENOENT' }));
+    mockGitClient.listWorktreesWithBranches.mockResolvedValue([
+      { path: '/repo/worktrees/w1', branch: 'w1' },
+    ]);
+
+    await gitOpsService.removeWorktree('/repo/worktrees/w1', project);
+
+    expect(mockGitClient.deleteWorktree).toHaveBeenCalledWith('w1');
+    expect(mockRm).not.toHaveBeenCalled();
+  });
+
+  it('does not delete files when canonical path lookup fails', async () => {
+    mockRealpath.mockRejectedValueOnce(Object.assign(new Error('denied'), { code: 'EACCES' }));
+
+    await expect(gitOpsService.removeWorktree('/repo/worktrees/w1', project)).rejects.toThrow(
+      'denied'
+    );
+
     expect(mockGitClient.deleteWorktree).not.toHaveBeenCalled();
     expect(mockRm).not.toHaveBeenCalled();
   });

--- a/src/backend/services/workspace/service/worktree/git-ops.service.test.ts
+++ b/src/backend/services/workspace/service/worktree/git-ops.service.test.ts
@@ -6,6 +6,7 @@ const mockGetSnapshot = vi.hoisted(() => vi.fn());
 const mockGetStats = vi.hoisted(() => vi.fn());
 const mockPathExists = vi.hoisted(() => vi.fn());
 const mockRm = vi.hoisted(() => vi.fn());
+const mockWarn = vi.hoisted(() => vi.fn());
 const mockRealpath = vi.hoisted(() => vi.fn());
 const mockGitStateInvalidate = vi.hoisted(() => vi.fn());
 const mockGitStateRemove = vi.hoisted(() => vi.fn());
@@ -26,6 +27,10 @@ vi.mock('@/backend/lib/shell', () => ({
 
 vi.mock('@/backend/lib/file-helpers', () => ({
   pathExists: (...args: unknown[]) => mockPathExists(...args),
+}));
+
+vi.mock('@/backend/services/logger.service', () => ({
+  createLogger: () => ({ warn: mockWarn }),
 }));
 
 vi.mock('node:fs/promises', () => ({
@@ -316,6 +321,24 @@ describe('gitOpsService', () => {
       'Refusing to remove worktree because requested path does not match project'
     );
     expect(mockGitClient.listWorktreesWithBranches).not.toHaveBeenCalled();
+    expect(mockGitClient.deleteWorktree).not.toHaveBeenCalled();
+    expect(mockRm).not.toHaveBeenCalled();
+  });
+
+  it('warns without guessing a registration when the base link no longer resolves', async () => {
+    mockRealpath.mockRejectedValueOnce(Object.assign(new Error('missing'), { code: 'ENOENT' }));
+    mockGitClient.listWorktreesWithBranches.mockResolvedValueOnce([
+      { path: '/canonical/worktrees/w1' },
+      { path: '/another/worktrees/w1' },
+    ]);
+    mockPathExists.mockResolvedValueOnce(false);
+
+    await gitOpsService.removeWorktree('/repo/worktrees/w1', project);
+
+    expect(mockWarn).toHaveBeenCalledWith(
+      expect.stringContaining('worktree base'),
+      expect.objectContaining({ worktreePath: '/repo/worktrees/w1' })
+    );
     expect(mockGitClient.deleteWorktree).not.toHaveBeenCalled();
     expect(mockRm).not.toHaveBeenCalled();
   });

--- a/src/backend/services/workspace/service/worktree/git-ops.service.ts
+++ b/src/backend/services/workspace/service/worktree/git-ops.service.ts
@@ -4,11 +4,14 @@ import { GitClientFactory } from '@/backend/clients/git.client';
 import { ApplicationError } from '@/backend/lib/application-error';
 import { pathExists } from '@/backend/lib/file-helpers';
 import { gitCommand } from '@/backend/lib/shell';
+import { createLogger } from '@/backend/services/logger.service';
 import {
   getStats,
   type WorkspaceGitStats,
   workspaceGitStateService,
 } from '@/backend/services/workspace-git-state.service';
+
+const logger = createLogger('git-ops');
 
 export type { WorkspaceGitStats };
 
@@ -181,6 +184,10 @@ class GitOpsService {
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
         throw error;
       }
+      logger.warn(
+        'Cannot resolve worktree base; checking only the configured path. Restore missing base symlinks to clean up canonical Git registrations.',
+        { worktreePath, worktreeBasePath: path.dirname(expectedWorktreePath) }
+      );
     }
     const registeredWorktree = (await gitClient.listWorktreesWithBranches()).find(
       (entry) => path.resolve(entry.path) === canonicalWorktreePath

--- a/src/backend/services/workspace/service/worktree/git-ops.service.ts
+++ b/src/backend/services/workspace/service/worktree/git-ops.service.ts
@@ -169,8 +169,21 @@ class GitOpsService {
       throw new Error('Refusing to remove worktree because requested path does not match project');
     }
 
+    // Git records real paths. Resolve the base separately so a missing worktree
+    // still matches its registration and can be removed through Git.
+    let canonicalWorktreePath = expectedWorktreePath;
+    try {
+      canonicalWorktreePath = path.join(
+        await fs.realpath(path.dirname(expectedWorktreePath)),
+        worktreeName
+      );
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error;
+      }
+    }
     const registeredWorktree = (await gitClient.listWorktreesWithBranches()).find(
-      (entry) => path.resolve(entry.path) === expectedWorktreePath
+      (entry) => path.resolve(entry.path) === canonicalWorktreePath
     );
     if (registeredWorktree) {
       try {

--- a/src/backend/services/workspace/service/worktree/git-ops.symlink.integration.test.ts
+++ b/src/backend/services/workspace/service/worktree/git-ops.symlink.integration.test.ts
@@ -1,0 +1,63 @@
+import { execFile } from 'node:child_process';
+import { mkdir, mkdtemp, rm, symlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/backend/services/workspace-git-state.service', () => ({
+  workspaceGitStateService: { invalidate: vi.fn(), remove: vi.fn() },
+}));
+
+import { gitOpsService } from './git-ops.service';
+
+const execFileAsync = promisify(execFile);
+let testRoot: string | undefined;
+
+afterEach(async () => {
+  if (testRoot) {
+    await rm(testRoot, { recursive: true, force: true, maxRetries: 3 });
+    testRoot = undefined;
+  }
+});
+
+describe('worktree removal through a symlinked base directory', () => {
+  it.each([false, true])(
+    'clears Git registration when directory is missing: %s',
+    async (missing) => {
+      testRoot = await mkdtemp(path.join(tmpdir(), 'ff-worktree-symlink-'));
+      const repoPath = path.join(testRoot, 'repo');
+      const actualBase = path.join(testRoot, 'actual');
+      const worktreeBasePath = path.join(testRoot, 'linked');
+      await mkdir(repoPath);
+      await mkdir(actualBase);
+      await symlink(actualBase, worktreeBasePath, 'dir');
+      const git = (...args: string[]) => execFileAsync('git', args, { cwd: repoPath });
+      await git('init');
+      await git(
+        '-c',
+        'user.name=Test',
+        '-c',
+        'user.email=test@example.invalid',
+        'commit',
+        '--allow-empty',
+        '-m',
+        'Initial'
+      );
+      const worktreePath = path.join(worktreeBasePath, 'workspace');
+      await git('worktree', 'add', '-b', 'test-branch', worktreePath);
+      if (missing) {
+        await rm(worktreePath, { recursive: true, force: true });
+      }
+
+      await gitOpsService.removeWorktree(worktreePath, { repoPath, worktreeBasePath });
+
+      expect((await git('worktree', 'list', '--porcelain')).stdout).not.toContain(
+        'refs/heads/test-branch'
+      );
+      await expect(
+        git('worktree', 'add', path.join(worktreeBasePath, 'replacement'), 'test-branch')
+      ).resolves.toBeDefined();
+    }
+  );
+});

--- a/src/backend/services/workspace/service/worktree/git-ops.symlink.integration.test.ts
+++ b/src/backend/services/workspace/service/worktree/git-ops.symlink.integration.test.ts
@@ -22,8 +22,8 @@ afterEach(async () => {
 });
 
 describe('worktree removal through a symlinked base directory', () => {
-  it.each([false, true])(
-    'clears Git registration when directory is missing: %s',
+  it.each(['present', 'worktree-missing', 'base-link-missing'])(
+    'clears Git registration after resolving the base: %s',
     async (missing) => {
       testRoot = await mkdtemp(path.join(tmpdir(), 'ff-worktree-symlink-'));
       const repoPath = path.join(testRoot, 'repo');
@@ -46,8 +46,18 @@ describe('worktree removal through a symlinked base directory', () => {
       );
       const worktreePath = path.join(worktreeBasePath, 'workspace');
       await git('worktree', 'add', '-b', 'test-branch', worktreePath);
-      if (missing) {
+      if (missing === 'worktree-missing') {
         await rm(worktreePath, { recursive: true, force: true });
+      }
+
+      if (missing === 'base-link-missing') {
+        await rm(worktreeBasePath);
+        await gitOpsService.removeWorktree(worktreePath, { repoPath, worktreeBasePath });
+        expect((await git('worktree', 'list', '--porcelain')).stdout).toContain(
+          'refs/heads/test-branch'
+        );
+        // Restoring the link recovers the identity needed for safe Git cleanup.
+        await symlink(actualBase, worktreeBasePath, 'dir');
       }
 
       await gitOpsService.removeWorktree(worktreePath, { repoPath, worktreeBasePath });


### PR DESCRIPTION
Worktree cleanup compared configured paths with Git's canonical paths, so a symlinked worktree base caused directory-only deletion and left Git registrations that blocked branch reuse. Resolve the base directory before matching registrations, including when the worktree directory is already missing, while keeping the configured-path safety check.

Fixes #1924.

Validation: `pnpm check:fix`, `pnpm typecheck`, 38 affected tests (including real Git symlink and missing-directory regressions), and `pnpm check`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

