### PR TITLE
Show Electron rejection stack traces (#1907)

### DIFF
--- a/electron/main/fatal-error-handlers.test.ts
+++ b/electron/main/fatal-error-handlers.test.ts
@@ -37,6 +37,21 @@ describe('fatal Electron error handlers', () => {
     );
   });
 
+  it.each(['plain rejection', null, undefined])('shows non-Error rejection %s', (reason) => {
+    const { app, dialog, process } = createHandlerHarness();
+    process.emit('unhandledRejection', reason);
+    expect(dialog.showErrorBox).toHaveBeenCalledWith('Unhandled Rejection', String(reason));
+    expect(app.quit).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the message when an Error has no stack', () => {
+    const { dialog, process } = createHandlerHarness();
+    const reason = new Error('no stack');
+    reason.stack = undefined;
+    process.emit('unhandledRejection', reason);
+    expect(dialog.showErrorBox).toHaveBeenCalledWith('Unhandled Rejection', String(reason));
+  });
+
   it('shows unhandled rejections and quits after the dialog', () => {
     const { app, dialog, logger, process } = createHandlerHarness();
     const reason = new Error('async setup failed');
@@ -44,7 +59,7 @@ describe('fatal Electron error handlers', () => {
     process.emit('unhandledRejection', reason);
 
     expect(logger.error).toHaveBeenCalledWith('[electron] Unhandled rejection:', reason);
-    expect(dialog.showErrorBox).toHaveBeenCalledWith('Unhandled Rejection', String(reason));
+    expect(dialog.showErrorBox).toHaveBeenCalledWith('Unhandled Rejection', reason.stack);
     expect(app.quit).toHaveBeenCalledTimes(1);
     expect(dialog.showErrorBox.mock.invocationCallOrder[0]).toBeLessThan(
       app.quit.mock.invocationCallOrder[0]

--- a/electron/main/fatal-error-handlers.ts
+++ b/electron/main/fatal-error-handlers.ts
@@ -36,7 +36,10 @@ export function registerFatalErrorHandlers({
 
   process.on('unhandledRejection', (reason) => {
     logger.error('[electron] Unhandled rejection:', reason);
-    dialog.showErrorBox('Unhandled Rejection', String(reason));
+    dialog.showErrorBox(
+      'Unhandled Rejection',
+      reason instanceof Error ? reason.stack || String(reason) : String(reason)
+    );
     app.quit();
   });
 }


### PR DESCRIPTION
Unhandled promise rejections with Error reasons currently show only the error message in the Electron crash dialog, dropping the stack trace. Preserve the stack when available and retain string fallback for stackless Errors and non-Error reasons.

Fixes #1907.

Validation: regression failed before the fix; all 6 fatal-handler tests pass. Ran `pnpm check:fix`, `pnpm typecheck`, `pnpm check`, and the normal pre-commit checks.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

