### PR TITLE
Bound workspace file previews and untracked diffs

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -14,6 +14,7 @@ the one that matches your change before you touch it.
 | [workspace-state.md](./workspace-state.md) | Run script, auto-iteration state, the Kanban column projection |
 | [agent-runtime.md](./agent-runtime.md) | ACP runtime, provider sub-agents, child workspaces, quick actions |
 | [integrations.md](./integrations.md) | GitHub, Linear, periodic tasks |
+| [file-previews.md](./file-previews.md) | Bounded file reads, UTF-8 truncation, untracked diff limits |
 | [client-loading.md](./client-loading.md) | Route chunks, diagram loading, startup bundle measurement |
 
 Keep these current. When behaviour changes, update the note in the same PR — a

--- a/docs/architecture/file-previews.md
+++ b/docs/architecture/file-previews.md
@@ -3,8 +3,11 @@
 The workspace file reader caps disk reads at 1 MiB plus one byte of lookahead.
 The shared reader in `src/backend/lib/file-preview.ts` reads from one open
 file descriptor, loops over short reads until EOF or the limit, and closes the
-descriptor on success or failure. File growth after the initial stat cannot
-increase the read budget. The returned `size` is the size observed by that stat;
+descriptor on success or failure. It accepts only regular files, checking the
+path before opening and the descriptor before reading. Nonblocking open prevents
+a FIFO swapped in between these checks from waiting for a writer. File growth
+after the descriptor stat cannot increase the read budget. The returned `size`
+is the size observed by that stat;
 previews are not an atomic snapshot of concurrently edited files.
 
 `workspace.readFile` returns at most the first 1 MiB of file bytes decoded as
@@ -15,7 +18,9 @@ Complete files retain their existing UTF-8 decoding behavior, including BOMs
 and replacement characters for malformed bytes.
 
 The untracked-file fallback in `workspace.getFileDiff` uses the same bounded
-reader. Files larger than 1 MiB produce a `PAYLOAD_TOO_LARGE` error that directs
+reader after confirming the path is absent from the Git index. Tracked files
+with empty Git diffs retain an empty diff regardless of file size. Untracked
+files larger than 1 MiB produce a `PAYLOAD_TOO_LARGE` error that directs
 the user to the file preview, instead of expanding a partial file into a
 misleading unified diff. Files within the limit retain the existing diff
 format. Diffs produced by Git and screenshot reads follow their existing paths.

--- a/docs/architecture/file-previews.md
+++ b/docs/architecture/file-previews.md
@@ -1,0 +1,21 @@
+# File previews
+
+The workspace file reader caps disk reads at 1 MiB plus one byte of lookahead.
+The shared reader in `src/backend/lib/file-preview.ts` reads from one open
+file descriptor, loops over short reads until EOF or the limit, and closes the
+descriptor on success or failure. File growth after the initial stat cannot
+increase the read budget. The returned `size` is the size observed by that stat;
+previews are not an atomic snapshot of concurrently edited files.
+
+`workspace.readFile` returns at most the first 1 MiB of file bytes decoded as
+UTF-8, omitting a codepoint split at the cutoff. Its `truncated` flag identifies
+oversized text files. Binary detection still looks for NUL bytes in the first
+8 KiB and returns the binary placeholder, full stat size, and `truncated: false`.
+Complete files retain their existing UTF-8 decoding behavior, including BOMs
+and replacement characters for malformed bytes.
+
+The untracked-file fallback in `workspace.getFileDiff` uses the same bounded
+reader. Files larger than 1 MiB produce a `PAYLOAD_TOO_LARGE` error that directs
+the user to the file preview, instead of expanding a partial file into a
+misleading unified diff. Files within the limit retain the existing diff
+format. Diffs produced by Git and screenshot reads follow their existing paths.

--- a/src/backend/lib/file-preview.ts
+++ b/src/backend/lib/file-preview.ts
@@ -1,14 +1,21 @@
-import { open } from 'node:fs/promises';
+import { constants, type Stats } from 'node:fs';
+import { open, stat } from 'node:fs/promises';
 import { MAX_FILE_SIZE } from './file-helpers';
