### PR TITLE
Complete startup scripts after the shell exits

### DIFF
--- a/docs/architecture/workspace-state.md
+++ b/docs/architecture/workspace-state.md
@@ -7,6 +7,13 @@ wire, the v4 export format and the client are unchanged.
 
 ## Run script
 
+Startup provisioning follows the main shell's exit. Output pipes normally drain
+to closure, with a one-second limit after exit so background descendants that
+inherit the pipes cannot keep provisioning open. Later output is drained and
+discarded until those descendants close their pipes, so writing after provisioning
+does not interrupt them. Persistent background commands should redirect output if
+it needs to remain available after startup.
+
 The workspace's dev server lives in a 1:1 `WorkspaceRunScript` row (`command`,
 `postRunCommand`, `cleanupCommand`, `pid`, `port`, `startedAt`, `status`),
 written only by `workspace-run-script.accessor.ts`; reads flatten it back under

--- a/src/backend/services/constants.ts
+++ b/src/backend/services/constants.ts
@@ -16,6 +16,7 @@ export const SERVICE_TIMEOUT_MS = Object.freeze({
   cliLatestVersionCheck: 3000,
   cliUpgrade: 120_000,
   startupScriptForceKillGrace: 5000,
+  startupScriptOutputDrain: 1000,
   portLsof: 2000,
   ratchetWorkspaceCheck: 90_000,
 } as const);

