### PR TITLE
Suppress completion notifications after workspace archive

### DIFF
--- a/docs/architecture/workspace-state.md
+++ b/docs/architecture/workspace-state.md
@@ -153,3 +153,7 @@ once. The idle event captures the count before the asynchronous workspace lookup
 so a subsequent interval cannot change an earlier notification. Lookups and
 notification requests run in idle order per workspace; a failed lookup does not
 block later intervals, and separate workspaces can proceed independently.
+
+Archiving or deleting a workspace clears its activity state and invalidates any
+pending completion notification. Restarted activity gets a new state, so an older
+lookup cannot notify for that earlier lifecycle.

--- a/docs/architecture/workspace-state.md
+++ b/docs/architecture/workspace-state.md
@@ -156,4 +156,5 @@ block later intervals, and separate workspaces can proceed independently.
 
 Archiving or deleting a workspace clears its activity state and invalidates any
 pending completion notification. Restarted activity gets a new state, so an older
-lookup cannot notify for that earlier lifecycle.
+lookup cannot notify for that earlier lifecycle. Clearing also detaches the old
+notification chain, so restarted work does not wait for an earlier lookup.

--- a/src/backend/services/workspace/service/lifecycle/activity.service.test.ts
+++ b/src/backend/services/workspace/service/lifecycle/activity.service.test.ts
@@ -158,6 +158,45 @@ describe('WorkspaceActivityService', () => {
     }
   });
 
+  it.each([false, true])(
+    'suppresses pending notifications after clearing a workspace (restarted: %s)',
+    async (restart) => {
+      const workspaceId = 'notification-cleared';
+      workspaceIds.push(workspaceId);
+      const lookup = createDeferred<{ name: string }>();
+      mockFindById.mockReturnValueOnce(lookup.promise);
+      const onNotification = vi.fn();
+      workspaceActivityService.on('request_notification', onNotification);
+      try {
+        workspaceActivityService.markSessionRunning(workspaceId, 'old-session');
+        workspaceActivityService.markSessionIdle(workspaceId, 'old-session');
+        await flushNotifications();
+        workspaceActivityService.clearWorkspace(workspaceId);
+        if (restart) {
+          workspaceActivityService.markSessionRunning(workspaceId, 'new-session');
+        }
+        lookup.resolve({ name: 'Test Workspace' });
+        await flushNotifications();
+        expect(onNotification).not.toHaveBeenCalled();
+
+        if (restart) {
+          workspaceActivityService.markSessionIdle(workspaceId, 'new-session');
+          await flushNotifications();
+          expect(onNotification).toHaveBeenCalledExactlyOnceWith({
+            workspaceId,
+            workspaceName: 'Test Workspace',
+            sessionCount: 1,
+            finishedAt: expect.any(Date),
+          });
+        }
+      } finally {
+        lookup.resolve({ name: 'Test Workspace' });
+        await flushNotifications();
+        workspaceActivityService.off('request_notification', onNotification);
+      }
+    }
+  );
+
   const workspaceIds: string[] = [];
 
   afterEach(async () => {

--- a/src/backend/services/workspace/service/lifecycle/activity.service.test.ts
+++ b/src/backend/services/workspace/service/lifecycle/activity.service.test.ts
@@ -197,6 +197,38 @@ describe('WorkspaceActivityService', () => {
     }
   );
 
+  it('notifies restarted work while an old lifecycle lookup remains pending', async () => {
+    const workspaceId = 'notification-restart-pending';
+    workspaceIds.push(workspaceId);
+    const lookup = createDeferred<{ name: string }>();
+    mockFindById.mockReturnValueOnce(lookup.promise);
+    const onNotification = vi.fn();
+    workspaceActivityService.on('request_notification', onNotification);
+    try {
+      workspaceActivityService.markSessionRunning(workspaceId, 'old-session');
+      workspaceActivityService.markSessionIdle(workspaceId, 'old-session');
+      await flushNotifications();
+      workspaceActivityService.clearWorkspace(workspaceId);
+      workspaceActivityService.markSessionRunning(workspaceId, 'new-session');
+      workspaceActivityService.markSessionIdle(workspaceId, 'new-session');
+      await flushNotifications();
+      expect(onNotification).toHaveBeenCalledExactlyOnceWith({
+        workspaceId,
+        workspaceName: 'Test Workspace',
+        sessionCount: 1,
+        finishedAt: expect.any(Date),
+      });
+
+      lookup.resolve({ name: 'Old Workspace' });
+      await flushNotifications();
+      expect(onNotification).toHaveBeenCalledOnce();
+    } finally {
+      lookup.resolve({ name: 'Old Workspace' });
+      await flushNotifications();
+      workspaceActivityService.off('request_notification', onNotification);
+    }
+  });
+
   const workspaceIds: string[] = [];
 
   afterEach(async () => {

--- a/src/backend/services/workspace/service/lifecycle/activity.service.ts
+++ b/src/backend/services/workspace/service/lifecycle/activity.service.ts
@@ -176,6 +176,7 @@ class WorkspaceActivityService extends EventEmitter {
    */
   clearWorkspace(workspaceId: string): void {
     this.workspaceStates.delete(workspaceId);
+    this.notificationChains.delete(workspaceId);
   }
 }
 

--- a/src/backend/services/workspace/service/lifecycle/activity.service.ts
+++ b/src/backend/services/workspace/service/lifecycle/activity.service.ts
@@ -29,12 +29,19 @@ class WorkspaceActivityService extends EventEmitter {
 
     // Serialize each workspace's lookups so busy intervals notify in idle order.
     this.on('workspace_idle', ({ workspaceId, finishedAt, sessionCount }) => {
+      const activityState = this.workspaceStates.get(workspaceId);
       const previous = this.notificationChains.get(workspaceId) ?? Promise.resolve();
       const notification = previous
         .then(async () => {
           const workspace = await workspaceAccessor.findById(workspaceId);
           if (!workspace) {
             logger.warn('Workspace not found for notification', { workspaceId });
+            return;
+          }
+
+          // Clearing a workspace invalidates its queued notifications, even if
+          // activity starts again before this lookup resolves.
+          if (!activityState || this.workspaceStates.get(workspaceId) !== activityState) {
             return;
           }
 


### PR DESCRIPTION
A completion lookup queued before a workspace is archived could still emit a Workspace Ready notification afterward. Pending notifications now retain their original activity state and are suppressed when that state is cleared or replaced; a restarted workspace can still notify for new work.

Closes #2262.

Validation: reproduced both cleared and restarted races before the fix; all 9 activity tests pass. `pnpm check:fix`, `pnpm typecheck`, and `pnpm check` pass, along with commit-hook migration/dependency/unused-code checks. The Codex schema check skips locally because installed CLI 0.154.0 differs from pinned 0.153.4; CI enforces the pinned check.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

