### PR TITLE
Wait for ACP child exit after SIGKILL (#2203)

### DIFF
--- a/src/backend/services/session/service/acp/acp-runtime-manager.termination.test.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-manager.termination.test.ts
@@ -232,7 +232,8 @@ describe('AcpRuntimeManager', () => {
       vi.useFakeTimers();
       try {
         const stopPromise = manager.stopClient('session-1');
-        await vi.advanceTimersByTimeAsync(5100);
+        // Exhaust both the SIGTERM grace period and SIGKILL exit wait.
+        await vi.advanceTimersByTimeAsync(10_100);
         await stopPromise;
 
         expect(child.kill).toHaveBeenCalledWith('SIGTERM');
@@ -263,7 +264,8 @@ describe('AcpRuntimeManager', () => {
       vi.useFakeTimers();
       try {
         const stopPromise = manager.stopClient('session-1');
-        await vi.advanceTimersByTimeAsync(5100);
+        // Exhaust both the SIGTERM grace period and SIGKILL exit wait.
+        await vi.advanceTimersByTimeAsync(10_100);
         await stopPromise;
       } finally {
         vi.useRealTimers();

--- a/src/backend/services/session/service/acp/acp-runtime-supervisor.termination.test.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-supervisor.termination.test.ts
@@ -317,6 +317,37 @@ describe('AcpRuntimeSupervisor termination and shutdown ownership', () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
+  it('waits for the asynchronous process exit after sending SIGKILL', async () => {
+    const handle = createTestProcessHandle();
+    const child = mockChildOf(handle);
+    child.kill = vi.fn(() => true);
+    const { supervisor } = createHarness(() => Promise.resolve(handle));
+    await install(supervisor);
+    vi.useFakeTimers();
+
+    try {
+      let stopped = false;
+      const stop = supervisor.stopClient('session-1').then(() => {
+        stopped = true;
+      });
+      await vi.advanceTimersByTimeAsync(5001);
+
+      expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+      expect(stopped).toBe(false);
+      expect(supervisor.getInstalledHandle('session-1')).toBe(handle);
+
+      child.signalCode = 'SIGKILL';
+      child.emit('exit', null, 'SIGKILL');
+      await stop;
+
+      expect(stopped).toBe(true);
+      expect(supervisor.getInstalledHandle('session-1')).toBeUndefined();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('accepts a pending exit when SIGKILL reports that the process is already gone', async () => {
     // Catches a process exiting after the grace-period check but before SIGKILL is delivered.
     const handle = createTestProcessHandle();
@@ -427,7 +458,7 @@ describe('AcpRuntimeSupervisor termination and shutdown ownership', () => {
     );
     vi.useFakeTimers();
     const stop = supervisor.stopClient('session-1');
-    await vi.advanceTimersByTimeAsync(5001);
+    await vi.advanceTimersByTimeAsync(10_001);
     await stop;
     vi.useRealTimers();
     await install(supervisor);

--- a/src/backend/services/session/service/acp/acp-runtime-supervisor.ts
+++ b/src/backend/services/session/service/acp/acp-runtime-supervisor.ts
@@ -691,6 +691,7 @@ export class AcpRuntimeSupervisor {
       });
       try {
         this.sendProcessSignal(sessionId, handle, 'SIGKILL');
+        await raceWithSoftTimeout(exitPromise, STOP_TIMEOUT_MS);
       } catch (error) {
         await raceWithSoftTimeout(exitPromise, STOP_TIMEOUT_MS);
         if (!(terminationObserved || hasExited())) {


### PR DESCRIPTION
Wait for the child exit after successfully sending SIGKILL before finishing ACP runtime cleanup. The wait remains bounded by the existing five-second stop timeout, preserving best-effort shutdown and failed-signal handling.

Closes #2203.

Validation: delayed-exit regression failed before the fix; 40 supervisor tests pass. `pnpm check:fix`, `pnpm typecheck`, and `pnpm check` pass.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



The broader runtime-manager termination suite also passes (20 tests). Its no-exit fake-timer cases now advance through both the SIGTERM grace period and the SIGKILL exit wait; late-event suppression assertions are unchanged.