+
+function assertRegularFile(stats: Stats) {
+  if (!stats.isFile()) {
+    throw new Error(stats.isDirectory() ? 'Path is a directory' : 'Path is not a regular file');
+  }
+}
 
 /** Read at most one preview plus a byte of lookahead, even if the file grows. */
 export async function readFilePrefix(fullPath: string) {
-  const handle = await open(fullPath, 'r');
+  assertRegularFile(await stat(fullPath));
+  // A regular file can be replaced with a FIFO between stat and open.
+  const handle = await open(fullPath, constants.O_RDONLY | constants.O_NONBLOCK);
   try {
     const stats = await handle.stat();
-    if (stats.isDirectory()) {
-      throw new Error('Path is a directory');
-    }
+    assertRegularFile(stats);
 
     const buffer = Buffer.allocUnsafe(MAX_FILE_SIZE + 1);
     let offset = 0;

--- a/src/backend/lib/file-preview.ts
+++ b/src/backend/lib/file-preview.ts
@@ -1,0 +1,31 @@
+import { open } from 'node:fs/promises';
+import { MAX_FILE_SIZE } from './file-helpers';
+
+/** Read at most one preview plus a byte of lookahead, even if the file grows. */
+export async function readFilePrefix(fullPath: string) {
+  const handle = await open(fullPath, 'r');
+  try {
+    const stats = await handle.stat();
+    if (stats.isDirectory()) {
+      throw new Error('Path is a directory');
+    }
+
+    const buffer = Buffer.allocUnsafe(MAX_FILE_SIZE + 1);
+    let offset = 0;
+    while (offset < buffer.length) {
+      const { bytesRead } = await handle.read(buffer, offset, buffer.length - offset, offset);
+      if (bytesRead === 0) {
+        break;
+      }
+      offset += bytesRead;
+    }
+
+    return {
+      buffer: buffer.subarray(0, Math.min(offset, MAX_FILE_SIZE)),
+      size: stats.size,
+      truncated: stats.size > MAX_FILE_SIZE || offset > MAX_FILE_SIZE,
+    };
+  } finally {
+    await handle.close();
+  }
+}

--- a/src/backend/trpc/workspace/files.preview.router.test.ts
+++ b/src/backend/trpc/workspace/files.preview.router.test.ts
@@ -1,0 +1,180 @@
+import { mkdir, open, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockWorkspace = vi.hoisted(() => vi.fn());
+vi.mock('./workspace-helpers', () => ({
+  getWorkspaceWithWorktreeOrThrow: mockWorkspace,
+}));
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return { ...actual, open: vi.fn(actual.open) };
+});
+
+import { workspaceFilesRouter } from './files.trpc';
+
+const LIMIT = 1024 * 1024;
+const caller = workspaceFilesRouter.createCaller({ appContext: { services: {} } } as never);
+const readPreview = () => caller.readFile({ workspaceId: 'w1', path: 'preview.txt' });
+
+describe('workspace file previews', () => {
+  let rootDir: string;
+  let chunkSize: number | undefined;
+  let readError: Error | undefined;
+  let replaceOnRead: string | undefined;
+  const readLengths: number[] = [];
+  const handles: Awaited<ReturnType<typeof open>>[] = [];
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    chunkSize = undefined;
+    readError = undefined;
+    replaceOnRead = undefined;
+    readLengths.length = 0;
+    const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');
+    vi.mocked(open).mockImplementation(async (...args) => {
+      const handle = await actual.open(...args);
+      handles.push(handle);
+      const originalRead = handle.read;
+      vi.spyOn(handle, 'read').mockImplementation(async (...args: unknown[]) => {
+        if (readError) {
+          throw readError;
+        }
+        if (replaceOnRead !== undefined) {
+          await writeFile(join(rootDir, 'preview.txt'), replaceOnRead);
+          replaceOnRead = undefined;
+        }
+        if (chunkSize && typeof args[2] === 'number') {
+          args[2] = Math.min(args[2], chunkSize);
+        }
+        readLengths.push(Number(args[2]));
+        return Reflect.apply(originalRead, handle, args);
+      });
+      vi.spyOn(handle, 'readFile');
+      vi.spyOn(handle, 'close');
+      return handle;
+    });
+    rootDir = join(tmpdir(), `file-preview-${crypto.randomUUID()}`);
+    await mkdir(rootDir);
+    mockWorkspace.mockResolvedValue({ worktreePath: rootDir });
+  });
+
+  afterEach(async () => {
+    for (const handle of handles.splice(0)) {
+      await handle.close();
+    }
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  it.each([false, true])('bounds reads of a large sparse file (binary: %s)', async (binary) => {
+    const handle = await open(join(rootDir, 'preview.txt'), 'w');
+    const prefix = Buffer.alloc(LIMIT + 1, 'a');
+    if (binary) {
+      prefix[0] = 0;
+    }
+    await handle.write(prefix);
+    await handle.truncate(512 * LIMIT);
+    await handle.close();
+
+    const result = await readPreview();
+    expect(result).toMatchObject({ size: 512 * LIMIT, truncated: !binary, isBinary: binary });
+    expect(result.content.length).toBeLessThanOrEqual(LIMIT);
+    const reader = handles.at(-1);
+    expect(reader).toBeDefined();
+    if (!reader) {
+      throw new Error('Missing file handle');
+    }
+    expect(reader.readFile).not.toHaveBeenCalled();
+    expect(readLengths.length).toBeGreaterThan(0);
+    expect(readLengths.reduce((sum, length) => sum + length, 0)).toBeLessThanOrEqual(LIMIT + 1);
+    expect(reader.close).toHaveBeenCalledOnce();
+  });
+
+  it.each(['é', '€', '😀'])('omits a %s codepoint cut at the byte limit', async (codepoint) => {
+    await writeFile(join(rootDir, 'preview.txt'), `${'a'.repeat(LIMIT - 1)}${codepoint}tail`);
+    const result = await readPreview();
+    expect(result.content.length).toBe(LIMIT - 1);
+    expect(result.content.endsWith('a')).toBe(true);
+    expect(result.content).not.toContain('\uFFFD');
+    expect(result.truncated).toBe(true);
+  });
+
+  it.each([0, LIMIT - 1, LIMIT, LIMIT + 1])('handles a file of %i bytes', async (size) => {
+    await writeFile(join(rootDir, 'preview.txt'), 'a'.repeat(size));
+    const result = await readPreview();
+    expect(result).toMatchObject({ size, truncated: size > LIMIT, isBinary: false });
+    expect(result.content.length).toBe(Math.min(size, LIMIT));
+  });
+
+  it('preserves binary detection in the first 8 KiB and the binary response contract', async () => {
+    const contents = Buffer.alloc(LIMIT + 10, 'a');
+    contents[8191] = 0;
+    await writeFile(join(rootDir, 'preview.txt'), contents);
+    expect(await readPreview()).toEqual({
+      content: '[Binary file - cannot display]',
+      language: 'text',
+      truncated: false,
+      size: LIMIT + 10,
+      isBinary: true,
+    });
+    contents[8191] = 97;
+    contents[8192] = 0;
+    await writeFile(join(rootDir, 'preview.txt'), contents);
+    expect(await readPreview()).toMatchObject({ isBinary: false, truncated: true });
+  });
+
+  it('assembles short reads without treating them as EOF', async () => {
+    await writeFile(join(rootDir, 'preview.txt'), 'a😀éz');
+    chunkSize = 2;
+    expect(await readPreview()).toMatchObject({ content: 'a😀éz', size: 8, truncated: false });
+  });
+
+  it('stops at EOF if a file shrinks after stat', async () => {
+    await writeFile(join(rootDir, 'preview.txt'), 'a'.repeat(100));
+    replaceOnRead = 'short';
+    expect(await readPreview()).toMatchObject({ content: 'short', size: 100, truncated: false });
+  });
+
+  it('caps reads and flags truncation when a file grows after stat', async () => {
+    await writeFile(join(rootDir, 'preview.txt'), 'short');
+    replaceOnRead = 'a'.repeat(LIMIT + 10);
+    const result = await readPreview();
+    expect(result).toMatchObject({ size: 5, truncated: true });
+    expect(result.content.length).toBe(LIMIT);
+    expect(readLengths.reduce((sum, length) => sum + length, 0)).toBeLessThanOrEqual(LIMIT + 1);
+  });
+
+  it('retains a complete multibyte codepoint ending exactly at the byte limit', async () => {
+    await writeFile(join(rootDir, 'preview.txt'), `${'a'.repeat(LIMIT - 4)}😀`);
+    const result = await readPreview();
+    expect(result).toMatchObject({ size: LIMIT, truncated: false });
+    expect(result.content.endsWith('😀')).toBe(true);
+    expect(Buffer.byteLength(result.content)).toBe(LIMIT);
+  });
+
+  it('closes the descriptor when reading fails', async () => {
+    await writeFile(join(rootDir, 'preview.txt'), 'text');
+    readError = new Error('read failed');
+    await expect(readPreview()).rejects.toThrow('read failed');
+    expect(handles.at(-1)?.close).toHaveBeenCalledOnce();
+  });
+
+  it('rejects directories and closes the descriptor', async () => {
+    await mkdir(join(rootDir, 'preview.txt'));
+    await expect(readPreview()).rejects.toThrow('Path is a directory');
+    expect(handles.at(-1)?.close).toHaveBeenCalledOnce();
+  });
+
+  it('keeps valid complete Unicode and malformed trailing bytes at EOF', async () => {
+    await writeFile(
+      join(rootDir, 'preview.txt'),
+      Buffer.from([0xef, 0xbb, 0xbf, 0xc3, 0xa9, 0xe2])
+    );
+    expect(await readPreview()).toMatchObject({
+      content: '\uFEFFé\uFFFD',
+      truncated: false,
+      size: 6,
+    });
+  });
+});

--- a/src/backend/trpc/workspace/files.preview.router.test.ts
+++ b/src/backend/trpc/workspace/files.preview.router.test.ts
@@ -1,3 +1,5 @@
+import { execFileSync } from 'node:child_process';
+import { closeSync, constants, openSync } from 'node:fs';
 import { mkdir, open, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -23,6 +25,7 @@ describe('workspace file previews', () => {
   let chunkSize: number | undefined;
   let readError: Error | undefined;
   let replaceOnRead: string | undefined;
+  let replaceWithFifoOnOpen: boolean;
   const readLengths: number[] = [];
   const handles: Awaited<ReturnType<typeof open>>[] = [];
 
@@ -31,9 +34,15 @@ describe('workspace file previews', () => {
     chunkSize = undefined;
     readError = undefined;
     replaceOnRead = undefined;
+    replaceWithFifoOnOpen = false;
     readLengths.length = 0;
     const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');
     vi.mocked(open).mockImplementation(async (...args) => {
+      if (replaceWithFifoOnOpen) {
+        replaceWithFifoOnOpen = false;
+        await rm(join(rootDir, 'preview.txt'));
+        execFileSync('mkfifo', [join(rootDir, 'preview.txt')]);
+      }
       const handle = await actual.open(...args);
       handles.push(handle);
       const originalRead = handle.read;
@@ -160,11 +169,41 @@ describe('workspace file previews', () => {
     expect(handles.at(-1)?.close).toHaveBeenCalledOnce();
   });
 
-  it('rejects directories and closes the descriptor', async () => {
+  it('rejects directories before opening a descriptor', async () => {
     await mkdir(join(rootDir, 'preview.txt'));
     await expect(readPreview()).rejects.toThrow('Path is a directory');
-    expect(handles.at(-1)?.close).toHaveBeenCalledOnce();
+    expect(handles).toHaveLength(0);
   });
+
+  it.skipIf(process.platform === 'win32').each([false, true])(
+    'rejects a FIFO without waiting for a writer (replaced during open: %s)',
+    async (replacedDuringOpen) => {
+      const fullPath = join(rootDir, 'preview.txt');
+      if (replacedDuringOpen) {
+        await writeFile(fullPath, 'regular file');
+        replaceWithFifoOnOpen = true;
+      } else {
+        execFileSync('mkfifo', [fullPath]);
+      }
+      // Release a regressed blocking open so a failure cannot strand a worker.
+      let neededWriter = false;
+      const release = setTimeout(() => {
+        neededWriter = true;
+        const writer = openSync(fullPath, constants.O_RDWR | constants.O_NONBLOCK);
+        closeSync(writer);
+      }, 1000);
+      try {
+        await expect(readPreview()).rejects.toThrow('Path is not a regular file');
+        expect(neededWriter).toBe(false);
+        expect(readLengths).toEqual([]);
+        if (replacedDuringOpen) {
+          expect(handles.at(-1)?.close).toHaveBeenCalledOnce();
+        }
+      } finally {
+        clearTimeout(release);
+      }
+    }
+  );
 
   it('keeps valid complete Unicode and malformed trailing bytes at EOF', async () => {
     await writeFile(

--- a/src/backend/trpc/workspace/files.trpc.ts
+++ b/src/backend/trpc/workspace/files.trpc.ts
@@ -1,14 +1,15 @@
-import { open, readdir, readFile, stat, unlink } from 'node:fs/promises';
+import { readdir, readFile, stat, unlink } from 'node:fs/promises';
 import path from 'node:path';
+import { StringDecoder } from 'node:string_decoder';
 import { z } from 'zod';
 import { toError } from '@/backend/lib/error-utils';
 import {
   type FileEntry,
   isBinaryContent,
   isPathSafe,
-  MAX_FILE_SIZE,
   searchFilesRecursive,
 } from '@/backend/lib/file-helpers';
+import { readFilePrefix } from '@/backend/lib/file-preview';
 import { type Context, publicProcedure, router } from '@/backend/trpc/trpc';
 import { getLanguageFromPath } from '@/lib/language-detection';
 import { getWorkspaceWithWorktree, getWorkspaceWithWorktreeOrThrow } from './workspace-helpers';
@@ -192,21 +193,7 @@ export const workspaceFilesRouter = router({
 
       const fullPath = path.join(worktreePath, input.path);
 
-      const fh = await open(fullPath, 'r');
-      let fileSize: number;
-      let buffer: Buffer;
-      try {
-        const stats = await fh.stat();
-        if (stats.isDirectory()) {
-          throw new Error('Path is a directory');
-        }
-        fileSize = stats.size;
-        buffer = await fh.readFile();
-      } finally {
-        await fh.close();
-      }
-
-      const truncated = fileSize > MAX_FILE_SIZE;
+      const { buffer, size: fileSize, truncated } = await readFilePrefix(fullPath);
 
       // Check if binary
       if (isBinaryContent(buffer)) {
@@ -219,11 +206,10 @@ export const workspaceFilesRouter = router({
         };
       }
 
-      // Convert to string, potentially truncated
-      let content = buffer.toString('utf-8');
-      if (truncated) {
-        content = content.slice(0, MAX_FILE_SIZE);
-      }
+      // Hold back any incomplete UTF-8 character at a truncated byte boundary.
+      // At EOF, preserve Buffer.toString's replacement of malformed trailing bytes.
+      const decoder = new StringDecoder('utf8');
+      const content = truncated ? decoder.write(buffer) : decoder.end(buffer);
 
       return {
         content,

--- a/src/backend/trpc/workspace/git.router.test.ts
+++ b/src/backend/trpc/workspace/git.router.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -96,6 +97,8 @@ describe('workspaceGitRouter', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGitCommand.mockReset();
+    mockGitCommand.mockResolvedValue({ code: 0, stdout: '', stderr: '' });
     rootDir = join(tmpdir(), `workspace-git-${Date.now()}-${Math.random().toString(16).slice(2)}`);
     mkdirSync(rootDir, { recursive: true });
   });
@@ -331,6 +334,60 @@ describe('workspaceGitRouter', () => {
       code: 'PAYLOAD_TOO_LARGE',
       message: expect.stringContaining('1 MiB'),
     });
+  });
+
+  it.each([12, 1024 * 1024 + 1])(
+    'preserves an empty diff for an unchanged tracked file of %i bytes',
+    async (size) => {
+      const runGit = (args: string[]) =>
+        execFileSync('git', ['-c', 'core.hooksPath=/dev/null', ...args], {
+          cwd: rootDir,
+          encoding: 'utf-8',
+        });
+      runGit(['init', '--initial-branch=main']);
+      writeFileSync(join(rootDir, 'tracked.txt'), 'a'.repeat(size));
+      runGit(['add', '--', 'tracked.txt']);
+      runGit([
+        '-c',
+        'user.name=Test',
+        '-c',
+        'user.email=test@example.com',
+        'commit',
+        '-m',
+        'Initial',
+      ]);
+      mockGetWorkspaceWithProjectAndWorktreeOrThrow.mockResolvedValue({
+        workspace: { id: 'w1', project: { defaultBranch: 'main' } },
+        worktreePath: rootDir,
+      });
+      mockGetMergeBase.mockResolvedValue(null);
+      mockGitCommand.mockImplementation((args: string[]) => ({
+        code: 0,
+        stdout: runGit(args),
+        stderr: '',
+      }));
+
+      await expect(
+        createCaller().getFileDiff({ workspaceId: 'w1', filePath: 'tracked.txt' })
+      ).resolves.toEqual({ diff: '' });
+    }
+  );
+
+  it('reports a tracked-file lookup failure without fabricating a new-file diff', async () => {
+    writeFileSync(join(rootDir, 'tracked.txt'), 'existing content');
+    mockGetWorkspaceWithProjectAndWorktreeOrThrow.mockResolvedValue({
+      workspace: { id: 'w1', project: { defaultBranch: 'main' } },
+      worktreePath: rootDir,
+    });
+    mockGetMergeBase.mockResolvedValue(null);
+    mockGitCommand
+      .mockResolvedValueOnce({ code: 0, stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ code: 0, stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ code: 128, stdout: '', stderr: 'index unavailable' });
+
+    await expect(
+      createCaller().getFileDiff({ workspaceId: 'w1', filePath: 'tracked.txt' })
+    ).rejects.toThrow('Git tracked-file check failed: index unavailable');
   });
 
   it('handles getFileDiff validation, read failures, direct success, and git errors', async () => {

--- a/src/backend/trpc/workspace/git.router.test.ts
+++ b/src/backend/trpc/workspace/git.router.test.ts
@@ -25,7 +25,8 @@ vi.mock('@/backend/lib/shell', () => ({
   gitCommand: (...args: unknown[]) => mockGitCommand(...args),
 }));
 
-vi.mock('@/backend/lib/file-helpers', () => ({
+vi.mock('@/backend/lib/file-helpers', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/backend/lib/file-helpers')>()),
   isPathSafe: mockIsPathSafe,
 }));
 
@@ -299,6 +300,37 @@ describe('workspaceGitRouter', () => {
     const diff = await caller.getFileDiff({ workspaceId: 'w1', filePath });
     expect(diff.diff).toContain('new file mode 100644');
     expect(diff.diff).toContain(`+++ b/${filePath}`);
+  });
+
+  it('returns a complete untracked diff for a file exactly at the byte limit', async () => {
+    writeFileSync(join(rootDir, 'exact.txt'), 'a'.repeat(1024 * 1024));
+    mockGetWorkspaceWithProjectAndWorktreeOrThrow.mockResolvedValue({
+      workspace: { id: 'w1', project: { defaultBranch: 'main' } },
+      worktreePath: rootDir,
+    });
+    mockGetMergeBase.mockResolvedValue(null);
+    mockGitCommand.mockResolvedValue({ code: 0, stdout: '', stderr: '' });
+
+    const { diff } = await createCaller().getFileDiff({ workspaceId: 'w1', filePath: 'exact.txt' });
+    expect(diff).toContain('@@ -0,0 +1,1 @@');
+    expect(diff.split('\n').at(-1)?.length).toBe(1024 * 1024 + 1);
+  });
+
+  it('rejects oversized untracked files instead of constructing an unbounded diff', async () => {
+    writeFileSync(join(rootDir, 'large.txt'), 'a'.repeat(1024 * 1024 + 1));
+    mockGetWorkspaceWithProjectAndWorktreeOrThrow.mockResolvedValue({
+      workspace: { id: 'w1', project: { defaultBranch: 'main' } },
+      worktreePath: rootDir,
+    });
+    mockGetMergeBase.mockResolvedValue(null);
+    mockGitCommand.mockResolvedValue({ code: 0, stdout: '', stderr: '' });
+
+    await expect(
+      createCaller().getFileDiff({ workspaceId: 'w1', filePath: 'large.txt' })
+    ).rejects.toMatchObject({
+      code: 'PAYLOAD_TOO_LARGE',
+      message: expect.stringContaining('1 MiB'),
+    });
   });
 
   it('handles getFileDiff validation, read failures, direct success, and git errors', async () => {

--- a/src/backend/trpc/workspace/git.trpc.ts
+++ b/src/backend/trpc/workspace/git.trpc.ts
@@ -27,6 +27,17 @@ async function getSnapshotForWorkspace(ctx: Context, workspaceId: string) {
   });
 }
 
+async function isTrackedFile(worktreePath: string, filePath: string): Promise<boolean> {
+  const result = await gitCommand(
+    ['--literal-pathspecs', 'ls-files', '--cached', '-z', '--', filePath],
+    worktreePath
+  );
+  if (result.code !== 0) {
+    throw new Error(`Git tracked-file check failed: ${result.stderr}`);
+  }
+  return result.stdout !== '';
+}
+
 export const workspaceGitRouter = router({
   // Get git status for workspace
   getGitStatus: publicProcedure
@@ -144,6 +155,10 @@ export const workspaceGitRouter = router({
 
       // If still empty, try to show the file for new untracked files
       if (result.stdout.trim() === '' && result.code === 0) {
+        if (await isTrackedFile(worktreePath, input.filePath)) {
+          return { diff: '' };
+        }
+
         // For untracked files, show bounded files as an addition
         const fullPath = path.join(worktreePath, input.filePath);
         let preview: Awaited<ReturnType<typeof readFilePrefix>>;

--- a/src/backend/trpc/workspace/git.trpc.ts
+++ b/src/backend/trpc/workspace/git.trpc.ts
@@ -1,7 +1,8 @@
-import { readFile } from 'node:fs/promises';
 import path from 'node:path';
+import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 import { isPathSafe } from '@/backend/lib/file-helpers';
+import { readFilePrefix } from '@/backend/lib/file-preview';
 import { gitCommand } from '@/backend/lib/shell';
 import { type Context, publicProcedure, router } from '@/backend/trpc/trpc';
 import {
@@ -143,25 +144,34 @@ export const workspaceGitRouter = router({
 
       // If still empty, try to show the file for new untracked files
       if (result.stdout.trim() === '' && result.code === 0) {
-        // For untracked files, show the entire file as an addition
+        // For untracked files, show bounded files as an addition
         const fullPath = path.join(worktreePath, input.filePath);
+        let preview: Awaited<ReturnType<typeof readFilePrefix>>;
         try {
-          const content = await readFile(fullPath, 'utf-8');
-          // Format as a unified diff for a new file
-          const lines = content.split('\n');
-          const diffContent = [
-            `diff --git a/${input.filePath} b/${input.filePath}`,
-            'new file mode 100644',
-            '--- /dev/null',
-            `+++ b/${input.filePath}`,
-            `@@ -0,0 +1,${lines.length} @@`,
-            ...lines.map((line) => `+${line}`),
-          ].join('\n');
-          return { diff: diffContent };
+          preview = await readFilePrefix(fullPath);
         } catch {
           // File doesn't exist or can't be read
           return { diff: '' };
         }
+        if (preview.truncated) {
+          throw new TRPCError({
+            code: 'PAYLOAD_TOO_LARGE',
+            message:
+              'File is too large to display as a diff (limit: 1 MiB). Open the file preview instead.',
+          });
+        }
+        const content = preview.buffer.toString('utf-8');
+        // Format as a unified diff for a new file
+        const lines = content.split('\n');
+        const diffContent = [
+          `diff --git a/${input.filePath} b/${input.filePath}`,
+          'new file mode 100644',
+          '--- /dev/null',
+          `+++ b/${input.filePath}`,
+          `@@ -0,0 +1,${lines.length} @@`,
+          ...lines.map((line) => `+${line}`),
+        ].join('\n');
+        return { diff: diffContent };
       }
 
       if (result.code !== 0) {


### PR DESCRIPTION
File previews previously loaded and decoded entire files before truncating their displayed content. Read at most 1 MiB plus one lookahead byte, preserving total-size metadata and binary detection and omitting UTF-8 characters split by the preview boundary.

The untracked-file diff fallback now returns a clear `PAYLOAD_TOO_LARGE` error above 1 MiB instead of reading and expanding an unbounded file. An index lookup keeps unchanged tracked files on the empty-diff path regardless of size. The reader rejects non-regular files before open and revalidates the opened descriptor; nonblocking open also prevents a FIFO replacement race from waiting for a writer. Concurrent file edits remain non-atomic; size describes the initial stat.

Validation: `pnpm check:fix`, `pnpm typecheck`, `pnpm check`, all commit hooks, and independent review passed. Regressions cover bounded sparse-file reads, multibyte boundaries, short reads, concurrent growth, descriptor cleanup, existing/replacement FIFOs, and small/large unchanged tracked files.

The latest full `pnpm test --maxWorkers=4` run passed 5,522 tests with four skipped and two failures in unchanged Git-fixture cleanup (`ENOTEMPTY`, including Git AI files created during teardown). Both failed fixtures and the changed router suites passed together on rerun: 34 tests. No unrelated source or assertions were changed.
