### PR TITLE
Isolate workspace snapshot reconciliation failures (#2265)

### DIFF
--- a/docs/architecture/workspace-state.md
+++ b/docs/architecture/workspace-state.md
@@ -123,7 +123,9 @@ of them behind the one query (~20s at 68 worktrees).
 
 `gitStats` is a reconciliation field. Each snapshot poll first seeds all
 database and runtime fields, retaining any cached Git stats, then releases the
-startup snapshot barrier. It recomputes Git stats with bounded concurrency and
+startup snapshot barrier. A runtime snapshot failure is isolated to its workspace;
+healthy workspaces still seed, stale entries are removed, and Git refresh continues.
+It recomputes Git stats with bounded concurrency and
 publishes each workspace as soon as its Git commands finish; one slow worktree
 cannot hold the rest of the board. A failed Git refresh retains a non-null
 cached value, while a workspace that no longer has a worktree is explicitly

--- a/src/backend/orchestration/snapshot-reconciliation.orchestrator.test.ts
+++ b/src/backend/orchestration/snapshot-reconciliation.orchestrator.test.ts
@@ -291,7 +291,7 @@ describe('SnapshotReconciliationService', () => {
       store.upsert('ws-stale', { projectId: 'proj-1' }, 'reconciliation', 1);
       service = new SnapshotReconciliationService({
         createLogger: () => ({
-          info: vi.fn(),
+          info: mockLoggerInfo,
           warn: mockLoggerWarn,
           debug: vi.fn(),
           error: vi.fn(),
@@ -322,6 +322,19 @@ describe('SnapshotReconciliationService', () => {
       expect(store.getByWorkspaceId('ws-broken')).toBeUndefined();
       expect(result.staleEntriesRemoved).toBe(1);
       expect(result.gitStatsComputed).toBe(1);
+      expect(result).toMatchObject({
+        workspacesScanned: 2,
+        workspacesReconciled: 1,
+        workspacesSkipped: 1,
+      });
+      expect(mockLoggerInfo).toHaveBeenCalledWith(
+        'Reconciliation complete',
+        expect.objectContaining({
+          workspacesScanned: 2,
+          workspacesReconciled: 1,
+          workspacesSkipped: 1,
+        })
+      );
       expect(mockLoggerWarn).toHaveBeenCalledWith(
         'Failed to build authoritative fields for workspace',
         { workspaceId: 'ws-broken', error: 'runtime unavailable' }

--- a/src/backend/orchestration/snapshot-reconciliation.orchestrator.test.ts
+++ b/src/backend/orchestration/snapshot-reconciliation.orchestrator.test.ts
@@ -3,7 +3,11 @@ import { SERVICE_THRESHOLDS } from '@/backend/services/constants';
 import type { SnapshotUpdateInput, WorkspaceSnapshotEntry } from '@/backend/services/workspace';
 import { deriveWorkspaceFlowState } from '@/backend/services/workspace';
 import { deriveWorkspaceSidebarStatus } from '@/shared/core';
-import type { SessionRuntimeState } from '@/shared/session-runtime';
+import {
+  createMockBridges,
+  createMockWorkspace,
+  createSnapshotEntry,
+} from './snapshot-reconciliation.test-helpers';
 
 // ---------------------------------------------------------------------------
 // Module mocks
@@ -65,115 +69,6 @@ import {
 // ---------------------------------------------------------------------------
 // Test helpers
 // ---------------------------------------------------------------------------
-
-function createMockWorkspace(overrides: Record<string, unknown> = {}): Record<string, unknown> {
-  return {
-    id: 'ws-1',
-    projectId: 'proj-1',
-    name: 'Test Workspace',
-    status: 'READY',
-    createdAt: new Date('2026-01-01T00:00:00Z'),
-    branchName: 'feature/test',
-    hasHadSessions: true,
-    worktreePath: '/path/to/worktree',
-    prUrl: 'https://github.com/org/repo/pull/1',
-    prNumber: 1,
-    prState: 'OPEN',
-    prCiStatus: 'SUCCESS',
-    prUpdatedAt: new Date('2026-01-02T00:00:00Z'),
-    ratchetEnabled: true,
-    ratchetState: 'IDLE',
-    ratchetDispatchOutcome: 'DIED',
-    ratchetDispatchRetryCount: SERVICE_THRESHOLDS.ratchetDispatchMaxRetries,
-    ratchetDispatchStalled: true,
-    prHasMergeConflict: false,
-    mode: 'STANDARD',
-    autoIterationStatus: null,
-    runScriptStatus: 'IDLE',
-    agentSessions: [
-      {
-        id: 'cs-1',
-        name: 'Chat 1',
-        workflow: 'followup',
-        model: 'claude-sonnet',
-        status: 'IDLE',
-        updatedAt: new Date('2026-01-03T10:00:00Z'),
-      },
-      {
-        id: 'cs-2',
-        name: 'Chat 2',
-        workflow: 'followup',
-        model: 'claude-sonnet',
-        status: 'IDLE',
-        updatedAt: new Date('2026-01-03T12:00:00Z'),
-      },
-    ],
-    terminalSessions: [{ id: 'ts-1', updatedAt: new Date('2026-01-03T11:00:00Z') }],
-    project: { defaultBranch: 'main' },
-    ...overrides,
-  };
-}
-
-function createMockBridges(): ReconciliationBridges {
-  const runtime: SessionRuntimeState = {
-    phase: 'idle',
-    processState: 'alive',
-    activity: 'IDLE',
-    updatedAt: '2026-01-03T12:00:00.000Z',
-  };
-  return {
-    session: {
-      getRuntimeSnapshot: vi.fn().mockReturnValue(runtime),
-      getAllPendingRequests: vi.fn().mockReturnValue(new Map()),
-    },
-  };
-}
-
-function createSnapshotEntry(
-  overrides: Partial<WorkspaceSnapshotEntry> = {}
-): WorkspaceSnapshotEntry {
-  return {
-    workspaceId: 'ws-1',
-    projectId: 'proj-1',
-    version: 1,
-    computedAt: '2026-01-01T00:00:00Z',
-    source: 'reconciliation',
-    name: 'Test Workspace',
-    status: 'READY',
-    createdAt: '2026-01-01T00:00:00Z',
-    branchName: 'feature/test',
-    prUrl: 'https://github.com/org/repo/pull/1',
-    prNumber: 1,
-    prState: 'OPEN',
-    prCiStatus: 'SUCCESS',
-    prUpdatedAt: '2026-01-02T00:00:00Z',
-    ratchetEnabled: true,
-    ratchetState: 'IDLE',
-    ratchetDispatchOutcome: 'DIED',
-    ratchetDispatchRetryCount: SERVICE_THRESHOLDS.ratchetDispatchMaxRetries,
-    runScriptStatus: 'IDLE',
-    hasHadSessions: true,
-    isWorking: false,
-    pendingRequestType: null,
-    sessionSummaries: [],
-    gitStats: null,
-    lastActivityAt: null,
-    sidebarStatus: { activityState: 'IDLE', ciState: 'NONE' },
-    kanbanColumn: 'WAITING',
-    flowPhase: 'NO_PR',
-    ciObservation: 'NOT_FETCHED',
-    ratchetButtonAnimated: false,
-    fieldTimestamps: {
-      workspace: 0,
-      pr: 0,
-      session: 0,
-      ratchet: 0,
-      runScript: 0,
-      reconciliation: 0,
-    },
-    ...overrides,
-  } as WorkspaceSnapshotEntry;
-}
 
 // ---------------------------------------------------------------------------
 // Tests: detectDrift (pure function)
@@ -380,6 +275,59 @@ describe('SnapshotReconciliationService', () => {
   });
 
   describe('reconcile()', () => {
+    it('isolates runtime snapshot failures while seeding, cleaning stale entries, and refreshing git', async () => {
+      const { WorkspaceSnapshotStore } = await vi.importActual<
+        typeof import('@/backend/services/workspace')
+      >('@/backend/services/workspace');
+      const store = new WorkspaceSnapshotStore();
+      store.configure({
+        deriveFlowState: (input) =>
+          deriveWorkspaceFlowState({
+            ...input,
+            prUpdatedAt: input.prUpdatedAt ? new Date(input.prUpdatedAt) : null,
+          }),
+        deriveSidebarStatus: deriveWorkspaceSidebarStatus,
+      });
+      store.upsert('ws-stale', { projectId: 'proj-1' }, 'reconciliation', 1);
+      service = new SnapshotReconciliationService({
+        createLogger: () => ({
+          info: vi.fn(),
+          warn: mockLoggerWarn,
+          debug: vi.fn(),
+          error: vi.fn(),
+        }),
+        gitOpsService: { getWorkspaceGitStats: mockGetWorkspaceGitStats },
+        session: bridges.session,
+        workspaceMaintenanceService: { findActiveWithSessionsAndProject: mockFindAllNonArchived },
+        workspaceSnapshotStore: store,
+      });
+      mockFindAllNonArchived.mockResolvedValue([
+        createMockWorkspace({ id: 'ws-broken' }),
+        createMockWorkspace({ id: 'ws-healthy', agentSessions: [] }),
+      ]);
+      vi.mocked(bridges.session.getRuntimeSnapshot).mockImplementation(() => {
+        throw new Error('runtime unavailable');
+      });
+      const gitStats = { total: 5, additions: 3, deletions: 2, hasUncommitted: false };
+      mockGetWorkspaceGitStats.mockResolvedValue(gitStats);
+
+      const result = await service.reconcile();
+
+      expect(store.getByWorkspaceId('ws-healthy')).toMatchObject({
+        name: 'Test Workspace',
+        sessionSummaries: [],
+        gitStats,
+      });
+      expect(store.getByWorkspaceId('ws-stale')).toBeUndefined();
+      expect(store.getByWorkspaceId('ws-broken')).toBeUndefined();
+      expect(result.staleEntriesRemoved).toBe(1);
+      expect(result.gitStatsComputed).toBe(1);
+      expect(mockLoggerWarn).toHaveBeenCalledWith(
+        'Failed to build authoritative fields for workspace',
+        { workspaceId: 'ws-broken', error: 'runtime unavailable' }
+      );
+    });
+
     it('upserts all non-archived workspaces with authoritative data', async () => {
       const ws1 = createMockWorkspace({ id: 'ws-1' });
       const ws2 = createMockWorkspace({

--- a/src/backend/orchestration/snapshot-reconciliation.orchestrator.ts
+++ b/src/backend/orchestration/snapshot-reconciliation.orchestrator.ts
@@ -87,6 +87,7 @@ export interface ReconciliationResult {
   workspacesChanged: number;
   deltasEmitted: number;
   workspacesReconciled: number;
+  workspacesSkipped: number;
   driftsDetected: number;
   staleEntriesRemoved: number;
   gitStatsComputed: number;
@@ -429,11 +430,14 @@ export class SnapshotReconciliationService {
       // 5. Log summary after every streamed git update has settled.
       const durationMs = Date.now() - pollStartTs;
       const workspacesChanged = changedWorkspaceIds.size;
+      const workspacesSkipped = failedWorkspaceIds.size;
+      const workspacesReconciled = workspaces.length - workspacesSkipped;
       this.logger.info('Reconciliation complete', {
         workspacesScanned: workspaces.length,
         workspacesChanged,
         deltasEmitted,
-        workspacesReconciled: workspaces.length,
+        workspacesReconciled,
+        workspacesSkipped,
         driftsDetected,
         staleEntriesRemoved,
         gitStatsComputed,
@@ -444,7 +448,8 @@ export class SnapshotReconciliationService {
         workspacesScanned: workspaces.length,
         workspacesChanged,
         deltasEmitted,
-        workspacesReconciled: workspaces.length,
+        workspacesReconciled,
+        workspacesSkipped,
         driftsDetected,
         staleEntriesRemoved,
         gitStatsComputed,

--- a/src/backend/orchestration/snapshot-reconciliation.orchestrator.ts
+++ b/src/backend/orchestration/snapshot-reconciliation.orchestrator.ts
@@ -312,6 +312,7 @@ export class SnapshotReconciliationService {
       let staleEntriesRemoved = 0;
       let gitStatsComputed = 0;
       const changedWorkspaceIds = new Set<string>();
+      const failedWorkspaceIds = new Set<string>();
 
       const recordUpsert = (
         workspaceId: string,
@@ -328,7 +329,17 @@ export class SnapshotReconciliationService {
       // 3. Seed DB and runtime fields without waiting for git. Omitting gitStats
       // preserves an existing cached value until this pass computes a replacement.
       for (const ws of workspaces) {
-        const authoritativeFields = this.buildAuthoritativeFields(ws, allPendingRequests);
+        let authoritativeFields: SnapshotUpdateInput;
+        try {
+          authoritativeFields = this.buildAuthoritativeFields(ws, allPendingRequests);
+        } catch (error) {
+          failedWorkspaceIds.add(ws.id);
+          this.logger.warn('Failed to build authoritative fields for workspace', {
+            workspaceId: ws.id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          continue;
+        }
         if (!ws.worktreePath) {
           authoritativeFields.gitStats = null;
         }
@@ -375,7 +386,7 @@ export class SnapshotReconciliationService {
       await Promise.all(
         workspaces.map((ws) => {
           const worktreePath = ws.worktreePath;
-          if (!worktreePath) {
+          if (!worktreePath || failedWorkspaceIds.has(ws.id)) {
             return Promise.resolve();
           }
           return gitLimit(async () => {

--- a/src/backend/orchestration/snapshot-reconciliation.test-helpers.test.ts
+++ b/src/backend/orchestration/snapshot-reconciliation.test-helpers.test.ts
@@ -1,0 +1,8 @@
+import { expect, it } from 'vitest';
+import { WorkspaceSnapshotEntrySchema } from '@/shared/workspace-snapshot';
+import { createSnapshotEntry } from './snapshot-reconciliation.test-helpers';
+
+it('creates a snapshot fixture accepted by the snapshot wire schema', () => {
+  const entry = createSnapshotEntry();
+  expect(WorkspaceSnapshotEntrySchema.parse(entry)).toEqual(entry);
+});

--- a/src/backend/orchestration/snapshot-reconciliation.test-helpers.ts
+++ b/src/backend/orchestration/snapshot-reconciliation.test-helpers.ts
@@ -89,6 +89,10 @@ export function createSnapshotEntry(
     prUpdatedAt: '2026-01-02T00:00:00Z',
     ratchetEnabled: true,
     ratchetState: 'IDLE',
+    ratchetDispatchStalled: true,
+    hasMergeConflict: false,
+    mode: 'STANDARD',
+    autoIterationStatus: null,
     ratchetDispatchOutcome: 'DIED',
     ratchetDispatchRetryCount: SERVICE_THRESHOLDS.ratchetDispatchMaxRetries,
     runScriptStatus: 'IDLE',
@@ -103,6 +107,12 @@ export function createSnapshotEntry(
     flowPhase: 'NO_PR',
     ciObservation: 'NOT_FETCHED',
     ratchetButtonAnimated: false,
+    statusReason: {
+      code: 'READY_FOR_NEXT_PROMPT',
+      label: 'Ready for next prompt',
+      tone: 'neutral',
+      needsUser: true,
+    },
     fieldTimestamps: {
       workspace: 0,
       pr: 0,
@@ -112,5 +122,5 @@ export function createSnapshotEntry(
       reconciliation: 0,
     },
     ...overrides,
-  } as WorkspaceSnapshotEntry;
+  };
 }

--- a/src/backend/orchestration/snapshot-reconciliation.test-helpers.ts
+++ b/src/backend/orchestration/snapshot-reconciliation.test-helpers.ts
@@ -1,0 +1,116 @@
+import { vi } from 'vitest';
+import { SERVICE_THRESHOLDS } from '@/backend/services/constants';
+import type { WorkspaceSnapshotEntry } from '@/backend/services/workspace';
+import type { SessionRuntimeState } from '@/shared/session-runtime';
+import type { ReconciliationBridges } from './snapshot-reconciliation.orchestrator';
+
+export function createMockWorkspace(
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    id: 'ws-1',
+    projectId: 'proj-1',
+    name: 'Test Workspace',
+    status: 'READY',
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    branchName: 'feature/test',
+    hasHadSessions: true,
+    worktreePath: '/path/to/worktree',
+    prUrl: 'https://github.com/org/repo/pull/1',
+    prNumber: 1,
+    prState: 'OPEN',
+    prCiStatus: 'SUCCESS',
+    prUpdatedAt: new Date('2026-01-02T00:00:00Z'),
+    ratchetEnabled: true,
+    ratchetState: 'IDLE',
+    ratchetDispatchOutcome: 'DIED',
+    ratchetDispatchRetryCount: SERVICE_THRESHOLDS.ratchetDispatchMaxRetries,
+    ratchetDispatchStalled: true,
+    prHasMergeConflict: false,
+    mode: 'STANDARD',
+    autoIterationStatus: null,
+    runScriptStatus: 'IDLE',
+    agentSessions: [
+      {
+        id: 'cs-1',
+        name: 'Chat 1',
+        workflow: 'followup',
+        model: 'claude-sonnet',
+        status: 'IDLE',
+        updatedAt: new Date('2026-01-03T10:00:00Z'),
+      },
+      {
+        id: 'cs-2',
+        name: 'Chat 2',
+        workflow: 'followup',
+        model: 'claude-sonnet',
+        status: 'IDLE',
+        updatedAt: new Date('2026-01-03T12:00:00Z'),
+      },
+    ],
+    terminalSessions: [{ id: 'ts-1', updatedAt: new Date('2026-01-03T11:00:00Z') }],
+    project: { defaultBranch: 'main' },
+    ...overrides,
+  };
+}
+
+export function createMockBridges(): ReconciliationBridges {
+  const runtime: SessionRuntimeState = {
+    phase: 'idle',
+    processState: 'alive',
+    activity: 'IDLE',
+    updatedAt: '2026-01-03T12:00:00.000Z',
+  };
+  return {
+    session: {
+      getRuntimeSnapshot: vi.fn().mockReturnValue(runtime),
+      getAllPendingRequests: vi.fn().mockReturnValue(new Map()),
+    },
+  };
+}
+
+export function createSnapshotEntry(
+  overrides: Partial<WorkspaceSnapshotEntry> = {}
+): WorkspaceSnapshotEntry {
+  return {
+    workspaceId: 'ws-1',
+    projectId: 'proj-1',
+    version: 1,
+    computedAt: '2026-01-01T00:00:00Z',
+    source: 'reconciliation',
+    name: 'Test Workspace',
+    status: 'READY',
+    createdAt: '2026-01-01T00:00:00Z',
+    branchName: 'feature/test',
+    prUrl: 'https://github.com/org/repo/pull/1',
+    prNumber: 1,
+    prState: 'OPEN',
+    prCiStatus: 'SUCCESS',
+    prUpdatedAt: '2026-01-02T00:00:00Z',
+    ratchetEnabled: true,
+    ratchetState: 'IDLE',
+    ratchetDispatchOutcome: 'DIED',
+    ratchetDispatchRetryCount: SERVICE_THRESHOLDS.ratchetDispatchMaxRetries,
+    runScriptStatus: 'IDLE',
+    hasHadSessions: true,
+    isWorking: false,
+    pendingRequestType: null,
+    sessionSummaries: [],
+    gitStats: null,
+    lastActivityAt: null,
+    sidebarStatus: { activityState: 'IDLE', ciState: 'NONE' },
+    kanbanColumn: 'WAITING',
+    flowPhase: 'NO_PR',
+    ciObservation: 'NOT_FETCHED',
+    ratchetButtonAnimated: false,
+    fieldTimestamps: {
+      workspace: 0,
+      pr: 0,
+      session: 0,
+      ratchet: 0,
+      runScript: 0,
+      reconciliation: 0,
+    },
+    ...overrides,
+  } as WorkspaceSnapshotEntry;
+}


### PR DESCRIPTION
A single throwing session runtime snapshot aborted reconciliation for later workspaces and prevented stale-entry cleanup and Git refresh. Isolate authoritative-field failures per workspace, log the affected workspace, and let healthy seeds, cleanup, and Git updates finish. Skip Git refresh for a failed seed so a Git-only upsert cannot recreate an unseeded workspace without its required project identity.

Adds a real-store regression covering the failed seed, healthy workspace data and Git stats, and stale removal. Shared test fixtures move into a helper to keep the suite under its file-length limit and are validated against the snapshot wire schema. Summary/result counters distinguish scanned, reconciled, and skipped workspaces.

Closes #2265.

Validation: regression failed before the fix (including the Git-only upsert hazard); all 32 reconciliation and fixture tests pass; `pnpm check:fix`, `pnpm typecheck`, `pnpm check`, and `pnpm check:imports`; all pre-commit checks. The Codex schema check skips locally because CLI 0.154.0 differs from pinned 0.153.4; CI enforces it.
