### PR TITLE
Count working agents in completion notifications (#1906)

### DIFF
--- a/docs/architecture/workspace-state.md
+++ b/docs/architecture/workspace-state.md
@@ -135,4 +135,6 @@ Workspace completion notifications count the distinct sessions that worked in
 the uninterrupted busy interval ending at the idle transition. Historical idle
 sessions do not inflate the count, and repeated turns from one session count
 once. The idle event captures the count before the asynchronous workspace lookup,
-so a subsequent interval cannot change an earlier notification.
+so a subsequent interval cannot change an earlier notification. Lookups and
+notification requests run in idle order per workspace; a failed lookup does not
+block later intervals, and separate workspaces can proceed independently.

--- a/docs/architecture/workspace-state.md
+++ b/docs/architecture/workspace-state.md
@@ -128,3 +128,11 @@ and excludes, and reftable state. Object and reflog writes are ignored because
 the associated ref event performs the invalidation. If the shared watcher fails,
 all of its dependents switch to the five-minute fallback expiry; removing the
 last dependent closes it.
+
+## Completion notifications
+
+Workspace completion notifications count the distinct sessions that worked in
+the uninterrupted busy interval ending at the idle transition. Historical idle
+sessions do not inflate the count, and repeated turns from one session count
+once. The idle event captures the count before the asynchronous workspace lookup,
+so a subsequent interval cannot change an earlier notification.

--- a/src/backend/services/workspace/service/lifecycle/activity.service.test.ts
+++ b/src/backend/services/workspace/service/lifecycle/activity.service.test.ts
@@ -9,6 +9,39 @@ vi.mock('@/backend/services/workspace/resources/workspace.accessor', () => ({
 import { workspaceActivityService } from './activity.service';
 
 describe('WorkspaceActivityService', () => {
+  it('counts unique sessions in each busy interval for notifications', async () => {
+    const workspaceId = 'notification-count';
+    workspaceIds.push(workspaceId);
+    const notifications: number[] = [];
+    const onNotification = (event: { workspaceId: string; sessionCount: number }) => {
+      if (event.workspaceId === workspaceId) {
+        notifications.push(event.sessionCount);
+      }
+    };
+    workspaceActivityService.on('request_notification', onNotification);
+    try {
+      workspaceActivityService.markSessionRunning(workspaceId, 's1');
+      workspaceActivityService.markSessionRunning(workspaceId, 's2');
+      workspaceActivityService.markSessionIdle(workspaceId, 's1');
+      workspaceActivityService.markSessionRunning(workspaceId, 's1');
+      workspaceActivityService.markSessionRunning(workspaceId, 's1');
+      workspaceActivityService.markSessionIdle(workspaceId, 's1');
+      workspaceActivityService.markSessionRunning(workspaceId, 's3');
+      workspaceActivityService.markSessionIdle(workspaceId, 's2');
+      workspaceActivityService.markSessionIdle(workspaceId, 's3');
+
+      // Start another interval before the prior notification's DB lookup resolves.
+      workspaceActivityService.markSessionRunning(workspaceId, 's1');
+      workspaceActivityService.markSessionIdle(workspaceId, 's1');
+      workspaceActivityService.markSessionIdle(workspaceId, 's1');
+      await Promise.resolve();
+
+      expect(notifications).toEqual([3, 1]);
+    } finally {
+      workspaceActivityService.off('request_notification', onNotification);
+    }
+  });
+
   const workspaceIds: string[] = [];
 
   afterEach(() => {

--- a/src/backend/services/workspace/service/lifecycle/activity.service.test.ts
+++ b/src/backend/services/workspace/service/lifecycle/activity.service.test.ts
@@ -1,12 +1,20 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+const { mockFindById } = vi.hoisted(() => ({
+  mockFindById: vi.fn().mockResolvedValue({ name: 'Test Workspace', agentSessions: [] }),
+}));
+
 vi.mock('@/backend/services/workspace/resources/workspace.accessor', () => ({
   workspaceAccessor: {
-    findById: vi.fn().mockResolvedValue({ name: 'Test Workspace', agentSessions: [] }),
+    findById: mockFindById,
   },
 }));
 
 import { workspaceActivityService } from './activity.service';
+
+async function flushNotifications(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
 
 describe('WorkspaceActivityService', () => {
   it('counts unique sessions in each busy interval for notifications', async () => {
@@ -34,7 +42,7 @@ describe('WorkspaceActivityService', () => {
       workspaceActivityService.markSessionRunning(workspaceId, 's1');
       workspaceActivityService.markSessionIdle(workspaceId, 's1');
       workspaceActivityService.markSessionIdle(workspaceId, 's1');
-      await Promise.resolve();
+      await flushNotifications();
 
       expect(notifications).toEqual([3, 1]);
     } finally {
@@ -42,9 +50,105 @@ describe('WorkspaceActivityService', () => {
     }
   });
 
+  it('preserves busy interval order while an earlier workspace lookup is pending', async () => {
+    const workspaceId = 'notification-order';
+    workspaceIds.push(workspaceId);
+    const lookup = Promise.withResolvers<{ name: string }>();
+    mockFindById.mockReturnValueOnce(lookup.promise);
+    const notifications: number[] = [];
+    const onNotification = (event: { workspaceId: string; sessionCount: number }) => {
+      if (event.workspaceId === workspaceId) {
+        notifications.push(event.sessionCount);
+      }
+    };
+    workspaceActivityService.on('request_notification', onNotification);
+    try {
+      workspaceActivityService.markSessionRunning(workspaceId, 's1');
+      workspaceActivityService.markSessionRunning(workspaceId, 's2');
+      workspaceActivityService.markSessionIdle(workspaceId, 's1');
+      workspaceActivityService.markSessionIdle(workspaceId, 's2');
+      workspaceActivityService.markSessionRunning(workspaceId, 's1');
+      workspaceActivityService.markSessionIdle(workspaceId, 's1');
+      await flushNotifications();
+
+      expect(notifications).toEqual([]);
+      expect(mockFindById).toHaveBeenCalledTimes(1);
+      lookup.resolve({ name: 'Test Workspace' });
+      await flushNotifications();
+      expect(notifications).toEqual([2, 1]);
+    } finally {
+      lookup.resolve({ name: 'Test Workspace' });
+      await flushNotifications();
+      workspaceActivityService.off('request_notification', onNotification);
+    }
+  });
+
+  it('allows other workspaces to notify while a workspace lookup is pending', async () => {
+    const workspaceId = 'notification-slow';
+    const otherWorkspaceId = 'notification-independent';
+    workspaceIds.push(workspaceId, otherWorkspaceId);
+    const lookup = Promise.withResolvers<{ name: string }>();
+    mockFindById.mockReturnValueOnce(lookup.promise);
+    const notifications: string[] = [];
+    const onNotification = (event: { workspaceId: string }) => {
+      notifications.push(event.workspaceId);
+    };
+    workspaceActivityService.on('request_notification', onNotification);
+    try {
+      workspaceActivityService.markSessionRunning(workspaceId, 's1');
+      workspaceActivityService.markSessionIdle(workspaceId, 's1');
+      workspaceActivityService.markSessionRunning(otherWorkspaceId, 's1');
+      workspaceActivityService.markSessionIdle(otherWorkspaceId, 's1');
+      await flushNotifications();
+
+      expect(notifications).toEqual([otherWorkspaceId]);
+      lookup.resolve({ name: 'Test Workspace' });
+      await flushNotifications();
+      expect(notifications).toEqual([otherWorkspaceId, workspaceId]);
+    } finally {
+      lookup.resolve({ name: 'Test Workspace' });
+      await flushNotifications();
+      workspaceActivityService.off('request_notification', onNotification);
+    }
+  });
+
+  it('continues queued notifications after a workspace lookup fails', async () => {
+    const workspaceId = 'notification-failure';
+    workspaceIds.push(workspaceId);
+    const lookup = Promise.withResolvers<{ name: string }>();
+    mockFindById.mockReturnValueOnce(lookup.promise);
+    const onNotification = vi.fn();
+    workspaceActivityService.on('request_notification', onNotification);
+    try {
+      workspaceActivityService.markSessionRunning(workspaceId, 's1');
+      workspaceActivityService.markSessionRunning(workspaceId, 's2');
+      workspaceActivityService.markSessionIdle(workspaceId, 's1');
+      workspaceActivityService.markSessionIdle(workspaceId, 's2');
+      workspaceActivityService.markSessionRunning(workspaceId, 's1');
+      workspaceActivityService.markSessionIdle(workspaceId, 's1');
+      await flushNotifications();
+      expect(onNotification).not.toHaveBeenCalled();
+
+      lookup.reject(new Error('Lookup failed'));
+      await flushNotifications();
+      expect(onNotification).toHaveBeenCalledExactlyOnceWith({
+        workspaceId,
+        workspaceName: 'Test Workspace',
+        sessionCount: 1,
+        finishedAt: expect.any(Date),
+      });
+    } finally {
+      lookup.resolve({ name: 'Test Workspace' });
+      await flushNotifications();
+      workspaceActivityService.off('request_notification', onNotification);
+    }
+  });
+
   const workspaceIds: string[] = [];
 
-  afterEach(() => {
+  afterEach(async () => {
+    await flushNotifications();
+    mockFindById.mockClear();
     for (const workspaceId of workspaceIds) {
       workspaceActivityService.clearWorkspace(workspaceId);
     }

--- a/src/backend/services/workspace/service/lifecycle/activity.service.test.ts
+++ b/src/backend/services/workspace/service/lifecycle/activity.service.test.ts
@@ -12,6 +12,20 @@ vi.mock('@/backend/services/workspace/resources/workspace.accessor', () => ({
 
 import { workspaceActivityService } from './activity.service';
 
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
 async function flushNotifications(): Promise<void> {
   await new Promise<void>((resolve) => setImmediate(resolve));
 }
@@ -53,7 +67,7 @@ describe('WorkspaceActivityService', () => {
   it('preserves busy interval order while an earlier workspace lookup is pending', async () => {
     const workspaceId = 'notification-order';
     workspaceIds.push(workspaceId);
-    const lookup = Promise.withResolvers<{ name: string }>();
+    const lookup = createDeferred<{ name: string }>();
     mockFindById.mockReturnValueOnce(lookup.promise);
     const notifications: number[] = [];
     const onNotification = (event: { workspaceId: string; sessionCount: number }) => {
@@ -87,7 +101,7 @@ describe('WorkspaceActivityService', () => {
     const workspaceId = 'notification-slow';
     const otherWorkspaceId = 'notification-independent';
     workspaceIds.push(workspaceId, otherWorkspaceId);
-    const lookup = Promise.withResolvers<{ name: string }>();
+    const lookup = createDeferred<{ name: string }>();
     mockFindById.mockReturnValueOnce(lookup.promise);
     const notifications: string[] = [];
     const onNotification = (event: { workspaceId: string }) => {
@@ -115,7 +129,7 @@ describe('WorkspaceActivityService', () => {
   it('continues queued notifications after a workspace lookup fails', async () => {
     const workspaceId = 'notification-failure';
     workspaceIds.push(workspaceId);
-    const lookup = Promise.withResolvers<{ name: string }>();
+    const lookup = createDeferred<{ name: string }>();
     mockFindById.mockReturnValueOnce(lookup.promise);
     const onNotification = vi.fn();
     workspaceActivityService.on('request_notification', onNotification);

--- a/src/backend/services/workspace/service/lifecycle/activity.service.ts
+++ b/src/backend/services/workspace/service/lifecycle/activity.service.ts
@@ -22,29 +22,39 @@ interface WorkspaceActivityState {
 
 class WorkspaceActivityService extends EventEmitter {
   private workspaceStates = new Map<string, WorkspaceActivityState>();
+  private readonly notificationChains = new Map<string, Promise<void>>();
 
   constructor() {
     super();
 
-    // Listen for workspace idle events and trigger notification requests
-    this.on('workspace_idle', async ({ workspaceId, finishedAt, sessionCount }) => {
-      try {
-        const workspace = await workspaceAccessor.findById(workspaceId);
-        if (!workspace) {
-          logger.warn('Workspace not found for notification', { workspaceId });
-          return;
-        }
+    // Serialize each workspace's lookups so busy intervals notify in idle order.
+    this.on('workspace_idle', ({ workspaceId, finishedAt, sessionCount }) => {
+      const previous = this.notificationChains.get(workspaceId) ?? Promise.resolve();
+      const notification = previous
+        .then(async () => {
+          const workspace = await workspaceAccessor.findById(workspaceId);
+          if (!workspace) {
+            logger.warn('Workspace not found for notification', { workspaceId });
+            return;
+          }
 
-        // Emit event to frontend for suppression check
-        this.emit('request_notification', {
-          workspaceId,
-          workspaceName: workspace.name,
-          sessionCount,
-          finishedAt,
+          // Emit event to frontend for suppression check.
+          this.emit('request_notification', {
+            workspaceId,
+            workspaceName: workspace.name,
+            sessionCount,
+            finishedAt,
+          });
+        })
+        .catch((error) => {
+          logger.error('Failed to process workspace idle event', toError(error), { workspaceId });
+        })
+        .finally(() => {
+          if (this.notificationChains.get(workspaceId) === notification) {
+            this.notificationChains.delete(workspaceId);
+          }
         });
-      } catch (error) {
-        logger.error('Failed to process workspace idle event', toError(error), { workspaceId });
-      }
+      this.notificationChains.set(workspaceId, notification);
     });
   }
 

--- a/src/backend/services/workspace/service/lifecycle/activity.service.ts
+++ b/src/backend/services/workspace/service/lifecycle/activity.service.ts
@@ -15,6 +15,7 @@ const logger = createLogger('workspace-activity');
 interface WorkspaceActivityState {
   workspaceId: string;
   runningSessions: Map<string, number>; // Session ID to current activity generation.
+  participatingSessions: Set<string>; // Unique sessions in the current busy interval.
   currentGeneration: number;
   lastActivityAt: Date;
 }
@@ -26,7 +27,7 @@ class WorkspaceActivityService extends EventEmitter {
     super();
 
     // Listen for workspace idle events and trigger notification requests
-    this.on('workspace_idle', async ({ workspaceId, finishedAt }) => {
+    this.on('workspace_idle', async ({ workspaceId, finishedAt, sessionCount }) => {
       try {
         const workspace = await workspaceAccessor.findById(workspaceId);
         if (!workspace) {
@@ -38,7 +39,7 @@ class WorkspaceActivityService extends EventEmitter {
         this.emit('request_notification', {
           workspaceId,
           workspaceName: workspace.name,
-          sessionCount: workspace.agentSessions.length,
+          sessionCount,
           finishedAt,
         });
       } catch (error) {
@@ -57,6 +58,7 @@ class WorkspaceActivityService extends EventEmitter {
       state = {
         workspaceId,
         runningSessions: new Map(),
+        participatingSessions: new Set(),
         currentGeneration: 0,
         lastActivityAt: new Date(),
       };
@@ -64,6 +66,10 @@ class WorkspaceActivityService extends EventEmitter {
     }
 
     const wasIdle = state.runningSessions.size === 0;
+    if (wasIdle) {
+      state.participatingSessions.clear();
+    }
+    state.participatingSessions.add(sessionId);
     state.currentGeneration += 1;
     const generation = state.currentGeneration;
     state.runningSessions.set(sessionId, generation);
@@ -127,6 +133,7 @@ class WorkspaceActivityService extends EventEmitter {
       this.emit('workspace_idle', {
         workspaceId,
         finishedAt: state.lastActivityAt,
+        sessionCount: state.participatingSessions.size,
       });
     }
   }


### PR DESCRIPTION
Workspace completion notifications counted every persisted session, including historical sessions that did no work. Count distinct sessions participating in the busy interval instead, and capture that count in the idle event before looking up workspace metadata.

Workspace lookups and notification requests are serialized per workspace so a slower lookup cannot reorder successive completions. Queue failures recover without blocking later intervals, and other workspaces proceed independently.

Regressions cover overlapping sessions, repeated starts, staggered arrivals, back-to-back intervals with a pending lookup, independent workspaces, and lookup failure recovery. Documents the count and ordering semantics.

Validation: `pnpm check:fix`, `pnpm typecheck`, `pnpm build`, 65 affected activity/event-forwarder/event-collector/lifecycle tests, and `pnpm check` (including Codex schema verification). The ordering regression was verified failing before the fix and passing afterward.

Fixes #1906.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

