### PR TITLE
Refresh CLI authentication after terminal login

### DIFF
--- a/docs/architecture/integrations.md
+++ b/docs/architecture/integrations.md
@@ -13,9 +13,11 @@ identical in-flight reads. Do not spawn `gh` directly from a service. See
 [pull-requests.md](./pull-requests.md) for how the ratchet and the PR sync poll
 share that budget.
 
-CLI authentication checks normally use cached health. Closing the admin setup
-terminal or choosing Recheck forces a fresh check through both the aggregate
-CLI cache and GitHub's own cache, then updates the status displayed in the UI.
+CLI authentication checks normally use cached health. Closing the setup terminal
+in admin settings or project onboarding, or choosing Recheck, forces a fresh
+check through both the aggregate CLI cache and GitHub's own cache. Forced checks
+wait for older refreshes before rechecking so pre-login results cannot overwrite
+the new status displayed in the UI.
 
 ## Linear
 

--- a/docs/architecture/integrations.md
+++ b/docs/architecture/integrations.md
@@ -13,6 +13,10 @@ identical in-flight reads. Do not spawn `gh` directly from a service. See
 [pull-requests.md](./pull-requests.md) for how the ratchet and the PR sync poll
 share that budget.
 
+CLI authentication checks normally use cached health. Closing the admin setup
+terminal or choosing Recheck forces a fresh check through both the aggregate
+CLI cache and GitHub's own cache, then updates the status displayed in the UI.
+
 ## Linear
 
 A per-project issue provider can be set to Linear with an encrypted API key plus

--- a/scripts/file-length-baseline.json
+++ b/scripts/file-length-baseline.json
@@ -5,7 +5,7 @@
   "src/backend/orchestration/workspace-init.orchestrator.test.ts": 1895,
   "src/backend/routers/websocket/terminal.handler.test.ts": 1012,
   "src/backend/services/github/service/github-cli.service.test.ts": 1912,
-  "src/backend/services/github/service/github-cli.service.ts": 1131,
+  "src/backend/services/github/service/github-cli.service.ts": 1129,
   "src/backend/services/ratchet/service/ratchet-pr-state.helpers.test.ts": 1209,
   "src/backend/services/ratchet/service/ratchet.service.test.ts": 4682,
   "src/backend/services/ratchet/service/ratchet.service.ts": 1035,

--- a/src/backend/orchestration/cli-health.service.test.ts
+++ b/src/backend/orchestration/cli-health.service.test.ts
@@ -235,6 +235,7 @@ describe('cliHealthService', () => {
     expect(checkClaudeSpy).toHaveBeenCalledTimes(1);
     expect(checkCodexSpy).toHaveBeenCalledTimes(1);
     expect(mockGithubCheckHealth).toHaveBeenCalledTimes(1);
+    expect(mockGithubCheckHealth).toHaveBeenCalledWith(true);
     expect(first.allHealthy).toBe(true);
   });
 

--- a/src/backend/orchestration/cli-health.service.test.ts
+++ b/src/backend/orchestration/cli-health.service.test.ts
@@ -239,6 +239,30 @@ describe('cliHealthService', () => {
     expect(first.allHealthy).toBe(true);
   });
 
