### PR TITLE
Virtualize large diffs and highlight in a worker

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { StorybookConfig } from '@storybook/react-vite';
 import tailwindcss from '@tailwindcss/vite';
+import { workerSafeAliases } from '../scripts/vite-worker-aliases';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -28,6 +29,7 @@ const config: StorybookConfig = {
     config.resolve = config.resolve || {};
     config.resolve.alias = {
       ...config.resolve.alias,
+      ...workerSafeAliases,
       '@': path.resolve(__dirname, '../src'),
       '@prisma-gen': path.resolve(__dirname, '../prisma/generated'),
     };

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -22,3 +22,6 @@ stale rationale is worse than no rationale, because it is believed.
 Related: `docs/design/` holds point-in-time design documents (including an
 `archive/` of superseded ones). Those record what was decided at a moment;
 these files record what is true now.
+
+Client diff rendering: see [diff-rendering.md](./diff-rendering.md) for workers,
+virtual rows, scroll anchors, and visual verification.

--- a/docs/architecture/diff-rendering.md
+++ b/docs/architecture/diff-rendering.md
@@ -15,7 +15,10 @@ languages leave the plain diff usable. Markdown preview does not start a worker.
 keeps a row index and offset for virtual diffs, so remounting a tab can restore
 the same line even before the full diff has been measured. Width changes discard
 stale offscreen heights while preserving the current row anchor. Old pixel-only
-scroll records remain supported.
+scroll records migrate to row anchors by measuring a contiguous prefix in bounded
+windows before restoring the requested pixel offset. This one-time migration can
+take several frames for a deep position; user gestures cancel it. Intermediate
+measurement positions never replace the saved scroll record.
 
 For visual checks, run `pnpm storybook` and open **Workspace / DiffLines**. The
 stories cover a small diff, a 10,000-line diff, and wrapped rows. Check the last

--- a/docs/architecture/diff-rendering.md
+++ b/docs/architecture/diff-rendering.md
@@ -1,0 +1,31 @@
+# Diff rendering
+
+The workspace diff viewer displays plain text immediately and requests syntax
+highlighting from `diff-highlight.worker.ts`. Whole-diff tokenization runs in a
+module worker so multiline syntax is preserved without running Prism on the UI
+thread. Vite and Storybook alias the entity decoder to its DOM-free export; the
+default browser export requires `document` and cannot run in a worker. A bundle
+regression test executes the production-resolved code without DOM globals.
+Worker messages are validated, and the worker is terminated after its
+reply, on failure, or when its diff/theme changes. Unsupported workers or
+languages leave the plain diff usable. Markdown preview does not start a worker.
+
+`DiffLines` mounts all rows for small diffs and a measured virtual window above
+200 rows. Wrapped lines are measured at their rendered height. Scroll storage
+keeps a row index and offset for virtual diffs, so remounting a tab can restore
+the same line even before the full diff has been measured. Width changes discard
+stale offscreen heights while preserving the current row anchor. Old pixel-only
+scroll records remain supported.
+
+For visual checks, run `pnpm storybook` and open **Workspace / DiffLines**. The
+stories cover a small diff, a 10,000-line diff, and wrapped rows. Check the last
+line, resize a wrapped diff, and toggle light/dark themes. Virtualized views
+only mount visible and overscan rows; native browser text search and selection
+operate on that mounted window.
+
+The frontend production build (`pnpm exec vite build`) emits a separate module
+worker asset. Focused regression checks:
+
+```sh
+pnpm test src/client/features/workspace/diff-viewer.test.tsx src/client/features/workspace/diff-highlight.worker.test.ts
+```

--- a/scripts/diff-worker-build.test.ts
+++ b/scripts/diff-worker-build.test.ts
@@ -43,6 +43,7 @@ describe('diff worker production bundle', () => {
         },
       });
       expect(reply).toBeDefined();
+      expect(reply).not.toBeNull();
       // Maps come from another JS realm, so compare iterable entries.
       const entries = Array.from(
         reply as Map<number, Array<{ content: string; style?: { color: string } }>>

--- a/scripts/diff-worker-build.test.ts
+++ b/scripts/diff-worker-build.test.ts
@@ -1,0 +1,58 @@
+import { fileURLToPath } from 'node:url';
+import { runInNewContext } from 'node:vm';
+import { build } from 'vite';
+import { describe, expect, it } from 'vitest';
+
+// Exercise browser package resolution: jsdom/Node imports alone would hide DOM-only exports.
+describe('diff worker production bundle', () => {
+  it('highlights without document or window in the worker global', async () => {
+    const projectRoot = fileURLToPath(new URL('../', import.meta.url));
+    const result = await build({
+      root: projectRoot,
+      logLevel: 'silent',
+      build: {
+        write: false,
+        lib: {
+          entry: fileURLToPath(
+            new URL('../src/client/features/workspace/diff-highlight.worker.ts', import.meta.url)
+          ),
+          formats: ['iife'],
+          name: 'DiffWorker',
+        },
+      },
+    });
+    const output = Array.isArray(result) ? result[0] : result;
+    if (output && 'output' in output) {
+      const chunk = output.output.find((output) => output.type === 'chunk');
+      expect(chunk).toBeDefined();
+      let reply: unknown;
+      const scope: {
+        onmessage?: (event: { data: unknown }) => void;
+        postMessage: (data: unknown) => void;
+      } = {
+        postMessage: (data) => {
+          reply = data;
+        },
+      };
+      runInNewContext(chunk?.code ?? '', { self: scope });
+      scope.onmessage?.({
+        data: {
+          lines: [{ type: 'addition', content: 'const greeting = "hello";' }],
+          language: 'typescript',
+          theme: { keyword: { color: 'purple' } },
+        },
+      });
+      expect(reply).toBeDefined();
+      // Maps come from another JS realm, so compare iterable entries.
+      const entries = Array.from(
+        reply as Map<number, Array<{ content: string; style?: { color: string } }>>
+      );
+      expect(entries[0]?.[1].map((token) => token.content).join('')).toBe(
+        'const greeting = "hello";'
+      );
+      expect(entries[0]?.[1]).toContainEqual({ content: 'const', style: { color: 'purple' } });
+    } else {
+      throw new Error('Expected a single worker build');
+    }
+  });
+});

--- a/scripts/vite-worker-aliases.ts
+++ b/scripts/vite-worker-aliases.ts
@@ -1,0 +1,14 @@
+import { createRequire } from 'node:module';
+
+const requireFromRefractor = createRequire(import.meta.resolve('refractor'));
+const requireFromEntities = createRequire(requireFromRefractor.resolve('parse-entities'));
+
+// Refractor's entity decoder offers a DOM-free default export, but its browser
+// export calls document.createElement at module load. Vite shares dependency
+// resolution with module workers in dev, so use the DOM-free version in both
+// environments. Resolve through the owning dependencies to support pnpm layouts.
+export const workerSafeAliases = {
+  'decode-named-character-reference': requireFromEntities.resolve(
+    'decode-named-character-reference'
+  ),
+};

--- a/src/client/features/workspace/diff-highlight-protocol.ts
+++ b/src/client/features/workspace/diff-highlight-protocol.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-const styleSchema = z.record(z.string(), z.union([z.string(), z.number()]));
+const styleSchema = z.record(z.string(), z.union([z.string(), z.number()]).optional());
 
 export const diffHighlightRequestSchema = z.object({
   lines: z.array(

--- a/src/client/features/workspace/diff-highlight-protocol.ts
+++ b/src/client/features/workspace/diff-highlight-protocol.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+const styleSchema = z.record(z.string(), z.union([z.string(), z.number()]));
+
+export const diffHighlightRequestSchema = z.object({
+  lines: z.array(
+    z.object({
+      type: z.enum(['header', 'addition', 'deletion', 'context', 'hunk']),
+      content: z.string(),
+      lineNumber: z.object({ old: z.number().optional(), new: z.number().optional() }).optional(),
+    })
+  ),
+  language: z.string(),
+  theme: z.record(z.string(), styleSchema),
+});
+
+export const diffHighlightResponseSchema = z
+  .map(
+    z.number().int().nonnegative(),
+    z.array(z.object({ content: z.string(), style: styleSchema.optional() }))
+  )
+  .nullable();

--- a/src/client/features/workspace/diff-highlight.worker.test.ts
+++ b/src/client/features/workspace/diff-highlight.worker.test.ts
@@ -18,14 +18,19 @@ describe('diff highlighting worker', () => {
             { type: 'context', content: '*/' },
           ],
           language: 'typescript',
-          theme: { comment: { color: 'gray' } },
+          theme: { comment: { color: 'gray', fontStyle: undefined } },
         },
       })
     );
     const tokens = post.mock.calls[0]?.[0] as LineTokenMap;
+    expect(tokens).not.toBeNull();
     expect(tokens.has(0)).toBe(false);
-    expect(tokens.get(2)).toEqual([{ content: 'old comment', style: { color: 'gray' } }]);
-    expect(tokens.get(3)).toEqual([{ content: 'new comment', style: { color: 'gray' } }]);
+    expect(tokens.get(2)).toEqual([
+      { content: 'old comment', style: { color: 'gray', fontStyle: undefined } },
+    ]);
+    expect(tokens.get(3)).toEqual([
+      { content: 'new comment', style: { color: 'gray', fontStyle: undefined } },
+    ]);
   });
 
   it('returns a plain-text fallback for malformed requests', () => {

--- a/src/client/features/workspace/diff-highlight.worker.test.ts
+++ b/src/client/features/workspace/diff-highlight.worker.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from 'vitest';
+import type { LineTokenMap } from '@/lib/diff/syntax-highlight';
+import './diff-highlight.worker';
+
+describe('diff highlighting worker', () => {
+  it('preserves multiline syntax and maps old/new tokens to original diff rows', () => {
+    const post = vi.spyOn(window, 'postMessage').mockImplementation(() => undefined);
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: {
+          lines: [
+            { type: 'hunk', content: '@@ -1,3 +1,3 @@' },
+            { type: 'context', content: '/* comment begins' },
+            { type: 'deletion', content: 'old comment' },
+            { type: 'addition', content: 'new comment' },
+            { type: 'context', content: '*/' },
+          ],
+          language: 'typescript',
+          theme: { comment: { color: 'gray' } },
+        },
+      })
+    );
+    const tokens = post.mock.calls[0]?.[0] as LineTokenMap;
+    expect(tokens.has(0)).toBe(false);
+    expect(tokens.get(2)).toEqual([{ content: 'old comment', style: { color: 'gray' } }]);
+    expect(tokens.get(3)).toEqual([{ content: 'new comment', style: { color: 'gray' } }]);
+  });
+
+  it('returns a plain-text fallback for malformed requests', () => {
+    const post = vi.spyOn(window, 'postMessage').mockImplementation(() => undefined);
+    window.dispatchEvent(new MessageEvent('message', { data: { lines: 'invalid' } }));
+    expect(post.mock.calls[0]?.[0]).toBeNull();
+  });
+});

