### PR TITLE
Avoid counting duplicate result token usage twice

### DIFF
--- a/src/client/features/chat/reducer/helpers.ts
+++ b/src/client/features/chat/reducer/helpers.ts
@@ -276,14 +276,6 @@ function upsertClaudeMessageAtOrder(
   return applyRendererMessages(state, updatedMessages);
 }
 
-function hasResultAtOrder(state: ChatState, order: number): boolean {
-  const index = state.agentMessageOrderToIndex.get(order);
-  const message = index === undefined ? undefined : state.messages[index];
-  return (
-    message?.source === 'agent' && message.order === order && message.message?.type === 'result'
-  );
-}
-
 /**
  * Handle WS_AGENT_MESSAGE action - processes Claude messages and stores them.
  */
@@ -298,11 +290,12 @@ export function handleClaudeMessage(
   // Runtime transitions are driven by session_runtime_updated events.
   // Result messages only update token stats here.
   if (claudeMsg.type === 'result') {
-    // A replayed result may update its transcript entry, but its usage is already counted.
-    if (!hasResultAtOrder(state, order)) {
+    // Results may be suppressed or trimmed, so accounting cannot depend on rendered messages.
+    if (!state.countedResultOrders.has(order)) {
       baseState = {
         ...baseState,
         tokenStats: updateTokenStatsFromResult(baseState.tokenStats, claudeMsg),
+        countedResultOrders: new Set(state.countedResultOrders).add(order),
       };
     }
 

--- a/src/client/features/chat/reducer/helpers.ts
+++ b/src/client/features/chat/reducer/helpers.ts
@@ -276,6 +276,14 @@ function upsertClaudeMessageAtOrder(
   return applyRendererMessages(state, updatedMessages);
 }
 
+function hasResultAtOrder(state: ChatState, order: number): boolean {
+  const index = state.agentMessageOrderToIndex.get(order);
+  const message = index === undefined ? undefined : state.messages[index];
+  return (
+    message?.source === 'agent' && message.order === order && message.message?.type === 'result'
+  );
+}
+
 /**
  * Handle WS_AGENT_MESSAGE action - processes Claude messages and stores them.
  */
@@ -290,10 +298,13 @@ export function handleClaudeMessage(
   // Runtime transitions are driven by session_runtime_updated events.
   // Result messages only update token stats here.
   if (claudeMsg.type === 'result') {
-    baseState = {
-      ...baseState,
-      tokenStats: updateTokenStatsFromResult(baseState.tokenStats, claudeMsg),
-    };
+    // A replayed result may update its transcript entry, but its usage is already counted.
+    if (!hasResultAtOrder(state, order)) {
+      baseState = {
+        ...baseState,
+        tokenStats: updateTokenStatsFromResult(baseState.tokenStats, claudeMsg),
+      };
+    }
 
     if (shouldSuppressDuplicateResultMessage(baseState.messages, claudeMsg)) {
       return baseState;

--- a/src/client/features/chat/reducer/result-dedup.test.ts
+++ b/src/client/features/chat/reducer/result-dedup.test.ts
@@ -1,7 +1,69 @@
 import { describe, expect, it } from 'vitest';
 import { type ChatAction, chatReducer, createInitialChatState } from './index';
 
+const resultAction: Extract<ChatAction, { type: 'WS_AGENT_MESSAGE' }> = {
+  type: 'WS_AGENT_MESSAGE',
+  payload: {
+    order: 42,
+    message: {
+      type: 'result',
+      result: 'Done',
+      usage: { input_tokens: 100, output_tokens: 50 },
+      duration_ms: 1000,
+    },
+  },
+};
+
 describe('result delivery token accounting', () => {
+  it('counts suppressed results once', () => {
+    const withAssistant = chatReducer(createInitialChatState(), {
+      type: 'WS_AGENT_MESSAGE',
+      payload: {
+        order: 41,
+        message: { type: 'assistant', message: { role: 'assistant', content: 'Done' } },
+      },
+    });
+    const once = chatReducer(withAssistant, resultAction);
+    expect(once.messages).toHaveLength(1);
+    expect(once.tokenStats.inputTokens).toBe(100);
+    expect(chatReducer(once, resultAction).tokenStats).toEqual(once.tokenStats);
+  });
+
+  it('remembers counted results after the renderer trims them', () => {
+    const once = chatReducer(createInitialChatState({ rendererTranscriptLimit: 1 }), resultAction);
+    const trimmed = chatReducer(once, {
+      type: 'WS_AGENT_MESSAGE',
+      payload: {
+        order: 43,
+        message: { type: 'assistant', message: { role: 'assistant', content: 'Next turn' } },
+      },
+    });
+    expect(trimmed.messages.some((message) => message.order === 42)).toBe(false);
+    expect(chatReducer(trimmed, resultAction).tokenStats).toEqual(once.tokenStats);
+  });
+
+  it.each(['CLEAR_CHAT', 'RESET_FOR_SESSION_SWITCH', 'SESSION_SWITCH_START'] as const)(
+    'allows the same order to count after %s resets usage',
+    (type) => {
+      const once = chatReducer(createInitialChatState(), resultAction);
+      const reset = chatReducer(once, { type });
+      expect(reset.tokenStats.inputTokens).toBe(0);
+      expect(chatReducer(reset, resultAction).tokenStats).toEqual(once.tokenStats);
+    }
+  );
+
+  it('reconstructs counted results during replay hydration', () => {
+    const once = chatReducer(createInitialChatState(), resultAction);
+    const replayed = chatReducer(once, {
+      type: 'SESSION_REPLAY_BATCH',
+      payload: {
+        replayEvents: [{ type: 'agent_message', data: resultAction.payload.message, order: 42 }],
+      },
+    });
+    expect(replayed.tokenStats).toEqual(once.tokenStats);
+    expect(chatReducer(replayed, resultAction).tokenStats).toEqual(once.tokenStats);
+  });
+
   it('counts a same-order result once while retaining distinct results', () => {
     const action: ChatAction = {
       type: 'WS_AGENT_MESSAGE',

--- a/src/client/features/chat/reducer/result-dedup.test.ts
+++ b/src/client/features/chat/reducer/result-dedup.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { type ChatAction, chatReducer, createInitialChatState } from '../reducer';
+import { type ChatAction, chatReducer, createInitialChatState } from './index';
 
 describe('result delivery token accounting', () => {
   it('counts a same-order result once while retaining distinct results', () => {

--- a/src/client/features/chat/reducer/result-dedup.test.ts
+++ b/src/client/features/chat/reducer/result-dedup.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { type ChatAction, chatReducer, createInitialChatState } from '../reducer';
+
+describe('result delivery token accounting', () => {
+  it('counts a same-order result once while retaining distinct results', () => {
+    const action: ChatAction = {
+      type: 'WS_AGENT_MESSAGE',
+      payload: {
+        order: 42,
+        message: {
+          type: 'result',
+          usage: {
+            input_tokens: 1000,
+            output_tokens: 500,
+            cache_read_input_tokens: 200,
+            cache_creation_input_tokens: 100,
+          },
+          duration_ms: 2000,
+          duration_api_ms: 1500,
+          total_cost_usd: 0.05,
+          num_turns: 1,
+        },
+      },
+    };
+    const once = chatReducer(createInitialChatState(), action);
+    const twice = chatReducer(once, action);
+    expect(twice.messages).toHaveLength(1);
+    expect(twice.tokenStats).toEqual(once.tokenStats);
+    const next = chatReducer(twice, { ...action, payload: { ...action.payload, order: 43 } });
+    expect(next.tokenStats.inputTokens).toBe(2000);
+    expect(next.tokenStats.outputTokens).toBe(1000);
+  });
+});

--- a/src/client/features/chat/reducer/result-dedup.test.ts
+++ b/src/client/features/chat/reducer/result-dedup.test.ts
@@ -15,6 +15,58 @@ const resultAction: Extract<ChatAction, { type: 'WS_AGENT_MESSAGE' }> = {
 };
 
 describe('result delivery token accounting', () => {
+  it('preserves counted usage when a snapshot trims the result from the renderer', () => {
+    const counted = chatReducer(
+      createInitialChatState({ rendererTranscriptLimit: 1 }),
+      resultAction
+    );
+    const snapshot = chatReducer(counted, {
+      type: 'SESSION_SNAPSHOT',
+      payload: {
+        messages: [
+          ...counted.messages,
+          {
+            id: 'next-message',
+            source: 'agent',
+            order: 43,
+            timestamp: '2026-09-10T12:01:00Z',
+            message: { type: 'assistant', message: { role: 'assistant', content: 'Next turn' } },
+          },
+        ],
+        queuedMessages: [],
+        sessionRuntime: counted.sessionRuntime,
+      },
+    });
+    expect(snapshot.messages.map((message) => message.order)).toEqual([43]);
+    expect(snapshot.tokenStats).toEqual(counted.tokenStats);
+    expect(chatReducer(snapshot, resultAction).tokenStats).toEqual(counted.tokenStats);
+  });
+
+  it('counts a snapshotted result on its first usage-bearing delivery', () => {
+    const initial = createInitialChatState();
+    const snapshot = chatReducer(initial, {
+      type: 'SESSION_SNAPSHOT',
+      payload: {
+        messages: [
+          {
+            id: 'result-42',
+            source: 'agent',
+            order: 42,
+            timestamp: '2026-09-10T12:00:00Z',
+            message: resultAction.payload.message,
+          },
+        ],
+        queuedMessages: [],
+        sessionRuntime: initial.sessionRuntime,
+      },
+    });
+    // Snapshots reconcile transcript rows; they do not add usage to tokenStats.
+    expect(snapshot.tokenStats.inputTokens).toBe(0);
+    const firstDelivery = chatReducer(snapshot, resultAction);
+    expect(firstDelivery.tokenStats.inputTokens).toBe(100);
+    expect(chatReducer(firstDelivery, resultAction).tokenStats).toEqual(firstDelivery.tokenStats);
+  });
+
   it('counts suppressed results once', () => {
     const withAssistant = chatReducer(createInitialChatState(), {
       type: 'WS_AGENT_MESSAGE',

--- a/src/client/features/chat/reducer/state.ts
+++ b/src/client/features/chat/reducer/state.ts
@@ -21,6 +21,7 @@ function createBaseResetState(): Pick<
   | 'activeHooks'
   | 'taskNotifications'
   | 'tokenStats'
+  | 'countedResultOrders'
   | 'pendingUserMessageUuids'
   | 'messageIdToUuid'
   | 'localUserMessageIds'
@@ -49,6 +50,7 @@ function createBaseResetState(): Pick<
     activeHooks: new Map(),
     taskNotifications: [],
     tokenStats: createEmptyTokenStats(),
+    countedResultOrders: new Set(),
     pendingUserMessageUuids: [],
     messageIdToUuid: new Map(),
     localUserMessageIds: new Set(),
@@ -86,6 +88,7 @@ function createSessionSwitchResetState(): Pick<
   | 'slashCommands'
   | 'slashCommandsLoaded'
   | 'tokenStats'
+  | 'countedResultOrders'
   | 'pendingUserMessageUuids'
   | 'messageIdToUuid'
   | 'localUserMessageIds'
@@ -137,6 +140,7 @@ export function createInitialChatState(overrides?: Partial<ChatState>): ChatStat
     slashCommands: [],
     slashCommandsLoaded: false,
     tokenStats: createEmptyTokenStats(),
+    countedResultOrders: new Set(),
     pendingUserMessageUuids: [],
     messageIdToUuid: new Map(),
     localUserMessageIds: new Set(),

--- a/src/client/features/chat/reducer/types.ts
+++ b/src/client/features/chat/reducer/types.ts
@@ -219,6 +219,8 @@ export interface ChatState {
   slashCommandsLoaded: boolean;
   /** Accumulated token usage stats for the session */
   tokenStats: TokenStats;
+  /** Result orders included in tokenStats, independent of renderer retention. */
+  countedResultOrders: Set<number>;
   /**
    * Queue of SDK-assigned UUIDs waiting to be mapped to user messages.
    * Used when UUIDs arrive before their corresponding messages.


### PR DESCRIPTION
Result usage is now counted once per transcript order, independently of whether that result is rendered, suppressed as duplicate text, or trimmed from the visible history. Counted orders reset alongside token totals on chat/session resets and replay hydration. Transcript snapshots preserve existing totals and counted orders; snapshot rows alone do not add usage. Transcript upserts and distinct-result accumulation retain their existing behavior.

Closes #2267.

Validation: `pnpm check:fix`, `pnpm typecheck`, `pnpm test src/client/features/chat/reducer/result-dedup.test.ts src/client/features/chat/chat-reducer.test.ts` (173 tests), `pnpm check`, and `pnpm check:imports` passed, as did pre-commit checks. New suppressed/trimmed-result regressions failed before the review fix; reset, replay hydration, and snapshot accounting cases also pass. The local Codex schema check skips CLI 0.154.0 versus pinned 0.153.4; CI enforces the pinned check.