+  it('prevents an older aggregate refresh from overwriting a forced result', async () => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(0);
+    const healthy = { isInstalled: true, isAuthenticated: true };
+    const checkClaude = vi.spyOn(cliHealthService, 'checkClaudeCLI').mockResolvedValue(healthy);
+    vi.spyOn(cliHealthService, 'checkCodexCLI').mockResolvedValue(healthy);
+    mockGithubCheckHealth.mockResolvedValue(healthy);
+    await cliHealthService.checkHealth();
+
+    let finishOld!: (value: typeof healthy) => void;
+    checkClaude.mockReturnValueOnce(
+      new Promise((resolve) => {
+        finishOld = resolve;
+      })
+    );
+    now.mockReturnValue(30_001);
+    await cliHealthService.checkHealth();
+    const forced = cliHealthService.checkHealth(true);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    finishOld({ isInstalled: true, isAuthenticated: false });
+    expect((await forced).allHealthy).toBe(true);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect((await cliHealthService.checkHealth()).allHealthy).toBe(true);
+  });
+
   it('reports unhealthy when Claude or GitHub are unauthenticated', async () => {
     vi.spyOn(cliHealthService, 'checkClaudeCLI').mockResolvedValue({
       isInstalled: true,

--- a/src/backend/orchestration/cli-health.service.ts
+++ b/src/backend/orchestration/cli-health.service.ts
@@ -270,20 +270,20 @@ class CLIHealthService {
     }
 
     // First call or forceRefresh: fetch synchronously.
-    const status = await this.runHealthCheck();
+    const status = await this.runHealthCheck(forceRefresh);
     this.cachedStatus = status;
     this.cacheTimestamp = Date.now();
     return status;
   }
 
-  private async runHealthCheck(): Promise<CLIHealthStatus> {
+  private async runHealthCheck(forceRefresh = false): Promise<CLIHealthStatus> {
     logger.debug('Checking CLI health...');
 
     // Run checks in parallel
     const [claude, codex, github] = await Promise.all([
       this.checkClaudeCLI(),
       this.checkCodexCLI(),
-      githubCLIService.checkHealth(),
+      githubCLIService.checkHealth(forceRefresh),
     ]);
 
     const status: CLIHealthStatus = {

--- a/src/backend/orchestration/cli-health.service.ts
+++ b/src/backend/orchestration/cli-health.service.ts
@@ -52,7 +52,7 @@ export interface CLIUpgradeResult {
 class CLIHealthService {
   private cachedStatus: CLIHealthStatus | null = null;
   private cacheTimestamp = 0;
-  private refreshInFlight = false;
+  private refreshInFlight: Promise<CLIHealthStatus> | null = null;
 
   private extractSemver(value: string | undefined): string | undefined {
     if (!value) {
@@ -247,33 +247,37 @@ class CLIHealthService {
    * firing a background refresh. forceRefresh bypasses this and blocks.
    */
   async checkHealth(forceRefresh = false): Promise<CLIHealthStatus> {
-    const now = Date.now();
-    const isValid = this.cachedStatus && now - this.cacheTimestamp < SERVICE_CACHE_TTL_MS.cliHealth;
-
-    if (!forceRefresh && this.cachedStatus) {
-      if (!(isValid || this.refreshInFlight)) {
-        // Stale — kick off background refresh and return stale value immediately.
-        this.refreshInFlight = true;
-        this.runHealthCheck()
-          .then((status) => {
-            this.cachedStatus = status;
-            this.cacheTimestamp = Date.now();
-          })
-          .catch(() => {
-            // Keep stale value on error.
-          })
-          .finally(() => {
-            this.refreshInFlight = false;
-          });
-      }
-      return this.cachedStatus;
+    // Serialize forced refreshes after older checks so they cannot overwrite new auth.
+    if (forceRefresh && this.refreshInFlight) {
+      await this.refreshInFlight.catch(() => undefined);
     }
-
-    // First call or forceRefresh: fetch synchronously.
-    const status = await this.runHealthCheck(forceRefresh);
-    this.cachedStatus = status;
-    this.cacheTimestamp = Date.now();
-    return status;
+    const cached = this.cachedStatus;
+    if (
+      !forceRefresh &&
+      cached &&
+      Date.now() - this.cacheTimestamp < SERVICE_CACHE_TTL_MS.cliHealth
+    ) {
+      return cached;
+    }
+    if (!this.refreshInFlight) {
+      const refresh = this.runHealthCheck(forceRefresh)
+        .then((status) => {
+          this.cachedStatus = status;
+          this.cacheTimestamp = Date.now();
+          return status;
+        })
+        .finally(() => {
+          if (this.refreshInFlight === refresh) {
+            this.refreshInFlight = null;
+          }
+        });
+      this.refreshInFlight = refresh;
+    }
+    if (!forceRefresh && cached) {
+      void this.refreshInFlight.catch(() => undefined);
+      return cached;
+    }
+    return this.refreshInFlight;
   }
 
   private async runHealthCheck(forceRefresh = false): Promise<CLIHealthStatus> {
@@ -315,7 +319,7 @@ class CLIHealthService {
   clearCache(): void {
     this.cachedStatus = null;
     this.cacheTimestamp = 0;
-    this.refreshInFlight = false;
+    this.refreshInFlight = null;
   }
 }
 

--- a/src/backend/services/github/service/github-cli-health-cache.test.ts
+++ b/src/backend/services/github/service/github-cli-health-cache.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, expect, it, vi } from 'vitest';
+
+const mockExecFile = vi.hoisted(() => vi.fn());
+vi.mock('node:child_process', () => ({ execFile: mockExecFile }));
+vi.mock('node:util', () => ({ promisify: (fn: unknown) => fn }));
+vi.mock('@/backend/services/logger.service', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+import { githubCLIService } from './github-cli.service';
+
+beforeEach(() => {
+  mockExecFile.mockReset();
+  githubCLIService.clearCaches();
+});
+
+it('refreshes cached authentication immediately when explicitly requested', async () => {
+  mockExecFile
+    .mockResolvedValueOnce({ stdout: 'gh version 2.20.0', stderr: '' })
+    .mockRejectedValueOnce(new Error('not logged in'));
+  expect((await githubCLIService.checkHealth()).isAuthenticated).toBe(false);
+
+  mockExecFile.mockResolvedValue({ stdout: 'gh version 2.20.0', stderr: '' });
+  expect((await githubCLIService.checkHealth()).isAuthenticated).toBe(false);
+  expect((await githubCLIService.checkHealth(true)).isAuthenticated).toBe(true);
+  expect((await githubCLIService.checkHealth()).isAuthenticated).toBe(true);
+});

--- a/src/backend/services/github/service/github-cli-health-cache.test.ts
+++ b/src/backend/services/github/service/github-cli-health-cache.test.ts
@@ -25,3 +25,31 @@ it('refreshes cached authentication immediately when explicitly requested', asyn
   expect((await githubCLIService.checkHealth(true)).isAuthenticated).toBe(true);
   expect((await githubCLIService.checkHealth()).isAuthenticated).toBe(true);
 });
+
+it('waits for pre-login background checks before forcing a new authentication check', async () => {
+  const now = vi.spyOn(Date, 'now').mockReturnValue(0);
+  mockExecFile
+    .mockResolvedValueOnce({ stdout: 'gh version 2.20.0', stderr: '' })
+    .mockRejectedValueOnce(new Error('not logged in'));
+  await githubCLIService.checkHealth();
+
+  let rejectOldAuth!: (error: Error) => void;
+  mockExecFile
+    .mockResolvedValueOnce({ stdout: 'gh version 2.20.0', stderr: '' })
+    .mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectOldAuth = reject;
+        })
+    )
+    .mockResolvedValue({ stdout: 'gh version 2.20.0', stderr: '' });
+  now.mockReturnValue(30_001);
+  expect((await githubCLIService.checkHealth()).isAuthenticated).toBe(false);
+  await vi.waitFor(() => expect(rejectOldAuth).toBeTypeOf('function'));
+  const forced = githubCLIService.checkHealth(true);
+  // Let the forced check reach the old in-flight auth process before it settles.
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  rejectOldAuth(new Error('pre-login result'));
+  expect((await forced).isAuthenticated).toBe(true);
+  expect((await githubCLIService.checkHealth()).isAuthenticated).toBe(true);
+});

--- a/src/backend/services/github/service/github-cli.service.ts
+++ b/src/backend/services/github/service/github-cli.service.ts
@@ -213,9 +213,9 @@ class GitHubCLIService {
    * Check if gh CLI is installed and authenticated.
    * Result is cached for 30 s (stale-while-revalidate).
    */
-  async checkHealth(): Promise<GitHubCLIHealthStatus> {
+  async checkHealth(forceRefresh = false): Promise<GitHubCLIHealthStatus> {
     const now = Date.now();
-    if (this.cachedHealth) {
+    if (!forceRefresh && this.cachedHealth) {
       const isStale = now - this.cachedHealth.fetchedAt >= this.HEALTH_CACHE_TTL_MS;
       if (isStale && !this.healthRefreshInFlight) {
         this.healthRefreshInFlight = true;
@@ -232,7 +232,7 @@ class GitHubCLIService {
       }
       return this.cachedHealth.result;
     }
-    // First call: no cache — fetch synchronously.
+    // First call or explicit refresh: wait for current authentication status.
     const result = await this.runCheckHealth();
     this.cachedHealth = { result, fetchedAt: Date.now() };
     return result;

--- a/src/backend/services/github/service/github-cli.service.ts
+++ b/src/backend/services/github/service/github-cli.service.ts
@@ -94,7 +94,7 @@ class GitHubCLIService {
 
   // Stale-while-revalidate caches for expensive GitHub CLI calls.
   private cachedHealth: { result: GitHubCLIHealthStatus; fetchedAt: number } | null = null;
-  private healthRefreshInFlight = false;
+  private healthRefreshInFlight: Promise<GitHubCLIHealthStatus> | null = null;
   private readonly HEALTH_CACHE_TTL_MS = 30_000;
 
   private readonly issueCache = new Map<string, { issues: GitHubIssue[]; fetchedAt: number }>();
@@ -107,7 +107,7 @@ class GitHubCLIService {
   /** Clear all caches — used in tests to prevent cross-test contamination. */
   clearCaches(): void {
     this.cachedHealth = null;
-    this.healthRefreshInFlight = false;
+    this.healthRefreshInFlight = null;
     this.issueCache.clear();
     this.issueRefreshInFlight.clear();
     this.rateLimitedUntil = null;
@@ -209,33 +209,31 @@ class GitHubCLIService {
     }
   }
 
-  /**
-   * Check if gh CLI is installed and authenticated.
-   * Result is cached for 30 s (stale-while-revalidate).
-   */
+  /** Cached gh health; forced checks wait for earlier checks before rechecking auth. */
   async checkHealth(forceRefresh = false): Promise<GitHubCLIHealthStatus> {
-    const now = Date.now();
-    if (!forceRefresh && this.cachedHealth) {
-      const isStale = now - this.cachedHealth.fetchedAt >= this.HEALTH_CACHE_TTL_MS;
-      if (isStale && !this.healthRefreshInFlight) {
-        this.healthRefreshInFlight = true;
-        this.runCheckHealth()
-          .then((result) => {
-            this.cachedHealth = { result, fetchedAt: Date.now() };
-          })
-          .catch(() => {
-            // Keep stale value on error.
-          })
-          .finally(() => {
-            this.healthRefreshInFlight = false;
-          });
-      }
-      return this.cachedHealth.result;
+    // Finish pre-login checks before starting fresh work, including exec singleflight.
+    if (forceRefresh && this.healthRefreshInFlight) {
+      await this.healthRefreshInFlight.catch(() => undefined);
     }
-    // First call or explicit refresh: wait for current authentication status.
-    const result = await this.runCheckHealth();
-    this.cachedHealth = { result, fetchedAt: Date.now() };
-    return result;
+    const cached = this.cachedHealth;
+    if (!forceRefresh && cached && Date.now() - cached.fetchedAt < this.HEALTH_CACHE_TTL_MS) {
+      return cached.result;
+    }
+    if (!this.healthRefreshInFlight) {
+      const refresh = this.runCheckHealth()
+        .then((result) => {
+          this.cachedHealth = { result, fetchedAt: Date.now() };
+          return result;
+        })
+        .finally(() => {
+          if (this.healthRefreshInFlight === refresh) {
+            this.healthRefreshInFlight = null;
+          }
+        });
+      this.healthRefreshInFlight = refresh;
+    }
+    void this.healthRefreshInFlight.catch(() => undefined);
+    return !forceRefresh && cached ? cached.result : this.healthRefreshInFlight;
   }
 
   private async runCheckHealth(): Promise<GitHubCLIHealthStatus> {

--- a/src/client/features/project/onboarding-cli-health.tsx
+++ b/src/client/features/project/onboarding-cli-health.tsx
@@ -5,6 +5,7 @@ import {
   TerminalIcon,
   WarningIcon,
 } from '@phosphor-icons/react';
+import { useCLIHealthRefresh } from '@/client/hooks/use-cli-health-refresh';
 import { trpc } from '@/client/lib/trpc';
 import { Button } from '@/components/ui/button';
 import { Spinner } from '@/components/ui/spinner';
@@ -81,10 +82,10 @@ function buildItems(health: {
 }
 
 export function OnboardingCliHealth({ onOpenTerminal }: OnboardingCliHealthProps) {
+  const { refresh, isRefreshing } = useCLIHealthRefresh();
   const {
     data: health,
     isLoading,
-    refetch,
     isRefetching,
   } = trpc.admin.checkCLIHealth.useQuery(
     { forceRefresh: false },
@@ -116,10 +117,12 @@ export function OnboardingCliHealth({ onOpenTerminal }: OnboardingCliHealthProps
           variant="ghost"
           size="sm"
           className="h-7 px-2 text-xs text-muted-foreground"
-          onClick={() => refetch()}
-          disabled={isRefetching}
+          onClick={() => void refresh()}
+          disabled={isRefetching || isRefreshing}
         >
-          <ArrowsClockwiseIcon className={`mr-1 h-3 w-3 ${isRefetching ? 'animate-spin' : ''}`} />
+          <ArrowsClockwiseIcon
+            className={`mr-1 h-3 w-3 ${isRefetching || isRefreshing ? 'animate-spin' : ''}`}
+          />
           Recheck
         </Button>
       </div>

--- a/src/client/hooks/use-cli-health-refresh.ts
+++ b/src/client/hooks/use-cli-health-refresh.ts
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { trpc } from '@/client/lib/trpc';
+
+export function useCLIHealthRefresh() {
+  const utils = trpc.useUtils();
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const refresh = async () => {
+    setIsRefreshing(true);
+    try {
+      const health = await utils.admin.checkCLIHealth.fetch(
+        { forceRefresh: true },
+        { staleTime: 0 }
+      );
+      utils.admin.checkCLIHealth.setData({ forceRefresh: false }, health);
+    } catch {
+      toast.error('Failed to refresh CLI authentication status. Try Recheck again.');
+    } finally {
+      setIsRefreshing(false);
+    }
+  };
+
+  return { refresh, isRefreshing };
+}

--- a/src/client/routes/admin/CliAuthSection.test.tsx
+++ b/src/client/routes/admin/CliAuthSection.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { observable } from '@trpc/server/observable';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { trpc } from '@/client/lib/trpc';
+import { CliAuthSection } from './CliAuthSection';
+
+vi.mock('@/client/features/project/use-setup-terminal', () => ({
+  useSetupTerminal: () => ({ connected: false, showTerminal: false, gaveUp: false }),
+}));
+
+beforeEach(() => vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true));
+afterEach(() => vi.unstubAllGlobals());
+
+describe('CLI authentication refresh', () => {
+  it.each(['Recheck', 'terminal close'])('refreshes displayed status after %s', async (trigger) => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: 5000 } },
+    });
+    let authenticated = false;
+    const client = trpc.createClient({
+      links: [
+        () =>
+          ({ op }) =>
+            observable((observer) => {
+              const fresh =
+                typeof op.input === 'object' &&
+                op.input !== null &&
+                'forceRefresh' in op.input &&
+                op.input.forceRefresh === true &&
+                authenticated;
+              observer.next({
+                result: {
+                  data: {
+                    claude: { isInstalled: true, isAuthenticated: fresh },
+                    codex: { isInstalled: true, isAuthenticated: fresh },
+                    github: { isInstalled: true, isAuthenticated: fresh },
+                    allHealthy: fresh,
+                  },
+                },
+              });
+              observer.complete();
+            }),
+      ],
+    });
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const click = async (label: string) => {
+      const button = Array.from(document.querySelectorAll('button')).find((item) =>
+        item.textContent?.includes(label)
+      );
+      expect(button).toBeDefined();
+      await act(async () => {
+        button?.click();
+        // React Query schedules observer notifications for the next task.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    };
+    try {
+      await act(async () =>
+        root.render(
+          <trpc.Provider client={client} queryClient={queryClient}>
+            <QueryClientProvider client={queryClient}>
+              <CliAuthSection />
+            </QueryClientProvider>
+          </trpc.Provider>
+        )
+      );
+      await vi.waitFor(() => expect(container.textContent).toContain('run claude login'));
+      // Warm the forced-query cache before the login, within production staleTime.
+      await click('Recheck');
+      authenticated = true;
+      if (trigger === 'terminal close') {
+        await click('Open Terminal to Log In');
+        await click('Close');
+      } else {
+        await click('Recheck');
+      }
+      await vi.waitFor(() => {
+        expect(container.textContent).not.toContain('run claude login');
+        expect(container.textContent?.match(/Ready/g)).toHaveLength(3);
+      });
+    } finally {
+      await act(async () => root.unmount());
+      queryClient.clear();
+      container.remove();
+    }
+  });
+});

--- a/src/client/routes/admin/CliAuthSection.tsx
+++ b/src/client/routes/admin/CliAuthSection.tsx
@@ -2,19 +2,16 @@ import { TerminalIcon } from '@phosphor-icons/react';
 import { useState } from 'react';
 import { OnboardingCliHealth } from '@/client/features/project/onboarding-cli-health';
 import { SetupTerminalModal } from '@/client/features/project/setup-terminal-modal';
-import { trpc } from '@/client/lib/trpc';
+import { useCLIHealthRefresh } from '@/client/hooks/use-cli-health-refresh';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 
 export function CliAuthSection() {
   const [terminalOpen, setTerminalOpen] = useState(false);
-  const { refetch } = trpc.admin.checkCLIHealth.useQuery(
-    { forceRefresh: false },
-    { enabled: false }
-  );
+  const { refresh } = useCLIHealthRefresh();
 
   const handleCloseTerminal = () => {
     setTerminalOpen(false);
-    refetch();
+    void refresh();
   };
 
   return (

--- a/src/client/routes/admin/SettingsSections.stories.tsx
+++ b/src/client/routes/admin/SettingsSections.stories.tsx
@@ -9,6 +9,7 @@ import { trpc } from '@/client/lib/trpc';
 import type { FactoryConfig } from '@/shared/schemas/factory-config.schema';
 import { AppInfoSection } from './AppInfoSection';
 import { ChatProviderDefaultsSection } from './ChatProviderDefaultsSection';
+import { CliAuthSection } from './CliAuthSection';
 import { DataBackupSection } from './DataBackupSection';
 import { IdeSettingsSection } from './IdeSettingsSection';
 import { NotificationSettingsSection } from './NotificationSettingsSection';
@@ -79,10 +80,19 @@ function SettingsStoryProvider({
           efforts: [{ value: 'medium', label: 'Medium' }],
         },
       }),
-      'admin.checkCLIHealth': () => ({
-        claude: { isInstalled: true },
-        codex: { isInstalled: true },
-      }),
+      'admin.checkCLIHealth': (input) => {
+        const fresh =
+          typeof input === 'object' &&
+          input !== null &&
+          'forceRefresh' in input &&
+          input.forceRefresh === true;
+        return {
+          claude: { isInstalled: true, isAuthenticated: fresh },
+          codex: { isInstalled: true, isAuthenticated: fresh },
+          github: { isInstalled: true, isAuthenticated: fresh },
+          allHealthy: fresh,
+        };
+      },
       'admin.downloadLogFile': () => 'Sample server log',
       'admin.getServerInfo': () => ({ backendPort: 3001 }),
       'admin.triggerRatchetCheck': () => ({ checked: 3, stateChanges: 1, actionsTriggered: 1 }),
@@ -410,5 +420,22 @@ export const ServerLogs: Story = {
     link.focus();
     await userEvent.tab();
     await expect(canvas.getByRole('button', { name: 'Download Log File' })).toHaveFocus();
+  },
+};
+
+export const RefreshCLIAuthentication: Story = {
+  render: () => (
+    <SettingsStoryProvider>
+      <CliAuthSection />
+    </SettingsStoryProvider>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByText(/run claude login/);
+    await userEvent.click(canvas.getByRole('button', { name: 'Recheck' }));
+    await waitFor(() => expect(canvas.getAllByText(/Ready/)).toHaveLength(3));
+    await expect(
+      canvas.queryByRole('button', { name: 'Open Terminal to Log In' })
+    ).not.toBeInTheDocument();
   },
 };

--- a/src/client/routes/projects/new.test.tsx
+++ b/src/client/routes/projects/new.test.tsx
@@ -11,6 +11,8 @@ import {
 import { SELECTED_PROJECT_KEY } from '@/client/lib/project-selection';
 import NewProjectPage from './new';
 
+const refreshHealthFetch = vi.fn().mockResolvedValue({ allHealthy: true });
+const setHealthData = vi.fn();
 const navigateMock = vi.fn();
 const useAppHeaderMock = vi.fn();
 const selectProjectSlugMock = vi.fn();
@@ -70,7 +72,8 @@ vi.mock('@/client/features/project/github-url-form', () => ({
 }));
 
 vi.mock('@/client/features/project/onboarding-cli-health', () => ({
-  OnboardingCliHealth: () => createElement('div', null, 'CLI Health'),
+  OnboardingCliHealth: ({ onOpenTerminal }: { onOpenTerminal: () => void }) =>
+    createElement('button', { onClick: onOpenTerminal }, 'Open setup terminal'),
 }));
 
 vi.mock('@/client/features/project/project-repo-form', () => ({
@@ -99,7 +102,8 @@ vi.mock('@/client/features/project/project-repo-form', () => ({
 }));
 
 vi.mock('@/client/features/project/setup-terminal-modal', () => ({
-  SetupTerminalModal: () => null,
+  SetupTerminalModal: ({ open, onClose }: { open: boolean; onClose: () => void }) =>
+    open ? createElement('button', { onClick: onClose }, 'Close setup terminal') : null,
 }));
 
 vi.mock('@/components/ui/button', () => ({
@@ -126,7 +130,9 @@ vi.mock('@/client/lib/trpc', () => ({
   trpc: {
     useUtils: () => ({
       project: { list: { invalidate: vi.fn() } },
-      admin: { checkCLIHealth: { invalidate: vi.fn() } },
+      admin: {
+        checkCLIHealth: { invalidate: vi.fn(), fetch: refreshHealthFetch, setData: setHealthData },
+      },
     }),
     project: {
       list: { useQuery: () => ({ data: projects }) },
@@ -285,4 +291,28 @@ describe('NewProjectPage local path submission', () => {
     });
     root.unmount();
   });
+});
+
+it('forces CLI authentication refresh when the setup terminal closes', async () => {
+  const existingProjects = projects.splice(0);
+  const { container, root } = renderPage();
+  const click = (label: string) => {
+    const button = Array.from(container.querySelectorAll('button')).find(
+      (entry) => entry.textContent === label
+    );
+    expect(button).toBeDefined();
+    flushSync(() => button?.click());
+  };
+  try {
+    click('Open setup terminal');
+    click('Close setup terminal');
+    await vi.waitFor(() =>
+      expect(setHealthData).toHaveBeenCalledWith({ forceRefresh: false }, { allHealthy: true })
+    );
+    expect(refreshHealthFetch).toHaveBeenCalledWith({ forceRefresh: true }, { staleTime: 0 });
+  } finally {
+    flushSync(() => root.unmount());
+    container.remove();
+    projects.push(...existingProjects);
+  }
 });

--- a/src/client/routes/projects/new.tsx
+++ b/src/client/routes/projects/new.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/client/features/project/project-repo-form';
 import { SetupTerminalModal } from '@/client/features/project/setup-terminal-modal';
 import type { ScriptType } from '@/client/features/project/startup-script-form';
+import { useCLIHealthRefresh } from '@/client/hooks/use-cli-health-refresh';
 import { useProjectHeaderNavigation } from '@/client/hooks/use-project-header-navigation';
 import { trpc } from '@/client/lib/trpc';
 import { Button } from '@/components/ui/button';
@@ -114,6 +115,7 @@ export default function NewProjectPage() {
   useAppHeader({ title: hasExistingProjects ? '' : 'New Project' });
 
   const utils = trpc.useUtils();
+  const { refresh: refreshCLIHealth } = useCLIHealthRefresh();
 
   // Local path creation
   const createProject = trpc.project.create.useMutation({
@@ -180,8 +182,8 @@ export default function NewProjectPage() {
     setTerminalOpen(false);
     // Re-check auth after terminal closes
     refetchAuth();
-    utils.admin.checkCLIHealth.invalidate();
-  }, [refetchAuth, utils.admin.checkCLIHealth]);
+    void refreshCLIHealth();
+  }, [refetchAuth, refreshCLIHealth]);
 
   const localFormProps = {
     error,


### PR DESCRIPTION
Refresh CLI authentication when the setup terminal closes in admin settings or project onboarding, and when the user selects Recheck. The refresh bypasses the client cache, forces both server health caches, and updates the status card. Forced checks wait for older refreshes so pre-login subprocess results cannot be reused or overwrite the fresh result.

Closes #2263.

Validation: reproduced and fixed repeated client-cache reads, GitHub singleflight overlap, aggregate-cache overwrite, and onboarding terminal-close regressions. All 117 tests in five affected suites pass. Settings story and integration documentation updated. `pnpm check:fix`, `pnpm typecheck`, `pnpm check`, `pnpm check:imports`, and pre-commit checks pass; the reduced legacy file-length ceiling was updated. Codex schema drift skips locally because installed CLI 0.154.0 differs from pinned 0.153.4; CI enforces the pinned version.
