### PR TITLE
Keep latest review activity at pagination limit (#2201)

### DIFF
--- a/docs/architecture/pull-requests.md
+++ b/docs/architecture/pull-requests.md
@@ -71,6 +71,11 @@ sweep. It is what moves a stuck workspace out of the WORKING column; the
 snapshot key hashes `statusCheckRollup` detail `WorkspacePR` does not store, so
 no reader can re-derive it.
 
+Inline review comment fetches retain at most 2,000 comments, ordered by newest
+update first at the API boundary. Hitting that budget drops older activity rather
+than the newest comment or edit used in the dispatch snapshot. Returned comments
+are in ascending update order.
+
 Review comments belonging to resolved review threads (GraphQL
 `reviewThreads.isResolved`) are excluded from fixer dispatch prompts and from
 the "has actionable review comments" trigger; they still count toward the

--- a/src/backend/services/github/service/github-cli-review-pagination.test.ts
+++ b/src/backend/services/github/service/github-cli-review-pagination.test.ts
@@ -1,0 +1,68 @@
+import { execFile } from 'node:child_process';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:child_process', () => ({ execFile: vi.fn() }));
+vi.mock('node:util', () => ({ promisify: (fn: unknown) => fn }));
+vi.mock('@/backend/services/logger.service', () => ({
+  createLogger: () => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+import { githubCLIService } from './github-cli.service';
+
+function comment(id: number, updatedAt: number = id) {
+  return {
+    id,
+    user: { login: 'reviewer' },
+    body: `Review ${id}`,
+    path: 'src/index.ts',
+    line: 1,
+    created_at: new Date(id * 1000).toISOString(),
+    updated_at: new Date(updatedAt * 1000).toISOString(),
+    html_url: `https://github.com/owner/repo/pull/1#discussion_r${id}`,
+  };
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  githubCLIService.clearCaches();
+});
+
+describe('review comment pagination', () => {
+  it('keeps the latest activity, including edits to old comments, at the page cap', async () => {
+    const comments = Array.from({ length: 2001 }, (_, index) => comment(index + 1));
+    comments[0] = comment(1, 3000);
+    vi.mocked(execFile).mockImplementation(((_command: string, args: string[]) => {
+      const url = new URL(`https://api.github.com/${args[1]}`);
+      const newestFirst =
+        url.searchParams.get('sort') === 'updated' && url.searchParams.get('direction') === 'desc';
+      const ordered = newestFirst
+        ? [...comments].sort((a, b) => b.updated_at.localeCompare(a.updated_at))
+        : comments;
+      const page = Number(url.searchParams.get('page'));
+      return Promise.resolve({
+        stdout: JSON.stringify(ordered.slice((page - 1) * 100, page * 100)),
+        stderr: '',
+      });
+    }) as never);
+
+    const result = await githubCLIService.getReviewComments('owner/repo', 1);
+
+    expect(execFile).toHaveBeenCalledTimes(20);
+    expect(result).toHaveLength(2000);
+    expect(result.map((entry) => entry.id)).toContain(2001);
+    expect(result.map((entry) => entry.id)).toContain(1);
+    expect(result.map((entry) => entry.id)).not.toContain(2);
+    expect(result.at(-1)?.updatedAt).toBe(comments[0]?.updated_at);
+  });
+
+  it('retains the since filter while fetching newest updates first', async () => {
+    vi.mocked(execFile).mockResolvedValue({ stdout: '[]', stderr: '' } as never);
+    const since = new Date('2026-09-01T00:00:00Z');
+    await githubCLIService.getReviewComments('owner/repo', 1, since);
+    expect(execFile).toHaveBeenCalledWith(
+      'gh',
+      ['api', expect.stringContaining(`&since=${since.toISOString()}`)],
+      expect.any(Object)
+    );
+  });
+});

--- a/src/backend/services/github/service/github-cli-review-pagination.test.ts
+++ b/src/backend/services/github/service/github-cli-review-pagination.test.ts
@@ -52,6 +52,8 @@ describe('review comment pagination', () => {
     expect(result.map((entry) => entry.id)).toContain(2001);
     expect(result.map((entry) => entry.id)).toContain(1);
     expect(result.map((entry) => entry.id)).not.toContain(2);
+    const updateTimes = result.map((entry) => entry.updatedAt);
+    expect(updateTimes).toEqual([...updateTimes].sort());
     expect(result.at(-1)?.updatedAt).toBe(comments[0]?.updated_at);
   });
 

--- a/src/backend/services/github/service/github-cli.service.ts
+++ b/src/backend/services/github/service/github-cli.service.ts
@@ -735,9 +735,9 @@ class GitHubCLIService {
     }>
   > {
     try {
-      // Paginate through all pages (100 per page) to avoid silently dropping comments beyond
-      // the first page. The `since` filter bounds incremental fetches; pagination ensures
-      // correctness for large PRs. Cap at MAX_PAGES to prevent unbounded API usage.
+      // Fetch newest updates first so the page cap retains the activity Ratchet uses
+      // for dispatch snapshots, including edits to old comments. Keep a bounded
+      // API budget and return the retained comments in ascending update order.
       const PAGE_SIZE = 100;
       const MAX_PAGES = 20;
       const allComments: Array<{
@@ -754,7 +754,7 @@ class GitHubCLIService {
       for (let page = 1; page <= MAX_PAGES; page++) {
         signal?.throwIfAborted();
         const sinceParam = since ? `&since=${since.toISOString()}` : '';
-        const path = `repos/${repo}/pulls/${prNumber}/comments?per_page=${PAGE_SIZE}&page=${page}${sinceParam}`;
+        const path = `repos/${repo}/pulls/${prNumber}/comments?per_page=${PAGE_SIZE}&page=${page}${sinceParam}&sort=updated&direction=desc`;
 
         const { stdout } = await this.exec(['api', path], {
           timeout: GH_TIMEOUT_MS.default,
@@ -795,7 +795,7 @@ class GitHubCLIService {
         }
       }
 
-      return allComments;
+      return allComments.reverse();
     } catch (error) {
       signal?.throwIfAborted();
       const errorType = classifyError(error);


### PR DESCRIPTION
The 20-page review-comment cap currently retains the oldest 2,000 comments, so newer comments and edits can disappear from Ratchet dispatch snapshots. Request `sort=updated&direction=desc` and reverse the retained results for ascending update order. The existing API budget and incremental `since` filter are preserved.

Fixes #2201. The regression uses 2,001 comments and edits the oldest one, proving that both the newest comment and newest edit survive truncation.

The report also questions review-summary pagination; `gh pr view --json reviews` already paginates those through [preloadPrReviews](https://github.com/cli/cli/blob/trunk/pkg/cmd/pr/shared/finder.go), so that path needs no change. GitHub documents that [direction requires an explicit sort](https://docs.github.com/en/rest/pulls/comments#list-review-comments-on-a-pull-request).

Validation: regression failed before the fix; all 99 tests in the GitHub CLI and pagination suites pass. Ran `pnpm check:fix`, `pnpm typecheck`, `pnpm check`, and normal pre-commit checks.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

