### PR TITLE
Stop voice capture when the selected session closes

### DIFF
--- a/src/client/features/voice/voice-mode-toggle.stories.tsx
+++ b/src/client/features/voice/voice-mode-toggle.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useEffect } from 'react';
+import { fn } from 'storybook/test';
+import { trpc } from '@/client/lib/trpc';
+import { VoiceModeToggle } from './voice-mode-toggle';
+
+const meta: Meta<typeof VoiceModeToggle> = {
+  title: 'Voice/VoiceModeToggle',
+  component: VoiceModeToggle,
+  args: { onFinalTranscript: fn() },
+  decorators: [
+    (Story) => {
+      const utils = trpc.useUtils();
+      useEffect(() => {
+        utils.voice.getConfig.setData(undefined, {
+          enabled: true,
+          hasApiKey: true,
+          ttsModel: 'aura-2-thalia-en',
+          ttsSpeed: 1,
+          utteranceEndMs: 1000,
+          bargeInSustainedMs: 300,
+        });
+      }, [utils]);
+      return <Story />;
+    },
+  ],
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const SessionClosed: Story = {
+  args: { sessionId: null },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Closing the selected session stops active or connecting microphone capture. Voice remains off until a session is selected.',
+      },
+    },
+  },
+};

--- a/src/client/features/voice/voice-mode-toggle.stories.tsx
+++ b/src/client/features/voice/voice-mode-toggle.stories.tsx
@@ -1,6 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { useEffect } from 'react';
-import { fn } from 'storybook/test';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { TRPCClientError } from '@trpc/client';
+import { observable } from '@trpc/server/observable';
+import { useState } from 'react';
+import { expect, fn, within } from 'storybook/test';
 import { trpc } from '@/client/lib/trpc';
 import { VoiceModeToggle } from './voice-mode-toggle';
 
@@ -10,18 +13,43 @@ const meta: Meta<typeof VoiceModeToggle> = {
   args: { onFinalTranscript: fn() },
   decorators: [
     (Story) => {
-      const utils = trpc.useUtils();
-      useEffect(() => {
-        utils.voice.getConfig.setData(undefined, {
-          enabled: true,
-          hasApiKey: true,
-          ttsModel: 'aura-2-thalia-en',
-          ttsSpeed: 1,
-          utteranceEndMs: 1000,
-          bargeInSustainedMs: 300,
-        });
-      }, [utils]);
-      return <Story />;
+      const [queryClient] = useState(
+        () => new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      );
+      const [client] = useState(() =>
+        trpc.createClient({
+          links: [
+            () =>
+              ({ op }) =>
+                observable((observer) => {
+                  if (op.path !== 'voice.getConfig') {
+                    observer.error(new TRPCClientError(`No story fixture for ${op.path}`));
+                    return;
+                  }
+                  observer.next({
+                    result: {
+                      data: {
+                        enabled: true,
+                        hasApiKey: true,
+                        ttsModel: 'aura-2-thalia-en',
+                        ttsSpeed: 1,
+                        utteranceEndMs: 1000,
+                        bargeInSustainedMs: 300,
+                      },
+                    },
+                  });
+                  observer.complete();
+                }),
+          ],
+        })
+      );
+      return (
+        <trpc.Provider client={client} queryClient={queryClient}>
+          <QueryClientProvider client={queryClient}>
+            <Story />
+          </QueryClientProvider>
+        </trpc.Provider>
+      );
     },
   ],
 };
@@ -30,11 +58,15 @@ type Story = StoryObj<typeof meta>;
 
 export const SessionClosed: Story = {
   args: { sessionId: null },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByRole('button', { name: 'Voice Off' })).toBeDisabled();
+  },
   parameters: {
     docs: {
       description: {
         story:
-          'Closing the selected session stops active or connecting microphone capture. Voice remains off until a session is selected.',
+          'Closing or switching the selected session stops active or connecting microphone capture. Voice remains off until a session is selected.',
       },
     },
   },

--- a/src/client/features/voice/voice-mode-toggle.test.tsx
+++ b/src/client/features/voice/voice-mode-toggle.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { flushSync } from 'react-dom';
+import { createRoot } from 'react-dom/client';
+import { describe, expect, it, vi } from 'vitest';
+import { VoiceModeToggle } from './voice-mode-toggle';
+
+const capture = vi.hoisted(() => ({
+  isCapturing: false,
+  isConnecting: false,
+  error: null,
+  start: vi.fn(),
+  stop: vi.fn(),
+}));
+vi.mock('./use-mic-capture', () => ({ useMicCapture: () => capture }));
+vi.mock('./use-voice-playback', () => ({
+  useVoicePlayback: () => ({ isSpeaking: false, primeAudioContext: vi.fn() }),
+}));
+vi.mock('@/client/lib/trpc', () => ({
+  trpc: {
+    voice: { getConfig: { useQuery: () => ({ data: { enabled: true, hasApiKey: true } }) } },
+  },
+}));
+vi.mock('@/client/lib/sound', () => ({ playSound: vi.fn() }));
+
+describe('VoiceModeToggle session invalidation', () => {
+  it.each(['capturing', 'connecting'] as const)(
+    'stops %s when the selected session closes',
+    (phase) => {
+      capture.isCapturing = phase === 'capturing';
+      capture.isConnecting = phase === 'connecting';
+      capture.stop.mockClear();
+      const container = document.createElement('div');
+      const root = createRoot(container);
+      const render = (sessionId: string | null) =>
+        flushSync(() =>
+          root.render(<VoiceModeToggle sessionId={sessionId} onFinalTranscript={vi.fn()} />)
+        );
+      try {
+        render('session-1');
+        expect(capture.stop).not.toHaveBeenCalled();
+        render(null);
+        expect(capture.stop).toHaveBeenCalledOnce();
+      } finally {
+        flushSync(() => root.unmount());
+      }
+    }
+  );
+});

