### PR TITLE
Avoid duplicate script failure banners in workspace chat

### DIFF
--- a/src/client/routes/projects/workspaces/workspace-detail-chat-content.test.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-chat-content.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { createRef } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot } from 'react-dom/client';
+import { describe, expect, it, vi } from 'vitest';
+import { EMPTY_CHAT_BAR_CAPABILITIES } from '@/shared/chat-capabilities';
+import { createInitialSessionRuntimeState } from '@/shared/session-runtime';
+import { ChatContent, type ChatContentProps } from './workspace-detail-chat-content';
+
+vi.mock('@/client/features/chat', () => ({
+  useGroupedChatMessages: () => [],
+  VirtualizedMessageList: () => null,
+  ChatInput: () => null,
+  PermissionPrompt: () => null,
+  QuestionPrompt: () => null,
+  RewindConfirmationDialog: () => null,
+}));
+vi.mock('@/client/features/voice', () => ({ VoiceModeToggle: () => null }));
+vi.mock('./use-retry-workspace-init', () => ({
+  useRetryWorkspaceInit: () => ({ retry: vi.fn(), retryInit: { isPending: false } }),
+}));
+
+describe('ChatContent init banner ownership', () => {
+  it.each(['warning', 'error'] as const)(
+    'leaves %s script failures to the workspace banner',
+    (kind) => {
+      const props = {
+        workspaceId: 'workspace-1',
+        sessionId: 'session-1',
+        messages: [],
+        queuedMessages: [],
+        sessionStatus: { phase: 'ready' },
+        sessionRuntime: createInitialSessionRuntimeState(),
+        chatCapabilities: EMPTY_CHAT_BAR_CAPABILITIES,
+        pendingRequest: { type: 'none' },
+        pendingMessages: new Map(),
+        inputRef: createRef(),
+        viewportRef: createRef(),
+        initBanner: {
+          kind,
+          message: 'Init script failed',
+          showRetry: true,
+          showPlay: false,
+          showDismiss: true,
+        },
+        isScriptFailed: true,
+      } as unknown as ChatContentProps;
+      const container = document.createElement('div');
+      const root = createRoot(container);
+      try {
+        flushSync(() => root.render(<ChatContent {...props} />));
+        expect(container.textContent).not.toContain('Init script failed');
+        flushSync(() => root.render(<ChatContent {...props} isScriptFailed={false} />));
+        expect(container.textContent).toContain('Init script failed');
+        expect(container.textContent).toContain('Retry setup');
+      } finally {
+        flushSync(() => root.unmount());
+      }
+    }
+  );
+});

--- a/src/client/routes/projects/workspaces/workspace-detail-chat-content.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-chat-content.tsx
@@ -68,6 +68,7 @@ export interface ChatContentProps {
   setConfigOption: ReturnType<typeof useChatWebSocket>['setConfigOption'];
   autoStartPending?: boolean;
   initBanner: WorkspaceInitBanner | null;
+  isScriptFailed: boolean;
 }
 
 interface InitStatusBannerProps {
@@ -249,7 +250,7 @@ export const ChatContent = memo(function ChatContent(props: ChatContentProps) {
             onPlay={() => undefined}
           />
         )}
-        {props.initBanner && props.initBanner.kind !== 'info' && (
+        {props.initBanner && !props.isScriptFailed && props.initBanner.kind !== 'info' && (
           <InitStatusBanner
             banner={props.initBanner}
             retryPending={retryInit.isPending}

--- a/src/client/routes/projects/workspaces/workspace-detail-container.tsx
+++ b/src/client/routes/projects/workspaces/workspace-detail-container.tsx
@@ -329,6 +329,7 @@ export function WorkspaceDetailContainer() {
     setConfigOption,
     autoStartPending: isIssueAutoStartPending,
     initBanner,
+    isScriptFailed,
   };
 
   return (

--- a/src/client/routes/projects/workspaces/workspace-overlays.stories.tsx
+++ b/src/client/routes/projects/workspaces/workspace-overlays.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
 import { ArchivingOverlay, InitializationOverlay, ScriptFailedBanner } from './workspace-overlays';
 
 const meta = {
@@ -72,4 +73,30 @@ export const ScriptFailedLongMessage: Story = {
       hasStartupScript={true}
     />
   ),
+};
+
+export const DismissibleScriptFailure: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Script failures have one workspace-level banner with retry, output, and dismissal controls. The chat does not repeat this banner.',
+      },
+    },
+  },
+  render: () => {
+    const [dismissed, setDismissed] = useState(false);
+    return dismissed ? (
+      <div />
+    ) : (
+      <ScriptFailedBanner
+        workspaceId="test-workspace"
+        initErrorMessage="Init script failed"
+        initOutput="Setup exited with code 1"
+        hasStartupScript
+        showDismiss
+        onDismiss={() => setDismissed(true)}
+      />
+    );
+  },
 };


### PR DESCRIPTION
Script failures now render only the workspace banner, which owns retry, output, and dismissal controls. The chat receives the existing `isScriptFailed` state and suppresses its duplicate inline warning/error banner; unrelated inline errors retain their current behavior.

Closes #2272.

Validation: `pnpm check:fix`, `pnpm typecheck`, `pnpm test src/client/routes/projects/workspaces/workspace-detail-chat-content.test.tsx src/client/routes/projects/workspaces/workspace-detail-view.test.tsx` (9 tests), and `pnpm check` passed. The warning and error regressions both failed before the fix. Includes a dismissible Storybook state; Storybook was typechecked, not browser-rendered. Pre-commit checks passed. The Codex schema check skipped locally because CLI 0.154.0 differs from pinned 0.153.4; CI enforces it.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/purplefish-ai/factory-factory/pull/2287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