--- a/src/client/features/workspace/diff-highlight.worker.ts
+++ b/src/client/features/workspace/diff-highlight.worker.ts
@@ -1,0 +1,12 @@
+import { tokenizeDiffLines } from '@/lib/diff/syntax-highlight';
+import { diffHighlightRequestSchema } from './diff-highlight-protocol';
+
+self.onmessage = (event: MessageEvent<unknown>) => {
+  const request = diffHighlightRequestSchema.safeParse(event.data);
+  if (!request.success) {
+    self.postMessage(null);
+    return;
+  }
+  const { lines, language, theme } = request.data;
+  self.postMessage(tokenizeDiffLines(lines, language, theme));
+};

--- a/src/client/features/workspace/diff-lines.stories.tsx
+++ b/src/client/features/workspace/diff-lines.stories.tsx
@@ -38,8 +38,16 @@ function DiffStoryContent({
   );
 }
 
-function DiffStory({ lines, theme = 'light' }: { lines: DiffLine[]; theme?: string }) {
-  const saved = useRef<ScrollState | null>(null);
+function DiffStory({
+  lines,
+  theme = 'light',
+  initialScrollState = null,
+}: {
+  lines: DiffLine[];
+  theme?: string;
+  initialScrollState?: ScrollState | null;
+}) {
+  const saved = useRef<ScrollState | null>(initialScrollState);
   const [visible, setVisible] = useState(true);
   return (
     <div className="space-y-2">
@@ -83,5 +91,12 @@ export const WrappedLines: Story = {
     lines: parseDetailedDiff(
       `@@ -0,0 +1,1000 @@\n${Array.from({ length: 1000 }, (_, i) => `+const value${i} = "${'A long line that wraps across the viewport. '.repeat((i % 5) + 1)}";`).join('\n')}`
     ),
+  },
+};
+
+export const LegacyWrappedPosition: Story = {
+  args: {
+    ...WrappedLines.args,
+    initialScrollState: { top: 24_007, left: 0 },
   },
 };

--- a/src/client/features/workspace/diff-lines.stories.tsx
+++ b/src/client/features/workspace/diff-lines.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { type RefObject, useRef, useState } from 'react';
+import { oneDark, oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import { Button } from '@/components/ui/button';
+import { calculateLineNumberWidth, parseDetailedDiff } from '@/lib/diff/parse';
+import type { DiffLine } from '@/lib/diff/types';
+import { DiffLines } from './diff-lines';
+import type { ScrollState } from './scroll-state';
+import { useDiffHighlighting } from './use-diff-highlighting';
+
+function DiffStoryContent({
+  lines,
+  theme,
+  saved,
+}: {
+  lines: DiffLine[];
+  theme: string;
+  saved: RefObject<ScrollState | null>;
+}) {
+  const viewport = useRef<HTMLDivElement>(null);
+  const tokens = useDiffHighlighting(lines, 'typescript', theme === 'dark' ? oneDark : oneLight);
+  return (
+    <div
+      ref={viewport}
+      className="h-[480px] w-full max-w-4xl overflow-auto border rounded bg-background text-foreground"
+    >
+      <DiffLines
+        lines={lines}
+        lineNumberWidth={calculateLineNumberWidth(lines)}
+        tokenMap={tokens}
+        scrollContainerRef={viewport}
+        scrollState={saved.current}
+        onScrollStateChange={(state) => {
+          saved.current = state;
+        }}
+      />
+    </div>
+  );
+}
+
+function DiffStory({ lines, theme = 'light' }: { lines: DiffLine[]; theme?: string }) {
+  const saved = useRef<ScrollState | null>(null);
+  const [visible, setVisible] = useState(true);
+  return (
+    <div className="space-y-2">
+      <Button variant="outline" onClick={() => setVisible((value) => !value)}>
+        {visible ? 'Hide diff' : 'Show diff'}
+      </Button>
+      {visible && <DiffStoryContent lines={lines} theme={theme} saved={saved} />}
+    </div>
+  );
+}
+
+const meta = {
+  title: 'Workspace/DiffLines',
+  component: DiffStory,
+  render: (args, context) => (
+    <DiffStory {...args} theme={context.globals.theme === 'dark' ? 'dark' : 'light'} />
+  ),
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof DiffStory>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const SmallDiff: Story = {
+  args: {
+    lines: parseDetailedDiff(
+      '@@ -1,3 +1,3 @@\n export function greet() {\n-  return "Hello";\n+  return "Welcome";\n }'
+    ),
+  },
+};
+
+export const LargeDiff: Story = {
+  args: {
+    lines: parseDetailedDiff(
+      `@@ -0,0 +1,10000 @@\n${Array.from({ length: 10_000 }, (_, i) => `+export const value${i} = { label: "Row ${i}", enabled: true };`).join('\n')}`
+    ),
+  },
+};
+
+export const WrappedLines: Story = {
+  args: {
+    lines: parseDetailedDiff(
+      `@@ -0,0 +1,1000 @@\n${Array.from({ length: 1000 }, (_, i) => `+const value${i} = "${'A long line that wraps across the viewport. '.repeat((i % 5) + 1)}";`).join('\n')}`
+    ),
+  },
+};

--- a/src/client/features/workspace/diff-lines.test.tsx
+++ b/src/client/features/workspace/diff-lines.test.tsx
@@ -15,6 +15,7 @@ const lines: DiffLine[] = Array.from({ length: 1000 }, (_, index) => ({
 let container: HTMLDivElement;
 let root: Root;
 let width = 320;
+let firstRowUnwrapped = false;
 let saved: ScrollState | null;
 const observers = new Set<ResizeObserverCallback>();
 
@@ -48,12 +49,16 @@ function Harness({ initial, count = 1000 }: { initial?: ScrollState | null; coun
 
 beforeEach(() => {
   width = 320;
+  firstRowUnwrapped = false;
   saved = null;
   vi.useFakeTimers();
   vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
   vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockImplementation(function (
     this: HTMLElement
   ) {
+    if (firstRowUnwrapped && this.dataset.index === '0') {
+      return 16;
+    }
     return this.hasAttribute('data-index') ? (width === 320 ? 64 : 32) : 320;
   });
   vi.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockImplementation(() => width);
@@ -126,7 +131,43 @@ it('restores the same wrapped row and intra-row offset after remount', async () 
   await act(() => root.render(null));
   await act(() => root.render(<Harness initial={persisted} />));
   await settle();
-  expect(container.querySelector('[data-index="500"]')).not.toBeNull();
+  const remountedViewport = container.querySelector<HTMLDivElement>('[data-viewport]')!;
+  const remountedRow = container.querySelector<HTMLElement>('[data-index="500"]');
+  expect(remountedRow).not.toBeNull();
+  expect(
+    remountedViewport.scrollTop - Number(remountedRow?.style.transform.match(/[\d.]+/)?.[0])
+  ).toBe(7);
+});
+
+it.each([
+  { top: 31_959, index: 500 },
+  { top: 1239, index: 20 },
+])('migrates legacy pixel offset $top using measured rows', async ({ top, index }) => {
+  firstRowUnwrapped = true;
+  await act(() => root.render(<Harness initial={{ top, left: 4 }} />));
+  for (let frame = 0; frame < 120; frame++) {
+    await act(() => vi.advanceTimersByTime(20));
+    expect(container.querySelectorAll('[data-index]').length).toBeLessThan(100);
+  }
+  const viewport = container.querySelector<HTMLDivElement>('[data-viewport]')!;
+  expect(viewport.scrollTop).toBe(top);
+  expect(viewport.scrollLeft).toBe(4);
+  expect(saved).toMatchObject({ top, diffAnchor: { index, offset: 7 } });
+});
+
+it('does not persist migration steps and lets user gestures cancel a legacy restore', async () => {
+  await act(() => root.render(<Harness initial={{ top: 32_007, left: 0 }} />));
+  await act(() => vi.advanceTimersByTime(20));
+  expect(saved).toBeNull();
+  const viewport = container.querySelector<HTMLDivElement>('[data-viewport]')!;
+  await act(() => {
+    viewport.dispatchEvent(new Event('wheel'));
+    viewport.scrollTop = 150;
+    viewport.dispatchEvent(new Event('scroll'));
+  });
+  await settle();
+  expect(viewport.scrollTop).toBe(150);
+  expect(saved?.top).toBe(150);
 });
 
 it('restores legacy pixel offsets for small diffs', async () => {

--- a/src/client/features/workspace/diff-lines.test.tsx
+++ b/src/client/features/workspace/diff-lines.test.tsx
@@ -1,0 +1,214 @@
+// @vitest-environment jsdom
+
+import { act, useRef } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import type { DiffLine } from '@/lib/diff/types';
+import { DiffLines } from './diff-lines';
+import type { ScrollState } from './scroll-state';
+
+const lines: DiffLine[] = Array.from({ length: 1000 }, (_, index) => ({
+  type: 'addition',
+  content: `wrapped row ${index}`,
+  lineNumber: { new: index + 1 },
+}));
+let container: HTMLDivElement;
+let root: Root;
+let width = 320;
+let saved: ScrollState | null;
+const observers = new Set<ResizeObserverCallback>();
+
+function Harness({ initial, count = 1000 }: { initial?: ScrollState | null; count?: number }) {
+  const viewport = useRef<HTMLDivElement>(null);
+  return (
+    <div>
+      <div
+        ref={viewport}
+        data-viewport=""
+        data-radix-scroll-area-viewport=""
+        style={{ height: 320, overflow: 'auto' }}
+      >
+        <DiffLines
+          lines={count === 1000 ? lines : lines.slice(0, count)}
+          lineNumberWidth={3}
+          tokenMap={null}
+          scrollContainerRef={viewport}
+          scrollState={initial}
+          onScrollStateChange={(state) => {
+            saved = state;
+          }}
+        />
+      </div>
+      <button type="button" data-scroll-thumb="">
+        Drag scrollbar
+      </button>
+    </div>
+  );
+}
+
+beforeEach(() => {
+  width = 320;
+  saved = null;
+  vi.useFakeTimers();
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockImplementation(function (
+    this: HTMLElement
+  ) {
+    return this.hasAttribute('data-index') ? (width === 320 ? 64 : 32) : 320;
+  });
+  vi.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockImplementation(() => width);
+  vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockImplementation(() => width);
+  vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(320);
+  vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockImplementation(function (
+    this: HTMLElement
+  ) {
+    return Number.parseFloat((this.firstElementChild as HTMLElement)?.style.height ?? '') || 64_000;
+  });
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      constructor(callback: ResizeObserverCallback) {
+        observers.add(callback);
+      }
+      observe() {
+        /* Sizes are supplied by the element metrics. */
+      }
+      unobserve() {
+        /* No native observation is active. */
+      }
+      disconnect() {
+        /* No native observation is active. */
+      }
+    }
+  );
+  HTMLElement.prototype.scrollTo = function (options) {
+    if (typeof options === 'object') {
+      this.scrollTop = options.top ?? this.scrollTop;
+      this.scrollLeft = options.left ?? this.scrollLeft;
+      setTimeout(() => this.dispatchEvent(new Event('scroll')), 0);
+    }
+  };
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(() => root.unmount());
+  container.remove();
+  observers.clear();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+async function settle() {
+  for (let frame = 0; frame < 20; frame++) {
+    await act(() => vi.advanceTimersByTime(20));
+  }
+}
+
+it('restores the same wrapped row and intra-row offset after remount', async () => {
+  await act(() =>
+    root.render(
+      <Harness initial={{ top: 32_007, left: 0, diffAnchor: { index: 500, offset: 7 } }} />
+    )
+  );
+  await settle();
+  const viewport = container.querySelector<HTMLDivElement>('[data-viewport]')!;
+  const row = container.querySelector<HTMLElement>('[data-index="500"]');
+  expect(row).not.toBeNull();
+  const start = Number(row?.style.transform.match(/[\d.]+/)?.[0]);
+  expect(viewport.scrollTop - start).toBe(7);
+  await act(() => viewport.dispatchEvent(new Event('scroll')));
+  expect(saved).toMatchObject({ diffAnchor: { index: 500, offset: 7 } });
+  const persisted = saved;
+  await act(() => root.render(null));
+  await act(() => root.render(<Harness initial={persisted} />));
+  await settle();
+  expect(container.querySelector('[data-index="500"]')).not.toBeNull();
+});
+
+it('restores legacy pixel offsets for small diffs', async () => {
+  await act(() => root.render(<Harness count={10} initial={{ top: 140, left: 4 }} />));
+  await settle();
+  const viewport = container.querySelector<HTMLDivElement>('[data-viewport]')!;
+  expect(viewport.scrollTop).toBe(140);
+  expect(viewport.scrollLeft).toBe(4);
+});
+
+it('preserves the visible anchor when width invalidates wrapped row measurements', async () => {
+  await act(() =>
+    root.render(
+      <Harness initial={{ top: 32_007, left: 0, diffAnchor: { index: 500, offset: 7 } }} />
+    )
+  );
+  await settle();
+  width = 640;
+  await act(() => {
+    for (const callback of observers) {
+      callback([], {} as ResizeObserver);
+    }
+  });
+  await settle();
+  const viewport = container.querySelector<HTMLDivElement>('[data-viewport]')!;
+  const row = container.querySelector<HTMLElement>('[data-index="500"]');
+  expect(row).not.toBeNull();
+  expect(viewport.scrollTop - Number(row?.style.transform.match(/[\d.]+/)?.[0])).toBe(7);
+  const nextRow = container.querySelector<HTMLElement>('[data-index="501"]');
+  expect(
+    Number(nextRow?.style.transform.match(/[\d.]+/)?.[0]) -
+      Number(row?.style.transform.match(/[\d.]+/)?.[0])
+  ).toBe(32);
+});
+
+it('keeps mounted wrapped rows measured at the top while resizing', async () => {
+  await act(() => root.render(<Harness />));
+  await settle();
+  const second = () => container.querySelector<HTMLElement>('[data-index="1"]');
+  expect(second()?.style.transform).toBe('translateY(64px)');
+  width = 640;
+  await act(() => {
+    for (const callback of observers) {
+      callback([], {} as ResizeObserver);
+    }
+  });
+  await settle();
+  expect(second()?.style.transform).toBe('translateY(32px)');
+});
+
+it('lets user scrolling interrupt a pending anchor restoration', async () => {
+  await act(() =>
+    root.render(
+      <Harness initial={{ top: 32_007, left: 0, diffAnchor: { index: 500, offset: 7 } }} />
+    )
+  );
+  const viewport = container.querySelector<HTMLDivElement>('[data-viewport]')!;
+  await act(() => {
+    viewport.dispatchEvent(new Event('wheel'));
+    viewport.scrollTop = 150;
+    viewport.dispatchEvent(new Event('scroll'));
+  });
+  await settle();
+  expect(viewport.scrollTop).toBe(150);
+  expect(saved?.top).toBe(150);
+});
+
+it('lets a sibling Radix scrollbar interrupt pending restoration', async () => {
+  await act(() =>
+    root.render(
+      <Harness initial={{ top: 32_007, left: 0, diffAnchor: { index: 500, offset: 7 } }} />
+    )
+  );
+  const currentViewport = container.querySelector<HTMLDivElement>('[data-viewport]')!;
+  await act(() => {
+    container
+      .querySelector('[data-scroll-thumb]')!
+      .dispatchEvent(new Event('pointerdown', { bubbles: true }));
+    currentViewport.scrollTop = 150;
+    currentViewport.dispatchEvent(new Event('scroll'));
+  });
+  await settle();
+  expect(currentViewport.scrollTop).toBe(150);
+  expect(saved?.top).toBe(150);
+});

--- a/src/client/features/workspace/diff-lines.tsx
+++ b/src/client/features/workspace/diff-lines.tsx
@@ -1,0 +1,164 @@
+import { useVirtualizer } from '@tanstack/react-virtual';
+import { type RefObject, useMemo } from 'react';
+import { withOccurrenceKeys } from '@/client/lib/list-keys';
+import { getDiffLineBackground, getDiffLinePrefix, getDiffLineTextColor } from '@/lib/diff/styles';
+import type { LineTokenMap, SyntaxToken } from '@/lib/diff/syntax-highlight';
+import type { DiffLine } from '@/lib/diff/types';
+import { cn } from '@/lib/utils';
+import type { ScrollState } from './scroll-state';
+import { useDiffScroll } from './use-diff-scroll';
+
+interface SyntaxHighlightedContentProps {
+  tokens: SyntaxToken[];
+}
+
+function SyntaxHighlightedContent({ tokens }: SyntaxHighlightedContentProps) {
+  return (
+    <>
+      {tokens.map((token, i) => {
+        const key = `${i}-${token.content.length}`;
+        return (
+          <span key={key} style={token.style}>
+            {token.content}
+          </span>
+        );
+      })}
+    </>
+  );
+}
+
+interface DiffLineProps {
+  line: DiffLine;
+  lineNumberWidth: number;
+  tokens?: SyntaxToken[] | null;
+}
+
+function DiffLineComponent({ line, lineNumberWidth, tokens }: DiffLineProps) {
+  const bgColor = getDiffLineBackground(line.type);
+  const prefix = getDiffLinePrefix(line.type);
+  const hasTokens = tokens != null && tokens.length > 0;
+  // When syntax tokens are available, let them control text color for code lines.
+  // Header/hunk lines and lines without tokens use the standard diff text color.
+  const textColor = hasTokens ? undefined : getDiffLineTextColor(line.type);
+
+  return (
+    <div className={cn('flex min-w-0 font-mono text-xs', bgColor)}>
+      {/* Line numbers */}
+      <div className="flex-shrink-0 flex text-muted-foreground border-r border-border select-none">
+        <span
+          className="box-content px-1 text-right border-r border-border tabular-nums"
+          style={{ width: `${lineNumberWidth}ch` }}
+        >
+          {line.lineNumber?.old ?? ''}
+        </span>
+        <span
+          className="box-content px-1 text-right tabular-nums"
+          style={{ width: `${lineNumberWidth}ch` }}
+        >
+          {line.lineNumber?.new ?? ''}
+        </span>
+      </div>
+
+      {/* Prefix — always uses diff text color */}
+      <span
+        className={cn('flex-shrink-0 w-4 text-center select-none', getDiffLineTextColor(line.type))}
+      >
+        {prefix}
+      </span>
+
+      {/* Content */}
+      <pre className={cn('min-w-0 flex-1 whitespace-pre-wrap break-all px-2', textColor)}>
+        {hasTokens ? <SyntaxHighlightedContent tokens={tokens} /> : line.content}
+      </pre>
+    </div>
+  );
+}
+
+export interface DiffLinesProps {
+  lines: DiffLine[];
+  lineNumberWidth: number;
+  tokenMap: LineTokenMap | null;
+  scrollContainerRef: RefObject<HTMLDivElement | null>;
+  scrollState?: ScrollState | null;
+  onScrollStateChange?: (state: ScrollState) => void;
+}
+
+/** Render small diffs normally; measure only visible rows in large, wrapping diffs. */
+export function DiffLines({
+  lines,
+  lineNumberWidth,
+  tokenMap,
+  scrollContainerRef,
+  scrollState,
+  onScrollStateChange,
+}: DiffLinesProps) {
+  const virtualized = lines.length > 200;
+  const virtualizer = useVirtualizer({
+    count: lines.length,
+    getScrollElement: () => scrollContainerRef.current,
+    estimateSize: () => 16,
+    overscan: 8,
+    enabled: virtualized,
+  });
+
+  const measurementVersion = useDiffScroll({
+    lines,
+    virtualizer,
+    virtualized,
+    scrollContainerRef,
+    scrollState,
+    onScrollStateChange,
+  });
+
+  const smallRows = useMemo(
+    () =>
+      virtualized
+        ? []
+        : withOccurrenceKeys(lines, (line) =>
+            JSON.stringify([line.type, line.lineNumber?.old, line.lineNumber?.new, line.content])
+          ),
+    [lines, virtualized]
+  );
+
+  if (!virtualized) {
+    return smallRows.map(({ item: line, key }, index) => (
+      <DiffLineComponent
+        key={key}
+        line={line}
+        lineNumberWidth={lineNumberWidth}
+        tokens={tokenMap?.get(index)}
+      />
+    ));
+  }
+
+  return (
+    <div style={{ height: virtualizer.getTotalSize(), width: '100%', position: 'relative' }}>
+      {virtualizer.getVirtualItems().map((row) => {
+        const line = lines[row.index];
+        if (!line) {
+          return null;
+        }
+        return (
+          <div
+            key={`${measurementVersion}-${row.key}`}
+            data-index={row.index}
+            ref={virtualizer.measureElement}
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              width: '100%',
+              transform: `translateY(${row.start}px)`,
+            }}
+          >
+            <DiffLineComponent
+              line={line}
+              lineNumberWidth={lineNumberWidth}
+              tokens={tokenMap?.get(row.index)}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/client/features/workspace/diff-viewer.test.tsx
+++ b/src/client/features/workspace/diff-viewer.test.tsx
@@ -119,7 +119,12 @@ describe('DiffViewer performance', () => {
     const current = TestWorker.instances.at(-1);
     await act(() =>
       current?.reply(
-        new Map([[1, [{ content: 'const changed = false;', style: { color: 'red' } }]]])
+        new Map([
+          [
+            1,
+            [{ content: 'const changed = false;', style: { color: 'red', fontStyle: undefined } }],
+          ],
+        ])
       )
     );
     expect(container.querySelector('pre span')?.getAttribute('style')).toContain('color: red');

--- a/src/client/features/workspace/diff-viewer.test.tsx
+++ b/src/client/features/workspace/diff-viewer.test.tsx
@@ -1,0 +1,173 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DiffViewer } from './diff-viewer';
+
+const query = vi.hoisted(() => ({ diff: '', theme: 'dark' }));
+vi.mock('./workspace-panel-context', () => ({
+  useWorkspacePanel: () => ({ getScrollState: () => null, setScrollState: () => undefined }),
+}));
+vi.mock('@/client/lib/trpc', () => ({
+  trpc: { workspace: { getFileDiff: { useQuery: () => ({ data: { diff: query.diff } }) } } },
+}));
+vi.mock('next-themes', () => ({ useTheme: () => ({ resolvedTheme: query.theme }) }));
+vi.mock('./use-persistent-scroll', () => ({
+  usePersistentScroll: () => ({ handleScroll: () => undefined }),
+}));
+
+class TestWorker {
+  static instances: TestWorker[] = [];
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onmessageerror: (() => void) | null = null;
+  terminated = false;
+  request: unknown;
+  constructor() {
+    TestWorker.instances.push(this);
+  }
+  postMessage(request: unknown) {
+    this.request = request;
+  }
+  terminate() {
+    this.terminated = true;
+  }
+  reply(data: unknown) {
+    this.onmessage?.({ data } as MessageEvent);
+  }
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  vi.stubGlobal('Worker', TestWorker);
+  TestWorker.instances = [];
+  query.theme = 'dark';
+  vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockImplementation(function (
+    this: HTMLElement
+  ) {
+    return this.hasAttribute('data-index') ? 16 : 320;
+  });
+  vi.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockReturnValue(640);
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {
+        /* Layout is supplied by the element size spies. */
+      }
+      unobserve() {
+        /* Layout is supplied by the element size spies. */
+      }
+      disconnect() {
+        /* Layout is supplied by the element size spies. */
+      }
+    }
+  );
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+afterEach(async () => {
+  await act(() => root.unmount());
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+async function render(filePath = 'example.ts') {
+  await act(() => root.render(<DiffViewer workspaceId="w1" filePath={filePath} tabId="diff-1" />));
+}
+
+function makeDiff(count: number) {
+  return `@@ -0,0 +1,${count} @@\n${Array.from({ length: count }, (_, i) => `+const value${i} = true;`).join('\n')}`;
+}
+
+describe('DiffViewer performance', () => {
+  it('renders a bounded window of a large diff and reaches later lines on scroll', async () => {
+    query.diff = makeDiff(10_000);
+    await render();
+    expect(container.textContent).toContain('const value0 = true;');
+    expect(container.querySelectorAll('pre').length).toBeLessThan(100);
+    expect(container.textContent).not.toContain('const value9999 = true;');
+    const viewport = container.querySelector<HTMLDivElement>('[data-radix-scroll-area-viewport]');
+    expect(viewport).not.toBeNull();
+    await act(() => {
+      if (viewport) {
+        viewport.scrollTop = 8000;
+        viewport.dispatchEvent(new Event('scroll'));
+      }
+    });
+    expect(container.textContent).toContain('const value500 = true;');
+    expect(container.querySelectorAll('pre').length).toBeLessThan(100);
+  });
+
+  it('shows plain text while highlighting in a worker and rejects stale results', async () => {
+    query.diff = makeDiff(2);
+    await render();
+    expect(container.textContent).toContain('const value0 = true;');
+    const first = TestWorker.instances.at(-1);
+    expect(first).toBeDefined();
+    query.diff = '@@ -0,0 +1,1 @@\n+const changed = false;';
+    await render();
+    expect(first?.terminated).toBe(true);
+    await act(() =>
+      first?.reply(new Map([[1, [{ content: 'STALE CONTENT', style: { color: 'red' } }]]]))
+    );
+    expect(container.textContent).not.toContain('STALE CONTENT');
+    const current = TestWorker.instances.at(-1);
+    await act(() =>
+      current?.reply(
+        new Map([[1, [{ content: 'const changed = false;', style: { color: 'red' } }]]])
+      )
+    );
+    expect(container.querySelector('pre span')?.getAttribute('style')).toContain('color: red');
+  });
+
+  it('discards old-theme highlights and terminates workers on failure and unmount', async () => {
+    query.diff = makeDiff(2);
+    await render();
+    const darkWorker = TestWorker.instances.at(-1);
+    await act(() =>
+      darkWorker?.reply(
+        new Map([[1, [{ content: 'const value0 = true;', style: { color: 'red' } }]]])
+      )
+    );
+    expect(container.querySelector('pre span')?.getAttribute('style')).toContain('color: red');
+    query.theme = 'light';
+    await render();
+    expect(container.querySelector('pre span')).toBeNull();
+    const lightWorker = TestWorker.instances.at(-1);
+    await act(() => lightWorker?.onerror?.());
+    expect(lightWorker?.terminated).toBe(true);
+    expect(container.textContent).toContain('const value0 = true;');
+    query.diff = makeDiff(3);
+    await render();
+    const lastWorker = TestWorker.instances.at(-1);
+    await act(() => root.render(null));
+    expect(lastWorker?.terminated).toBe(true);
+  });
+
+  it('ignores malformed worker replies without losing the visible diff', async () => {
+    query.diff = makeDiff(2);
+    await render();
+    await act(() => TestWorker.instances.at(-1)?.reply({ invalid: true }));
+    expect(container.textContent).toContain('const value0 = true;');
+    expect(container.querySelector('pre span')).toBeNull();
+  });
+
+  it('keeps the diff readable when a worker is unavailable or fails', async () => {
+    query.diff = makeDiff(2);
+    vi.stubGlobal(
+      'Worker',
+      class {
+        constructor() {
+          throw new Error('Workers unavailable');
+        }
+      }
+    );
+    await render();
+    expect(container.textContent).toContain('const value0 = true;');
+  });
+});

--- a/src/client/features/workspace/diff-viewer.tsx
+++ b/src/client/features/workspace/diff-viewer.tsx
@@ -1,26 +1,18 @@
 import { EyeIcon, FileCodeIcon, SpinnerGapIcon, WarningCircleIcon } from '@phosphor-icons/react';
 import { useTheme } from 'next-themes';
-import { useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { oneDark, oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism';
-import { withOccurrenceKeys } from '@/client/lib/list-keys';
 import { trpc } from '@/client/lib/trpc';
 import { Button } from '@/components/ui/button';
 import { MarkdownRenderer } from '@/components/ui/markdown';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import {
-  calculateLineNumberWidth,
-  type DiffLine,
-  getDiffLineBackground,
-  getDiffLinePrefix,
-  getDiffLineTextColor,
-  type LineTokenMap,
-  parseDetailedDiff,
-  type SyntaxToken,
-  tokenizeDiffLines,
-} from '@/lib/diff';
+import { calculateLineNumberWidth, parseDetailedDiff } from '@/lib/diff/parse';
 import { getLanguageFromPath } from '@/lib/language-detection';
-import { cn } from '@/lib/utils';
+import { DiffLines } from './diff-lines';
+import type { ScrollState } from './scroll-state';
+import { useDiffHighlighting } from './use-diff-highlighting';
 import { usePersistentScroll } from './use-persistent-scroll';
+import { useWorkspacePanel } from './workspace-panel-context';
 
 // =============================================================================
 // Types
@@ -84,78 +76,17 @@ function MarkdownPreview({ workspaceId, filePath }: MarkdownPreviewProps) {
   );
 }
 
-interface SyntaxHighlightedContentProps {
-  tokens: SyntaxToken[];
-}
-
-function SyntaxHighlightedContent({ tokens }: SyntaxHighlightedContentProps) {
-  return (
-    <>
-      {tokens.map((token, i) => {
-        const key = `${i}-${token.content.length}`;
-        return (
-          <span key={key} style={token.style}>
-            {token.content}
-          </span>
-        );
-      })}
-    </>
-  );
-}
-
-interface DiffLineProps {
-  line: DiffLine;
-  lineNumberWidth: number;
-  tokens?: SyntaxToken[] | null;
-}
-
-function DiffLineComponent({ line, lineNumberWidth, tokens }: DiffLineProps) {
-  const bgColor = getDiffLineBackground(line.type);
-  const prefix = getDiffLinePrefix(line.type);
-  const hasTokens = tokens != null && tokens.length > 0;
-  // When syntax tokens are available, let them control text color for code lines.
-  // Header/hunk lines and lines without tokens use the standard diff text color.
-  const textColor = hasTokens ? undefined : getDiffLineTextColor(line.type);
-
-  return (
-    <div className={cn('flex font-mono text-xs', bgColor)}>
-      {/* Line numbers */}
-      <div className="flex-shrink-0 flex text-muted-foreground border-r border-border select-none">
-        <span
-          className="box-content px-1 text-right border-r border-border tabular-nums"
-          style={{ width: `${lineNumberWidth}ch` }}
-        >
-          {line.lineNumber?.old ?? ''}
-        </span>
-        <span
-          className="box-content px-1 text-right tabular-nums"
-          style={{ width: `${lineNumberWidth}ch` }}
-        >
-          {line.lineNumber?.new ?? ''}
-        </span>
-      </div>
-
-      {/* Prefix — always uses diff text color */}
-      <span
-        className={cn('flex-shrink-0 w-4 text-center select-none', getDiffLineTextColor(line.type))}
-      >
-        {prefix}
-      </span>
-
-      {/* Content */}
-      <pre className={cn('flex-1 whitespace-pre-wrap break-all px-2', textColor)}>
-        {hasTokens ? <SyntaxHighlightedContent tokens={tokens} /> : line.content}
-      </pre>
-    </div>
-  );
-}
-
 // =============================================================================
 // Main Component
 // =============================================================================
 
 export function DiffViewer({ workspaceId, filePath, tabId }: DiffViewerProps) {
   const { resolvedTheme } = useTheme();
+  const { getScrollState, setScrollState } = useWorkspacePanel();
+  const saveDiffScrollState = useCallback(
+    (state: ScrollState) => setScrollState(tabId, 'code', state),
+    [setScrollState, tabId]
+  );
   const { data, isLoading, error } = trpc.workspace.getFileDiff.useQuery({
     workspaceId,
     filePath,
@@ -184,20 +115,7 @@ export function DiffViewer({ workspaceId, filePath, tabId }: DiffViewerProps) {
   const syntaxTheme = resolvedTheme === 'dark' ? oneDark : oneLight;
   const language = getLanguageFromPath(filePath);
 
-  const tokenMap: LineTokenMap | null = useMemo(() => {
-    if (parsedDiff.length === 0) {
-      return null;
-    }
-    return tokenizeDiffLines(parsedDiff, language, syntaxTheme);
-  }, [parsedDiff, language, syntaxTheme]);
-
-  const { handleScroll: handleDiffScroll } = usePersistentScroll({
-    tabId,
-    mode: 'code',
-    viewportRef: diffViewportRef,
-    enabled: !showPreview,
-    restoreDeps: [showPreview, filePath, data?.diff?.length],
-  });
+  const tokenMap = useDiffHighlighting(parsedDiff, language, syntaxTheme, !showPreview);
 
   const { handleScroll: handleMarkdownScroll } = usePersistentScroll({
     tabId,
@@ -270,19 +188,15 @@ export function DiffViewer({ workspaceId, filePath, tabId }: DiffViewerProps) {
           <MarkdownPreview workspaceId={workspaceId} filePath={filePath} />
         </ScrollArea>
       ) : (
-        <ScrollArea className="flex-1" onScroll={handleDiffScroll} viewportRef={diffViewportRef}>
-          <div className="min-w-fit">
-            {withOccurrenceKeys(parsedDiff, (line) =>
-              JSON.stringify([line.type, line.lineNumber?.old, line.lineNumber?.new, line.content])
-            ).map(({ item: line, key }, index) => (
-              <DiffLineComponent
-                key={key}
-                line={line}
-                lineNumberWidth={lineNumberWidth}
-                tokens={tokenMap?.get(index)}
-              />
-            ))}
-          </div>
+        <ScrollArea className="flex-1" viewportRef={diffViewportRef}>
+          <DiffLines
+            lines={parsedDiff}
+            lineNumberWidth={lineNumberWidth}
+            tokenMap={tokenMap}
+            scrollContainerRef={diffViewportRef}
+            scrollState={getScrollState(tabId, 'code')}
+            onScrollStateChange={saveDiffScrollState}
+          />
         </ScrollArea>
       )}
     </div>

--- a/src/client/features/workspace/scroll-state.test.ts
+++ b/src/client/features/workspace/scroll-state.test.ts
@@ -22,6 +22,26 @@ function createStorage() {
 }
 
 describe('scroll-state', () => {
+  it('round-trips a wrapped diff row anchor and ignores invalid anchors', () => {
+    const storage = createStorage();
+    storage.setItem(
+      makeScrollStorageKey('w'),
+      JSON.stringify({
+        v: 1,
+        states: {
+          valid: { top: 8000, left: 0, diffAnchor: { index: 500, offset: 7 } },
+          invalid: { top: 80, left: 0, diffAnchor: { index: -1, offset: 0 } },
+        },
+      })
+    );
+    const loaded = loadScrollStateRecord(storage, 'w');
+    expect(loaded.valid).toMatchObject({ diffAnchor: { index: 500, offset: 7 } });
+    expect(loaded.invalid).toMatchObject({ top: 80, left: 0 });
+    expect(loaded.invalid).not.toHaveProperty('diffAnchor');
+    saveScrollStateRecord(storage, 'w', upsertScrollState({}, 'tab', 'code', loaded.valid!));
+    expect(loadScrollStateRecord(storage, 'w')['tab:code']).toEqual(loaded.valid);
+  });
+
   it('round-trips scroll state records with versioned payload', () => {
     const storage = createStorage();
     const workspaceId = 'workspace-1';

--- a/src/client/features/workspace/scroll-state.ts
+++ b/src/client/features/workspace/scroll-state.ts
@@ -6,6 +6,7 @@ export interface ScrollState {
   top: number;
   left: number;
   stickToBottom?: boolean;
+  diffAnchor?: { index: number; offset: number };
 }
 
 export interface StorageLike {
@@ -21,10 +22,16 @@ interface ScrollStoragePayload {
 const STORAGE_VERSION = 1;
 const STORAGE_KEY_SCROLL_PREFIX = 'workspace-panel-scroll-';
 
+const DiffAnchorSchema = z.object({
+  index: z.number().int().nonnegative(),
+  offset: z.number().finite().nonnegative(),
+});
+
 const ScrollStateSchema = z.object({
   top: z.number().finite().min(0),
   left: z.number().finite().min(0),
   stickToBottom: z.boolean().optional(),
+  diffAnchor: DiffAnchorSchema.optional().catch(undefined),
 });
 
 const ScrollStoragePayloadSchema = z.object({
@@ -41,10 +48,12 @@ export function makeScrollStateKey(tabId: string, mode: ScrollMode): string {
 }
 
 function sanitizeScrollState(state: ScrollState): ScrollState {
+  const anchor = DiffAnchorSchema.safeParse(state.diffAnchor);
   return {
     top: Math.max(0, Number.isFinite(state.top) ? state.top : 0),
     left: Math.max(0, Number.isFinite(state.left) ? state.left : 0),
     stickToBottom: state.stickToBottom === true ? true : undefined,
+    ...(anchor.success ? { diffAnchor: anchor.data } : {}),
   };
 }
 

--- a/src/client/features/workspace/use-diff-highlighting.ts
+++ b/src/client/features/workspace/use-diff-highlighting.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+import type { LineTokenMap, PrismStylesheet } from '@/lib/diff/syntax-highlight';
+import type { DiffLine } from '@/lib/diff/types';
+import { diffHighlightResponseSchema } from './diff-highlight-protocol';
+
+interface HighlightResult {
+  lines: DiffLine[];
+  language: string;
+  theme: PrismStylesheet;
+  tokens: LineTokenMap | null;
+}
+
+/** Plain text remains usable while highlighting runs, or if workers are unavailable. */
+export function useDiffHighlighting(
+  lines: DiffLine[],
+  language: string,
+  theme: PrismStylesheet,
+  enabled = true
+): LineTokenMap | null {
+  const [result, setResult] = useState<HighlightResult | null>(null);
+
+  useEffect(() => {
+    if (!enabled || lines.length === 0 || language === 'text') {
+      return;
+    }
+    let active = true;
+    let worker: Worker | undefined;
+    try {
+      worker = new Worker(new URL('./diff-highlight.worker.ts', import.meta.url), {
+        type: 'module',
+      });
+      worker.onmessage = (event: MessageEvent<unknown>) => {
+        if (!active) {
+          return;
+        }
+        const parsed = diffHighlightResponseSchema.safeParse(event.data);
+        setResult({ lines, language, theme, tokens: parsed.success ? parsed.data : null });
+        worker?.terminate();
+      };
+      worker.onerror = () => worker?.terminate();
+      worker.onmessageerror = () => worker?.terminate();
+      worker.postMessage({ lines, language, theme });
+    } catch {
+      worker?.terminate();
+    }
+    return () => {
+      active = false;
+      worker?.terminate();
+    };
+  }, [enabled, lines, language, theme]);
+
+  return enabled &&
+    result?.lines === lines &&
+    result.language === language &&
+    result.theme === theme
+    ? result.tokens
+    : null;
+}

--- a/src/client/features/workspace/use-diff-scroll.ts
+++ b/src/client/features/workspace/use-diff-scroll.ts
@@ -1,0 +1,140 @@
+import type { Virtualizer } from '@tanstack/react-virtual';
+import { type RefObject, useEffect, useRef, useState } from 'react';
+import type { DiffLine } from '@/lib/diff/types';
+import type { ScrollState } from './scroll-state';
+
+interface DiffScrollOptions {
+  lines: DiffLine[];
+  virtualizer: Virtualizer<HTMLDivElement, Element>;
+  virtualized: boolean;
+  scrollContainerRef: RefObject<HTMLDivElement | null>;
+  scrollState?: ScrollState | null;
+  onScrollStateChange?: (state: ScrollState) => void;
+}
+
+/** Persist a visible row, since measured wrapping makes absolute offsets unstable. */
+export function useDiffScroll({
+  lines,
+  virtualizer,
+  virtualized,
+  scrollContainerRef,
+  scrollState,
+  onScrollStateChange,
+}: DiffScrollOptions) {
+  const latest = useRef({ scrollState, onScrollStateChange });
+  const [measurementVersion, setMeasurementVersion] = useState(0);
+  latest.current = { scrollState, onScrollStateChange };
+
+  useEffect(() => {
+    const viewport = scrollContainerRef.current;
+    if (!viewport) {
+      return;
+    }
+    let frame = 0;
+    let restoring = false;
+    const capture = (): ScrollState => {
+      const row = virtualized ? virtualizer.getVirtualItemForOffset(viewport.scrollTop) : undefined;
+      return {
+        top: viewport.scrollTop,
+        left: viewport.scrollLeft,
+        ...(row
+          ? {
+              diffAnchor: { index: row.index, offset: Math.max(0, viewport.scrollTop - row.start) },
+            }
+          : {}),
+      };
+    };
+    const persist = () => {
+      if (!restoring) {
+        latest.current.onScrollStateChange?.(capture());
+      }
+    };
+    const restore = (state: ScrollState | null | undefined, invalidate: boolean) => {
+      cancelAnimationFrame(frame);
+      restoring = true;
+      if (invalidate && virtualized) {
+        virtualizer.measure();
+        // Re-observe mounted rows too: clearing cached sizes does not itself
+        // produce ResizeObserver entries for elements whose size stayed fixed.
+        setMeasurementVersion((version) => version + 1);
+      }
+      if (!state) {
+        restoring = false;
+        return;
+      }
+      const anchor = virtualized ? state?.diffAnchor : undefined;
+      let remaining = 12;
+      let stable = 0;
+      let previousTop = -1;
+      const applyPosition = () => {
+        viewport.scrollLeft = state?.left ?? 0;
+        if (anchor && lines.length > 0) {
+          const index = Math.min(anchor.index, lines.length - 1);
+          const row = virtualizer.getVirtualItems().find((item) => item.index === index);
+          if (row) {
+            virtualizer.scrollToOffset(
+              row.start + Math.min(anchor.offset, Math.max(0, row.size - 1))
+            );
+          } else {
+            virtualizer.scrollToIndex(index, { align: 'start' });
+          }
+        } else {
+          viewport.scrollTop = Math.min(
+            state?.top ?? 0,
+            Math.max(0, viewport.scrollHeight - viewport.clientHeight)
+          );
+        }
+      };
+      const align = () => {
+        applyPosition();
+        stable = Math.abs(viewport.scrollTop - previousTop) < 1 ? stable + 1 : 0;
+        previousTop = viewport.scrollTop;
+        remaining -= 1;
+        if (stable < 3 && remaining > 0) {
+          frame = requestAnimationFrame(align);
+        } else {
+          restoring = false;
+          persist();
+        }
+      };
+      frame = requestAnimationFrame(align);
+    };
+    const cancelRestore = () => {
+      cancelAnimationFrame(frame);
+      restoring = false;
+    };
+    // Radix scrollbars are siblings of the viewport. Capture gestures on the
+    // containing Root so a thumb drag also cancels an in-flight restoration.
+    const gestureTarget = viewport.hasAttribute('data-radix-scroll-area-viewport')
+      ? (viewport.parentElement ?? viewport)
+      : viewport;
+    viewport.addEventListener('scroll', persist);
+    gestureTarget.addEventListener('wheel', cancelRestore, { passive: true, capture: true });
+    gestureTarget.addEventListener('touchstart', cancelRestore, { passive: true, capture: true });
+    gestureTarget.addEventListener('pointerdown', cancelRestore, true);
+    gestureTarget.addEventListener('keydown', cancelRestore, true);
+    let width = viewport.clientWidth;
+    const observer =
+      typeof ResizeObserver === 'undefined'
+        ? undefined
+        : new ResizeObserver(() => {
+            if (width === viewport.clientWidth) {
+              return;
+            }
+            width = viewport.clientWidth;
+            restore(capture(), true);
+          });
+    observer?.observe(viewport);
+    restore(latest.current.scrollState, true);
+    return () => {
+      cancelAnimationFrame(frame);
+      observer?.disconnect();
+      viewport.removeEventListener('scroll', persist);
+      gestureTarget.removeEventListener('wheel', cancelRestore, true);
+      gestureTarget.removeEventListener('touchstart', cancelRestore, true);
+      gestureTarget.removeEventListener('pointerdown', cancelRestore, true);
+      gestureTarget.removeEventListener('keydown', cancelRestore, true);
+    };
+  }, [lines, virtualized, virtualizer, scrollContainerRef]);
+  return measurementVersion;
+}

--- a/src/client/features/workspace/use-diff-scroll.ts
+++ b/src/client/features/workspace/use-diff-scroll.ts
@@ -12,6 +12,53 @@ interface DiffScrollOptions {
   onScrollStateChange?: (state: ScrollState) => void;
 }
 
+interface LegacyPositionProgress {
+  index: number;
+  top: number;
+  stalledFrames: number;
+}
+
+function measuredRowSize(virtualizer: Virtualizer<HTMLDivElement, Element>, index: number) {
+  const key = virtualizer.options.getItemKey(index);
+  const element = virtualizer.elementsCache.get(key);
+  // TanStack only caches sizes that differ from its estimate. A mounted row
+  // with the estimated height still supplies an actual measurement.
+  const size =
+    virtualizer.itemSizeCache.get(key) ??
+    (element?.isConnected
+      ? virtualizer.options.measureElement(element, undefined, virtualizer)
+      : undefined);
+  return size && size > 0 ? size : undefined;
+}
+
+// Pixel-only records predate virtualization. Measure a contiguous prefix in
+// bounded windows: estimates cannot identify the wrapped row at a saved offset.
+function advanceLegacyPosition(
+  virtualizer: Virtualizer<HTMLDivElement, Element>,
+  count: number,
+  top: number,
+  progress: LegacyPositionProgress
+): ScrollState['diffAnchor'] {
+  const previousIndex = progress.index;
+  while (progress.index < count) {
+    const size = measuredRowSize(virtualizer, progress.index);
+    if (size === undefined) {
+      virtualizer.scrollToIndex(progress.index, { align: 'start' });
+      progress.stalledFrames = progress.index === previousIndex ? progress.stalledFrames + 1 : 0;
+      return undefined;
+    }
+    if (progress.top + size > top || progress.index === count - 1) {
+      return {
+        index: progress.index,
+        offset: Math.min(top - progress.top, Math.max(0, size - 1)),
+      };
+    }
+    progress.top += size;
+    progress.index += 1;
+  }
+  return undefined;
+}
+
 /** Persist a visible row, since measured wrapping makes absolute offsets unstable. */
 export function useDiffScroll({
   lines,
@@ -32,6 +79,7 @@ export function useDiffScroll({
     }
     let frame = 0;
     let restoring = false;
+    let pendingState: ScrollState | null | undefined;
     const capture = (): ScrollState => {
       const row = virtualized ? virtualizer.getVirtualItemForOffset(viewport.scrollTop) : undefined;
       return {
@@ -52,6 +100,7 @@ export function useDiffScroll({
     const restore = (state: ScrollState | null | undefined, invalidate: boolean) => {
       cancelAnimationFrame(frame);
       restoring = true;
+      pendingState = state;
       if (invalidate && virtualized) {
         virtualizer.measure();
         // Re-observe mounted rows too: clearing cached sizes does not itself
@@ -62,7 +111,8 @@ export function useDiffScroll({
         restoring = false;
         return;
       }
-      const anchor = virtualized ? state?.diffAnchor : undefined;
+      let anchor = virtualized ? state.diffAnchor : undefined;
+      const migration = { index: 0, top: 0, stalledFrames: 0 };
       let remaining = 12;
       let stable = 0;
       let previousTop = -1;
@@ -94,14 +144,27 @@ export function useDiffScroll({
           frame = requestAnimationFrame(align);
         } else {
           restoring = false;
+          pendingState = null;
           persist();
         }
       };
-      frame = requestAnimationFrame(align);
+      const migrate = () => {
+        anchor = advanceLegacyPosition(virtualizer, lines.length, state.top, migration);
+        if (anchor) {
+          frame = requestAnimationFrame(align);
+          return;
+        }
+        // An unmeasurable/hidden viewport must not overwrite the saved state.
+        // Gestures still cancel restoration and resume ordinary persistence.
+        frame = migration.stalledFrames < 12 ? requestAnimationFrame(migrate) : 0;
+      };
+      const needsMigration = virtualized && !anchor && state.top > 0;
+      frame = requestAnimationFrame(needsMigration ? migrate : align);
     };
     const cancelRestore = () => {
       cancelAnimationFrame(frame);
       restoring = false;
+      pendingState = null;
     };
     // Radix scrollbars are siblings of the viewport. Capture gestures on the
     // containing Root so a thumb drag also cancels an in-flight restoration.
@@ -122,7 +185,7 @@ export function useDiffScroll({
               return;
             }
             width = viewport.clientWidth;
-            restore(capture(), true);
+            restore(pendingState ?? capture(), true);
           });
     observer?.observe(viewport);
     restore(latest.current.scrollState, true);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { resolve } from 'node:path';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
+import { workerSafeAliases } from './scripts/vite-worker-aliases';
 
 // Backend URL is set by the CLI when running in development mode
 const backendUrl = process.env.BACKEND_URL || 'http://localhost:3000';
@@ -21,6 +22,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      ...workerSafeAliases,
       '@': resolve(import.meta.dirname, './src'),
       '@prisma-gen': resolve(import.meta.dirname, './prisma/generated'),
     },


### PR DESCRIPTION
Large diffs synchronously highlighted every line and mounted the entire result. Render plain text immediately, move whole-diff highlighting into a worker, and virtualize diffs above 200 rows. A 10,000-line browser fixture now initially mounts 38 rows instead of 10,001, while retaining access to the final line.

Measured rows preserve wrapping. Persisted row anchors restore the same visible line after reopening or resizing; wheel, keyboard, touch, and scrollbar gestures cancel pending restoration. Legacy pixel-only scroll records migrate through bounded measurement windows before saving a row anchor, including mixed wrapped and unwrapped rows. Intermediate positions are never persisted. Worker failures leave usable plain text, and obsolete workers are terminated when the diff or theme changes.

Vite and Storybook resolve the syntax engine's entity decoder to its DOM-free export, verified by executing the bundled worker without `document` or `window`. No dependencies were added.

Validation:
- `pnpm check:fix`, `pnpm typecheck`, and `pnpm check` passed.
- Latest `pnpm test --maxWorkers=4`: 5,517 passed, four skipped, one unchanged Git-fixture cleanup failure (`ENOTEMPTY`). The failed fixture and five focused diff suites passed together on rerun: 23 tests. No unrelated source or assertions were changed.
- `pnpm exec vite build` and `pnpm build:storybook` passed.
- Chromium checks verified highlighting, bounded mounted rows, reaching the final line, and preserving a wrapped row across reopening and resizing, with no browser errors. A legacy 24,007-pixel position migrated to row 578 plus 23 pixels and preserved that anchor on remount with 28 rows mounted.
- Regression tests cover worker responses/failures, stale results, production worker resolution, measured wrapping, legacy scroll storage, gesture cancellation, and undefined CSS properties on both worker boundaries. Remount and worker-bundle assertions were strengthened.

Limitation: browser-native find and text selection operate on the mounted window in large virtualized diffs. Small diffs retain full rendering.

Independent of the chat and file-preview performance PRs; this branch targets `main` directly.
