### PR TITLE
Reject empty derived project slugs

### DIFF
--- a/src/backend/services/workspace/resources/project.accessor.test.ts
+++ b/src/backend/services/workspace/resources/project.accessor.test.ts
@@ -1,5 +1,39 @@
-import { describe, expect, it } from 'vitest';
-import { parseGitHubRemoteUrl } from './project.accessor';
+import { describe, expect, it, vi } from 'vitest';
+import { prisma } from '@/backend/db';
+import { parseGitHubRemoteUrl, projectAccessor } from './project.accessor';
+
+vi.mock('@/backend/db', () => ({
+  prisma: { project: { create: vi.fn().mockResolvedValue({ id: 'project-1' }) } },
+}));
+
+vi.mock('@/backend/lib/shell', () => ({
+  gitCommandC: vi.fn().mockResolvedValue({ code: 1, stdout: '', stderr: '' }),
+}));
+
+describe('project creation', () => {
+  it.each(['.', '/home/user/myrepo/.', '/', '/repos/---', '/repos/日本語'])(
+    'rejects a repository path with an empty derived slug: %s',
+    async (repoPath) => {
+      await expect(
+        projectAccessor.create({ repoPath }, { worktreeBaseDir: '/worktrees' })
+      ).rejects.toThrow('does not produce a valid slug');
+      expect(prisma.project.create).not.toHaveBeenCalled();
+    }
+  );
+
+  it('keeps a valid slug scoped beneath the shared worktree base', async () => {
+    await projectAccessor.create(
+      { repoPath: '/repos/My_Project' },
+      { worktreeBaseDir: '/worktrees' }
+    );
+    expect(prisma.project.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        slug: 'my-project',
+        worktreeBasePath: '/worktrees/my-project',
+      }),
+    });
+  });
+});
 
 describe('parseGitHubRemoteUrl', () => {
   describe('SSH URLs', () => {

--- a/src/backend/services/workspace/resources/project.accessor.ts
+++ b/src/backend/services/workspace/resources/project.accessor.ts
@@ -194,6 +194,11 @@ class ProjectAccessor {
   async create(data: CreateProjectInput, context: ProjectAccessorContext): Promise<Project> {
     const name = deriveNameFromPath(data.repoPath);
     const baseSlug = deriveSlugFromPath(data.repoPath);
+    if (!baseSlug) {
+      throw new Error(
+        `Unable to create project: repo path "${data.repoPath}" does not produce a valid slug`
+      );
+    }
 
     // Auto-detect GitHub info from git remote
     const githubInfo = await getGitHubInfoFromRepo(data.repoPath);


### PR DESCRIPTION
Reject repository paths whose derived project slug is empty before attempting a database insert. Paths such as `.` or punctuation-only directory names now fail clearly instead of creating an empty-slug project that stalls home-page navigation and shares the global worktree base.

Closes #2259.

Validation: five empty-slug regression cases failed before the guard and pass afterward; the valid-slug case preserves its project-specific worktree directory. All 24 accessor tests, `pnpm check:fix`, `pnpm typecheck`, `pnpm check`, and pre-commit checks passed. The local Codex schema check skipped because CLI 0.154.0 differs from pinned 0.153.4; CI enforces the pinned version.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