--- a/src/client/features/voice/voice-mode-toggle.test.tsx
+++ b/src/client/features/voice/voice-mode-toggle.test.tsx
@@ -23,26 +23,30 @@ vi.mock('@/client/lib/trpc', () => ({
 vi.mock('@/client/lib/sound', () => ({ playSound: vi.fn() }));
 
 describe('VoiceModeToggle session invalidation', () => {
-  it.each(['capturing', 'connecting'] as const)(
-    'stops %s when the selected session closes',
-    (phase) => {
-      capture.isCapturing = phase === 'capturing';
-      capture.isConnecting = phase === 'connecting';
-      capture.stop.mockClear();
-      const container = document.createElement('div');
-      const root = createRoot(container);
-      const render = (sessionId: string | null) =>
-        flushSync(() =>
-          root.render(<VoiceModeToggle sessionId={sessionId} onFinalTranscript={vi.fn()} />)
-        );
-      try {
-        render('session-1');
-        expect(capture.stop).not.toHaveBeenCalled();
-        render(null);
-        expect(capture.stop).toHaveBeenCalledOnce();
-      } finally {
-        flushSync(() => root.unmount());
-      }
+  it.each([
+    ['capturing', null],
+    ['connecting', null],
+    ['capturing', 'session-2'],
+    ['connecting', 'session-2'],
+  ] as const)('stops %s when the selected session changes to %s', (phase, nextSessionId) => {
+    capture.isCapturing = phase === 'capturing';
+    capture.isConnecting = phase === 'connecting';
+    capture.stop.mockClear();
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    const render = (sessionId: string | null) =>
+      flushSync(() =>
+        root.render(<VoiceModeToggle sessionId={sessionId} onFinalTranscript={vi.fn()} />)
+      );
+    try {
+      render('session-1');
+      expect(capture.stop).not.toHaveBeenCalled();
+      render('session-1');
+      expect(capture.stop).not.toHaveBeenCalled();
+      render(nextSessionId);
+      expect(capture.stop).toHaveBeenCalledOnce();
+    } finally {
+      flushSync(() => root.unmount());
     }
-  );
+  });
 });

--- a/src/client/features/voice/voice-mode-toggle.tsx
+++ b/src/client/features/voice/voice-mode-toggle.tsx
@@ -154,8 +154,11 @@ export function VoiceModeToggle({
     return () => stop();
   }, [stop]);
 
+  const previousSessionId = useRef(sessionId);
   useEffect(() => {
-    if (!sessionId && (isCapturing || isConnecting)) {
+    const sessionChanged = previousSessionId.current !== sessionId;
+    previousSessionId.current = sessionId;
+    if ((!sessionId || sessionChanged) && (isCapturing || isConnecting)) {
       stop();
       setVoiceModeOn(false);
     }

--- a/src/client/features/voice/voice-mode-toggle.tsx
+++ b/src/client/features/voice/voice-mode-toggle.tsx
@@ -154,6 +154,13 @@ export function VoiceModeToggle({
     return () => stop();
   }, [stop]);
 
+  useEffect(() => {
+    if (!sessionId && (isCapturing || isConnecting)) {
+      stop();
+      setVoiceModeOn(false);
+    }
+  }, [sessionId, isCapturing, isConnecting, stop]);
+
   const isThinking = Boolean(running) && !isSpeaking;
   const phase = derivePhase(isConnecting, isCapturing, isSpeaking, isThinking);
 


### PR DESCRIPTION
Closing or switching the selected chat session now stops active microphone capture or an in-progress connection attempt and disables voice playback. Speech cannot continue into another selected session while the component stays mounted. The closed-session story uses a local tRPC transport so it does not depend on a running backend.

Closes #2131.

Validation: `pnpm check:fix`, `pnpm typecheck`, `pnpm test src/client/features/voice/voice-mode-toggle.test.tsx src/client/features/voice/use-mic-capture.test.ts` (19 tests), `pnpm check`, `pnpm check:imports`, and `pnpm build:storybook` passed. Closure and non-null switch regressions cover both capturing and connecting. Headless Chromium verified the built story on initial load and reload: the Voice Off toggle is disabled, with zero backend fetch/XHR requests and zero page errors. Pre-commit checks passed. The local Codex schema check skips CLI 0.154.0 versus pinned 0.153.4; CI enforces it.
