### PR TITLE
Show and cancel queued messages in quick chat

### DIFF
--- a/src/client/features/kanban/quick-chat-content.stories.tsx
+++ b/src/client/features/kanban/quick-chat-content.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useRef, useState } from 'react';
+import { fn } from 'storybook/test';
+import type { UseChatWebSocketReturn } from '@/client/features/chat';
+import { DEFAULT_CHAT_SETTINGS, type QueuedMessage } from '@/lib/chat-protocol';
+import { EMPTY_CHAT_BAR_CAPABILITIES } from '@/shared/chat-capabilities';
+import { QuickChatContent } from './quick-chat-content';
+
+const meta: Meta<typeof QuickChatContent> = {
+  title: 'Kanban/QuickChatContent',
+  component: QuickChatContent,
+  parameters: { layout: 'padded' },
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const QueuedMessageCancellation: Story = {
+  render: () => {
+    const viewportRef = useRef<HTMLDivElement>(null);
+    const inputRef = useRef<HTMLTextAreaElement>(null);
+    const messagesEndRef = useRef<HTMLDivElement>(null);
+    const [queuedMessages, setQueuedMessages] = useState<QueuedMessage[]>([
+      {
+        id: 'queued-1',
+        text: 'Then add tests for the login flow',
+        timestamp: '2026-09-10T12:00:00.000Z',
+        settings: DEFAULT_CHAT_SETTINGS,
+      },
+    ]);
+    const chatState = {
+      messages: queuedMessages.map((message, order) => ({
+        ...message,
+        order,
+        source: 'user' as const,
+      })),
+      queuedMessages,
+      pendingMessages: new Map(),
+      pendingRequest: { type: 'none' },
+      sessionStatus: { phase: 'running' },
+      connected: true,
+      inputDraft: '',
+      chatSettings: DEFAULT_CHAT_SETTINGS,
+      chatCapabilities: EMPTY_CHAT_BAR_CAPABILITIES,
+      slashCommands: [],
+      slashCommandsLoaded: true,
+      acpConfigOptions: null,
+      inputRef,
+      messagesEndRef,
+      sendMessage: fn(),
+      stopChat: fn(),
+      updateSettings: fn(),
+      setInputDraft: fn(),
+      setConfigOption: fn(),
+      removeQueuedMessage: (id: string) =>
+        setQueuedMessages((messages) => messages.filter((message) => message.id !== id)),
+    } as unknown as UseChatWebSocketReturn;
+    return (
+      <div className="h-[480px] w-[400px] border">
+        <QuickChatContent
+          workspaceId="quick-chat-story"
+          chatState={chatState}
+          viewportRef={viewportRef}
+          onScroll={fn()}
+          isNearBottom
+          scrollToBottom={fn()}
+        />
+      </div>
+    );
+  },
+};

--- a/src/client/features/kanban/quick-chat-content.test.tsx
+++ b/src/client/features/kanban/quick-chat-content.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { createRef } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot } from 'react-dom/client';
+import { describe, expect, it, vi } from 'vitest';
+import type { UseChatWebSocketReturn } from '@/client/features/chat';
+import { QuickChatContent } from './quick-chat-content';
+
+const list = vi.hoisted(() => vi.fn((_props: unknown) => null));
+vi.mock('@/client/features/chat', () => ({
+  VirtualizedMessageList: list,
+  useGroupedChatMessages: (messages: unknown[]) => messages,
+  ChatInput: () => null,
+  PermissionPrompt: () => null,
+  QuestionPrompt: () => null,
+}));
+
+describe('QuickChatContent queue controls', () => {
+  it('passes the current queue and cancellation action to the message list', () => {
+    const removeQueuedMessage = vi.fn();
+    const chatState = {
+      messages: [],
+      queuedMessages: [{ id: 'queued-1' }],
+      pendingMessages: new Map(),
+      pendingRequest: { type: 'none' },
+      sessionStatus: { phase: 'running' },
+      removeQueuedMessage,
+    } as unknown as UseChatWebSocketReturn;
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    const render = () =>
+      flushSync(() =>
+        root.render(
+          <QuickChatContent
+            workspaceId="workspace-1"
+            chatState={chatState}
+            viewportRef={createRef()}
+            onScroll={vi.fn()}
+            isNearBottom
+            scrollToBottom={vi.fn()}
+          />
+        )
+      );
+    try {
+      render();
+      expect(list.mock.lastCall?.[0]).toMatchObject({
+        queuedMessageIds: new Set(['queued-1']),
+        onRemoveQueuedMessage: removeQueuedMessage,
+      });
+      chatState.queuedMessages = [];
+      render();
+      expect(list.mock.lastCall?.[0]).toMatchObject({ queuedMessageIds: new Set() });
+    } finally {
+      flushSync(() => root.unmount());
+    }
+  });
+});

--- a/src/client/features/kanban/quick-chat-content.test.tsx
+++ b/src/client/features/kanban/quick-chat-content.test.tsx
@@ -6,7 +6,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { UseChatWebSocketReturn } from '@/client/features/chat';
 import { QuickChatContent } from './quick-chat-content';
 
-const list = vi.hoisted(() => vi.fn((_props: unknown) => null));
+const list = vi.hoisted(() => vi.fn((_props: { queuedMessageIds?: Set<string> }) => null));
 vi.mock('@/client/features/chat', () => ({
   VirtualizedMessageList: list,
   useGroupedChatMessages: (messages: unknown[]) => messages,
@@ -49,7 +49,7 @@ describe('QuickChatContent queue controls', () => {
       });
       chatState.queuedMessages = [];
       render();
-      expect(list.mock.lastCall?.[0]).toMatchObject({ queuedMessageIds: new Set() });
+      expect(list.mock.lastCall?.[0]?.queuedMessageIds).toEqual(new Set());
     } finally {
       flushSync(() => root.unmount());
     }

--- a/src/client/features/kanban/quick-chat-content.tsx
+++ b/src/client/features/kanban/quick-chat-content.tsx
@@ -1,5 +1,5 @@
 import { ArrowDownIcon } from '@phosphor-icons/react';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import {
   ChatInput,
   PermissionPrompt,
@@ -28,6 +28,10 @@ export function QuickChatContent({
   scrollToBottom,
 }: QuickChatContentProps) {
   const groupedMessages = useGroupedChatMessages(chatState.messages);
+  const queuedMessageIds = useMemo(
+    () => new Set(chatState.queuedMessages.map((message) => message.id)),
+    [chatState.queuedMessages]
+  );
 
   const running = chatState.sessionStatus.phase === 'running';
   const stopping = chatState.sessionStatus.phase === 'stopping';
@@ -59,6 +63,8 @@ export function QuickChatContent({
           messagesEndRef={chatState.messagesEndRef}
           isNearBottom={isNearBottom}
           isCompacting={chatState.isCompacting}
+          queuedMessageIds={queuedMessageIds}
+          onRemoveQueuedMessage={chatState.removeQueuedMessage}
         />
       </div>
 


### PR DESCRIPTION
Kanban quick chat now marks queued messages and exposes their per-message cancel control, using the same message-list props as the main chat. Queue changes update the markers immediately. Includes a regression and an interactive Storybook queue example.

Closes #2270.

Validation: `pnpm check:fix`, `pnpm typecheck`, `pnpm test src/client/features/kanban/quick-chat-content.test.tsx` (red before the fix, green after), and `pnpm check` passed. Pre-commit checks passed. The local Codex schema check skipped because installed CLI 0.154.0 differs from pinned 0.153.4; CI enforces the pinned check. Storybook was typechecked, not browser-rendered.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

