### PR TITLE
Cancel pending ACP permissions on soft stops (#2215)

### DIFF
--- a/docs/architecture/agent-runtime.md
+++ b/docs/architecture/agent-runtime.md
@@ -17,7 +17,9 @@ Session init/load fails unless model/mode select options can be obtained from
 provider `configOptions` or legacy model/mode response fields. Permission requests
 present multi-option selection
 (`allow_once`, `allow_always`, `deny_once`, `deny_always`) and are bridged
-through ACP permission response handlers.
+through ACP permission response handlers. Soft cancellation (including voice stop
+and prompt timeout) resolves pending permission requests with a cancelled outcome,
+dismisses their prompts, and keeps the bridge available for later turns.
 
 Session stop history is durable: `SessionLifecycleEvent` rows are append-only,
 deduplicated by session/attempt key, merged chronologically with provider

--- a/src/backend/services/session/service/acp/acp-client-factory.test.ts
+++ b/src/backend/services/session/service/acp/acp-client-factory.test.ts
@@ -537,12 +537,13 @@ describe('AcpClientFactory', () => {
           outcome: { outcome: 'selected', optionId: 'bridge-choice' },
         }),
       } as unknown as AcpPermissionBridge;
-      await new AcpClientFactory().createClient(
+      const handle = await new AcpClientFactory().createClient(
         createParams({
           options: defaultOptions({ permissionPreset }),
           handlers: { permissionBridge },
         })
       );
+      expect(handle).toHaveProperty('permissionBridge', permissionBridge);
       const handler = mocks.connections[0]?.toClient({}) as {
         requestPermission(request: RequestPermissionRequest): Promise<{
           outcome: { optionId?: string };

--- a/src/backend/services/session/service/acp/acp-client-factory.ts
+++ b/src/backend/services/session/service/acp/acp-client-factory.ts
@@ -213,6 +213,7 @@ export class AcpClientFactory {
       ]);
 
       const handle = new AcpProcessHandle({
+        permissionBridge: handlers.permissionBridge,
         connection,
         child,
         provider: options.provider,

--- a/src/backend/services/session/service/acp/acp-permission-bridge.test.ts
+++ b/src/backend/services/session/service/acp/acp-permission-bridge.test.ts
@@ -105,6 +105,19 @@ describe('AcpPermissionBridge', () => {
     expect(response2).toEqual({ outcome: { outcome: 'cancelled' } });
   });
 
+  it('resolves every permission even if cancellation delivery throws', async () => {
+    const bridge = new AcpPermissionBridge(() => {
+      throw new Error('delivery failed');
+    });
+    const first = bridge.waitForUserResponse('req-1', createMockParams());
+    const second = bridge.waitForUserResponse('req-2', createMockParams());
+    expect(() => bridge.cancelAll()).not.toThrow();
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { outcome: { outcome: 'cancelled' } },
+      { outcome: { outcome: 'cancelled' } },
+    ]);
+  });
+
   it('cancelAll clears the pending map', () => {
     const bridge = new AcpPermissionBridge();
 

--- a/src/backend/services/session/service/acp/acp-permission-bridge.ts
+++ b/src/backend/services/session/service/acp/acp-permission-bridge.ts
@@ -1,4 +1,7 @@
 import type { RequestPermissionRequest, RequestPermissionResponse } from '@agentclientprotocol/sdk';
+import { createLogger } from '@/backend/services/logger.service';
+
+const logger = createLogger('acp-permission-bridge');
 
 interface PendingPermission {
   resolve: (response: RequestPermissionResponse) => void;
@@ -23,6 +26,8 @@ type ToolUserInputAnswers = Record<string, string[]>;
  */
 export class AcpPermissionBridge {
   private readonly pending = new Map<string, PendingPermission>();
+
+  constructor(private readonly onCancelled?: (requestId: string) => void) {}
 
   /**
    * Called by AcpClientHandler.requestPermission().
@@ -81,14 +86,20 @@ export class AcpPermissionBridge {
    * Resolves all pending Promises with cancelled outcome.
    */
   cancelAll(): void {
-    for (const entry of this.pending.values()) {
+    const entries = [...this.pending.entries()];
+    this.pending.clear();
+    for (const [requestId, entry] of entries) {
       entry.resolve({
         outcome: {
           outcome: 'cancelled',
         },
       });
+      try {
+        this.onCancelled?.(requestId);
+      } catch (error) {
+        logger.warn('Failed to deliver permission cancellation', { requestId, error });
+      }
     }
-    this.pending.clear();
   }
 
   /**

--- a/src/backend/services/session/service/acp/acp-process-handle.ts
+++ b/src/backend/services/session/service/acp/acp-process-handle.ts
@@ -5,6 +5,7 @@ import {
   type SubagentBrowseCapability,
   subagentBrowseCapabilitySchema,
 } from '@/shared/acp-protocol/subagents';
+import type { AcpPermissionBridge } from './acp-permission-bridge';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -13,6 +14,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 export class AcpProcessHandle {
   readonly connection: ClientSideConnection;
   readonly child: ChildProcess;
+  readonly permissionBridge?: AcpPermissionBridge;
   readonly provider: string;
   providerSessionId: string;
   agentCapabilities: Record<string, unknown>;
@@ -23,12 +25,14 @@ export class AcpProcessHandle {
   constructor(params: {
     connection: ClientSideConnection;
     child: ChildProcess;
+    permissionBridge?: AcpPermissionBridge;
     provider: string;
     providerSessionId: string;
     agentCapabilities: Record<string, unknown>;
   }) {
     this.connection = params.connection;
     this.child = params.child;
+    this.permissionBridge = params.permissionBridge;
     this.provider = params.provider;
     this.providerSessionId = params.providerSessionId;
     this.agentCapabilities = params.agentCapabilities;

--- a/src/backend/services/session/service/acp/acp-prompt-controller.test.ts
+++ b/src/backend/services/session/service/acp/acp-prompt-controller.test.ts
@@ -1,5 +1,6 @@
 import type { ContentBlock } from '@agentclientprotocol/sdk';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AcpPermissionBridge } from './acp-permission-bridge';
 import { AcpPromptController, type AcpPromptRuntimePort } from './acp-prompt-controller';
 import { PromptTimeoutError } from './acp-runtime-errors';
 import { createTestProcessHandle } from './acp-runtime-manager.test-helpers';
@@ -17,6 +18,42 @@ describe('AcpPromptController', () => {
       stopClient: vi.fn().mockResolvedValue(undefined),
     };
     controller = new AcpPromptController(runtimePort);
+  });
+
+  it.each(['soft stop', 'timeout'])('cancels pending permission responses on %s', async (mode) => {
+    const bridge = new AcpPermissionBridge();
+    const response = bridge.waitForUserResponse('request-1', {
+      sessionId: 'provider-session-1',
+      toolCall: { toolCallId: 'tool-1', title: 'Command' },
+      options: [],
+    });
+    const handle = Object.assign(
+      createTestProcessHandle({
+        connection: {
+          prompt: vi.fn().mockReturnValue(new Promise(() => undefined)),
+          cancel: vi.fn().mockResolvedValue(undefined),
+        },
+      }),
+      { permissionBridge: bridge }
+    );
+    handle.isPromptInFlight = true;
+    vi.useFakeTimers();
+    try {
+      if (mode === 'soft stop') {
+        await controller.cancelPrompt(sessionId, handle);
+      } else {
+        const sending = controller
+          .sendPrompt(sessionId, handle, prompt, 100)
+          .catch((error: unknown) => error);
+        await vi.advanceTimersByTimeAsync(100);
+        await expect(sending).resolves.toBeInstanceOf(PromptTimeoutError);
+      }
+      expect(bridge.pendingCount).toBe(0);
+      await expect(response).resolves.toEqual({ outcome: { outcome: 'cancelled' } });
+      expect(runtimePort.stopClient).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('returns the provider stop reason and clears the in-flight marker after a prompt resolves', async () => {
@@ -49,6 +86,25 @@ describe('AcpPromptController', () => {
 
   it('does not cancel when no handle was supplied', async () => {
     await expect(controller.cancelPrompt(sessionId, undefined)).resolves.toBe(false);
+  });
+
+  it('leaves permissions untouched when asked to cancel a stale handle', async () => {
+    const bridge = new AcpPermissionBridge();
+    void bridge.waitForUserResponse('request-1', {
+      sessionId: 'provider-session-1',
+      toolCall: { toolCallId: 'tool-1' },
+      options: [],
+    });
+    const connection = { cancel: vi.fn() };
+    const handle = Object.assign(createTestProcessHandle({ connection }), {
+      permissionBridge: bridge,
+    });
+    handle.isPromptInFlight = true;
+    runtimePort.isCurrentHandle = vi.fn(() => false);
+    await expect(controller.cancelPrompt(sessionId, handle)).resolves.toBe(false);
+    expect(bridge.hasPending('request-1')).toBe(true);
+    expect(connection.cancel).not.toHaveBeenCalled();
+    bridge.cancelAll();
   });
 
   it('does not cancel a handle without an in-flight prompt', async () => {

--- a/src/backend/services/session/service/acp/acp-prompt-controller.ts
+++ b/src/backend/services/session/service/acp/acp-prompt-controller.ts
@@ -69,6 +69,7 @@ export class AcpPromptController {
       return false;
     }
 
+    handle.permissionBridge?.cancelAll();
     await handle.connection.cancel({
       sessionId: handle.providerSessionId,
     });

--- a/src/backend/services/session/service/lifecycle/session.permission.service.test.ts
+++ b/src/backend/services/session/service/lifecycle/session.permission.service.test.ts
@@ -6,6 +6,7 @@ describe('SessionPermissionService', () => {
   const sessionDomain = {
     emitDelta: vi.fn(),
     setPendingInteractiveRequest: vi.fn(),
+    clearPendingInteractiveRequestIfMatches: vi.fn(),
   };
 
   function createService(): SessionPermissionService {
@@ -14,6 +15,30 @@ describe('SessionPermissionService', () => {
       sessionDomainService: unsafeCoerce(sessionDomain),
     });
   }
+
+  it('dismisses cancelled permission prompts while retaining the live bridge', async () => {
+    const service = createService();
+    const bridge = service.createPermissionBridge('session-1');
+    const params = unsafeCoerce<Parameters<typeof bridge.waitForUserResponse>[1]>({
+      toolCall: { toolCallId: 'tool-1', title: 'Command' },
+      options: [],
+    });
+    const response = bridge.waitForUserResponse('req-1', params);
+    bridge.cancelAll();
+    await expect(response).resolves.toEqual({ outcome: { outcome: 'cancelled' } });
+    expect(sessionDomain.emitDelta).toHaveBeenCalledWith('session-1', {
+      type: 'permission_cancelled',
+      requestId: 'req-1',
+    });
+    expect(sessionDomain.clearPendingInteractiveRequestIfMatches).toHaveBeenCalledWith(
+      'session-1',
+      'req-1'
+    );
+    expect(service.createPermissionBridge('session-1')).toBe(bridge);
+    const next = bridge.waitForUserResponse('req-2', params);
+    expect(service.respondToPermission('session-1', 'req-2', 'allow_once')).toBe(true);
+    await expect(next).resolves.toMatchObject({ outcome: { outcome: 'selected' } });
+  });
 
   it('resolves pending ACP permissions through the session bridge', async () => {
     const service = createService();

--- a/src/backend/services/session/service/lifecycle/session.permission.service.ts
+++ b/src/backend/services/session/service/lifecycle/session.permission.service.ts
@@ -26,7 +26,10 @@ export class SessionPermissionService {
       return existing;
     }
 
-    const bridge = new AcpPermissionBridge();
+    const bridge = new AcpPermissionBridge((requestId) => {
+      this.sessionDomainService.clearPendingInteractiveRequestIfMatches(sessionId, requestId);
+      this.sessionDomainService.emitDelta(sessionId, { type: 'permission_cancelled', requestId });
+    });
     this.acpPermissionBridges.set(sessionId, bridge);
     return bridge;
   }


### PR DESCRIPTION
Voice soft stops and prompt-timeout recovery now cancel pending ACP permission responses, clear the matching interactive request, and dismiss permission prompts. Cancellation uses the current runtime handle and preserves its permission bridge so later turns can request approval normally. Delivery failures cannot strand remaining permission responses.

Closes #2215.

Validation: regressions failed before the fix for soft-stop/timeout responses, factory bridge wiring, cancellation delivery, and callback failure. The full session capsule and voice-stop suites pass (1,178 tests; four intentionally skipped integration cases). `pnpm check:fix`, `pnpm typecheck`, and `pnpm check` pass.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