--- a/src/backend/services/run-script/service/startup-script.integration.test.ts
+++ b/src/backend/services/run-script/service/startup-script.integration.test.ts
@@ -35,8 +35,15 @@ it('completes provisioning while a background descendant still holds output pipe
     const result = await startupScriptService.runStartupScript(
       { id: 'background-init', worktreePath } as never,
       {
-        startupScriptCommand:
-          '(sleep 2; printf "late output\\n" && printf alive > background-wrote; sleep 30) & printf "descendant:%s\\n" "$!"; echo complete',
+        // exec keeps the reported PID on the only background process, including
+        // during the initial delay, so cleanup cannot orphan a sleep child.
+        startupScriptCommand: `(exec node -e '
+          setTimeout(() => {
+            process.stdout.write("late output\\n");
+            require("node:fs").writeFileSync("background-wrote", "alive");
+          }, 2000);
+          setTimeout(() => {}, 30000);
+        ') & printf "descendant:%s\\n" "$!"; echo complete`,
         startupScriptTimeout: 10,
       } as never
     );
@@ -48,7 +55,7 @@ it('completes provisioning while a background descendant still holds output pipe
       .toBe('alive');
     expect(result.stdout).not.toContain('late output');
     expect(descendantPid).toBeDefined();
-    // Completion must precede the inherited pipe closing when sleep exits.
+    // Completion must precede the inherited pipe closing when the descendant exits.
     expect(() => process.kill(descendantPid!, 0)).not.toThrow();
     expect(markReady).toHaveBeenCalledWith('background-init');
     expect(clearInitScriptPid).toHaveBeenCalledOnce();

--- a/src/backend/services/run-script/service/startup-script.integration.test.ts
+++ b/src/backend/services/run-script/service/startup-script.integration.test.ts
@@ -1,0 +1,65 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { expect, it, vi } from 'vitest';
+
+vi.mock('@/backend/services/logger.service', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+import { startupScriptService } from './startup-script.service';
+
+it('completes provisioning while a background descendant still holds output pipes', async () => {
+  const worktreePath = await mkdtemp(path.join(tmpdir(), 'ff-background-startup-'));
+  let descendantPid: number | undefined;
+  const markReady = vi.fn();
+  const clearInitScriptPid = vi.fn().mockResolvedValue(undefined);
+  startupScriptService.configure({
+    workspace: {
+      markReady,
+      markFailed: vi.fn(),
+      clearInitOutput: vi.fn().mockResolvedValue(undefined),
+      appendInitOutput: vi.fn((_workspaceId: string, output: string) => {
+        const match = /descendant:(\d+)/.exec(output);
+        if (match?.[1]) {
+          descendantPid = Number(match[1]);
+        }
+        return Promise.resolve();
+      }),
+      setInitScriptPid: vi.fn().mockResolvedValue(undefined),
+      clearInitScriptPid,
+    },
+  });
+
+  try {
+    const result = await startupScriptService.runStartupScript(
+      { id: 'background-init', worktreePath } as never,
+      {
+        startupScriptCommand:
+          '(sleep 2; printf "late output\\n" && printf alive > background-wrote; sleep 30) & printf "descendant:%s\\n" "$!"; echo complete',
+        startupScriptTimeout: 10,
+      } as never
+    );
+
+    expect(result).toMatchObject({ success: true, exitCode: 0, timedOut: false });
+    expect(result.stdout).toContain('complete\n');
+    await expect
+      .poll(() => readFile(path.join(worktreePath, 'background-wrote'), 'utf8'), { timeout: 2000 })
+      .toBe('alive');
+    expect(result.stdout).not.toContain('late output');
+    expect(descendantPid).toBeDefined();
+    // Completion must precede the inherited pipe closing when sleep exits.
+    expect(() => process.kill(descendantPid!, 0)).not.toThrow();
+    expect(markReady).toHaveBeenCalledWith('background-init');
+    expect(clearInitScriptPid).toHaveBeenCalledOnce();
+  } finally {
+    if (descendantPid) {
+      try {
+        process.kill(descendantPid, 'SIGTERM');
+      } catch {
+        // The descendant may already have exited if the test failed slowly.
+      }
+    }
+    await rm(worktreePath, { recursive: true, force: true, maxRetries: 3 });
+  }
+});

--- a/src/backend/services/run-script/service/startup-script.service.test.ts
+++ b/src/backend/services/run-script/service/startup-script.service.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, writeFileSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { PassThrough } from 'node:stream';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockSpawn = vi.hoisted(() => vi.fn());
@@ -37,8 +38,8 @@ import { startupScriptService } from './startup-script.service';
 
 class FakeProc extends EventEmitter {
   pid = 12_345;
-  stdout = new EventEmitter();
-  stderr = new EventEmitter();
+  stdout = new PassThrough();
+  stderr = new PassThrough();
   kill = vi.fn();
 }
 
@@ -176,6 +177,69 @@ describe('StartupScriptService', () => {
     });
     expect(markReady).toHaveBeenCalledWith('w1');
     expect(markFailed).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { code: 0, success: true },
+    { code: 7, success: false },
+  ])(
+    'finishes after shell exit $code when descendants keep output pipes open',
+    async ({ code, success }) => {
+      vi.useFakeTimers();
+      const proc = new FakeProc();
+      mockSpawn.mockReturnValue(proc);
+      const resultPromise = service.runStartupScript(
+        { id: 'w1', worktreePath: '/tmp/w1' } as never,
+        { startupScriptCommand: 'sleep 30 &', startupScriptTimeout: 30 } as never
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      proc.stdout.write('before exit\n');
+      proc.emit('exit', code, null);
+      proc.stdout.write('buffered output\n');
+
+      await vi.advanceTimersByTimeAsync(2000);
+
+      expect(success ? markReady : markFailed).toHaveBeenCalled();
+      await expect(resultPromise).resolves.toMatchObject({
+        success,
+        exitCode: code,
+        stdout: 'before exit\nbuffered output\n',
+        timedOut: false,
+      });
+      expect(proc.stdout.destroyed).toBe(false);
+      expect(proc.stderr.destroyed).toBe(false);
+      expect(mockClearInitScriptPid).toHaveBeenCalledOnce();
+      expect(proc.kill).not.toHaveBeenCalled();
+      const outputWrites = mockAppendInitOutput.mock.calls.length;
+      proc.stdout.write('late output\n');
+      proc.stderr.write('late error\n');
+      proc.emit('close', code, null);
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(mockAppendInitOutput).toHaveBeenCalledTimes(outputWrites);
+      expect(mockClearInitScriptPid).toHaveBeenCalledOnce();
+      expect(success ? markReady : markFailed).toHaveBeenCalledOnce();
+      expect(success ? markFailed : markReady).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(0);
+    }
+  );
+
+  it('captures trailing output before the pipes close normally', async () => {
+    vi.useFakeTimers();
+    const proc = new FakeProc();
+    mockSpawn.mockReturnValue(proc);
+    const resultPromise = service.runStartupScript(
+      { id: 'w1', worktreePath: '/tmp/w1' } as never,
+      { startupScriptCommand: 'echo tail', startupScriptTimeout: 30 } as never
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    proc.emit('exit', 0, null);
+    proc.stdout.write('tail\n');
+    proc.emit('close', 0, null);
+
+    await expect(resultPromise).resolves.toMatchObject({ success: true, stdout: 'tail\n' });
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(proc.kill).not.toHaveBeenCalled();
+    expect(mockClearInitScriptPid).toHaveBeenCalledOnce();
   });
 
   it('reports a process terminated by the timeout signal as timed out', async () => {

--- a/src/backend/services/run-script/service/startup-script.service.ts
+++ b/src/backend/services/run-script/service/startup-script.service.ts
@@ -246,16 +246,15 @@ class StartupScriptService {
       let stdout = '';
       let stderr = '';
       let killTimeoutHandle: NodeJS.Timeout | undefined;
-
-      proc.once('exit', () => {
-        processTerminated = true;
-      });
+      let outputDrainTimeoutHandle: NodeJS.Timeout | undefined;
+      let settled = false;
 
       const cleanupTimeouts = async (): Promise<void> => {
         clearTimeout(timeoutHandle);
         if (killTimeoutHandle) {
           clearTimeout(killTimeoutHandle);
         }
+        clearTimeout(outputDrainTimeoutHandle);
         if (proc.pid !== undefined) {
           await recordPidPromise;
           try {
@@ -286,14 +285,17 @@ class StartupScriptService {
       }, timeoutMs);
 
       const appendOutput = (target: 'stdout' | 'stderr', data: Buffer): void => {
+        // Keep draining inherited pipes without retaining output or interrupting
+        // background descendants that write after provisioning has completed.
+        if (settled) {
+          return;
+        }
         const str = data.toString();
         const maxSize = SERVICE_LIMITS.startupScriptOutputMaxBytes;
         const keepSize = SERVICE_LIMITS.startupScriptOutputTailBytes;
 
         // Stream output via callback if provided
-        if (onOutput) {
-          onOutput(str);
-        }
+        onOutput?.(str);
 
         if (target === 'stdout') {
           stdout += str;
@@ -311,16 +313,47 @@ class StartupScriptService {
       proc.stdout?.on('data', (data: Buffer) => appendOutput('stdout', data));
       proc.stderr?.on('data', (data: Buffer) => appendOutput('stderr', data));
 
-      proc.on('close', async (code, signal) => {
+      const finish = async (
+        code: number | null,
+        signal: NodeJS.Signals | null,
+        error?: Error
+      ): Promise<void> => {
+        if (settled) {
+          return;
+        }
+        settled = true;
         processTerminated = true;
         await cleanupTimeouts();
         const timedOut = signal !== null && timeoutSignalsSent.has(signal);
-        resolve({ success: code === 0 && !timedOut, exitCode: code, stdout, stderr, timedOut });
+        resolve({
+          success: !error && code === 0 && !timedOut,
+          exitCode: code,
+          stdout,
+          stderr: error?.message ?? stderr,
+          timedOut,
+        });
+      };
+
+      proc.once('exit', (code, signal) => {
+        if (settled) {
+          return;
+        }
+        processTerminated = true;
+        clearTimeout(timeoutHandle);
+        clearTimeout(killTimeoutHandle);
+        // Normally close follows once remaining output has drained. Descendants
+        // can inherit these pipes, so do not let them hold provisioning open.
+        outputDrainTimeoutHandle = setTimeout(() => {
+          void finish(code, signal);
+        }, SERVICE_TIMEOUT_MS.startupScriptOutputDrain);
       });
 
-      proc.on('error', async (error) => {
-        await cleanupTimeouts();
-        resolve({ success: false, exitCode: null, stdout, stderr: error.message, timedOut: false });
+      proc.on('close', (code, signal) => {
+        void finish(code, signal);
+      });
+
+      proc.on('error', (error) => {
+        void finish(null, null, error);
       });
     });
   }


### PR DESCRIPTION
A startup shell could exit successfully while a background descendant kept stdout/stderr open, leaving provisioning pending indefinitely. Complete after the shell exits and output drains, with a one-second drain limit; clear the recorded PID and settle once using the shell's exit status. After completion, continue draining and discarding descendant output so later writes do not interrupt background processes.

Fixes #1918.

Validation: `pnpm check:fix`, `pnpm typecheck`, 17 affected tests (including a real background process that writes after provisioning and successful/failed exits without pipe closure), and `pnpm check`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

