### PR TITLE
Handle non-Error Electron exceptions safely

### DIFF
--- a/electron/main/fatal-error-handlers.test.ts
+++ b/electron/main/fatal-error-handlers.test.ts
@@ -115,6 +115,14 @@ describe('fatal Electron error handlers', () => {
     );
   });
 
+  it.each(['plain exception', null, undefined])('shows non-Error exception %s', async (error) => {
+    const { app, dialog, process, serverManager } = createHandlerHarness();
+    process.emit('uncaughtException', error);
+    expect(dialog.showErrorBox).toHaveBeenCalledWith('Uncaught Exception', String(error));
+    expect(serverManager.stop).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(app.quit).toHaveBeenCalledTimes(1));
+  });
+
   it.each(['plain rejection', null, undefined])('shows non-Error rejection %s', async (reason) => {
     const { app, dialog, process } = createHandlerHarness();
     process.emit('unhandledRejection', reason);

--- a/electron/main/fatal-error-handlers.ts
+++ b/electron/main/fatal-error-handlers.ts
@@ -13,7 +13,7 @@ interface FatalErrorLogger {
 }
 
 interface FatalErrorProcess {
-  on(event: 'uncaughtException', listener: (error: Error) => void): this;
+  on(event: 'uncaughtException', listener: (error: unknown) => void): this;
   on(event: 'unhandledRejection', listener: (reason: unknown) => void): this;
 }
 
@@ -58,7 +58,10 @@ export function registerFatalErrorHandlers({
 
   process.on('uncaughtException', (error) => {
     logger.error('[electron] Uncaught exception:', error);
-    dialog.showErrorBox('Uncaught Exception', error.stack || String(error));
+    dialog.showErrorBox(
+      'Uncaught Exception',
+      error instanceof Error ? error.stack || String(error) : String(error)
+    );
     void shutdown();
   });
 


### PR DESCRIPTION
Handle non-Error values in Electron's uncaught-exception listener so throwing `null` or `undefined` still shows the fatal-error dialog and stops the backend before quitting. Treat the listener input as unknown and use the same guarded formatting as the rejection handler.

Closes #2264.

Validation: regression reproduced for both nullish values before the fix; all 14 fatal-handler tests now pass. `pnpm check:fix`, `pnpm typecheck`, `pnpm check`, and pre-commit checks passed. The local Codex schema check skipped because installed CLI 0.154.0 differs from pinned 0.153.4; CI enforces the pinned version.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

