### PR TITLE
Validate resumed branches under symlinked worktree bases

### DIFF
--- a/docs/architecture/workspace-state.md
+++ b/docs/architecture/workspace-state.md
@@ -6,7 +6,9 @@ the row back onto the workspace under the field's original name, so the snapshot
 wire, the v4 export format and the client are unchanged.
 
 Worktree cleanup matches Git's registered paths against the real worktree base
-directory, so a symlinked base still removes Git metadata. It resolves the base
+directory, so a symlinked base still removes Git metadata. Branch-resume
+validation also resolves the base before checking registered worktrees, so an
+already checked-out branch is rejected before creating a workspace. It resolves the base
 separately from the worktree so cleanup also works after the worktree is deleted.
 If the base symlink itself no longer resolves, cleanup logs a warning and matches
 only the exact configured path. Restore the original base symlink and retry to

--- a/src/backend/services/workspace/service/worktree/git-ops.service.test.ts
+++ b/src/backend/services/workspace/service/worktree/git-ops.service.test.ts
@@ -455,6 +455,27 @@ describe('gitOpsService', () => {
     await expect(gitOpsService.isBranchCheckedOut(project, 'feature/test')).resolves.toBe(false);
   });
 
+  it('recognizes a branch under a symlinked worktree base', async () => {
+    mockRealpath.mockImplementation(async (target: string) =>
+      target === '/repo/worktrees' ? '/actual/worktrees' : target
+    );
+    mockGitClient.listWorktreesWithBranches.mockResolvedValue([
+      { path: '/actual/worktrees/w1', branchName: 'feature/test' },
+    ]);
+    await expect(gitOpsService.isBranchCheckedOut(project, 'origin/feature/test')).resolves.toBe(
+      true
+    );
+    await expect(gitOpsService.isBranchCheckedOut(project, 'feature/other')).resolves.toBe(false);
+  });
+
+  it('matches the configured base when it no longer resolves', async () => {
+    mockRealpath.mockRejectedValueOnce(Object.assign(new Error('missing'), { code: 'ENOENT' }));
+    mockGitClient.listWorktreesWithBranches.mockResolvedValue([
+      { path: '/repo/worktrees/w1', branchName: 'feature/test' },
+    ]);
+    await expect(gitOpsService.isBranchCheckedOut(project, 'feature/test')).resolves.toBe(true);
+  });
+
   it('invalidates a partial worktree when creation fails', async () => {
     mockGitClient.createWorktree.mockRejectedValueOnce(new Error('create failed'));
 

--- a/src/backend/services/workspace/service/worktree/git-ops.service.ts
+++ b/src/backend/services/workspace/service/worktree/git-ops.service.ts
@@ -296,7 +296,20 @@ class GitOpsService {
 
     const normalizedBranch = this.normalizeBranchName(branchName);
     const worktrees = await gitClient.listWorktreesWithBranches();
-    const worktreeBasePath = path.resolve(project.worktreeBasePath);
+    let worktreeBasePath = path.resolve(project.worktreeBasePath);
+    try {
+      worktreeBasePath = await fs.realpath(worktreeBasePath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error;
+      }
+      logger.warn(
+        'Cannot resolve worktree base for branch checkout check; matching configured path',
+        {
+          worktreeBasePath,
+        }
+      );
+    }
     const basePrefix = `${worktreeBasePath}${path.sep}`;
     const repoPath = path.resolve(project.repoPath);
 


### PR DESCRIPTION
When the worktree base is configured through a symlink, branch-resume validation compared its lexical path with Git’s canonical worktree paths and missed branches already checked out. Resolve the base before matching so these requests fail validation before creating a failed workspace. Preserve configured-path matching when the base no longer exists, consistent with cleanup behavior.

Closes #2275.

Validation: symlink regression failed before the fix; all 23 git-ops tests pass, including unmatched branches and a missing base. `pnpm check:fix`, `pnpm typecheck`, `pnpm check`, and commit-hook checks pass. Codex schema drift skips locally because installed CLI 0.154.0 differs from pinned 0.153.4; CI enforces the pinned check.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

