### PR TITLE
Deduplicate Linear completion for merged PR snapshots (#2261)

### DIFF
--- a/docs/architecture/integrations.md
+++ b/docs/architecture/integrations.md
@@ -19,9 +19,11 @@ A per-project issue provider can be set to Linear with an encrypted API key plus
 team selection. Kanban intake uses Linear issues assigned to the configured
 viewer. Starting from an issue creates a linked workspace (`linearIssueId`,
 `linearIssueIdentifier`, `linearIssueUrl`), and workspace lifecycle events
-best-effort sync issue state back to Linear. PR merge completion runs when the
-snapshot transitions to merged or a different merged PR is linked; repeated
-polls of the same merged PR do not repeat the Linear update.
+best-effort sync issue state back to Linear. PR merge completion suppresses
+concurrent attempts and successful repeats for the same PR during a collector
+lifetime. Failed or incomplete transitions retry on later polls, and a seeded
+merged snapshot is attempted after startup. Removing a workspace or stopping
+the collector clears completion tracking.
 
 ## Periodic tasks
 

--- a/docs/architecture/integrations.md
+++ b/docs/architecture/integrations.md
@@ -19,7 +19,9 @@ A per-project issue provider can be set to Linear with an encrypted API key plus
 team selection. Kanban intake uses Linear issues assigned to the configured
 viewer. Starting from an issue creates a linked workspace (`linearIssueId`,
 `linearIssueIdentifier`, `linearIssueUrl`), and workspace lifecycle events
-best-effort sync issue state back to Linear.
+best-effort sync issue state back to Linear. PR merge completion runs when the
+snapshot transitions to merged or a different merged PR is linked; repeated
+polls of the same merged PR do not repeat the Linear update.
 
 ## Periodic tasks
 

--- a/src/backend/orchestration/event-collector.linear.test.ts
+++ b/src/backend/orchestration/event-collector.linear.test.ts
@@ -1,0 +1,99 @@
+import { EventEmitter } from 'node:events';
+import { describe, expect, it, vi } from 'vitest';
+import { PR_SNAPSHOT_UPDATED } from '@/backend/services/github';
+import { deriveWorkspaceFlowState, WorkspaceSnapshotStore } from '@/backend/services/workspace';
+import { deriveWorkspaceSidebarStatus } from '@/shared/core';
+import { createEventCollectorOrchestrator } from './event-collector.orchestrator';
+
+function createHarness(prState: 'OPEN' | 'MERGED' = 'OPEN') {
+  const store = new WorkspaceSnapshotStore();
+  store.configure({
+    deriveFlowState: (input) =>
+      deriveWorkspaceFlowState({
+        ...input,
+        prUpdatedAt: input.prUpdatedAt ? new Date(input.prUpdatedAt) : null,
+      }),
+    deriveSidebarStatus: deriveWorkspaceSidebarStatus,
+  });
+  store.upsert(
+    'ws-1',
+    {
+      projectId: 'project-1',
+      status: 'READY',
+      prState,
+      prNumber: 7,
+      prUrl: 'https://github.com/org/repo/pull/7',
+    },
+    'reconciliation',
+    1
+  );
+  const prSnapshotService = new EventEmitter();
+  const markIssueCompleted = vi.fn().mockResolvedValue(undefined);
+  const collector = createEventCollectorOrchestrator({
+    createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+    getWorkspaceLinearContext: vi
+      .fn()
+      .mockResolvedValue({ apiKey: 'test-key', linearIssueId: 'issue-1' }),
+    linearStateSyncService: { markIssueCompleted },
+    prSnapshotService,
+    prFetchCoordinator: { removeWorkspace: vi.fn() },
+    ratchetService: Object.assign(new EventEmitter(), {
+      checkWorkspaceById: vi.fn().mockResolvedValue(null),
+    }),
+    runScriptStateMachine: new EventEmitter(),
+    workspaceAutoIterationService: new EventEmitter(),
+    sessionDomainService: new EventEmitter(),
+    workspaceActivityService: Object.assign(new EventEmitter(), { clearWorkspace: vi.fn() }),
+    workspaceStateMachine: new EventEmitter(),
+    workspaceDataService: { findRatchetProjection: vi.fn().mockResolvedValue(null) },
+    workspaceSnapshotStore: store,
+  } as never);
+  collector.start();
+  const emitMerge = (prNumber = 7) =>
+    prSnapshotService.emit(PR_SNAPSHOT_UPDATED, {
+      workspaceId: 'ws-1',
+      prNumber,
+      prState: 'MERGED',
+      prCiStatus: 'SUCCESS',
+      prReviewState: null,
+      prUrl: `https://github.com/org/repo/pull/${prNumber}`,
+    });
+  return { collector, emitMerge, markIssueCompleted };
+}
+
+describe('Linear completion on PR merge', () => {
+  it('completes the linked issue once across repeated merged snapshots', async () => {
+    const { collector, emitMerge, markIssueCompleted } = createHarness();
+    try {
+      emitMerge();
+      emitMerge();
+      await Promise.resolve();
+      expect(markIssueCompleted).toHaveBeenCalledExactlyOnceWith('test-key', 'issue-1');
+    } finally {
+      collector.stop();
+    }
+  });
+
+  it('does not repeat completion for a seeded merged PR', async () => {
+    const { collector, emitMerge, markIssueCompleted } = createHarness('MERGED');
+    try {
+      emitMerge();
+      await Promise.resolve();
+      expect(markIssueCompleted).not.toHaveBeenCalled();
+    } finally {
+      collector.stop();
+    }
+  });
+
+  it('completes a newly linked merged PR after a previous merged PR', async () => {
+    const { collector, emitMerge, markIssueCompleted } = createHarness('MERGED');
+    try {
+      emitMerge(8);
+      emitMerge(8);
+      await Promise.resolve();
+      expect(markIssueCompleted).toHaveBeenCalledExactlyOnceWith('test-key', 'issue-1');
+    } finally {
+      collector.stop();
+    }
+  });
+});

--- a/src/backend/orchestration/event-collector.linear.test.ts
+++ b/src/backend/orchestration/event-collector.linear.test.ts
@@ -28,12 +28,13 @@ function createHarness(prState: 'OPEN' | 'MERGED' = 'OPEN') {
     1
   );
   const prSnapshotService = new EventEmitter();
-  const markIssueCompleted = vi.fn().mockResolvedValue(undefined);
+  const markIssueCompleted = vi.fn().mockResolvedValue(true);
+  const getWorkspaceLinearContext = vi
+    .fn()
+    .mockResolvedValue({ apiKey: 'test-key', linearIssueId: 'issue-1' });
   const collector = createEventCollectorOrchestrator({
     createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
-    getWorkspaceLinearContext: vi
-      .fn()
-      .mockResolvedValue({ apiKey: 'test-key', linearIssueId: 'issue-1' }),
+    getWorkspaceLinearContext,
     linearStateSyncService: { markIssueCompleted },
     prSnapshotService,
     prFetchCoordinator: { removeWorkspace: vi.fn() },
@@ -58,7 +59,7 @@ function createHarness(prState: 'OPEN' | 'MERGED' = 'OPEN') {
       prReviewState: null,
       prUrl: `https://github.com/org/repo/pull/${prNumber}`,
     });
-  return { collector, emitMerge, markIssueCompleted };
+  return { collector, emitMerge, markIssueCompleted, getWorkspaceLinearContext };
 }
 
 describe('Linear completion on PR merge', () => {
@@ -74,12 +75,89 @@ describe('Linear completion on PR merge', () => {
     }
   });
 
-  it('does not repeat completion for a seeded merged PR', async () => {
+  it('completes a seeded merged PR on its first poll', async () => {
     const { collector, emitMerge, markIssueCompleted } = createHarness('MERGED');
     try {
       emitMerge();
       await Promise.resolve();
+      expect(markIssueCompleted).toHaveBeenCalledExactlyOnceWith('test-key', 'issue-1');
+    } finally {
+      collector.stop();
+    }
+  });
+
+  it('retries when Linear context becomes available on a later poll', async () => {
+    const { collector, emitMerge, markIssueCompleted, getWorkspaceLinearContext } = createHarness();
+    getWorkspaceLinearContext.mockResolvedValueOnce(null);
+    try {
+      emitMerge();
+      await vi.waitFor(() => expect(getWorkspaceLinearContext).toHaveBeenCalledTimes(1));
       expect(markIssueCompleted).not.toHaveBeenCalled();
+      emitMerge();
+      await vi.waitFor(() =>
+        expect(markIssueCompleted).toHaveBeenCalledExactlyOnceWith('test-key', 'issue-1')
+      );
+    } finally {
+      collector.stop();
+    }
+  });
+
+  it.each(['reported', 'thrown'] as const)(
+    'retries a %s completion failure on the next poll',
+    async (failure) => {
+      const { collector, emitMerge, markIssueCompleted } = createHarness();
+      if (failure === 'reported') {
+        markIssueCompleted.mockResolvedValueOnce(false);
+      } else {
+        markIssueCompleted.mockRejectedValueOnce(new Error('Linear unavailable'));
+      }
+      try {
+        emitMerge();
+        await vi.waitFor(() => expect(markIssueCompleted).toHaveBeenCalledTimes(1));
+        emitMerge();
+        await vi.waitFor(() => expect(markIssueCompleted).toHaveBeenCalledTimes(2));
+        emitMerge();
+        await Promise.resolve();
+        expect(markIssueCompleted).toHaveBeenCalledTimes(2);
+      } finally {
+        collector.stop();
+      }
+    }
+  );
+
+  it('suppresses repeated polls while completion is in flight and after it succeeds', async () => {
+    const { collector, emitMerge, markIssueCompleted } = createHarness();
+    let resolve!: (completed: boolean) => void;
+    markIssueCompleted.mockReturnValueOnce(
+      new Promise<boolean>((done) => {
+        resolve = done;
+      })
+    );
+    try {
+      emitMerge();
+      await vi.waitFor(() => expect(markIssueCompleted).toHaveBeenCalledTimes(1));
+      emitMerge();
+      await Promise.resolve();
+      expect(markIssueCompleted).toHaveBeenCalledTimes(1);
+      resolve(true);
+      await Promise.resolve();
+      emitMerge();
+      await Promise.resolve();
+      expect(markIssueCompleted).toHaveBeenCalledTimes(1);
+    } finally {
+      collector.stop();
+    }
+  });
+
+  it('attempts completion again after the collector restarts', async () => {
+    const { collector, emitMerge, markIssueCompleted } = createHarness();
+    try {
+      emitMerge();
+      await vi.waitFor(() => expect(markIssueCompleted).toHaveBeenCalledTimes(1));
+      collector.stop();
+      collector.start();
+      emitMerge();
+      await vi.waitFor(() => expect(markIssueCompleted).toHaveBeenCalledTimes(2));
     } finally {
       collector.stop();
     }

--- a/src/backend/orchestration/event-collector.orchestrator.ts
+++ b/src/backend/orchestration/event-collector.orchestrator.ts
@@ -586,6 +586,10 @@ function startEventCollectorWithState(state: EventCollectorState): void {
       event.workspaceId
     );
     const shouldRefreshRatchet = shouldRefreshRatchetForPrSwitch(previousSnapshot, event);
+    // Capture the transition before the immediate upsert mutates the stored entry.
+    const shouldCompleteLinearIssue =
+      event.prState === 'MERGED' &&
+      (previousSnapshot?.prState !== 'MERGED' || shouldRefreshRatchet);
     const snapshotUpdate: SnapshotUpdateInput = {
       ...(event.prUrl !== undefined ? { prUrl: event.prUrl } : {}),
       prNumber: event.prNumber,
@@ -619,7 +623,7 @@ function startEventCollectorWithState(state: EventCollectorState): void {
     }
 
     // Transition linked Linear issue to completed when PR is merged
-    if (event.prState === 'MERGED') {
+    if (shouldCompleteLinearIssue) {
       void handleLinearIssueCompletedOnMerge(state, event.workspaceId);
     }
   };

--- a/src/backend/orchestration/event-collector.orchestrator.ts
+++ b/src/backend/orchestration/event-collector.orchestrator.ts
@@ -297,6 +297,7 @@ class EventCollectorState {
   readonly logger: Logger;
   activeCoalescer: EventCoalescer | null = null;
   lastIdlePrRefreshByWorkspace = new Map<string, number>();
+  linearMergeCompletions = new Map<string, { prIdentity: string }>();
   teardownListeners: Array<() => void> = [];
   ratchetProjection: RatchetProjectionWorker | null = null;
 
@@ -312,6 +313,7 @@ function removeWorkspaceWithState(state: EventCollectorState, workspaceId: strin
     state.dependencies.workspaceSnapshotStore.remove(workspaceId);
   }
   state.lastIdlePrRefreshByWorkspace.delete(workspaceId);
+  state.linearMergeCompletions.delete(workspaceId);
   state.dependencies.workspaceActivityService.clearWorkspace(workspaceId);
   state.dependencies.prFetchCoordinator.removeWorkspace(workspaceId);
 }
@@ -441,18 +443,28 @@ function buildWorkspaceStateChangeFields(event: WorkspaceStateChangedEvent): Sna
 
 async function handleLinearIssueCompletedOnMerge(
   state: EventCollectorState,
-  workspaceId: string
+  workspaceId: string,
+  prIdentity: string
 ): Promise<void> {
+  if (state.linearMergeCompletions.get(workspaceId)?.prIdentity === prIdentity) {
+    return;
+  }
+  const attempt = { prIdentity };
+  state.linearMergeCompletions.set(workspaceId, attempt);
+  let completed = false;
   try {
     const ctx = await state.dependencies.getWorkspaceLinearContext(workspaceId);
     if (!ctx) {
       return;
     }
 
-    await state.dependencies.linearStateSyncService.markIssueCompleted(
+    completed = await state.dependencies.linearStateSyncService.markIssueCompleted(
       ctx.apiKey,
       ctx.linearIssueId
     );
+    if (!completed) {
+      return;
+    }
     state.logger.info('Marked Linear issue as completed on PR merge', {
       workspaceId,
       linearIssueId: ctx.linearIssueId,
@@ -462,6 +474,10 @@ async function handleLinearIssueCompletedOnMerge(
       workspaceId,
       error: error instanceof Error ? error.message : String(error),
     });
+  } finally {
+    if (!completed && state.linearMergeCompletions.get(workspaceId) === attempt) {
+      state.linearMergeCompletions.delete(workspaceId);
+    }
   }
 }
 
@@ -586,10 +602,7 @@ function startEventCollectorWithState(state: EventCollectorState): void {
       event.workspaceId
     );
     const shouldRefreshRatchet = shouldRefreshRatchetForPrSwitch(previousSnapshot, event);
-    // Capture the transition before the immediate upsert mutates the stored entry.
-    const shouldCompleteLinearIssue =
-      event.prState === 'MERGED' &&
-      (previousSnapshot?.prState !== 'MERGED' || shouldRefreshRatchet);
+    const prIdentity = JSON.stringify([event.prNumber, event.prUrl ?? previousSnapshot?.prUrl]);
     const snapshotUpdate: SnapshotUpdateInput = {
       ...(event.prUrl !== undefined ? { prUrl: event.prUrl } : {}),
       prNumber: event.prNumber,
@@ -623,8 +636,8 @@ function startEventCollectorWithState(state: EventCollectorState): void {
     }
 
     // Transition linked Linear issue to completed when PR is merged
-    if (shouldCompleteLinearIssue) {
-      void handleLinearIssueCompletedOnMerge(state, event.workspaceId);
+    if (event.prState === 'MERGED') {
+      void handleLinearIssueCompletedOnMerge(state, event.workspaceId, prIdentity);
     }
   };
   dependencies.prSnapshotService.on(PR_SNAPSHOT_UPDATED, prSnapshotUpdatedHandler);
@@ -837,6 +850,7 @@ function stopEventCollectorWithState(state: EventCollectorState): void {
     state.activeCoalescer.flushAll();
     state.activeCoalescer = null;
     state.lastIdlePrRefreshByWorkspace.clear();
+    state.linearMergeCompletions.clear();
     state.logger.info('Event collector stopped');
   }
 }

--- a/src/backend/services/linear/service/linear-client.service.test.ts
+++ b/src/backend/services/linear/service/linear-client.service.test.ts
@@ -350,7 +350,9 @@ describe('LinearClientService', () => {
         updateIssue,
       });
 
-      await linearClientService.transitionIssueState('linear-api-key', 'issue-1', 'started');
+      await expect(
+        linearClientService.transitionIssueState('linear-api-key', 'issue-1', 'started')
+      ).resolves.toBe(false);
 
       expect(updateIssue).not.toHaveBeenCalled();
       expect(mockLoggerWarn).toHaveBeenCalledWith('Cannot transition issue: no team found', {
@@ -370,7 +372,9 @@ describe('LinearClientService', () => {
         updateIssue,
       });
 
-      await linearClientService.transitionIssueState('linear-api-key', 'issue-1', 'completed');
+      await expect(
+        linearClientService.transitionIssueState('linear-api-key', 'issue-1', 'completed')
+      ).resolves.toBe(false);
 
       expect(workflowStates).toHaveBeenCalled();
       expect(updateIssue).not.toHaveBeenCalled();
@@ -384,28 +388,37 @@ describe('LinearClientService', () => {
       );
     });
 
-    it('updates issue state when matching workflow state exists', async () => {
-      const getIssue = vi.fn().mockResolvedValue({
-        team: Promise.resolve({ id: 'team-1' }),
-      });
-      const updateIssue = vi.fn().mockResolvedValue(undefined);
-      const workflowStates = vi.fn().mockResolvedValue({
-        nodes: [{ id: 'state-1', name: 'Done', type: 'completed', position: 1 }],
-      });
-      setMockClient({
-        issue: getIssue,
-        workflowStates,
-        updateIssue,
-      });
+    it.each([true, false])(
+      'reports update success %s when a matching workflow state exists',
+      async (success) => {
+        const getIssue = vi.fn().mockResolvedValue({
+          team: Promise.resolve({ id: 'team-1' }),
+        });
+        const updateIssue = vi.fn().mockResolvedValue({ success });
+        const workflowStates = vi.fn().mockResolvedValue({
+          nodes: [{ id: 'state-1', name: 'Done', type: 'completed', position: 1 }],
+        });
+        setMockClient({
+          issue: getIssue,
+          workflowStates,
+          updateIssue,
+        });
 
-      await linearClientService.transitionIssueState('linear-api-key', 'issue-1', 'completed');
+        await expect(
+          linearClientService.transitionIssueState('linear-api-key', 'issue-1', 'completed')
+        ).resolves.toBe(success);
 
-      expect(updateIssue).toHaveBeenCalledWith('issue-1', { stateId: 'state-1' });
-      expect(mockLoggerInfo).toHaveBeenCalledWith('Transitioned Linear issue state', {
-        issueId: 'issue-1',
-        targetState: 'Done',
-        targetStateType: 'completed',
-      });
-    });
+        expect(updateIssue).toHaveBeenCalledWith('issue-1', { stateId: 'state-1' });
+        if (!success) {
+          expect(mockLoggerInfo).not.toHaveBeenCalled();
+          return;
+        }
+        expect(mockLoggerInfo).toHaveBeenCalledWith('Transitioned Linear issue state', {
+          issueId: 'issue-1',
+          targetState: 'Done',
+          targetStateType: 'completed',
+        });
+      }
+    );
   });
 });

--- a/src/backend/services/linear/service/linear-client.service.ts
+++ b/src/backend/services/linear/service/linear-client.service.ts
@@ -206,7 +206,7 @@ class LinearClientService {
     apiKey: string,
     issueId: string,
     targetStateType: 'started' | 'completed' | 'cancelled'
-  ): Promise<void> {
+  ): Promise<boolean> {
     const client = this.createClient(apiKey);
 
     // Get the issue to find its team
@@ -214,7 +214,7 @@ class LinearClientService {
     const team = await issue.team;
     if (!team) {
       logger.warn('Cannot transition issue: no team found', { issueId });
-      return;
+      return false;
     }
 
     // Find the target workflow state
@@ -225,15 +225,19 @@ class LinearClientService {
         teamId: team.id,
         targetStateType,
       });
-      return;
+      return false;
     }
 
-    await client.updateIssue(issueId, { stateId: targetState.id });
+    const result = await client.updateIssue(issueId, { stateId: targetState.id });
+    if (!result.success) {
+      return false;
+    }
     logger.info('Transitioned Linear issue state', {
       issueId,
       targetState: targetState.name,
       targetStateType,
     });
+    return true;
   }
 }
 

--- a/src/backend/services/linear/service/linear-state-sync.service.test.ts
+++ b/src/backend/services/linear/service/linear-state-sync.service.test.ts
@@ -57,9 +57,11 @@ describe('LinearStateSyncService', () => {
 
   describe('markIssueCompleted', () => {
     it('transitions issue to completed state', async () => {
-      mockTransitionIssueState.mockResolvedValue(undefined);
+      mockTransitionIssueState.mockResolvedValue(true);
 
-      await linearStateSyncService.markIssueCompleted('linear-api-key', 'issue-2');
+      await expect(
+        linearStateSyncService.markIssueCompleted('linear-api-key', 'issue-2')
+      ).resolves.toBe(true);
 
       expect(mockTransitionIssueState).toHaveBeenCalledWith(
         'linear-api-key',
@@ -69,10 +71,19 @@ describe('LinearStateSyncService', () => {
       expect(mockLoggerWarn).not.toHaveBeenCalled();
     });
 
+    it('reports an incomplete transition without marking it successful', async () => {
+      mockTransitionIssueState.mockResolvedValue(false);
+      await expect(
+        linearStateSyncService.markIssueCompleted('linear-api-key', 'issue-2')
+      ).resolves.toBe(false);
+    });
+
     it('logs warning when transition fails', async () => {
       mockTransitionIssueState.mockRejectedValue(new Error('Timeout'));
 
-      await linearStateSyncService.markIssueCompleted('linear-api-key', 'issue-2');
+      await expect(
+        linearStateSyncService.markIssueCompleted('linear-api-key', 'issue-2')
+      ).resolves.toBe(false);
 
       expect(mockLoggerWarn).toHaveBeenCalledWith('Failed to mark Linear issue as completed', {
         issueId: 'issue-2',

--- a/src/backend/services/linear/service/linear-state-sync.service.ts
+++ b/src/backend/services/linear/service/linear-state-sync.service.ts
@@ -31,14 +31,15 @@ class LinearStateSyncService {
    * Move a Linear issue to the first 'completed' workflow state.
    * Called when a workspace's PR is merged.
    */
-  async markIssueCompleted(apiKey: string, issueId: string): Promise<void> {
+  async markIssueCompleted(apiKey: string, issueId: string): Promise<boolean> {
     try {
-      await linearClientService.transitionIssueState(apiKey, issueId, 'completed');
+      return await linearClientService.transitionIssueState(apiKey, issueId, 'completed');
     } catch (error) {
       logger.warn('Failed to mark Linear issue as completed', {
         issueId,
         error: error instanceof Error ? error.message : String(error),
       });
+      return false;
     }
   }
 }


### PR DESCRIPTION
Repeated poll events for a merged PR reran Linear completion and its API calls. Track pending and successful completion attempts by workspace and PR identity to suppress duplicate work. Failed or incomplete updates remain retryable on the next poll, including after startup seeds an already-merged snapshot or Linear configuration becomes available. Completion tracking clears when a workspace is removed or the collector stops.

Linear completion now reports the actual update success through the client and sync service; missing teams/states and caught API errors are not cached as successful. Regressions exercise the real snapshot store, seeded merges, PR switches, concurrent polls, retries, absent context, and collector restarts.

Closes #2261.

Validation: red/green regressions; 80 focused tests across event collector and Linear services; `pnpm check:fix`, `pnpm typecheck`, `pnpm check`, and `pnpm check:imports`; all pre-commit checks. The Codex schema check skips locally because CLI 0.154.0 differs from pinned 0.153.4; CI enforces it.
