### PR TITLE
Preserve idle status during graceful shutdown (#2260)

### DIFF
--- a/docs/architecture/agent-runtime.md
+++ b/docs/architecture/agent-runtime.md
@@ -91,6 +91,11 @@ supervisor's incarnation identity and current purpose. Exit events also carry
 whether the stop was managed; coordinators consume this metadata directly,
 including after a browsing runtime is promoted to active use.
 
+Graceful server shutdown persists active sessions as `IDLE`, matching explicit
+stops, so deliberately stopped ratchet sessions are not retried as crashes on
+the next boot. Runtime-managed exits without a shutdown reservation still use
+the exit code to determine terminal status.
+
 Startup, termination, runtime exit, notifications, context, and workflow
 finalization each have one coordinator or service.
 

--- a/src/backend/services/session/service/lifecycle/session-lifecycle-gate.ts
+++ b/src/backend/services/session/service/lifecycle/session-lifecycle-gate.ts
@@ -104,6 +104,10 @@ export class SessionLifecycleGate {
     return this.stoppingSessions.has(sessionId);
   }
 
+  isBulkShutdownReserved(sessionId: string): boolean {
+    return this.shutdownSessions.has(sessionId);
+  }
+
   getGeneration(sessionId: string): number {
     return this.stopGenerations.get(sessionId) ?? this.advanceGeneration(sessionId);
   }

--- a/src/backend/services/session/service/lifecycle/session-runtime-exit.coordinator.test.ts
+++ b/src/backend/services/session/service/lifecycle/session-runtime-exit.coordinator.test.ts
@@ -31,6 +31,7 @@ function createExitCoordinatorHarness(options?: {
   browse?: boolean;
   lifecycleStopping?: boolean;
   explicitStopReserved?: boolean;
+  bulkShutdownReserved?: boolean;
 }) {
   const session = createLifecycleTestSession();
   const repository = {
@@ -63,6 +64,7 @@ function createExitCoordinatorHarness(options?: {
   const lifecycleGate = {
     isSessionStopping: vi.fn(() => options?.lifecycleStopping ?? false),
     isStopReserved: vi.fn(() => options?.explicitStopReserved ?? false),
+    isBulkShutdownReserved: vi.fn(() => options?.bulkShutdownReserved ?? false),
     releaseShutdown: vi.fn(),
   };
   const workflowFinalizer = {
@@ -272,17 +274,20 @@ describe('SessionRuntimeExitCoordinator', () => {
   );
 
   it.each([
-    ['runtime-managed', false],
-    ['shutdown-managed', true],
+    ['runtime-managed', false, SessionStatus.FAILED],
+    ['shutdown-managed', true, SessionStatus.IDLE],
   ] as const)(
-    'persists failed status for %s exits without an explicit stop reservation',
-    async (_caseName, lifecycleStopping) => {
-      const harness = createExitCoordinatorHarness({ lifecycleStopping });
+    'persists the appropriate status for %s exits without an explicit stop reservation',
+    async (_caseName, bulkShutdownReserved, status) => {
+      const harness = createExitCoordinatorHarness({
+        lifecycleStopping: bulkShutdownReserved,
+        bulkShutdownReserved,
+      });
 
       await harness.handlers.onRuntimeExit!(runtimeExit({ managed: true, exitCode: null }));
 
       expect(harness.repository.updateSession).toHaveBeenCalledWith('session-1', {
-        status: SessionStatus.FAILED,
+        status,
       });
       expect(harness.workflowFinalizer.finalizeRuntimeExit).toHaveBeenCalledWith(
         expect.objectContaining({ deliberate: true })

--- a/src/backend/services/session/service/lifecycle/session-runtime-exit.coordinator.ts
+++ b/src/backend/services/session/service/lifecycle/session-runtime-exit.coordinator.ts
@@ -38,7 +38,7 @@ type RuntimeExitCoordinatorDependencies = {
   lifecycleEventService: Pick<SessionLifecycleEventService, 'record'>;
   lifecycleGate: Pick<
     SessionLifecycleGate,
-    'isSessionStopping' | 'isStopReserved' | 'releaseShutdown'
+    'isSessionStopping' | 'isStopReserved' | 'isBulkShutdownReserved' | 'releaseShutdown'
   >;
   workflowFinalizer: Pick<SessionWorkflowFinalizer, 'finalizeRuntimeExit' | 'clearInactiveSession'>;
   onSessionExit?: (sessionId: string) => void;
@@ -77,6 +77,9 @@ export class SessionRuntimeExitCoordinator {
   async handleExit(event: AcpRuntimeExitEvent): Promise<void> {
     try {
       const stopWillPersistIdle = this.dependencies.lifecycleGate.isStopReserved(event.sessionId);
+      const bulkShutdownReserved = this.dependencies.lifecycleGate.isBulkShutdownReserved(
+        event.sessionId
+      );
       const deliberate =
         event.managed || this.dependencies.lifecycleGate.isSessionStopping(event.sessionId);
       this.dependencies.lifecycleGate.releaseShutdown(event.sessionId);
@@ -85,7 +88,7 @@ export class SessionRuntimeExitCoordinator {
         return;
       }
       this.prepareRuntimeExit(event.sessionId, event.exitCode);
-      await this.handleActiveExit(event, deliberate, stopWillPersistIdle);
+      await this.handleActiveExit(event, deliberate, stopWillPersistIdle, bulkShutdownReserved);
     } finally {
       if (event.purpose === 'browse') {
         acpTraceLogger.closeSession(event.sessionId);
@@ -139,7 +142,8 @@ export class SessionRuntimeExitCoordinator {
   private async handleActiveExit(
     event: AcpRuntimeExitEvent,
     deliberate: boolean,
-    stopWillPersistIdle: boolean
+    stopWillPersistIdle: boolean,
+    bulkShutdownReserved: boolean
   ): Promise<void> {
     try {
       this.dependencies.sessionDomainService.markProcessExit(event.sessionId, event.exitCode);
@@ -150,7 +154,7 @@ export class SessionRuntimeExitCoordinator {
       }
 
       if (!stopWillPersistIdle) {
-        await this.updatePersistedStatus(event);
+        await this.updatePersistedStatus(event, bulkShutdownReserved);
       }
       try {
         await this.recordUnexpectedExitIfNeeded(session, event, deliberate);
@@ -203,8 +207,13 @@ export class SessionRuntimeExitCoordinator {
     }
   }
 
-  private async updatePersistedStatus(event: AcpRuntimeExitEvent): Promise<void> {
-    const persistedStatus = getPersistedStatusForExitCode(event.exitCode);
+  private async updatePersistedStatus(
+    event: AcpRuntimeExitEvent,
+    bulkShutdownReserved: boolean
+  ): Promise<void> {
+    const persistedStatus = bulkShutdownReserved
+      ? SessionStatus.IDLE
+      : getPersistedStatusForExitCode(event.exitCode);
     try {
       await this.dependencies.repository.updateSession(event.sessionId, {
         status: persistedStatus,


### PR DESCRIPTION
Graceful server shutdown stopped ACP sessions deliberately but persisted signal exits as `FAILED`, causing ratchet fixers to be retried as crashes on the next boot. Capture the bulk-shutdown reservation before releasing it and persist those exits as `IDLE`. Explicit-stop ownership and runtime-managed failure classification remain intact.

The existing shutdown-managed test expectation changes from `FAILED` to `IDLE` because it encoded the reported bug; the runtime-managed case still expects `FAILED`.

Closes #2260.

Validation: red/green shutdown regression; 67 tests across runtime-exit, lifecycle gate, termination, facade, and composition suites; `pnpm check:fix`, `pnpm typecheck`, and `pnpm check`; all pre-commit checks (including migration drift and knip). The Codex schema check skips locally because installed CLI 0.154.0 differs from pinned 0.153.4; CI enforces it.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

