### PR TITLE
Retain logs across workspace startup script phases

### DIFF
--- a/docs/architecture/workspace-state.md
+++ b/docs/architecture/workspace-state.md
@@ -15,6 +15,9 @@ registrations could remove another workspace.
 
 ## Run script
 
+Startup output accumulates across factory setup and project startup phases. The
+first executed phase clears output from prior attempts; subsequent phases append.
+
 Startup provisioning follows the main shell's exit. Output pipes normally drain
 to closure, with a one-second limit after exit so background descendants that
 inherit the pipes cannot keep provisioning open. Later output is drained and

--- a/src/backend/orchestration/workspace-init-script-pipeline.test.ts
+++ b/src/backend/orchestration/workspace-init-script-pipeline.test.ts
@@ -1,0 +1,56 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { expect, it, vi } from 'vitest';
+import { startupScriptService } from '@/backend/services/run-script';
+
+vi.mock('@/backend/services/workspace', () => ({
+  workspaceStateMachine: { markReady: vi.fn(), markReadyWithWarning: vi.fn() },
+}));
+vi.mock('@/backend/services/logger.service', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+import { executeStartupScriptPipeline } from './workspace-init-script-pipeline';
+
+it.each([true, false])(
+  'retains every startup phase and clears previous attempts (setup: %s)',
+  async (setup) => {
+    const worktreePath = await mkdtemp(path.join(tmpdir(), 'ff-pipeline-output-'));
+    let output = 'previous attempt\n';
+    startupScriptService.configure({
+      workspace: {
+        markReady: vi.fn(),
+        markFailed: vi.fn(),
+        clearInitOutput: () => {
+          output = '';
+          return Promise.resolve();
+        },
+        appendInitOutput: (_id: string, chunk: string) => {
+          output += chunk;
+          return Promise.resolve();
+        },
+        setInitScriptPid: vi.fn().mockResolvedValue(undefined),
+        clearInitScriptPid: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+    const context = {
+      workspaceId: 'pipeline-output',
+      worktreePath,
+      workspaceWithProject: {
+        id: 'pipeline-output',
+        worktreePath,
+        project: { startupScriptCommand: 'echo project startup', startupScriptPath: null },
+      },
+      factoryConfig: setup ? { scripts: { setup: 'echo factory setup' } } : null,
+    } as Parameters<typeof executeStartupScriptPipeline>[0];
+    try {
+      await executeStartupScriptPipeline(context);
+      expect(output).toBe(setup ? 'factory setup\nproject startup\n' : 'project startup\n');
+      await executeStartupScriptPipeline(context);
+      expect(output).toBe(setup ? 'factory setup\nproject startup\n' : 'project startup\n');
+    } finally {
+      await rm(worktreePath, { recursive: true, force: true });
+    }
+  }
+);

--- a/src/backend/orchestration/workspace-init-script-pipeline.ts
+++ b/src/backend/orchestration/workspace-init-script-pipeline.ts
@@ -71,7 +71,8 @@ interface PhaseResult {
 
 async function runScriptPhase(
   context: StartupScriptPipelineContext,
-  phaseDefinition: StartupScriptPhaseDefinition
+  phaseDefinition: StartupScriptPhaseDefinition,
+  preserveInitOutput: boolean
 ): Promise<PhaseResult | null> {
   if (!phaseDefinition.shouldRun(context)) {
     return null;
@@ -81,7 +82,7 @@ async function runScriptPhase(
   const scriptResult = await startupScriptService.runStartupScript(
     { ...context.workspaceWithProject, worktreePath: context.worktreePath },
     phaseDefinition.buildProjectConfig(context),
-    { deferStateTransition: true }
+    { deferStateTransition: true, preserveInitOutput }
   );
 
   if (!scriptResult.success) {
@@ -102,7 +103,7 @@ export async function executeStartupScriptPipeline(
   let lastErrorMessage: string | undefined;
 
   for (const phaseDefinition of scriptPhaseDefinitions) {
-    const phaseResult = await runScriptPhase(context, phaseDefinition);
+    const phaseResult = await runScriptPhase(context, phaseDefinition, handled);
     if (phaseResult !== null) {
       handled = true;
       if (phaseResult.failed && phaseResult.errorMessage) {

--- a/src/backend/services/run-script/service/startup-script.service.ts
+++ b/src/backend/services/run-script/service/startup-script.service.ts
@@ -38,6 +38,8 @@ export interface RunStartupScriptOptions {
    * after all phases have run.
    */
   deferStateTransition?: boolean;
+  /** Keep output from earlier phases in the current startup pipeline. */
+  preserveInitOutput?: boolean;
 }
 
 class StartupScriptService {
@@ -100,8 +102,10 @@ class StartupScriptService {
     const startTime = Date.now();
     const timeoutMs = (project.startupScriptTimeout ?? 300) * 1000;
 
-    // Clear any previous output from retry attempts
-    await this.workspace.clearInitOutput(workspace.id);
+    // The first phase clears retry output; subsequent phases keep earlier logs.
+    if (!options?.preserveInitOutput) {
+      await this.workspace.clearInitOutput(workspace.id);
+    }
 
     // Create output streaming callback with debouncing
     const { callback: outputCallback, flush: flushOutput } = this.createDebouncedOutputCallback(


### PR DESCRIPTION
When factory setup and project startup both run, the project phase cleared setup logs from the shared initialization output. The first executed phase now clears previous-attempt output and subsequent phases preserve earlier logs. Standalone startup calls retain their existing clear-on-start behavior.

Closes #2266.

Validation: the actual-shell pipeline regression failed before the fix with only project output remaining. All 101 tests across pipeline, workspace initialization, startup unit, and startup integration suites pass, including single-phase and retry output behavior. `pnpm check:fix`, `pnpm typecheck`, `pnpm check`, and commit-hook checks pass. Codex schema drift skips locally because installed CLI 0.154.0 differs from pinned 0.153.4; CI enforces the pinned check.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

