### PR TITLE
Skip chat grouping scans for unchanged message arrays

### DIFF
--- a/docs/chat-message-flow.md
+++ b/docs/chat-message-flow.md
@@ -273,6 +273,19 @@ chatReducer(state, action)
 New React State
 ```
 
+### Grouping for display
+
+Main chat and quick chat use `useGroupedChatMessages` to retain stable tool groups
+between updates. An unchanged message array and length return the cached grouping
+before filtering, deduplication, or prefix scanning. Changing duplicate-result
+filtering creates a new grouper, even when the message array is unchanged.
+
+Message edits must replace the array and changed message objects, as the chat
+reducer does for streaming updates. The grouper also detects in-place appends and
+truncation by checking array length; same-length in-place edits are unsupported.
+New arrays still use the existing incremental grouping and history/late-result
+fallbacks.
+
 ### Key Actions
 
 | WebSocket Type | Redux Action | Effect |

--- a/src/client/features/chat/incremental-chat-grouping.test.ts
+++ b/src/client/features/chat/incremental-chat-grouping.test.ts
@@ -80,6 +80,54 @@ function toolSequences(messages: ReturnType<typeof oracle>) {
 }
 
 describe('createIncrementalChatGrouper', () => {
+  it.each([false, true])(
+    'does not read messages again for unchanged input (filterDuplicateResults: %s)',
+    (filterDuplicateResults) => {
+      let messageReads = 0;
+      const history = Array.from({ length: 1000 }, (_, index) => user(`user-${index}`, index));
+      const trackReads = (messages: ChatMessage[]) =>
+        new Proxy(messages, {
+          get(target, property, receiver) {
+            if (typeof property === 'string' && /^\d+$/.test(property)) {
+              messageReads += 1;
+            }
+            return Reflect.get(target, property, receiver);
+          },
+        });
+      const messages = trackReads(history);
+      const grouper = createIncrementalChatGrouper({ filterDuplicateResults });
+      const first = grouper.group(messages);
+      expect(first).toEqual(history);
+      expect(messageReads).toBeGreaterThan(0);
+
+      messageReads = 0;
+      expect(grouper.group(messages)).toBe(first);
+      expect(messageReads).toBe(0);
+
+      // An equivalent new array still needs preparation, then becomes the cached input.
+      const copiedMessages = trackReads([...history]);
+      expect(grouper.group(copiedMessages)).toBe(first);
+      expect(messageReads).toBeGreaterThan(0);
+      messageReads = 0;
+      expect(grouper.group(copiedMessages)).toBe(first);
+      expect(messageReads).toBe(0);
+    }
+  );
+
+  it('detects in-place truncation and caches the empty input', () => {
+    const grouper = createIncrementalChatGrouper();
+    const messages = [user('first', 0), user('second', 1)];
+    const first = grouper.group(messages);
+
+    messages.length = 1;
+    expect(grouper.group(messages)).toEqual([messages[0]]);
+    expect(first).toHaveLength(2);
+    messages.length = 0;
+    const empty = grouper.group(messages);
+    expect(empty).toEqual([]);
+    expect(grouper.group(messages)).toBe(empty);
+  });
+
   it('keeps completed historical tool groups stable while the final text streams', () => {
     const grouper = createIncrementalChatGrouper();
     const history = [

--- a/src/client/features/chat/incremental-chat-grouping.ts
+++ b/src/client/features/chat/incremental-chat-grouping.ts
@@ -24,6 +24,7 @@ interface GroupingSnapshot {
 }
 
 export interface IncrementalChatGrouper {
+  /** Replace the array and changed messages for edits; same-reference length changes are supported. */
   group: (messages: ChatMessage[]) => GroupedMessageItem[];
 }
 
@@ -307,28 +308,34 @@ export function createIncrementalChatGrouper(
 ): IncrementalChatGrouper {
   const filterDuplicateResults = options.filterDuplicateResults ?? false;
   let snapshot: GroupingSnapshot | undefined;
+  let previousInput: ChatMessage[] | undefined;
+  let previousInputLength = 0;
 
   return {
     group(messages) {
+      if (snapshot && messages === previousInput && messages.length === previousInputLength) {
+        return snapshot.grouped;
+      }
+
       const prepared = prepareMessages(messages, filterDuplicateResults);
       if (!snapshot) {
         snapshot = createFullSnapshot(prepared);
-        return snapshot.grouped;
+      } else {
+        const commonPrefix = commonPrefixLength(snapshot.messages, prepared);
+        if (commonPrefix !== snapshot.messages.length || commonPrefix !== prepared.length) {
+          const canReusePrefix =
+            commonPrefix > 0 &&
+            snapshot.segments.length === snapshot.grouped.length &&
+            !hasChangedHistoricalToolResult(snapshot.messages, prepared, commonPrefix) &&
+            !rewindCrossesHistoricalToolResult(snapshot.messages, prepared, commonPrefix);
+          snapshot = canReusePrefix
+            ? createIncrementalSnapshot(snapshot, prepared, commonPrefix)
+            : createFullSnapshot(prepared, snapshot);
+        }
       }
 
-      const commonPrefix = commonPrefixLength(snapshot.messages, prepared);
-      if (commonPrefix === snapshot.messages.length && commonPrefix === prepared.length) {
-        return snapshot.grouped;
-      }
-
-      const canReusePrefix =
-        commonPrefix > 0 &&
-        snapshot.segments.length === snapshot.grouped.length &&
-        !hasChangedHistoricalToolResult(snapshot.messages, prepared, commonPrefix) &&
-        !rewindCrossesHistoricalToolResult(snapshot.messages, prepared, commonPrefix);
-      snapshot = canReusePrefix
-        ? createIncrementalSnapshot(snapshot, prepared, commonPrefix)
-        : createFullSnapshot(prepared, snapshot);
+      previousInput = messages;
+      previousInputLength = messages.length;
       return snapshot.grouped;
     },
   };

--- a/src/client/features/chat/use-grouped-chat-messages.test.tsx
+++ b/src/client/features/chat/use-grouped-chat-messages.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+
+import { createElement } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot } from 'react-dom/client';
+import { expect, it } from 'vitest';
+import type { ChatMessage } from '@/lib/chat-protocol';
+import { useGroupedChatMessages } from './use-grouped-chat-messages';
+
+it('updates duplicate filtering when options change with the same message array', () => {
+  const messages: ChatMessage[] = [
+    {
+      id: 'answer',
+      source: 'agent',
+      message: {
+        type: 'assistant',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'same' }] },
+      },
+      timestamp: '2026-09-08T00:00:00.000Z',
+      order: 0,
+    },
+    {
+      id: 'result',
+      source: 'agent',
+      message: { type: 'result', result: 'same' },
+      timestamp: '2026-09-08T00:00:00.000Z',
+      order: 1,
+    },
+  ];
+  function Harness({ filterDuplicateResults }: { filterDuplicateResults?: boolean }) {
+    const grouped = useGroupedChatMessages(messages, { filterDuplicateResults });
+    return createElement('div', null, grouped.map((item) => item.id).join(','));
+  }
+  const container = document.createElement('div');
+  const root = createRoot(container);
+  const render = (filterDuplicateResults?: boolean) => {
+    flushSync(() => root.render(createElement(Harness, { filterDuplicateResults })));
+    return container.textContent;
+  };
+
+  try {
+    expect(render()).toBe('answer,result');
+    expect(render(true)).toBe('answer');
+    expect(render(true)).toBe('answer');
+    expect(render(false)).toBe('answer,result');
+    expect(render()).toBe('answer,result');
+  } finally {
+    flushSync(() => root.unmount());
+  }
+});


### PR DESCRIPTION
Chat grouping was filtering and comparing the full transcript even when React passed the same message array again. Cache the input identity and length before preprocessing, preserving append/truncation handling and option changes while eliminating unchanged-input scans.

Regression probes drop from 1,000 indexed message reads to zero for unchanged input, with duplicate filtering both enabled and disabled. Same-length edits continue to use the app's immutable array/message updates; that contract is documented.

Validation: full `pnpm test` (5,504 passed, 4 skipped), plus 12 focused tests; `pnpm check:fix`, `pnpm typecheck`, `pnpm check`; all commit hooks; independent code review.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

